### PR TITLE
Fix table chart config types

### DIFF
--- a/app/charts/chart-config-ui-options.ts
+++ b/app/charts/chart-config-ui-options.ts
@@ -46,6 +46,7 @@ interface ChartSpecs {
   area: ChartSpec;
   scatterplot: ChartSpec;
   pie: ChartSpec;
+  table: ChartSpec;
 }
 
 /**
@@ -202,5 +203,9 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
         options: [{ field: "color", values: ["palette"] }],
       },
     ],
+  },
+  table: {
+    chartType: "table",
+    encodings: [],
   },
 };

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -98,6 +98,17 @@ export const getInitialConfig = ({
           },
         },
       };
+    case "table":
+      return {
+        chartType,
+        filters: {},
+        settings: {
+          showSearch: false,
+          showAllRows: false,
+        },
+        sorting: [],
+        fields: {},
+      };
 
     // This code *should* be unreachable! If it's not, it means we haven't checked all cases (and we should get a TS error).
     default:

--- a/app/components/data-download.tsx
+++ b/app/components/data-download.tsx
@@ -24,11 +24,19 @@ export const DataDownload = memo(
     chartConfig: ChartConfig;
   }) => {
     const locale = useLocale();
+    const measures =
+      "y" in chartConfig.fields ? [chartConfig.fields.y.componentIri] : [];
+    // FIXME for table downloads
+    if (measures.length === 0) {
+      console.warn(
+        "DataDownload: no measures selected (not implemented to for table charts)"
+      );
+    }
     const [{ data }] = useDataCubeObservationsQuery({
       variables: {
         locale,
         iri: dataSetIri,
-        measures: [chartConfig.fields.y.componentIri], // FIXME: Other fields may also be measures
+        measures, // FIXME: Other fields may also be measures
         filters: chartConfig.filters,
       },
     });

--- a/app/configurator/components/chart-controls/color-palette.tsx
+++ b/app/configurator/components/chart-controls/color-palette.tsx
@@ -11,6 +11,7 @@ import { Icon } from "../../../icons";
 import { Label } from "../../../components/form";
 import { DimensionFieldsWithValuesFragment } from "../../../graphql/query-hooks";
 import { useCallback } from "react";
+import { SegmentField } from "../../config-types";
 
 const palettes: Array<{
   label: string;
@@ -106,7 +107,8 @@ export const ColorPalette = ({ field, disabled, component }: Props) => {
         {state.state === "CONFIGURING_CHART" && (
           <Flex>
             {getPalette(
-              state.chartConfig.fields.segment?.palette || "category10"
+              (state.chartConfig.fields.segment as SegmentField)?.palette ||
+                "category10"
             ).map((color: string) => (
               <ColorSquare key={color} color={color} disabled={disabled} />
             ))}
@@ -206,7 +208,9 @@ const ColorPaletteReset = ({
           field,
           path: "colorMapping",
           colorMapping: mapColorsToComponentValuesIris({
-            palette: state.chartConfig?.fields.segment?.palette || "category10",
+            palette:
+              (state.chartConfig?.fields.segment as SegmentField)?.palette ||
+              "category10",
             component,
           }),
         },
@@ -214,13 +218,13 @@ const ColorPaletteReset = ({
     [component, dispatch, field, state.chartConfig]
   );
 
-  if (state.chartConfig.fields.segment?.colorMapping) {
+  if ((state.chartConfig.fields.segment as SegmentField)?.colorMapping) {
     // Compare palette colors & colorMapping colors
     const currentPalette = getPalette(
-      state.chartConfig.fields.segment?.palette
+      (state.chartConfig.fields.segment as SegmentField)?.palette
     );
     const colorMappingColors = Object.values(
-      state.chartConfig.fields.segment?.colorMapping
+      (state.chartConfig.fields.segment as SegmentField)?.colorMapping ?? {}
     );
 
     const nbMatchedColors = colorMappingColors.length;

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -229,7 +229,9 @@ export const MultiFilterField = ({
       </Box>
       {color && (checked ?? fieldChecked) && (
         <ColorPickerMenu
-          colors={getPalette(state.chartConfig.fields.segment?.palette)}
+          colors={getPalette(
+            (state.chartConfig.fields.segment as { palette: string })?.palette
+          )}
           selectedColor={color}
           onChange={(c) => updateColor(c)}
         />

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -29,6 +29,7 @@ import {
   FilterTab,
 } from "./chart-controls/control-tab";
 import { Checkbox, Input, Radio, Select } from "../../components/form";
+import { SegmentField } from "../config-types";
 
 export const ControlTabField = ({
   component,
@@ -230,7 +231,7 @@ export const MultiFilterField = ({
       {color && (checked ?? fieldChecked) && (
         <ColorPickerMenu
           colors={getPalette(
-            (state.chartConfig.fields.segment as { palette: string })?.palette
+            (state.chartConfig.fields.segment as SegmentField)?.palette
           )}
           selectedColor={color}
           onChange={(c) => updateColor(c)}

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -1,3 +1,4 @@
+import get from "lodash/get";
 import { Trans } from "@lingui/macro";
 import { Box, Button } from "@theme-ui/components";
 import { useCallback } from "react";
@@ -74,9 +75,11 @@ export const DimensionValuesMultiFilter = ({
 
         {dimension.values.map((dv) => {
           if (state.state === "CONFIGURING_CHART") {
-            const color =
-              state.chartConfig.fields.segment?.colorMapping &&
-              state.chartConfig.fields.segment?.colorMapping[dv.value];
+            const color = get(state.chartConfig.fields, [
+              "segment",
+              "colorMapping",
+              dv.value,
+            ]);
             return (
               <MultiFilterField
                 key={dv.value}

--- a/app/configurator/config-types.ts
+++ b/app/configurator/config-types.ts
@@ -82,7 +82,8 @@ export type ColorMapping = t.TypeOf<typeof ColorMapping>;
 const GenericField = t.type({ componentIri: t.string });
 export type GenericField = t.TypeOf<typeof GenericField>;
 
-export type GenericFields = Record<string, GenericField | undefined>;
+const GenericFields = t.record(t.string, t.union([GenericField, t.undefined]));
+export type GenericFields = t.TypeOf<typeof GenericFields>;
 
 const SegmentField = t.intersection([
   t.type({
@@ -287,62 +288,51 @@ export type PieFields = t.TypeOf<typeof PieFields>;
 export type PieConfig = t.TypeOf<typeof PieConfig>;
 
 const ColumnStyle = t.union([
-  t.literal("text"),
-  t.literal("category"),
-  t.literal("heatmap"),
-  t.literal("bar"),
-]);
-const TableColumn = t.intersection([
   t.type({
-    componentIri: t.string,
-    isGroup: t.boolean,
-    isHidden: t.boolean,
-    textStyle: t.union([t.literal("regular"), t.literal("bold")]),
-    columnStyle: ColumnStyle,
-  }),
-  t.partial({
-    // text
+    type: t.literal("text"),
     textColor: t.string,
     columnColor: t.string,
   }),
-  t.partial({
-    // heatmap
-    palette: t.string,
-  }),
-  t.partial({
-    // category
+  t.type({
+    type: t.literal("category"),
     palette: t.string,
     colorMapping: ColorMapping,
   }),
-  t.partial({
-    // bar
+  t.type({ type: t.literal("heatmap"), palette: t.string }),
+  t.type({
+    type: t.literal("bar"),
     barColorPositive: t.string,
     barColorNegative: t.string,
     barColorBackground: t.string,
     barShowBackground: t.boolean,
   }),
 ]);
+const TableColumn = t.type({
+  componentIri: t.string,
+  isGroup: t.boolean,
+  isHidden: t.boolean,
+  textStyle: t.union([t.literal("regular"), t.literal("bold")]),
+  columnStyle: ColumnStyle,
+});
 
 export type TableColumn = t.TypeOf<typeof TableColumn>;
 
-const TableFields = t.type({
-  settings: t.type({
-    showSearch: t.boolean,
-    showAllRows: t.boolean,
-  }),
-  sorting: t.array(
-    t.type({
-      sortingType: SortingType,
-      sortingOrder: SortingOrder,
-    })
-  ),
-  columns: t.array(TableColumn),
-});
+const TableFields = t.record(t.string, TableColumn);
 const TableConfig = t.type(
   {
     chartType: t.literal("table"),
-    filters: Filters,
     fields: TableFields,
+    filters: Filters,
+    settings: t.type({
+      showSearch: t.boolean,
+      showAllRows: t.boolean,
+    }),
+    sorting: t.array(
+      t.type({
+        componentIri: t.string,
+        sortingOrder: SortingOrder,
+      })
+    ),
   },
   "TableConfig"
 );

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -407,19 +407,27 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
               });
             // FIXME: This should be more chart specific
             // (no "stacked" for scatterplots for instance)
-            draft.chartConfig.fields.segment = {
-              componentIri: action.value.componentIri,
-              palette: "category10",
-              type: "stacked",
-              sorting: { sortingType: "byDimensionLabel", sortingOrder: "asc" },
-              colorMapping: colorMapping,
-            };
+            // Filter for table to make TS happy :/
+            if (draft.chartConfig.chartType !== "table") {
+              draft.chartConfig.fields.segment = {
+                componentIri: action.value.componentIri,
+                palette: "category10",
+                type: "stacked",
+                sorting: {
+                  sortingType: "byDimensionLabel",
+                  sortingOrder: "asc",
+                },
+                colorMapping: colorMapping,
+              };
+            }
           }
         } else {
           // The field is being updated
           if (
             action.value.field === "segment" &&
-            draft.chartConfig.fields.segment
+            "segment" in draft.chartConfig.fields &&
+            draft.chartConfig.fields.segment &&
+            "palette" in draft.chartConfig.fields.segment
           ) {
             const component = action.value.dataSetMetadata.dimensions.find(
               (dim) => dim.iri === action.value.componentIri
@@ -428,7 +436,7 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
               component &&
               mapColorsToComponentValuesIris({
                 palette:
-                  draft.chartConfig.fields.segment?.palette || "category10",
+                  draft.chartConfig.fields.segment.palette || "category10",
                 component,
               });
 


### PR DESCRIPTION
Made the following changes to the TableConfig type:

- Removed `columns` array in favor of re-using `fields` map (keys will be numbers or something similar)
- Added a union type for all possible `columnStyle` variants. Easier to typecheck, because we don't use partials anymore. This means that these options are now nested within `columnStyle`, e.g. `{ ..., columnStyle: { type: "text", textColor: "#333", columnColor: "#fff" } }`

"Fixed" type errors in a few places. Mostly because `segment` is expected to be a color field and table is the only chart type that doesn't use this field. Probably need to improve this later.