### PR TITLE
Localize date and number formatting

### DIFF
--- a/app/components/charts-generic/areas/areas-state.tsx
+++ b/app/components/charts-generic/areas/areas-state.tsx
@@ -26,11 +26,11 @@ import * as React from "react";
 import { ReactNode, useCallback, useMemo } from "react";
 import { AreaFields, Observation } from "../../../domain";
 import {
-  formatDateAuto,
   formatNumber,
   getPalette,
   isNumber,
   parseDate,
+  useFormatFullDateAuto,
 } from "../../../domain/helpers";
 import { sortByIndex } from "../../../lib/array";
 import { estimateTextWidth } from "../../../lib/estimate-text-width";
@@ -68,6 +68,7 @@ const useAreasState = ({
   aspectRatio: number;
 }): AreasState => {
   const width = useWidth();
+  const formatDateAuto = useFormatFullDateAuto();
 
   const hasSegment = fields.segment;
 

--- a/app/components/charts-generic/areas/areas-state.tsx
+++ b/app/components/charts-generic/areas/areas-state.tsx
@@ -26,11 +26,11 @@ import * as React from "react";
 import { ReactNode, useCallback, useMemo } from "react";
 import { AreaFields, Observation } from "../../../domain";
 import {
-  formatNumber,
   getPalette,
   isNumber,
   parseDate,
   useFormatFullDateAuto,
+  useFormatNumber,
 } from "../../../domain/helpers";
 import { sortByIndex } from "../../../lib/array";
 import { estimateTextWidth } from "../../../lib/estimate-text-width";
@@ -68,6 +68,7 @@ const useAreasState = ({
   aspectRatio: number;
 }): AreasState => {
   const width = useWidth();
+  const formatNumber = useFormatNumber();
   const formatDateAuto = useFormatFullDateAuto();
 
   const hasSegment = fields.segment;

--- a/app/components/charts-generic/axis/axis-height-linear.tsx
+++ b/app/components/charts-generic/axis/axis-height-linear.tsx
@@ -7,11 +7,13 @@ import { useChartTheme } from "../use-chart-theme";
 import { ColumnsState } from "../columns/columns-state";
 import { LinesState } from "../lines/lines-state";
 import { AreasState } from "../areas/areas-state";
+import { useFormatNumber } from "../../../domain/helpers";
 
 const TICK_MIN_HEIGHT = 50;
 
 export const AxisHeightLinear = () => {
   const ref = useRef<SVGGElement>(null);
+  const formatNumber = useFormatNumber();
 
   const { yScale, yAxisLabel, bounds } = useChartState() as
     | ColumnsState
@@ -23,7 +25,12 @@ export const AxisHeightLinear = () => {
   const { labelColor, labelFontSize, gridColor, fontFamily } = useChartTheme();
 
   const mkAxis = (g: Selection<SVGGElement, unknown, null, undefined>) => {
-    g.call(axisLeft(yScale).ticks(ticks).tickSizeInner(-bounds.chartWidth));
+    g.call(
+      axisLeft(yScale)
+        .ticks(ticks)
+        .tickSizeInner(-bounds.chartWidth)
+        .tickFormat(formatNumber)
+    );
 
     g.select(".domain").remove();
 

--- a/app/components/charts-generic/axis/axis-width-linear.tsx
+++ b/app/components/charts-generic/axis/axis-width-linear.tsx
@@ -6,9 +6,10 @@ import { useChartState } from "../use-chart-state";
 import { useChartTheme } from "../use-chart-theme";
 import { ScatterplotState } from "../scatterplot/scatterplot-state";
 import { estimateTextWidth } from "../../../lib/estimate-text-width";
-import { formatNumber } from "../../../domain/helpers";
+import { useFormatNumber } from "../../../domain/helpers";
 
 export const AxisWidthLinear = () => {
+  const formatNumber = useFormatNumber();
   const { xScale, bounds, xAxisLabel } = useChartState() as ScatterplotState;
   const { chartWidth, chartHeight, margins } = bounds;
   const { labelColor, labelFontSize, gridColor, fontFamily } = useChartTheme();
@@ -26,9 +27,7 @@ export const AxisWidthLinear = () => {
         .tickSizeOuter(-chartHeight)
     );
 
-    g.selectAll(".tick line")
-      .attr("stroke", gridColor)
-      .attr("stroke-width", 1);
+    g.selectAll(".tick line").attr("stroke", gridColor).attr("stroke-width", 1);
     g.selectAll(".tick text")
       .attr("font-size", labelFontSize)
       .attr("font-family", fontFamily)

--- a/app/components/charts-generic/axis/axis-width-linear.tsx
+++ b/app/components/charts-generic/axis/axis-width-linear.tsx
@@ -25,6 +25,7 @@ export const AxisWidthLinear = () => {
         .tickValues(tickValues)
         .tickSizeInner(-chartHeight)
         .tickSizeOuter(-chartHeight)
+        .tickFormat(formatNumber)
     );
 
     g.selectAll(".tick line").attr("stroke", gridColor).attr("stroke-width", 1);

--- a/app/components/charts-generic/axis/axis-width-time.tsx
+++ b/app/components/charts-generic/axis/axis-width-time.tsx
@@ -2,20 +2,18 @@ import { axisBottom } from "d3-axis";
 import { select, Selection } from "d3-selection";
 import * as React from "react";
 import { useEffect, useRef } from "react";
-import { useChartTheme } from "../use-chart-theme";
-import { useChartState } from "../use-chart-state";
-import { LinesState } from "../lines/lines-state";
-import { AreasState } from "../areas/areas-state";
-import { formatDateAuto } from "../../../domain/helpers";
+import { useFormatShortDateAuto } from "../../../domain/helpers";
 import { estimateTextWidth } from "../../../lib/estimate-text-width";
-import { max } from "d3-array";
+import { AreasState } from "../areas/areas-state";
+import { LinesState } from "../lines/lines-state";
+import { useChartState } from "../use-chart-state";
+import { useChartTheme } from "../use-chart-theme";
 
 export const AxisTime = () => {
   const ref = useRef<SVGGElement>(null);
+  const formatDateAuto = useFormatShortDateAuto();
 
-  const { xScale, yScale, bounds, xUniqueValues } = useChartState() as
-    | LinesState
-    | AreasState;
+  const { xScale, yScale, bounds } = useChartState() as LinesState | AreasState;
 
   const {
     labelColor,
@@ -27,10 +25,7 @@ export const AxisTime = () => {
 
   const hasNegativeValues = yScale.domain()[0] < 0;
 
-  const labelLengths = xUniqueValues.map((v) =>
-    estimateTextWidth(formatDateAuto(v))
-  );
-  const maxLabelLength = max(labelLengths, (d) => d) || 70;
+  const maxLabelLength = estimateTextWidth("99.99.9999") || 70;
 
   // This could be useful: use data points as tick values,
   // but it does not solve the problem of overlapping.
@@ -38,17 +33,15 @@ export const AxisTime = () => {
   //   bounds.chartWidth / (maxLabelLength + 20) > xUniqueValues.length
   //     ? xUniqueValues
   //     : null;
-  const ticks = Math.min(
-    xUniqueValues.length,
-    bounds.chartWidth / (maxLabelLength + 20)
-  );
+  const ticks = bounds.chartWidth / (maxLabelLength + 20);
+
+  console.log({ ticks });
 
   const mkAxis = (g: Selection<SVGGElement, unknown, null, undefined>) => {
     g.call(
       axisBottom(xScale)
         .ticks(ticks)
         .tickFormat((x) => formatDateAuto(x as Date))
-      // .tickValues(tickValues as $FixMe)
     );
     g.select(".domain").remove();
     g.selectAll(".tick line").attr(
@@ -69,8 +62,9 @@ export const AxisTime = () => {
   return (
     <g
       ref={ref}
-      transform={`translate(${bounds.margins.left}, ${bounds.chartHeight +
-        bounds.margins.top})`}
+      transform={`translate(${bounds.margins.left}, ${
+        bounds.chartHeight + bounds.margins.top
+      })`}
     />
   );
 };
@@ -99,8 +93,9 @@ export const AxisTimeDomain = () => {
   return (
     <g
       ref={ref}
-      transform={`translate(${bounds.margins.left}, ${bounds.chartHeight +
-        bounds.margins.top})`}
+      transform={`translate(${bounds.margins.left}, ${
+        bounds.chartHeight + bounds.margins.top
+      })`}
     />
   );
 };

--- a/app/components/charts-generic/axis/axis-width-time.tsx
+++ b/app/components/charts-generic/axis/axis-width-time.tsx
@@ -25,7 +25,9 @@ export const AxisTime = () => {
 
   const hasNegativeValues = yScale.domain()[0] < 0;
 
-  const maxLabelLength = estimateTextWidth("99.99.9999") || 70;
+  // Approximate the longest date format we're using for
+  // Roughly equivalent to estimateTextWidth("99.99.9999", 12);
+  const maxLabelLength = 70;
 
   // This could be useful: use data points as tick values,
   // but it does not solve the problem of overlapping.
@@ -34,8 +36,6 @@ export const AxisTime = () => {
   //     ? xUniqueValues
   //     : null;
   const ticks = bounds.chartWidth / (maxLabelLength + 20);
-
-  console.log({ ticks });
 
   const mkAxis = (g: Selection<SVGGElement, unknown, null, undefined>) => {
     g.call(

--- a/app/components/charts-generic/columns/columns-grouped-state.tsx
+++ b/app/components/charts-generic/columns/columns-grouped-state.tsx
@@ -16,7 +16,7 @@ import {
   SortingType,
   SortingOrder,
 } from "../../../domain";
-import { formatNumber, getPalette, mkNumber } from "../../../domain/helpers";
+import { getPalette, mkNumber, useFormatNumber } from "../../../domain/helpers";
 import { estimateTextWidth } from "../../../lib/estimate-text-width";
 import { Tooltip } from "../annotations/tooltip";
 import {
@@ -58,6 +58,7 @@ const useGroupedColumnsState = ({
   aspectRatio: number;
 }): GroupedColumnsState => {
   const width = useWidth();
+  const formatNumber = useFormatNumber();
 
   const getX = useCallback(
     (d: Observation): string => d[fields.x.componentIri] as string,

--- a/app/components/charts-generic/columns/columns-stacked-state.tsx
+++ b/app/components/charts-generic/columns/columns-stacked-state.tsx
@@ -22,7 +22,7 @@ import {
   SortingType,
 } from "../../../domain/config-types";
 import { Observation, ObservationValue } from "../../../domain/data";
-import { formatNumber, getPalette, isNumber } from "../../../domain/helpers";
+import { getPalette, isNumber, useFormatNumber } from "../../../domain/helpers";
 import { sortByIndex } from "../../../lib/array";
 import { estimateTextWidth } from "../../../lib/estimate-text-width";
 import { Tooltip } from "../annotations/tooltip";
@@ -61,6 +61,7 @@ const useColumnsStackedState = ({
   aspectRatio: number;
 }): StackedColumnsState => {
   const width = useWidth();
+  const formatNumber = useFormatNumber();
 
   const getX = useCallback(
     (d: Observation): string => d[fields.x.componentIri] as string,

--- a/app/components/charts-generic/columns/columns-state.tsx
+++ b/app/components/charts-generic/columns/columns-state.tsx
@@ -14,7 +14,7 @@ import {
   SortingOrder,
   SortingType,
 } from "../../../domain/config-types";
-import { formatNumber, getPalette, mkNumber } from "../../../domain/helpers";
+import { getPalette, mkNumber, useFormatNumber } from "../../../domain/helpers";
 import { estimateTextWidth } from "../../../lib/estimate-text-width";
 import { Tooltip } from "../annotations/tooltip";
 import { PADDING_INNER, PADDING_OUTER } from "../columns/constants";
@@ -49,6 +49,7 @@ const useColumnsState = ({
   aspectRatio: number;
 }): ColumnsState => {
   const width = useWidth();
+  const formatNumber = useFormatNumber();
 
   const getX = useCallback(
     (d: Observation): string => d[fields.x.componentIri] as string,

--- a/app/components/charts-generic/lines/hover-line-values.tsx
+++ b/app/components/charts-generic/lines/hover-line-values.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
 import { useChartState } from "../use-chart-state";
-import { LinesState } from "./lines-state";
 import { useInteraction } from "../use-interaction";
-import { formatNumber } from "../../../domain/helpers";
+import { LinesState } from "./lines-state";
 
 export const HoverLineValues = () => {
   const {
@@ -12,9 +11,10 @@ export const HoverLineValues = () => {
     yScale,
     grouped,
     colors,
-    bounds
+    bounds,
   } = useChartState() as LinesState;
   const [state] = useInteraction();
+
   // const { x, visible, segment } = state.tooltip;
 
   // const segmentData = segment && grouped.get(segment);

--- a/app/components/charts-generic/lines/lines-state.tsx
+++ b/app/components/charts-generic/lines/lines-state.tsx
@@ -11,20 +11,20 @@ import * as React from "react";
 import { ReactNode, useCallback, useMemo } from "react";
 import { LineFields, Observation, ObservationValue } from "../../../domain";
 import {
-  formatDateAuto,
   formatNumber,
   getPalette,
   mkNumber,
   parseDate,
+  useFormatFullDateAuto,
 } from "../../../domain/helpers";
+import { sortByIndex } from "../../../lib/array";
 import { estimateTextWidth } from "../../../lib/estimate-text-width";
 import { useTheme } from "../../../themes";
 import { Tooltip } from "../annotations/tooltip";
 import { LEFT_MARGIN_OFFSET } from "../constants";
-import { Bounds, Observer, useWidth } from "../use-width";
 import { ChartContext, ChartProps } from "../use-chart-state";
 import { InteractionProvider } from "../use-interaction";
-import { sortByIndex } from "../../../lib/array";
+import { Bounds, Observer, useWidth } from "../use-width";
 
 export interface LinesState {
   data: Observation[];
@@ -57,6 +57,7 @@ const useLinesState = ({
 }): LinesState => {
   const theme = useTheme();
   const width = useWidth();
+  const formatDateAuto = useFormatFullDateAuto();
 
   const getGroups = (d: Observation): string =>
     d[fields.x.componentIri] as string;

--- a/app/components/charts-generic/lines/lines-state.tsx
+++ b/app/components/charts-generic/lines/lines-state.tsx
@@ -11,11 +11,11 @@ import * as React from "react";
 import { ReactNode, useCallback, useMemo } from "react";
 import { LineFields, Observation, ObservationValue } from "../../../domain";
 import {
-  formatNumber,
   getPalette,
   mkNumber,
   parseDate,
   useFormatFullDateAuto,
+  useFormatNumber,
 } from "../../../domain/helpers";
 import { sortByIndex } from "../../../lib/array";
 import { estimateTextWidth } from "../../../lib/estimate-text-width";
@@ -57,6 +57,7 @@ const useLinesState = ({
 }): LinesState => {
   const theme = useTheme();
   const width = useWidth();
+  const formatNumber = useFormatNumber();
   const formatDateAuto = useFormatFullDateAuto();
 
   const getGroups = (d: Observation): string =>

--- a/app/components/charts-generic/pie/pie-state.tsx
+++ b/app/components/charts-generic/pie/pie-state.tsx
@@ -8,7 +8,7 @@ import {
   SortingType,
   SortingOrder,
 } from "../../../domain";
-import { formatNumber, getPalette } from "../../../domain/helpers";
+import { getPalette, useFormatNumber } from "../../../domain/helpers";
 import { Tooltip } from "../annotations/tooltip";
 import { Bounds, Observer, useWidth } from "../use-width";
 import { ChartContext, ChartProps } from "../use-chart-state";
@@ -63,6 +63,7 @@ const usePieState = ({
   aspectRatio: number;
 }): PieState => {
   const width = useWidth();
+  const formatNumber = useFormatNumber();
 
   const getY = useCallback(
     (d: Observation): number => +d[fields.y.componentIri] as number,

--- a/app/components/charts-generic/scatterplot/scatterplot-state.tsx
+++ b/app/components/charts-generic/scatterplot/scatterplot-state.tsx
@@ -3,7 +3,7 @@ import { ScaleLinear, scaleLinear, ScaleOrdinal, scaleOrdinal } from "d3-scale";
 import * as React from "react";
 import { ReactNode } from "react";
 import { Observation, ScatterPlotFields } from "../../../domain";
-import { formatNumber, getPalette, mkNumber } from "../../../domain/helpers";
+import { getPalette, mkNumber, useFormatNumber } from "../../../domain/helpers";
 import { Tooltip } from "../annotations/tooltip";
 import { Bounds, Observer, useWidth } from "../use-width";
 import { ChartContext, ChartProps } from "../use-chart-state";
@@ -38,6 +38,7 @@ const useScatterplotState = ({
   aspectRatio: number;
 }): ScatterplotState => {
   const width = useWidth();
+  const formatNumber = useFormatNumber();
 
   const getX = (d: Observation): number => +d[fields.x.componentIri];
   const getY = (d: Observation): number => +d[fields.y.componentIri];

--- a/app/components/dataset-metadata.tsx
+++ b/app/components/dataset-metadata.tsx
@@ -5,10 +5,11 @@ import { ReactNode } from "react";
 import { useDataCubeMetadataQuery } from "../graphql/query-hooks";
 import { useLocale } from "../lib/use-locale";
 import { Loading } from "./hint";
-import { formatDate } from "../domain/helpers";
+import { useFormatFullDateAuto } from "../domain/helpers";
 
 export const DataSetMetadata = ({ dataSetIri }: { dataSetIri: string }) => {
   const locale = useLocale();
+  const formatDate = useFormatFullDateAuto();
   const [{ data }] = useDataCubeMetadataQuery({
     variables: { iri: dataSetIri, locale },
   });

--- a/app/components/datatable.tsx
+++ b/app/components/datatable.tsx
@@ -7,7 +7,7 @@ import {
 } from "../graphql/query-hooks";
 import { useLocale } from "../lib/use-locale";
 import { Loading } from "./hint";
-import { formatNumber } from "../domain/helpers";
+import { useFormatNumber } from "../domain/helpers";
 
 type Header = ComponentFieldsFragment;
 
@@ -20,6 +20,7 @@ const Table = ({
   headers: Header[];
   observations: Observation[];
 }) => {
+  const formatNumber = useFormatNumber();
   return (
     <Box
       as="table"

--- a/app/domain/helpers.tsx
+++ b/app/domain/helpers.tsx
@@ -25,7 +25,7 @@ import * as React from "react";
 import { DimensionFieldsWithValuesFragment } from "../graphql/query-hooks";
 import { IconName } from "../icons";
 import { useLocale } from "../lib/use-locale";
-import { d3TimeFormatLocales, Locales } from "../locales/locales";
+import { d3TimeFormatLocales, Locales, d3FormatLocales } from "../locales/locales";
 
 // FIXME: We should cover more time format
 const parseTime = timeParse("%Y-%m-%dT%H:%M:%S");
@@ -114,7 +114,16 @@ export const useFormatShortDateAuto = () => {
   return formatter;
 };
 
-export const formatNumber = (x: number): string => format(",.2~f")(x);
+// export const formatNumber = (x: number): string => format(",.2~f")(x);
+
+export const useFormatNumber = () => {
+  const locale = useLocale();
+  const formatter = React.useMemo(() => {
+    const { format } = d3FormatLocales[locale];
+    return format(",.2~f")
+  }, [locale]);
+  return formatter;
+}
 
 export const getIconName = (name: string): IconName => {
   switch (name) {

--- a/app/domain/helpers.tsx
+++ b/app/domain/helpers.tsx
@@ -44,35 +44,6 @@ export const isNumber = (x: $IntentionalAny): boolean =>
   typeof x === "number" && !isNaN(x);
 export const mkNumber = (x: $IntentionalAny): number => +x;
 
-// const formatLocale = d3TimeFormatLocales[locale];
-
-export const formatDate = timeFormat("%B %d, %Y");
-
-export const formatDateAuto = (date: Date, locale: Locales) => {
-  const { format } = d3TimeFormatLocales[locale];
-  const formatSecond = timeFormat(":%S");
-  const formatMinute = timeFormat("%I:%M");
-  const formatHour = timeFormat("%I %p");
-  const formatDay = timeFormat("%d %B %Y");
-  const formatWeek = timeFormat("%b %d");
-  const formatMonth = timeFormat("%B");
-  const formatYear = timeFormat("%Y");
-
-  return (timeMinute(date) < date
-    ? formatSecond
-    : timeHour(date) < date
-    ? formatMinute
-    : timeDay(date) < date
-    ? formatHour
-    : timeMonth(date) < date
-    ? timeWeek(date) < date
-      ? format("%d.%m.%Y")
-      : formatWeek
-    : timeYear(date) < date
-    ? formatMonth
-    : formatYear)(date);
-};
-
 /**
  * Formats dates automatically based on their precision in LONG form.
  *
@@ -83,9 +54,9 @@ export const useFormatFullDateAuto = () => {
   const formatter = React.useMemo(() => {
     const { format } = d3TimeFormatLocales[locale];
 
-    const formatSecond = format("%H:%M:%S %d.%m.%Y");
-    const formatMinute = format("%H:%M %d.%m.%Y");
-    const formatHour = format("%H:%M %d.%m.%Y");
+    const formatSecond = format("%d.%m.%Y %H:%M:%S");
+    const formatMinute = format("%d.%m.%Y %H:%M");
+    const formatHour = format("%d.%m.%Y %H:%M");
     const formatDay = format("%d.%m.%Y");
     const formatMonth = format("%m.%Y");
     const formatYear = format("%Y");

--- a/app/domain/helpers.tsx
+++ b/app/domain/helpers.tsx
@@ -24,6 +24,8 @@ import { timeFormat, timeParse } from "d3-time-format";
 import * as React from "react";
 import { DimensionFieldsWithValuesFragment } from "../graphql/query-hooks";
 import { IconName } from "../icons";
+import { useLocale } from "../lib/use-locale";
+import { d3TimeFormatLocales, Locales } from "../locales/locales";
 
 // FIXME: We should cover more time format
 const parseTime = timeParse("%Y-%m-%dT%H:%M:%S");
@@ -46,15 +48,16 @@ export const mkNumber = (x: $IntentionalAny): number => +x;
 
 export const formatDate = timeFormat("%B %d, %Y");
 
-const formatSecond = timeFormat(":%S");
-const formatMinute = timeFormat("%I:%M");
-const formatHour = timeFormat("%I %p");
-const formatDay = timeFormat("%a %d");
-const formatWeek = timeFormat("%b %d");
-const formatMonth = timeFormat("%B");
-const formatYear = timeFormat("%Y");
+export const formatDateAuto = (date: Date, locale: Locales) => {
+  const { format } = d3TimeFormatLocales[locale];
+  const formatSecond = timeFormat(":%S");
+  const formatMinute = timeFormat("%I:%M");
+  const formatHour = timeFormat("%I %p");
+  const formatDay = timeFormat("%d %B %Y");
+  const formatWeek = timeFormat("%b %d");
+  const formatMonth = timeFormat("%B");
+  const formatYear = timeFormat("%Y");
 
-export const formatDateAuto = (date: Date) => {
   return (timeMinute(date) < date
     ? formatSecond
     : timeHour(date) < date
@@ -63,11 +66,81 @@ export const formatDateAuto = (date: Date) => {
     ? formatHour
     : timeMonth(date) < date
     ? timeWeek(date) < date
-      ? formatDay
+      ? format("%d.%m.%Y")
       : formatWeek
     : timeYear(date) < date
     ? formatMonth
     : formatYear)(date);
+};
+
+/**
+ * Formats dates automatically based on their precision in LONG form.
+ *
+ * Use wherever dates are displayed without being in context of other dates (e.g. in tooltips)
+ */
+export const useFormatFullDateAuto = () => {
+  const locale = useLocale();
+  const formatter = React.useMemo(() => {
+    const { format } = d3TimeFormatLocales[locale];
+
+    const formatSecond = format("%H:%M:%S %d.%m.%Y");
+    const formatMinute = format("%H:%M %d.%m.%Y");
+    const formatHour = format("%H:%M %d.%m.%Y");
+    const formatDay = format("%d.%m.%Y");
+    const formatMonth = format("%m.%Y");
+    const formatYear = format("%Y");
+
+    return (date: Date) => {
+      return (timeMinute(date) < date
+        ? formatSecond
+        : timeHour(date) < date
+        ? formatMinute
+        : timeDay(date) < date
+        ? formatHour
+        : timeMonth(date) < date
+        ? formatDay
+        : timeYear(date) < date
+        ? formatMonth
+        : formatYear)(date);
+    };
+  }, [locale]);
+
+  return formatter;
+};
+
+/**
+ * Formats dates automatically based on their precision in SHORT form.
+ *
+ * Use wherever dates are displayed in context of other dates (e.g. on time axes)
+ */
+export const useFormatShortDateAuto = () => {
+  const locale = useLocale();
+  const formatter = React.useMemo(() => {
+    const { format } = d3TimeFormatLocales[locale];
+
+    const formatSecond = format(":%S");
+    const formatMinute = format("%H:%M");
+    const formatHour = format("%H");
+    const formatDay = format("%d");
+    const formatMonth = format("%b");
+    const formatYear = format("%Y");
+
+    return (date: Date) => {
+      return (timeMinute(date) < date
+        ? formatSecond
+        : timeHour(date) < date
+        ? formatMinute
+        : timeDay(date) < date
+        ? formatHour
+        : timeMonth(date) < date
+        ? formatDay
+        : timeYear(date) < date
+        ? formatMonth
+        : formatYear)(date);
+    };
+  }, [locale]);
+
+  return formatter;
 };
 
 export const formatNumber = (x: number): string => format(",.2~f")(x);

--- a/app/locales/locales.ts
+++ b/app/locales/locales.ts
@@ -1,16 +1,15 @@
 // If translations get too big, we should load them dynamically. But for now it's fine.
-import catalogDe from "./de/messages.js";
-import catalogFr from "./fr/messages.js";
-import catalogIt from "./it/messages.js";
-import catalogEn from "./en/messages.js";
-
-import timeFormatDe from "d3-time-format/locale/de-CH.json";
-import timeFormatFr from "d3-time-format/locale/fr-FR.json";
-import timeFormatIt from "d3-time-format/locale/it-IT.json";
-import timeFormatEn from "d3-time-format/locale/en-GB.json";
-
 // Use the same number format in each language
 import numberFormatCh from "d3-format/locale/de-CH.json";
+import { timeFormatLocale, TimeLocaleDefinition } from "d3-time-format";
+import timeFormatDe from "d3-time-format/locale/de-CH.json";
+import timeFormatEn from "d3-time-format/locale/en-GB.json";
+import timeFormatFr from "d3-time-format/locale/fr-FR.json";
+import timeFormatIt from "d3-time-format/locale/it-IT.json";
+import catalogDe from "./de/messages.js";
+import catalogEn from "./en/messages.js";
+import catalogFr from "./fr/messages.js";
+import catalogIt from "./it/messages.js";
 
 export const defaultLocale = "de";
 
@@ -33,19 +32,19 @@ export const catalogs = {
   de: catalogDe,
   fr: catalogFr,
   it: catalogIt,
-  en: catalogEn
+  en: catalogEn,
 } as const;
 
 export const d3TimeFormatLocales = {
-  de: timeFormatDe,
-  fr: timeFormatFr,
-  it: timeFormatIt,
-  en: timeFormatEn
+  de: timeFormatLocale(timeFormatDe as TimeLocaleDefinition),
+  fr: timeFormatLocale(timeFormatFr as TimeLocaleDefinition),
+  it: timeFormatLocale(timeFormatIt as TimeLocaleDefinition),
+  en: timeFormatLocale(timeFormatEn as TimeLocaleDefinition),
 } as const;
 
 export const d3FormatLocales = {
   de: numberFormatCh,
   fr: numberFormatCh,
   it: numberFormatCh,
-  en: numberFormatCh
+  en: numberFormatCh,
 } as const;

--- a/app/locales/locales.ts
+++ b/app/locales/locales.ts
@@ -1,5 +1,6 @@
 // If translations get too big, we should load them dynamically. But for now it's fine.
 // Use the same number format in each language
+import { formatLocale, FormatLocaleDefinition } from "d3-format";
 import numberFormatCh from "d3-format/locale/de-CH.json";
 import { timeFormatLocale, TimeLocaleDefinition } from "d3-time-format";
 import timeFormatDe from "d3-time-format/locale/de-CH.json";
@@ -43,8 +44,8 @@ export const d3TimeFormatLocales = {
 } as const;
 
 export const d3FormatLocales = {
-  de: numberFormatCh,
-  fr: numberFormatCh,
-  it: numberFormatCh,
-  en: numberFormatCh,
+  de: formatLocale(numberFormatCh as FormatLocaleDefinition),
+  fr: formatLocale(numberFormatCh as FormatLocaleDefinition),
+  it: formatLocale(numberFormatCh as FormatLocaleDefinition),
+  en: formatLocale(numberFormatCh as FormatLocaleDefinition),
 } as const;


### PR DESCRIPTION
Replaces all uses of date/number formatting functions with localized ones. I created React hooks for both because the locale can then easily be read from context.

NB:
- Numbers are currently all formatted with the de-CH locale.
- Currencies are not handled since there's no formal definition of how they would be expressed in the Data Cube
- Date/time formatting is approximated to the shortest useful form using a multi-scale time format as described in [d3-time-format](https://github.com/d3/d3-time-format/blob/master/README.md), but since we lack working real-world datasets with anything other than day and year interval, it's not very thoroughly tested.
- Date/time is formatted differently on time axes (where they are abbreviated) and everywhere else. This is probably not bullet-proof in some edge cases and will need to be verified in the future.