### PR TITLE
Fix Column Order For Groups

### DIFF
--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -118,7 +118,7 @@ export const getInitialConfig = ({
             {
               componentIri: d.iri,
               componentType: d.__typename,
-              position: i,
+              index: i,
               isGroup: false,
               isHidden: false,
               columnStyle: {

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -27,7 +27,7 @@ import {
 import { DataCubeMetadata } from "../../graphql/types";
 import { IconName } from "../../icons";
 import { useLocale } from "../../locales/use-locale";
-import { ColumnStyle } from "../config-types";
+import { TableColumnOptions } from "../table/table-chart-options";
 import { ColorPalette } from "./chart-controls/color-palette";
 import {
   ControlSection,
@@ -35,12 +35,7 @@ import {
   SectionTitle,
 } from "./chart-controls/section";
 import { EmptyRightPanel } from "./empty-right-panel";
-import {
-  ChartFieldField,
-  ChartOptionCheckboxField,
-  ChartOptionRadioField,
-  ChartOptionSelectField,
-} from "./field";
+import { ChartFieldField, ChartOptionRadioField } from "./field";
 import {
   DimensionValuesMultiFilter,
   DimensionValuesSingleFilter,
@@ -464,158 +459,6 @@ const SingleFilter = ({
           )}
         </ControlSectionContent>
       </ControlSection>
-    </div>
-  );
-};
-
-const TableColumnOptions = ({
-  state,
-  metaData,
-}: {
-  state: ConfiguratorStateConfiguringChart;
-  metaData: DataCubeMetadata;
-}) => {
-  const { activeField } = state;
-
-  const panelRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (panelRef && panelRef.current) {
-      panelRef.current.focus();
-    }
-  }, [activeField]);
-
-  if (!activeField) {
-    return null;
-  }
-
-  // Active field is always a component IRI, like in filters
-  const component = [...metaData.dimensions, ...metaData.measures].find(
-    (d) => d.iri === activeField
-  );
-
-  if (!component) {
-    return <div>`No component ${activeField}`</div>;
-  }
-
-  const columnStyleOptions =
-    component.__typename === "NominalDimension" ||
-    component.__typename === "OrdinalDimension" ||
-    component.__typename === "TemporalDimension"
-      ? [
-          { value: "text", label: "text" },
-          { value: "category", label: "category" },
-        ]
-      : [
-          { value: "text", label: "text" },
-          { value: "heatmap", label: "heatmap" },
-          { value: "bar", label: "bar" },
-        ];
-
-  return (
-    <div
-      key={`control-panel-table-column-${activeField}`}
-      role="tabpanel"
-      id={`control-panel-table-column-${activeField}`}
-      aria-labelledby={`tab-${activeField}`}
-      ref={panelRef}
-      tabIndex={-1}
-    >
-      <ControlSection>
-        <SectionTitle iconName={"table"}>
-          {getFieldLabel("table.column")}
-        </SectionTitle>
-        <ControlSectionContent side="right">
-          {component.__typename !== "Measure" && (
-            <ChartOptionCheckboxField
-              label="isGroup"
-              field={activeField}
-              path="isGroup"
-            />
-          )}
-
-          {component.__typename === "Measure" && (
-            <ChartOptionCheckboxField
-              label="isHidden"
-              field={activeField}
-              path="isHidden"
-            />
-          )}
-        </ControlSectionContent>
-      </ControlSection>
-
-      <ControlSection>
-        <SectionTitle iconName={"image"}>
-          <Trans id="controls.section.columnstyle">Column Style</Trans>
-        </SectionTitle>
-        <ControlSectionContent side="right">
-          <ChartOptionSelectField<ColumnStyle>
-            id={"columnStyle"}
-            label={<Trans id="controls.select.columnStyle">Column Style</Trans>}
-            options={columnStyleOptions}
-            getValue={(type) => {
-              switch (type) {
-                case "text":
-                  return {
-                    type: "text",
-                    textStyle: "regular",
-                    textColor: "text",
-                    columnColor: "transparent",
-                  };
-                case "category":
-                  return {
-                    type: "category",
-                    textStyle: "regular",
-                    palette: "viridis",
-                    colorMapping: {},
-                  };
-                case "heatmap":
-                  return {
-                    type: "heatmap",
-                    textStyle: "regular",
-                    palette: "viridis",
-                  };
-                case "bar":
-                  return {
-                    type: "bar",
-                    textStyle: "regular",
-                    barColorPositive: "blue",
-                    barColorNegative: "red",
-                    barColorBackground: "red",
-                    barShowBackground: false,
-                  };
-                default:
-                  return undefined;
-              }
-            }}
-            getKey={(d) => d.type}
-            field={activeField}
-            path="columnStyle"
-          />
-        </ControlSectionContent>
-      </ControlSection>
-
-      {(component.__typename === "NominalDimension" ||
-        component.__typename === "OrdinalDimension" ||
-        component.__typename === "TemporalDimension") && (
-        <ControlSection>
-          <SectionTitle disabled={!component} iconName="filter">
-            <Trans id="controls.section.filter">Filter</Trans>
-          </SectionTitle>
-          <ControlSectionContent side="right" as="fieldset">
-            <legend style={{ display: "none" }}>
-              <Trans id="controls.section.filter">Filter</Trans>
-            </legend>
-            {component && (
-              <DimensionValuesMultiFilter
-                key={component.iri}
-                dimensionIri={component.iri}
-                dataSetIri={metaData.iri}
-              />
-            )}
-          </ControlSectionContent>
-        </ControlSection>
-      )}
     </div>
   );
 };

--- a/app/configurator/components/panel-left.tsx
+++ b/app/configurator/components/panel-left.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useConfiguratorState } from "..";
 import { ChartAnnotator } from "./chart-annotator";
 import { ChartConfigurator } from "./chart-configurator";
-import { ChartConfiguratorTable } from "./chart-configurator-table";
+import { ChartConfiguratorTable } from "../table/table-chart-configurator";
 import { ChartTypeSelector } from "./chart-type-selector";
 import { DataSetList } from "./dataset-selector";
 

--- a/app/configurator/components/ui-helpers.tsx
+++ b/app/configurator/components/ui-helpers.tsx
@@ -382,7 +382,5 @@ export const mapColorsToComponentValuesIris = ({
 };
 
 export const getOrderedTableColumns = (fields: TableFields): TableColumn[] => {
-  return Object.values(fields).sort((a, b) =>
-    ascending(a.position, b.position)
-  );
+  return Object.values(fields).sort((a, b) => ascending(a.index, b.index));
 };

--- a/app/configurator/config-types.ts
+++ b/app/configurator/config-types.ts
@@ -340,7 +340,7 @@ export type ColumnStyleBar = t.TypeOf<typeof ColumnStyleBar>;
 const TableColumn = t.type({
   componentIri: t.string,
   componentType: ComponentType,
-  position: t.number,
+  index: t.number,
   isGroup: t.boolean,
   isHidden: t.boolean,
   columnStyle: ColumnStyle,

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -112,6 +112,10 @@ export type ConfiguratorStateAction =
       value: { path: string | string[]; value: string };
     }
   | {
+      type: "CHART_CONFIG_REPLACED";
+      value: { chartConfig: ChartConfig };
+    }
+  | {
       type: "CHART_CONFIG_FILTER_SET_SINGLE";
       value: { dimensionIri: string; value: string };
     }
@@ -561,6 +565,12 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
     case "CHART_DESCRIPTION_CHANGED":
       if (draft.state === "DESCRIBING_CHART") {
         setWith(draft, `meta.${action.value.path}`, action.value.value, Object);
+      }
+      return draft;
+
+    case "CHART_CONFIG_REPLACED":
+      if (draft.state === "CONFIGURING_CHART") {
+        draft.chartConfig = action.value.chartConfig;
       }
       return draft;
 

--- a/app/configurator/table/table-chart-configurator.tsx
+++ b/app/configurator/table/table-chart-configurator.tsx
@@ -12,14 +12,14 @@ import { useDataCubeMetadataWithComponentValuesQuery } from "../../graphql/query
 import { useLocale } from "../../locales/use-locale";
 import { GenericFields, TableFields } from "../config-types";
 import { useConfiguratorState } from "../configurator-state";
-import { TabDropZone } from "./chart-controls/drag-and-drop-tab";
+import { TabDropZone } from "../components/chart-controls/drag-and-drop-tab";
 import {
   ControlSection,
   ControlSectionContent,
   SectionTitle,
-} from "./chart-controls/section";
-import { FilterTabField } from "./field";
-import { getOrderedTableColumns } from "./ui-helpers";
+} from "../components/chart-controls/section";
+import { FilterTabField } from "../components/field";
+import { getOrderedTableColumns } from "../components/ui-helpers";
 
 const reorderFields = ({
   fields,

--- a/app/configurator/table/table-chart-options.tsx
+++ b/app/configurator/table/table-chart-options.tsx
@@ -1,0 +1,251 @@
+import { Trans } from "@lingui/react";
+import get from "lodash/get";
+import React, {
+  ChangeEvent,
+  ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+} from "react";
+import { Checkbox } from "../../components/form";
+import { DataCubeMetadata } from "../../graphql/types";
+import {
+  ControlSection,
+  ControlSectionContent,
+  SectionTitle,
+} from "../components/chart-controls/section";
+import { ChartOptionSelectField } from "../components/field";
+import { DimensionValuesMultiFilter } from "../components/filters";
+import { getFieldLabel } from "../components/ui-helpers";
+import { FieldProps } from "../config-form";
+import {
+  ColumnStyle,
+  ConfiguratorStateConfiguringChart,
+} from "../config-types";
+import { useConfiguratorState } from "../configurator-state";
+import { updateIsGroup, updateIsHidden } from "./table-config-state";
+
+const useTableColumnOptionField = ({
+  path,
+  field,
+}: {
+  path: "isGroup" | "isHidden";
+  field: string;
+}): FieldProps => {
+  const [state, dispatch] = useConfiguratorState();
+
+  const onChange = useCallback<(e: ChangeEvent<HTMLInputElement>) => void>(
+    (e) => {
+      if (
+        state.state === "CONFIGURING_CHART" &&
+        state.chartConfig.chartType === "table"
+      ) {
+        const updater = path === "isGroup" ? updateIsGroup : updateIsHidden;
+
+        const chartConfig = updater(state.chartConfig, {
+          field,
+          value: e.currentTarget.checked,
+        });
+
+        dispatch({
+          type: "CHART_CONFIG_REPLACED",
+          value: {
+            chartConfig,
+          },
+        });
+      }
+    },
+    [state, path, field, dispatch]
+  );
+  const stateValue =
+    state.state === "CONFIGURING_CHART"
+      ? get(state, `chartConfig.fields["${field}"].${path}`, "")
+      : "";
+  const checked = stateValue ? stateValue : false;
+
+  return {
+    name: path,
+    checked,
+    onChange,
+  };
+};
+
+const ChartOptionCheckboxField = ({
+  label,
+  field,
+  path,
+  defaultChecked,
+  disabled = false,
+}: {
+  label: string | ReactNode;
+  field: string;
+  path: "isGroup" | "isHidden";
+  defaultChecked?: boolean;
+  disabled?: boolean;
+}) => {
+  const fieldProps = useTableColumnOptionField({
+    field,
+    path,
+  });
+
+  return (
+    <Checkbox
+      disabled={disabled}
+      label={label}
+      {...fieldProps}
+      checked={fieldProps.checked ?? defaultChecked}
+    ></Checkbox>
+  );
+};
+
+export const TableColumnOptions = ({
+  state,
+  metaData,
+}: {
+  state: ConfiguratorStateConfiguringChart;
+  metaData: DataCubeMetadata;
+}) => {
+  const { activeField } = state;
+
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (panelRef && panelRef.current) {
+      panelRef.current.focus();
+    }
+  }, [activeField]);
+
+  if (!activeField) {
+    return null;
+  }
+
+  // Active field is always a component IRI, like in filters
+  const component = [...metaData.dimensions, ...metaData.measures].find(
+    (d) => d.iri === activeField
+  );
+
+  if (!component) {
+    return <div>`No component ${activeField}`</div>;
+  }
+
+  const columnStyleOptions =
+    component.__typename === "NominalDimension" ||
+    component.__typename === "OrdinalDimension" ||
+    component.__typename === "TemporalDimension"
+      ? [
+          { value: "text", label: "text" },
+          { value: "category", label: "category" },
+        ]
+      : [
+          { value: "text", label: "text" },
+          { value: "heatmap", label: "heatmap" },
+          { value: "bar", label: "bar" },
+        ];
+
+  return (
+    <div
+      key={`control-panel-table-column-${activeField}`}
+      role="tabpanel"
+      id={`control-panel-table-column-${activeField}`}
+      aria-labelledby={`tab-${activeField}`}
+      ref={panelRef}
+      tabIndex={-1}
+    >
+      <ControlSection>
+        <SectionTitle iconName={"table"}>
+          {getFieldLabel("table.column")}
+        </SectionTitle>
+        <ControlSectionContent side="right">
+          {component.__typename !== "Measure" && (
+            <ChartOptionCheckboxField
+              label="isGroup"
+              field={activeField}
+              path="isGroup"
+            />
+          )}
+
+          {component.__typename === "Measure" && (
+            <ChartOptionCheckboxField
+              label="isHidden"
+              field={activeField}
+              path="isHidden"
+            />
+          )}
+        </ControlSectionContent>
+      </ControlSection>
+
+      <ControlSection>
+        <SectionTitle iconName={"image"}>
+          <Trans id="controls.section.columnstyle">Column Style</Trans>
+        </SectionTitle>
+        <ControlSectionContent side="right">
+          <ChartOptionSelectField<ColumnStyle>
+            id={"columnStyle"}
+            label={<Trans id="controls.select.columnStyle">Column Style</Trans>}
+            options={columnStyleOptions}
+            getValue={(type) => {
+              switch (type) {
+                case "text":
+                  return {
+                    type: "text",
+                    textStyle: "regular",
+                    textColor: "text",
+                    columnColor: "transparent",
+                  };
+                case "category":
+                  return {
+                    type: "category",
+                    textStyle: "regular",
+                    palette: "viridis",
+                    colorMapping: {},
+                  };
+                case "heatmap":
+                  return {
+                    type: "heatmap",
+                    textStyle: "regular",
+                    palette: "viridis",
+                  };
+                case "bar":
+                  return {
+                    type: "bar",
+                    textStyle: "regular",
+                    barColorPositive: "blue",
+                    barColorNegative: "red",
+                    barColorBackground: "red",
+                    barShowBackground: false,
+                  };
+                default:
+                  return undefined;
+              }
+            }}
+            getKey={(d) => d.type}
+            field={activeField}
+            path="columnStyle"
+          />
+        </ControlSectionContent>
+      </ControlSection>
+
+      {(component.__typename === "NominalDimension" ||
+        component.__typename === "OrdinalDimension" ||
+        component.__typename === "TemporalDimension") && (
+        <ControlSection>
+          <SectionTitle disabled={!component} iconName="filter">
+            <Trans id="controls.section.filter">Filter</Trans>
+          </SectionTitle>
+          <ControlSectionContent side="right" as="fieldset">
+            <legend style={{ display: "none" }}>
+              <Trans id="controls.section.filter">Filter</Trans>
+            </legend>
+            {component && (
+              <DimensionValuesMultiFilter
+                key={component.iri}
+                dimensionIri={component.iri}
+                dataSetIri={metaData.iri}
+              />
+            )}
+          </ControlSectionContent>
+        </ControlSection>
+      )}
+    </div>
+  );
+};

--- a/app/configurator/table/table-config-state.ts
+++ b/app/configurator/table/table-config-state.ts
@@ -1,0 +1,46 @@
+import produce from "immer";
+import { TableConfig } from "../config-types";
+
+/**
+ * When toggling `isGroup` of a field, we need to make sure the fields are correctly ordered
+ */
+export const updateIsGroup = produce(
+  (
+    chartConfig: TableConfig,
+    {
+      field,
+      value,
+    }: {
+      field: string;
+      value: boolean;
+    }
+  ): TableConfig => {
+    if (chartConfig.fields[field]) {
+      chartConfig.fields[field].isGroup = value;
+    }
+
+    return chartConfig;
+  }
+);
+
+/**
+ * When toggling `isHidden` of a field, we need to make sure the fields are correctly ordered
+ */
+export const updateIsHidden = produce(
+  (
+    chartConfig: TableConfig,
+    {
+      field,
+      value,
+    }: {
+      field: string;
+      value: boolean;
+    }
+  ): TableConfig => {
+    if (chartConfig.fields[field]) {
+      chartConfig.fields[field].isHidden = value;
+    }
+
+    return chartConfig;
+  }
+);

--- a/app/configurator/table/table-config-state.ts
+++ b/app/configurator/table/table-config-state.ts
@@ -1,5 +1,50 @@
 import produce from "immer";
+import { DraggableLocation } from "react-beautiful-dnd";
+import { getOrderedTableColumns } from "../components/ui-helpers";
 import { TableConfig } from "../config-types";
+
+export const moveFields = produce(
+  (
+    chartConfig: TableConfig,
+    {
+      source,
+      destination,
+    }: {
+      source: DraggableLocation;
+      destination: DraggableLocation;
+    }
+  ): TableConfig => {
+    const fieldsArray = getOrderedTableColumns(chartConfig.fields);
+    let groupFields = [...fieldsArray.filter((f) => f.isGroup)];
+    let columnFields = [...fieldsArray.filter((f) => !f.isGroup)];
+
+    let sourceFields =
+      source.droppableId === "columns" ? columnFields : groupFields;
+    let destinationFields =
+      destination.droppableId === "columns" ? columnFields : groupFields;
+
+    destinationFields.splice(
+      destination.index,
+      0,
+      sourceFields.splice(source.index, 1)[0]
+    );
+
+    const allFields = [
+      ...groupFields.map((f, i) => ({ ...f, isGroup: true, position: i })),
+      ...columnFields.map((f, i) => ({
+        ...f,
+        isGroup: false,
+        position: groupFields.length + i,
+      })),
+    ];
+
+    chartConfig.fields = Object.fromEntries(
+      allFields.map((f) => [f.componentIri, f])
+    );
+
+    return chartConfig;
+  }
+);
 
 /**
  * When toggling `isGroup` of a field, we need to make sure the fields are correctly ordered
@@ -15,9 +60,36 @@ export const updateIsGroup = produce(
       value: boolean;
     }
   ): TableConfig => {
-    if (chartConfig.fields[field]) {
-      chartConfig.fields[field].isGroup = value;
+    if (!chartConfig.fields[field]) {
+      return chartConfig;
     }
+    // We assume all groups come first in the array!
+    const fieldsArray = getOrderedTableColumns(chartConfig.fields);
+    let groupFields = [...fieldsArray.filter((f) => f.isGroup)];
+    let columnFields = [...fieldsArray.filter((f) => !f.isGroup)];
+
+    if (value === true) {
+      // If value is true, move to the _bottom_ of the groups section
+      groupFields.push(chartConfig.fields[field]);
+      columnFields.splice(columnFields.indexOf(chartConfig.fields[field]), 1);
+    } else {
+      // If value is false, move to the _top_ of the columns section
+      groupFields.splice(columnFields.indexOf(chartConfig.fields[field]), 1);
+      columnFields.unshift(chartConfig.fields[field]);
+    }
+
+    const allFields = [
+      ...groupFields.map((f, i) => ({ ...f, isGroup: true, position: i })),
+      ...columnFields.map((f, i) => ({
+        ...f,
+        isGroup: false,
+        position: groupFields.length + i,
+      })),
+    ];
+
+    chartConfig.fields = Object.fromEntries(
+      allFields.map((f) => [f.componentIri, f])
+    );
 
     return chartConfig;
   }

--- a/app/configurator/table/table-config-state.ts
+++ b/app/configurator/table/table-config-state.ts
@@ -30,13 +30,13 @@ export const moveFields = produce(
       sourceFields.splice(source.index, 1)[0]
     );
 
-    // Update positions and isGroup status for each field after moving
+    // Update indexes and isGroup status for each field after moving
     groupFields.forEach((f, i) => {
-      f.position = i;
+      f.index = i;
       f.isGroup = true;
     });
     columnFields.forEach((f, i) => {
-      f.position = groupFields.length + i;
+      f.index = groupFields.length + i;
       f.isGroup = false;
     });
 
@@ -81,9 +81,9 @@ export const updateIsGroup = produce(
       ...columnFields,
     ];
 
-    // Update position for each field
+    // Update index for each field
     allFields.forEach((f, i) => {
-      f.position = i;
+      f.index = i;
     });
 
     return chartConfig;

--- a/app/configurator/table/table-config-state.ts
+++ b/app/configurator/table/table-config-state.ts
@@ -109,9 +109,20 @@ export const updateIsHidden = produce(
       value: boolean;
     }
   ): TableConfig => {
-    if (chartConfig.fields[field]) {
-      chartConfig.fields[field].isHidden = value;
+    if (!chartConfig.fields[field]) {
+      return chartConfig;
     }
+
+    chartConfig.fields[field].isHidden = value;
+
+    // If field is _not_ a measure, add/remove it to/from the filters
+    // if (chartConfig.fields[field].componentType !== "Measure") {
+    //   if (value === true) {
+    //     chartConfig.filters[field] = { type: "single", value: "TODO" };
+    //   } else {
+    //     delete chartConfig.filters[field];
+    //   }
+    // }
 
     return chartConfig;
   }

--- a/app/docs/fixtures.ts
+++ b/app/docs/fixtures.ts
@@ -759,7 +759,7 @@ export const tableConfig: TableConfig = {
     "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/0": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/0",
-      position: 1,
+      index: 1,
       isGroup: false,
       isHidden: false,
       componentType: "NominalDimension",
@@ -773,7 +773,7 @@ export const tableConfig: TableConfig = {
     "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/1": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/1",
-      position: 2,
+      index: 2,
       isGroup: false,
       isHidden: false,
       componentType: "NominalDimension",
@@ -787,7 +787,7 @@ export const tableConfig: TableConfig = {
     "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2",
-      position: 3,
+      index: 3,
       isGroup: true,
       isHidden: false,
       componentType: "NominalDimension",
@@ -801,7 +801,7 @@ export const tableConfig: TableConfig = {
     "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/3": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/3",
-      position: 4,
+      index: 4,
       isGroup: false,
       isHidden: false,
       componentType: "NominalDimension",
@@ -815,7 +815,7 @@ export const tableConfig: TableConfig = {
     "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/4": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/4",
-      position: 5,
+      index: 5,
       isGroup: false,
       isHidden: false,
       componentType: "NominalDimension",
@@ -829,7 +829,7 @@ export const tableConfig: TableConfig = {
     "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/0": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/0",
-      position: 6,
+      index: 6,
       isGroup: false,
       isHidden: false,
       componentType: "Measure",
@@ -843,7 +843,7 @@ export const tableConfig: TableConfig = {
     "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/1": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/1",
-      position: 7,
+      index: 7,
       isGroup: false,
       isHidden: false,
       componentType: "Measure",
@@ -856,7 +856,7 @@ export const tableConfig: TableConfig = {
     "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/2": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/2",
-      position: 8,
+      index: 8,
       isGroup: false,
       isHidden: false,
       componentType: "Measure",
@@ -870,7 +870,7 @@ export const tableConfig: TableConfig = {
     "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/3": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/3",
-      position: 9,
+      index: 9,
       isGroup: false,
       isHidden: false,
       componentType: "Measure",
@@ -884,7 +884,7 @@ export const tableConfig: TableConfig = {
     "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/4": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/4",
-      position: 10,
+      index: 10,
       isGroup: false,
       isHidden: false,
       componentType: "Measure",
@@ -900,7 +900,7 @@ export const tableConfig: TableConfig = {
     "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/5": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/5",
-      position: 11,
+      index: 11,
       isGroup: false,
       isHidden: false,
       componentType: "Measure",
@@ -909,7 +909,7 @@ export const tableConfig: TableConfig = {
     "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/6": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/6",
-      position: 12,
+      index: 12,
       isGroup: false,
       isHidden: false,
       componentType: "Measure",
@@ -922,7 +922,7 @@ export const tableConfig: TableConfig = {
     "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/7": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/7",
-      position: 13,
+      index: 13,
       isGroup: false,
       isHidden: false,
       componentType: "Measure",
@@ -936,7 +936,7 @@ export const tableConfig: TableConfig = {
     "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/8": {
       componentIri:
         "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/8",
-      position: 14,
+      index: 14,
       isGroup: false,
       isHidden: false,
       componentType: "Measure",


### PR DESCRIPTION
Fixes not updating `position` when toggling `isGroup` on columns.

Renamed column `position` to `index`.