### PR TITLE
Table Config Changes

### DIFF
--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -1,15 +1,13 @@
-import { DataCubeMetadata } from "../graphql/types";
-import { unreachableError } from "../lib/unreachable";
 import {
   ChartConfig,
   ChartType,
-  ColumnFields,
   GenericFields,
   TableColumn,
-  TableFields,
 } from "../configurator";
 import { getCategoricalDimensions, getTimeDimensions } from "../domain/data";
 import { mapColorsToComponentValuesIris } from "../domain/helpers";
+import { DataCubeMetadata } from "../graphql/types";
+import { unreachableError } from "../lib/unreachable";
 
 export const getInitialConfig = ({
   chartType,
@@ -116,16 +114,18 @@ export const getInitialConfig = ({
         sorting: [],
         fields: Object.fromEntries<TableColumn>(
           [...dimensions, ...measures].map((d, i) => [
-            i,
+            d.iri,
             {
               componentIri: d.iri,
+              componentType: d.__typename,
+              position: i,
               isGroup: false,
               isHidden: false,
               columnStyle: {
                 textStyle: "regular",
                 type: "text",
-                textColor: "#000",
-                columnColor: "#fff",
+                textColor: "text",
+                columnColor: "transparent",
               },
             },
           ])

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -109,10 +109,11 @@ export const ChartPreview = ({ dataSetIri }: { dataSetIri: string }) => {
               />
             )}
             {state.chartConfig.chartType === "table" && (
-              <ChartTableVisualization
-                dataSetIri={dataSetIri}
-                chartConfig={state.chartConfig}
-              />
+              <div>TODO</div>
+              // <ChartTableVisualization
+              //   dataSetIri={dataSetIri}
+              //   chartConfig={state.chartConfig}
+              // />
             )}
           </Flex>
         </>

--- a/app/configurator/components/chart-controls/drag-and-drop-tab.tsx
+++ b/app/configurator/components/chart-controls/drag-and-drop-tab.tsx
@@ -12,7 +12,7 @@ import { ControlSection, ControlSectionContent, SectionTitle } from "./section";
 type Props = {
   id: string;
   title: ReactNode;
-  items: { iri: string }[];
+  items: { componentIri: string }[];
   metaData: DataCubeMetadata;
 };
 export const TabDropZone = ({ id, items, title, metaData }: Props) => {
@@ -51,9 +51,13 @@ export const TabDropZone = ({ id, items, title, metaData }: Props) => {
                 >
                   &nbsp;
                 </Box> */}
-                {items.map((item, i) => {
+                {items.map(({ componentIri }, i) => {
                   return (
-                    <Draggable key={item.iri} draggableId={item.iri} index={i}>
+                    <Draggable
+                      key={componentIri}
+                      draggableId={componentIri}
+                      index={i}
+                    >
                       {(
                         { innerRef, draggableProps, dragHandleProps },
                         { isDragging }
@@ -71,11 +75,11 @@ export const TabDropZone = ({ id, items, title, metaData }: Props) => {
                             }}
                           >
                             <DraggableTabField
-                              key={item.iri}
+                              key={componentIri}
                               component={
-                                components.find((d) => d.iri === item.iri)!
+                                components.find((d) => d.iri === componentIri)!
                               }
-                              value={`${item.iri}`}
+                              value={`${componentIri}`}
                               upperLabel={`${getFieldLabel(`table.column`)} ${
                                 i + 1
                               }`}

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -27,7 +27,7 @@ import {
 import { DataCubeMetadata } from "../../graphql/types";
 import { IconName } from "../../icons";
 import { useLocale } from "../../locales/use-locale";
-import { ColumnStyle, TableFields } from "../config-types";
+import { ColumnStyle } from "../config-types";
 import { ColorPalette } from "./chart-controls/color-palette";
 import {
   ControlSection,
@@ -526,11 +526,21 @@ const TableColumnOptions = ({
           {getFieldLabel("table.column")}
         </SectionTitle>
         <ControlSectionContent side="right">
-          <ChartOptionCheckboxField
-            label="isGroup"
-            field={activeField}
-            path="isGroup"
-          />
+          {component.__typename !== "Measure" && (
+            <ChartOptionCheckboxField
+              label="isGroup"
+              field={activeField}
+              path="isGroup"
+            />
+          )}
+
+          {component.__typename === "Measure" && (
+            <ChartOptionCheckboxField
+              label="isHidden"
+              field={activeField}
+              path="isHidden"
+            />
+          )}
         </ControlSectionContent>
       </ControlSection>
 

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -494,11 +494,7 @@ const TableColumnOptions = ({
     (d) => d.iri === activeField
   );
 
-  const activeFieldKey = Object.entries(
-    state.chartConfig.fields as TableFields
-  ).find(([key, field]) => field.componentIri === activeField)?.[0];
-
-  if (!component || !activeFieldKey) {
+  if (!component) {
     return <div>`No component ${activeField}`</div>;
   }
 
@@ -532,7 +528,7 @@ const TableColumnOptions = ({
         <ControlSectionContent side="right">
           <ChartOptionCheckboxField
             label="isGroup"
-            field={activeFieldKey}
+            field={activeField}
             path="isGroup"
           />
         </ControlSectionContent>
@@ -553,8 +549,8 @@ const TableColumnOptions = ({
                   return {
                     type: "text",
                     textStyle: "regular",
-                    textColor: "#000",
-                    columnColor: "#fff",
+                    textColor: "text",
+                    columnColor: "transparent",
                   };
                 case "category":
                   return {
@@ -583,7 +579,7 @@ const TableColumnOptions = ({
               }
             }}
             getKey={(d) => d.type}
-            field={activeFieldKey}
+            field={activeField}
             path="columnStyle"
           />
         </ControlSectionContent>

--- a/app/configurator/components/ui-helpers.tsx
+++ b/app/configurator/components/ui-helpers.tsx
@@ -1,4 +1,5 @@
 import { Trans } from "@lingui/macro";
+import { ascending } from "d3-array";
 import { scaleOrdinal } from "d3-scale";
 import {
   interpolateBlues,
@@ -33,6 +34,7 @@ import { DimensionFieldsWithValuesFragment } from "../../graphql/query-hooks";
 import { IconName } from "../../icons";
 import { d3FormatLocales, d3TimeFormatLocales } from "../../locales/locales";
 import { useLocale } from "../../locales/use-locale";
+import { TableColumn, TableFields } from "../config-types";
 
 // FIXME: We should cover more time format
 const parseTime = timeParse("%Y-%m-%dT%H:%M:%S");
@@ -377,4 +379,10 @@ export const mapColorsToComponentValuesIris = ({
     colorMapping[`${dv.value}` as string] = colorScale(dv.value) as string;
   });
   return colorMapping;
+};
+
+export const getOrderedTableColumns = (fields: TableFields): TableColumn[] => {
+  return Object.values(fields).sort((a, b) =>
+    ascending(a.position, b.position)
+  );
 };

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -104,7 +104,7 @@ export const useChartOptionSelectField = <ValueType extends {} = string>({
 
   let value: ValueType | undefined;
   if (state.state === "CONFIGURING_CHART") {
-    value = get(state, `chartConfig.fields.${field}.${path}`);
+    value = get(state, `chartConfig.fields["${field}"].${path}`);
   }
   return {
     name: path,
@@ -140,7 +140,7 @@ export const useChartOptionRadioField = ({
   );
   const stateValue =
     state.state === "CONFIGURING_CHART"
-      ? get(state, `chartConfig.fields.${field}.${path}`, "")
+      ? get(state, `chartConfig.fields["${field}"].${path}`, "")
       : "";
   const checked = stateValue ? stateValue === value : undefined;
 
@@ -176,7 +176,7 @@ export const useChartOptionBooleanField = ({
   );
   const stateValue =
     state.state === "CONFIGURING_CHART"
-      ? get(state, `chartConfig.fields.${field}.${path}`, "")
+      ? get(state, `chartConfig.fields["${field}"].${path}`, "")
       : "";
   const checked = stateValue ? stateValue : false;
 

--- a/app/configurator/config-types.ts
+++ b/app/configurator/config-types.ts
@@ -3,6 +3,16 @@ import { fold } from "fp-ts/lib/Either";
 import { pipe } from "fp-ts/lib/pipeable";
 import * as t from "io-ts";
 
+const ComponentType = t.union([
+  t.literal("Attribute"),
+  t.literal("Measure"),
+  t.literal("TemporalDimension"),
+  t.literal("NominalDimension"),
+  t.literal("OrdinalDimension"),
+]);
+
+export type ComponentType = t.TypeOf<typeof ComponentType>;
+
 // Filters
 const FilterValueMulti = t.type(
   {
@@ -329,6 +339,8 @@ export type ColumnStyleBar = t.TypeOf<typeof ColumnStyleBar>;
 
 const TableColumn = t.type({
   componentIri: t.string,
+  componentType: ComponentType,
+  position: t.number,
   isGroup: t.boolean,
   isHidden: t.boolean,
   columnStyle: ColumnStyle,

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -496,7 +496,7 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       if (draft.state === "CONFIGURING_CHART") {
         setWith(
           draft,
-          `chartConfig.fields.${action.value.field}.${action.value.path}`,
+          `chartConfig.fields["${action.value.field}"].${action.value.path}`,
           action.value.value,
           Object
         );
@@ -518,13 +518,13 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       if (draft.state === "CONFIGURING_CHART") {
         setWith(
           draft,
-          `chartConfig.fields.${action.value.field}.palette`,
+          `chartConfig.fields["${action.value.field}"].palette`,
           action.value.value,
           Object
         );
         setWith(
           draft,
-          `chartConfig.fields.${action.value.field}.colorMapping`,
+          `chartConfig.fields["${action.value.field}"].colorMapping`,
           action.value.colorMapping,
           Object
         );
@@ -534,7 +534,7 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       if (draft.state === "CONFIGURING_CHART") {
         setWith(
           draft,
-          `chartConfig.fields.${action.value.field}.${action.value.path}`,
+          `chartConfig.fields["${action.value.field}"].${action.value.path}`,
           action.value.colorMapping,
           Object
         );

--- a/app/docs/fixtures.ts
+++ b/app/docs/fixtures.ts
@@ -1,9 +1,4 @@
-import {
-  ConfiguratorState,
-  ColumnFields,
-  TableFields,
-  TableConfig,
-} from "../configurator";
+import { ColumnFields, ConfiguratorState, TableConfig } from "../configurator";
 import { ComponentFieldsFragment } from "../graphql/query-hooks";
 
 export const states: ConfiguratorState[] = [
@@ -761,11 +756,13 @@ export const tableConfig: TableConfig = {
     { componentIri: "two", sortingOrder: "desc" },
   ],
   fields: {
-    "0": {
+    "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/0": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/0",
+      position: 1,
       isGroup: false,
       isHidden: false,
+      componentType: "NominalDimension",
       columnStyle: {
         type: "text",
         textStyle: "regular",
@@ -773,11 +770,13 @@ export const tableConfig: TableConfig = {
         columnColor: "#fff",
       },
     },
-    "1": {
+    "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/1": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/1",
+      position: 2,
       isGroup: false,
       isHidden: false,
+      componentType: "NominalDimension",
       columnStyle: {
         type: "text",
         textStyle: "regular",
@@ -785,11 +784,13 @@ export const tableConfig: TableConfig = {
         columnColor: "#fff",
       },
     },
-    "2": {
+    "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2",
+      position: 3,
       isGroup: true,
       isHidden: false,
+      componentType: "NominalDimension",
       columnStyle: {
         type: "category",
         palette: "set3",
@@ -797,11 +798,13 @@ export const tableConfig: TableConfig = {
         colorMapping: {},
       },
     },
-    "3": {
+    "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/3": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/3",
+      position: 4,
       isGroup: false,
       isHidden: false,
+      componentType: "NominalDimension",
       columnStyle: {
         type: "text",
         textStyle: "regular",
@@ -809,11 +812,13 @@ export const tableConfig: TableConfig = {
         columnColor: "aliceblue",
       },
     },
-    "4": {
+    "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/4": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/4",
+      position: 5,
       isGroup: false,
       isHidden: false,
+      componentType: "NominalDimension",
       columnStyle: {
         type: "text",
         textStyle: "regular",
@@ -821,11 +826,13 @@ export const tableConfig: TableConfig = {
         columnColor: "#fff",
       },
     },
-    "5": {
+    "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/0": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/0",
+      position: 6,
       isGroup: false,
       isHidden: false,
+      componentType: "Measure",
       columnStyle: {
         type: "text",
         textStyle: "regular",
@@ -833,22 +840,26 @@ export const tableConfig: TableConfig = {
         columnColor: "#fff",
       },
     },
-    "6": {
+    "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/1": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/1",
+      position: 7,
       isGroup: false,
       isHidden: false,
+      componentType: "Measure",
       columnStyle: {
         type: "heatmap",
         palette: "oranges",
         textStyle: "regular",
       },
     },
-    "7": {
+    "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/2": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/2",
+      position: 8,
       isGroup: false,
       isHidden: false,
+      componentType: "Measure",
       columnStyle: {
         type: "text",
         textStyle: "regular",
@@ -856,11 +867,13 @@ export const tableConfig: TableConfig = {
         columnColor: "#fff",
       },
     },
-    "8": {
+    "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/3": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/3",
+      position: 9,
       isGroup: false,
       isHidden: false,
+      componentType: "Measure",
       columnStyle: {
         type: "text",
         textStyle: "regular",
@@ -868,11 +881,13 @@ export const tableConfig: TableConfig = {
         columnColor: "#fff",
       },
     },
-    "9": {
+    "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/4": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/4",
+      position: 10,
       isGroup: false,
       isHidden: false,
+      componentType: "Measure",
       columnStyle: {
         type: "bar",
         textStyle: "regular",
@@ -882,29 +897,35 @@ export const tableConfig: TableConfig = {
         barShowBackground: true,
       },
     },
-    "10": {
+    "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/5": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/5",
+      position: 11,
       isGroup: false,
       isHidden: false,
+      componentType: "Measure",
       columnStyle: { type: "heatmap", palette: "turbo", textStyle: "regular" },
     },
-    "11": {
+    "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/6": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/6",
+      position: 12,
       isGroup: false,
       isHidden: false,
+      componentType: "Measure",
       columnStyle: {
         type: "heatmap",
         textStyle: "regular",
         palette: "cividis",
       },
     },
-    "12": {
+    "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/7": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/7",
+      position: 13,
       isGroup: false,
       isHidden: false,
+      componentType: "Measure",
       columnStyle: {
         type: "text",
         textStyle: "regular",
@@ -912,11 +933,13 @@ export const tableConfig: TableConfig = {
         columnColor: "#fff",
       },
     },
-    "13": {
+    "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/8": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/8",
+      position: 14,
       isGroup: false,
       isHidden: false,
+      componentType: "Measure",
       columnStyle: {
         type: "text",
         textStyle: "regular",


### PR DESCRIPTION
- Table fields are now keyed by IRI
- Added `position` and `componentType` to table fields
- Added `getOrderedTableColumns()` helper

_Not yet solved_: when the `isGroup` or `isHidden` field properties are changed, the `position` is not updated. This can lead to some inconsitency in the orderint of the columns in the sidebar but shouldn't affect the table itself too much anymore since fields are now accessed by IRI instead of their array index.