### PR TITLE
Use latest available cube version automatically

### DIFF
--- a/app/rdf/parse.ts
+++ b/app/rdf/parse.ts
@@ -19,6 +19,7 @@ export const parseCube = ({
 }): ResolvedDataCube => {
   const outOpts = { language: getQueryLocales(locale) };
 
+  // See https://github.com/zazuko/cube-creator/blob/master/apis/core/bootstrap/shapes/dataset.ts for current list of cube metadata
   return {
     cube,
     locale,

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -63,9 +63,14 @@ export const getCube = async ({
 
   const cube = await source.cube(iri);
 
-  if (!cube) {
+  // FIXME: the 2nd condition should not be necessary but due to a but in the query lib, a inexistent cube is not actually null. See https://github.com/zazuko/rdf-cube-view-query/issues/41
+  if (!cube || (cube?.out()?.terms?.length ?? 0) === 0) {
     return null;
   }
+  // -> This should work instead:
+  // if (!cube) {
+  //   return null;
+  // }
 
   const versionHistory = cube.in(ns.schema.hasPart)?.term;
   const isPublished =


### PR DESCRIPTION
After a visualization is created, it should not be locked to the data cube version current at the time of creation but automatically try to pick and display the latest version of the cube (preferring published over draft cubes).