### PR TITLE
Support for Key Dimensions

### DIFF
--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -157,7 +157,13 @@ export const Select = ({
 } & SelectProps) => {
   const locale = useLocale();
   const sortedOptions = useMemo(() => {
-    return [...options].sort((a, b) => a.label.localeCompare(b.label, locale));
+    const noneOptions = options.filter((o) => o.isNoneValue);
+    const restOptions = options.filter((o) => !o.isNoneValue);
+
+    return [
+      ...noneOptions,
+      ...restOptions.sort((a, b) => a.label.localeCompare(b.label, locale)),
+    ];
   }, [options, locale]);
 
   return (
@@ -190,7 +196,7 @@ export const Select = ({
           <option
             key={opt.value}
             disabled={opt.disabled}
-            value={opt.value || undefined}
+            value={opt.value ?? undefined}
           >
             {opt.label}
           </option>

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -27,8 +27,11 @@ export const ChartConfigurator = ({
 
   if (data?.dataCubeByIri) {
     const mappedIris = getFieldComponentIris(state.chartConfig.fields);
-    const unMappedDimensions = data?.dataCubeByIri.dimensions.filter(
-      (dim) => !mappedIris.has(dim.iri)
+    const requiredFilterDimensions = data?.dataCubeByIri.dimensions.filter(
+      (dim) => !mappedIris.has(dim.iri) && dim.isKeyDimension
+    );
+    const optionalFilterDimensions = data?.dataCubeByIri.dimensions.filter(
+      (dim) => !mappedIris.has(dim.iri) && !dim.isKeyDimension
     );
 
     return (
@@ -54,13 +57,25 @@ export const ChartConfigurator = ({
             <Trans id="controls.section.data.filters">Filters</Trans>
           </SectionTitle>
           <ControlSectionContent side="left" aria-labelledby="controls-data">
-            {unMappedDimensions.map((dimension, i) => (
+            {requiredFilterDimensions.map((dimension, i) => (
               <Box sx={{ px: 2, mb: 2 }} key={dimension.iri}>
                 <DataFilterSelect
                   dimensionIri={dimension.iri}
                   label={dimension.label}
                   options={dimension.values}
                   disabled={false}
+                  id={`select-single-filter-${i}`}
+                />
+              </Box>
+            ))}
+            {optionalFilterDimensions.map((dimension, i) => (
+              <Box sx={{ px: 2, mb: 2 }} key={dimension.iri}>
+                <DataFilterSelect
+                  dimensionIri={dimension.iri}
+                  label={dimension.label}
+                  options={dimension.values}
+                  disabled={false}
+                  isOptional
                   id={`select-single-filter-${i}`}
                 />
               </Box>

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -34,7 +34,7 @@ import {
 import { EmptyRightPanel } from "./empty-right-panel";
 import { ChartFieldField, ChartOptionRadioField } from "./field";
 import { DimensionValuesMultiFilter, TimeFilter } from "./filters";
-import { getFieldLabel, getFieldLabelHint, getIconName } from "./ui-helpers";
+import { getFieldLabel, getIconName } from "./ui-helpers";
 
 export const ChartOptionsSelector = ({
   state,
@@ -130,6 +130,15 @@ const EncodingOptionsPanel = ({
 }) => {
   const { measures, dimensions } = metaData;
   const panelRef = useRef<HTMLDivElement>(null);
+
+  const getFieldLabelHint = {
+    x: t({ id: "controls.select.dimension", message: "Select a dimension" }),
+    y: t({ id: "controls.select.measure", message: "Select a measure" }),
+    segment: t({
+      id: "controls.select.dimension",
+      message: "Select a dimension",
+    }),
+  };
 
   useEffect(() => {
     if (panelRef && panelRef.current) {

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -1,9 +1,8 @@
 import { t } from "@lingui/macro";
 import get from "lodash/get";
-import { ChangeEvent, ReactNode, useCallback } from "react";
+import { ChangeEvent, ReactNode, useCallback, useMemo } from "react";
 import { Box, Flex } from "theme-ui";
 import {
-  FIELD_VALUE_NONE,
   Option,
   useActiveFieldField,
   useChartFieldField,
@@ -21,6 +20,7 @@ import {
   useChartOptionSelectField,
   useSingleFilterSelect,
 } from "../config-form";
+import { FIELD_VALUE_NONE } from "../constants";
 import { ColorPickerMenu } from "./chart-controls/color-picker";
 import { AnnotatorTab, ControlTab } from "./chart-controls/control-tab";
 import { getPalette } from "./ui-helpers";
@@ -57,21 +57,46 @@ export const DataFilterSelect = ({
   options,
   id,
   disabled,
+  isOptional,
 }: {
   dimensionIri: string;
   label: string;
   options: Option[];
   id: string;
   disabled?: boolean;
+  isOptional?: boolean;
 }) => {
   const fieldProps = useSingleFilterSelect({ dimensionIri });
+
+  const noneLabel = t({
+    id: "controls.dimensionvalue.none",
+    message: `No Filter`,
+  });
+
+  const optionalLabel = t({
+    id: "controls.select.optional",
+    message: `optional`,
+  });
+
+  const allOptions = useMemo(() => {
+    return isOptional
+      ? [
+          {
+            value: FIELD_VALUE_NONE,
+            label: noneLabel,
+            isNoneValue: true,
+          },
+          ...options,
+        ]
+      : options;
+  }, [isOptional, options, noneLabel]);
 
   return (
     <Select
       id={id}
-      label={label}
+      label={isOptional ? `${label} (${optionalLabel})` : label}
       disabled={disabled}
-      options={options}
+      options={allOptions}
       {...fieldProps}
     ></Select>
   );
@@ -318,7 +343,7 @@ export const ChartFieldField = ({
   dataSetMetadata,
 }: {
   componentIri?: string;
-  label: string | ReactNode;
+  label: string;
   field: string;
   options: Option[];
   optional?: boolean;
@@ -330,13 +355,21 @@ export const ChartFieldField = ({
     dataSetMetadata,
   });
 
-  const noneLabel = t({ id: "controls.dimension.none", message: `None` });
+  const noneLabel = t({
+    id: "controls.dimension.none",
+    message: `No dimension selected`,
+  });
+
+  const optionalLabel = t({
+    id: "controls.select.optional",
+    message: `optional`,
+  });
 
   return (
     <Select
       key={`select-${field}-dimension`}
       id={field}
-      label={label}
+      label={optional ? `${label} (${optionalLabel})` : label}
       disabled={disabled}
       options={
         optional
@@ -344,6 +377,7 @@ export const ChartFieldField = ({
               {
                 value: FIELD_VALUE_NONE,
                 label: noneLabel,
+                isNoneValue: true,
               },
               ...options,
             ]

--- a/app/configurator/components/ui-helpers.tsx
+++ b/app/configurator/components/ui-helpers.tsx
@@ -1,44 +1,43 @@
 import { Trans } from "@lingui/macro";
 import {
-  timeDay,
-  timeHour,
-  timeMinute,
-  timeMonth,
-  timeYear,
-  scaleOrdinal,
   ascending,
-  schemeBlues,
-  schemeGreens,
-  schemeGreys,
-  schemeOranges,
-  schemePurples,
-  schemeReds,
+  CountableTimeInterval,
+  interpolateBlues,
   interpolateBrBG,
+  interpolateGreens,
+  interpolateGreys,
+  interpolateOranges,
   interpolatePiYG,
   interpolatePRGn,
   interpolatePuOr,
-  interpolateBlues,
-  interpolateGreens,
-  interpolateOranges,
   interpolatePurples,
-  interpolateGreys,
   interpolateReds,
+  NumberValue,
+  scaleOrdinal,
   schemeAccent,
+  schemeBlues,
   schemeCategory10,
   schemeDark2,
+  schemeGreens,
+  schemeGreys,
+  schemeOranges,
   schemePaired,
   schemePastel1,
   schemePastel2,
+  schemePurples,
+  schemeReds,
   schemeSet1,
   schemeSet2,
   schemeSet3,
   schemeTableau10,
-  NumberValue,
-  timeWeek,
+  timeDay,
+  timeHour,
+  timeMinute,
+  timeMonth,
   timeSecond,
-  CountableTimeInterval,
+  timeWeek,
+  timeYear,
 } from "d3";
-
 import { timeParse } from "d3-time-format";
 import { ReactNode, useMemo } from "react";
 import {
@@ -420,12 +419,6 @@ export const getFieldLabel = (field: string): ReactNode => {
     default:
       return field;
   }
-};
-
-export const getFieldLabelHint = {
-  x: <Trans id="controls.select.dimension">Select a dimension</Trans>,
-  y: <Trans id="controls.select.measure">Select a measure</Trans>,
-  segment: <Trans id="controls.select.dimension">Select a dimension</Trans>,
 };
 
 export const getPalette = (palette?: string): ReadonlyArray<string> => {

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -10,6 +10,7 @@ import { getFieldComponentIri } from "../charts";
 import { DataCubeMetadata } from "../graphql/types";
 import { ChartType } from "./config-types";
 import { useConfiguratorState } from "./configurator-state";
+import { FIELD_VALUE_NONE } from "./constants";
 
 // interface FieldProps {
 //   name: HTMLInputElement["name"]
@@ -18,6 +19,7 @@ import { useConfiguratorState } from "./configurator-state";
 export type Option = {
   value: string | $FixMe;
   label: string | $FixMe;
+  isNoneValue?: boolean;
   disabled?: boolean;
 };
 
@@ -27,8 +29,6 @@ export type FieldProps = Pick<
 >;
 
 // Generic ------------------------------------------------------------------
-
-export const FIELD_VALUE_NONE = "FIELD_VALUE_NONE";
 
 export const useChartFieldField = ({
   field,
@@ -283,7 +283,11 @@ export const useSingleFilterSelect = ({
 
   let value: string | undefined;
   if (state.state === "CONFIGURING_CHART") {
-    value = get(state.chartConfig, ["filters", dimensionIri, "value"], "");
+    value = get(
+      state.chartConfig,
+      ["filters", dimensionIri, "value"],
+      FIELD_VALUE_NONE
+    );
   }
   return {
     value,

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -15,7 +15,6 @@ import {
   getInitialConfig,
   getPossibleChartType,
 } from "../charts";
-import { DimensionFieldsWithValuesFragment } from "../graphql/query-hooks";
 import { DataCubeMetadata } from "../graphql/types";
 import { createChartId } from "../lib/create-chart-id";
 import { unreachableError } from "../lib/unreachable";
@@ -33,6 +32,7 @@ import {
   GenericFields,
   InteractiveFiltersConfig,
 } from "./config-types";
+import { FIELD_VALUE_NONE } from "./constants";
 
 export type ConfiguratorStateAction =
   | { type: "INITIALIZED"; value: ConfiguratorState }
@@ -642,10 +642,15 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
     case "CHART_CONFIG_FILTER_SET_SINGLE":
       if (draft.state === "CONFIGURING_CHART") {
         const { dimensionIri, value } = action.value;
-        draft.chartConfig.filters[dimensionIri] = {
-          type: "single",
-          value,
-        };
+
+        if (value === FIELD_VALUE_NONE) {
+          delete draft.chartConfig.filters[dimensionIri];
+        } else {
+          draft.chartConfig.filters[dimensionIri] = {
+            type: "single",
+            value,
+          };
+        }
       }
       return draft;
 

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -15,6 +15,7 @@ import {
   getInitialConfig,
   getPossibleChartType,
 } from "../charts";
+import { DimensionFieldsWithValuesFragment } from "../graphql/query-hooks";
 import { DataCubeMetadata } from "../graphql/types";
 import { createChartId } from "../lib/create-chart-id";
 import { unreachableError } from "../lib/unreachable";
@@ -208,6 +209,8 @@ const deriveFiltersFromFields = produce(
     const isFiltered = (iri: string) => !isField(iri) || isPreFiltered(iri);
 
     dimensions.forEach((dimension) => {
+      console.log(dimension.iri, dimension.isKeyDimension);
+
       const f = filters[dimension.iri];
       if (f !== undefined) {
         // Fix wrong filter type
@@ -222,7 +225,7 @@ const deriveFiltersFromFields = produce(
         }
       } else {
         // Add filter for this dim if it's not one of the selected multi filter fields
-        if (isFiltered(dimension.iri)) {
+        if (isFiltered(dimension.iri) && dimension.isKeyDimension) {
           filters[dimension.iri] = {
             type: "single",
             value: dimension.values[0].value,

--- a/app/configurator/constants.ts
+++ b/app/configurator/constants.ts
@@ -1,0 +1,1 @@
+export const FIELD_VALUE_NONE = "FIELD_VALUE_NONE";

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -29,6 +29,7 @@ fragment dimensionFields on Dimension {
 fragment dimensionFieldsWithValues on Dimension {
   iri
   label
+  isKeyDimension
   values
 }
 

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -73,6 +73,7 @@ export type Dimension = {
   label: Scalars['String'];
   unit?: Maybe<Scalars['String']>;
   scaleType?: Maybe<Scalars['String']>;
+  isKeyDimension: Scalars['Boolean'];
   values: Array<Scalars['DimensionValue']>;
 };
 
@@ -82,6 +83,7 @@ export type NominalDimension = Dimension & {
   label: Scalars['String'];
   unit?: Maybe<Scalars['String']>;
   scaleType?: Maybe<Scalars['String']>;
+  isKeyDimension: Scalars['Boolean'];
   values: Array<Scalars['DimensionValue']>;
 };
 
@@ -91,6 +93,7 @@ export type OrdinalDimension = Dimension & {
   label: Scalars['String'];
   unit?: Maybe<Scalars['String']>;
   scaleType?: Maybe<Scalars['String']>;
+  isKeyDimension: Scalars['Boolean'];
   values: Array<Scalars['DimensionValue']>;
 };
 
@@ -112,6 +115,7 @@ export type TemporalDimension = Dimension & {
   timeFormat: Scalars['String'];
   unit?: Maybe<Scalars['String']>;
   scaleType?: Maybe<Scalars['String']>;
+  isKeyDimension: Scalars['Boolean'];
   values: Array<Scalars['DimensionValue']>;
 };
 
@@ -121,6 +125,7 @@ export type Measure = Dimension & {
   label: Scalars['String'];
   unit?: Maybe<Scalars['String']>;
   scaleType?: Maybe<Scalars['String']>;
+  isKeyDimension: Scalars['Boolean'];
   values: Array<Scalars['DimensionValue']>;
 };
 
@@ -178,13 +183,13 @@ type DimensionFields_Measure_Fragment = { __typename: 'Measure', iri: string, la
 
 export type DimensionFieldsFragment = DimensionFields_NominalDimension_Fragment | DimensionFields_OrdinalDimension_Fragment | DimensionFields_TemporalDimension_Fragment | DimensionFields_Measure_Fragment;
 
-type DimensionFieldsWithValues_NominalDimension_Fragment = { __typename: 'NominalDimension', iri: string, label: string, values: Array<any> };
+type DimensionFieldsWithValues_NominalDimension_Fragment = { __typename: 'NominalDimension', iri: string, label: string, isKeyDimension: boolean, values: Array<any> };
 
-type DimensionFieldsWithValues_OrdinalDimension_Fragment = { __typename: 'OrdinalDimension', iri: string, label: string, values: Array<any> };
+type DimensionFieldsWithValues_OrdinalDimension_Fragment = { __typename: 'OrdinalDimension', iri: string, label: string, isKeyDimension: boolean, values: Array<any> };
 
-type DimensionFieldsWithValues_TemporalDimension_Fragment = { __typename: 'TemporalDimension', iri: string, label: string, values: Array<any> };
+type DimensionFieldsWithValues_TemporalDimension_Fragment = { __typename: 'TemporalDimension', iri: string, label: string, isKeyDimension: boolean, values: Array<any> };
 
-type DimensionFieldsWithValues_Measure_Fragment = { __typename: 'Measure', iri: string, label: string, values: Array<any> };
+type DimensionFieldsWithValues_Measure_Fragment = { __typename: 'Measure', iri: string, label: string, isKeyDimension: boolean, values: Array<any> };
 
 export type DimensionFieldsWithValuesFragment = DimensionFieldsWithValues_NominalDimension_Fragment | DimensionFieldsWithValues_OrdinalDimension_Fragment | DimensionFieldsWithValues_TemporalDimension_Fragment | DimensionFieldsWithValues_Measure_Fragment;
 
@@ -342,6 +347,7 @@ export const DimensionFieldsWithValuesFragmentDoc = gql`
     fragment dimensionFieldsWithValues on Dimension {
   iri
   label
+  isKeyDimension
   values
 }
     `;

--- a/app/graphql/resolver-types.ts
+++ b/app/graphql/resolver-types.ts
@@ -78,6 +78,7 @@ export type Dimension = {
   label: Scalars['String'];
   unit?: Maybe<Scalars['String']>;
   scaleType?: Maybe<Scalars['String']>;
+  isKeyDimension: Scalars['Boolean'];
   values: Array<Scalars['DimensionValue']>;
 };
 
@@ -87,6 +88,7 @@ export type NominalDimension = Dimension & {
   label: Scalars['String'];
   unit?: Maybe<Scalars['String']>;
   scaleType?: Maybe<Scalars['String']>;
+  isKeyDimension: Scalars['Boolean'];
   values: Array<Scalars['DimensionValue']>;
 };
 
@@ -96,6 +98,7 @@ export type OrdinalDimension = Dimension & {
   label: Scalars['String'];
   unit?: Maybe<Scalars['String']>;
   scaleType?: Maybe<Scalars['String']>;
+  isKeyDimension: Scalars['Boolean'];
   values: Array<Scalars['DimensionValue']>;
 };
 
@@ -117,6 +120,7 @@ export type TemporalDimension = Dimension & {
   timeFormat: Scalars['String'];
   unit?: Maybe<Scalars['String']>;
   scaleType?: Maybe<Scalars['String']>;
+  isKeyDimension: Scalars['Boolean'];
   values: Array<Scalars['DimensionValue']>;
 };
 
@@ -126,6 +130,7 @@ export type Measure = Dimension & {
   label: Scalars['String'];
   unit?: Maybe<Scalars['String']>;
   scaleType?: Maybe<Scalars['String']>;
+  isKeyDimension: Scalars['Boolean'];
   values: Array<Scalars['DimensionValue']>;
 };
 
@@ -239,6 +244,7 @@ export type ResolversTypes = ResolversObject<{
   DataCube: ResolverTypeWrapper<ResolvedDataCube>;
   Int: ResolverTypeWrapper<Scalars['Int']>;
   Dimension: ResolverTypeWrapper<ResolvedDimension>;
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
   NominalDimension: ResolverTypeWrapper<ResolvedDimension>;
   OrdinalDimension: ResolverTypeWrapper<ResolvedDimension>;
   TimeUnit: TimeUnit;
@@ -248,7 +254,6 @@ export type ResolversTypes = ResolversObject<{
   Float: ResolverTypeWrapper<Scalars['Float']>;
   DataCubeResultOrder: DataCubeResultOrder;
   Query: ResolverTypeWrapper<{}>;
-  Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
 }>;
 
 /** Mapping between all available schema types and the resolvers parents */
@@ -262,6 +267,7 @@ export type ResolversParentTypes = ResolversObject<{
   DataCube: ResolvedDataCube;
   Int: Scalars['Int'];
   Dimension: ResolvedDimension;
+  Boolean: Scalars['Boolean'];
   NominalDimension: ResolvedDimension;
   OrdinalDimension: ResolvedDimension;
   TemporalDimension: ResolvedDimension;
@@ -269,7 +275,6 @@ export type ResolversParentTypes = ResolversObject<{
   DataCubeResult: Omit<DataCubeResult, 'dataCube'> & { dataCube: ResolversParentTypes['DataCube'] };
   Float: Scalars['Float'];
   Query: {};
-  Boolean: Scalars['Boolean'];
 }>;
 
 export interface ObservationScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Observation'], any> {
@@ -319,6 +324,7 @@ export type DimensionResolvers<ContextType = any, ParentType extends ResolversPa
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   unit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   scaleType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  isKeyDimension?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   values?: Resolver<Array<ResolversTypes['DimensionValue']>, ParentType, ContextType>;
 }>;
 
@@ -327,6 +333,7 @@ export type NominalDimensionResolvers<ContextType = any, ParentType extends Reso
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   unit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   scaleType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  isKeyDimension?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   values?: Resolver<Array<ResolversTypes['DimensionValue']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
@@ -336,6 +343,7 @@ export type OrdinalDimensionResolvers<ContextType = any, ParentType extends Reso
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   unit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   scaleType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  isKeyDimension?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   values?: Resolver<Array<ResolversTypes['DimensionValue']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
@@ -347,6 +355,7 @@ export type TemporalDimensionResolvers<ContextType = any, ParentType extends Res
   timeFormat?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   unit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   scaleType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  isKeyDimension?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   values?: Resolver<Array<ResolversTypes['DimensionValue']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
@@ -356,6 +365,7 @@ export type MeasureResolvers<ContextType = any, ParentType extends ResolversPare
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   unit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   scaleType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  isKeyDimension?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   values?: Resolver<Array<ResolversTypes['DimensionValue']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;

--- a/app/graphql/resolvers.ts
+++ b/app/graphql/resolvers.ts
@@ -191,6 +191,8 @@ const DataCube: DataCubeResolvers = {
 const dimensionResolvers = {
   iri: ({ data: { iri } }: ResolvedDimension) => iri,
   label: ({ data: { name } }: ResolvedDimension) => name,
+  isKeyDimension: ({ data: { isKeyDimension } }: ResolvedDimension) =>
+    isKeyDimension,
   unit: ({ data: { unit } }: ResolvedDimension) => unit ?? null,
   scaleType: ({ data: { scaleType } }: ResolvedDimension) => scaleType ?? null,
   values: async (dimension: ResolvedDimension) => {

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -44,6 +44,7 @@ interface Dimension {
   label: String!
   unit: String
   scaleType: String
+  isKeyDimension: Boolean!
   values: [DimensionValue!]!
 }
 
@@ -52,6 +53,7 @@ type NominalDimension implements Dimension {
   label: String!
   unit: String
   scaleType: String
+  isKeyDimension: Boolean!
   values: [DimensionValue!]!
 }
 
@@ -60,6 +62,7 @@ type OrdinalDimension implements Dimension {
   label: String!
   unit: String
   scaleType: String
+  isKeyDimension: Boolean!
   values: [DimensionValue!]!
 }
 
@@ -80,6 +83,7 @@ type TemporalDimension implements Dimension {
   timeFormat: String!
   unit: String
   scaleType: String
+  isKeyDimension: Boolean!
   values: [DimensionValue!]!
 }
 
@@ -88,6 +92,7 @@ type Measure implements Dimension {
   label: String!
   unit: String
   scaleType: String
+  isKeyDimension: Boolean!
   values: [DimensionValue!]!
 }
 

--- a/app/graphql/shared-types.ts
+++ b/app/graphql/shared-types.ts
@@ -36,6 +36,7 @@ export type ResolvedDimension = {
     iri: string;
     isLiteral: boolean;
     isNumerical: boolean;
+    isKeyDimension: boolean;
     hasUndefinedValues: boolean;
     unit?: string;
     dataType?: string;

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -6,14 +6,45 @@ msgstr ""
 "X-Generator: POEditor.com\n"
 "Project-Id-Version: visualize.admin.ch\n"
 "Language: de\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: app/components/chart-preview.tsx:63
+msgid "annotation.add.description"
+msgstr "[ Ohne Beschreibung ]"
+
+#: app/components/chart-preview.tsx:55
+msgid "annotation.add.title"
+msgstr "[ Ohne Titel ]"
+
+#: app/pages/v/[chartId].tsx:83
+msgid "button.copy.visualization"
+msgstr "Diese Visualisierung kopieren"
 
 #: app/components/data-download.tsx:73
 msgid "button.download.data"
 msgstr "Daten herunterladen"
 
+#: app/components/data-download.tsx:46
+msgid "button.download.runsparqlquery"
+msgstr "SPARQL-Abfrage ausführen"
+
 #: app/components/publish-actions.tsx:146
 msgid "button.embed"
 msgstr "Einbetten"
+
+#: app/components/publish-actions.tsx:168
+#: app/components/publish-actions.tsx:171
+msgid "button.hint.click.to.copy"
+msgstr "Kopieren"
+
+#: app/components/publish-actions.tsx:194
+msgid "button.hint.copied"
+msgstr "Kopiert!"
 
 #: app/pages/v/[chartId].tsx:78
 msgid "button.new.visualization"
@@ -35,606 +66,9 @@ msgstr "Veröffentlichen"
 msgid "button.share"
 msgstr "Teilen"
 
-#: app/configurator/components/ui-helpers.tsx:222
-msgid "controls.axis.horizontal"
-msgstr "Horizontale Achse"
-
-#: app/configurator/components/ui-helpers.tsx:308
-msgid "controls.chart.type.area"
-msgstr "Flächen"
-
-#: app/configurator/components/ui-helpers.tsx:304
-msgid "controls.chart.type.bar"
-msgstr "Balken"
-
-#: app/configurator/components/ui-helpers.tsx:302
-msgid "controls.chart.type.column"
-msgstr "Säulen"
-
-#: app/configurator/components/ui-helpers.tsx:306
-msgid "controls.chart.type.line"
-msgstr "Linien"
-
-#: app/configurator/components/ui-helpers.tsx:310
-msgid "controls.chart.type.scatterplot"
-msgstr "Scatterplot"
-
-#: app/configurator/components/chart-controls/color-palette.tsx:40
-msgid "controls.color.palette"
-msgstr "Farbpalette"
-
-#: app/configurator/components/ui-helpers.tsx:249
-msgid "controls.column.grouped"
-msgstr "gruppiert"
-
-#: app/configurator/components/ui-helpers.tsx:247
-msgid "controls.column.stacked"
-msgstr "gestapelt"
-
-#: app/configurator/components/ui-helpers.tsx:244
-msgid "controls.description"
-msgstr "Beschreibung hinzufügen"
-
-#: app/configurator/components/filters.tsx:50
-msgid "controls.filter.select.all"
-msgstr "Alle auswählen"
-
-#: app/configurator/components/ui-helpers.tsx:225
-msgid "controls.measure"
-msgstr "Messwert"
-
-#: app/configurator/components/chart-annotator.tsx:12
-msgid "controls.section.description"
-msgstr "Titel & Beschreibung"
-
-#: app/configurator/components/chart-options-selector.tsx:87
-#: app/configurator/components/chart-options-selector.tsx:91
-#: app/configurator/table/table-chart-options.tsx:182
-#: app/configurator/table/table-chart-options.tsx:186
-msgid "controls.section.filter"
-msgstr "Filter"
-
-#: app/configurator/components/chart-type-selector.tsx:87
-#: app/configurator/components/chart-type-selector.tsx:90
-msgid "controls.select.chart.type"
-msgstr "Diagrammtyp"
-
-#: app/configurator/components/ui-helpers.tsx:331
-#: app/configurator/components/ui-helpers.tsx:333
-msgid "controls.select.dimension"
-msgstr "Dimension auswählen"
-
-#: app/configurator/components/ui-helpers.tsx:332
-msgid "controls.select.measure"
-msgstr "Messwert auswählen"
-
-#: app/configurator/components/ui-helpers.tsx:242
-msgid "controls.title"
-msgstr "Titel hinzufügen"
-
-#: app/configurator/components/dataset-preview.tsx:55
-msgid "datatable.showing.first.rows"
-msgstr "Die ersten 10 Zeilen werden angezeigt"
-
-#: app/pages/v/[chartId].tsx:69
-msgid "hint.create.your.own.chart"
-msgstr "Sie können diese Visualisierung kopieren oder mit Schweizer Open Government Data eine neue Visualisierung erstellen."
-
-#: app/pages/v/[chartId].tsx:65
-msgid "hint.how.to.share"
-msgstr "Sie können diese Visualisierung teilen oder sie einbetten. Zudem können Sie eine neue Visualisierung erstellen oder die gezeigte Visualisierung kopieren."
-
-#: app/components/hint.tsx:54
-msgid "hint.loading.data"
-msgstr "Lade Daten …"
-
-#: app/configurator/components/chart-type-selector.tsx:94
-msgid "hint.no.visualization.with.dataset"
-msgstr "Mit dem ausgewählten Datensatz kann keine Visualisierung erstellt werden."
-
-#: app/components/hint.tsx:167
-msgid "hint.publication.success"
-msgstr "Die Visualisierung ist jetzt veröffentlicht. Sie können sie teilen oder einbetten, indem Sie die URL kopieren oder das Menü unten verwenden."
-
-#: app/components/hint.tsx:80
-msgid "hint.select.dataset"
-msgstr "Datensatz auswählen"
-
-#: app/components/hint.tsx:83
-msgid "hint.select.dataset.to.preview"
-msgstr "Bitte Datensatz auswählen, um eine Vorschau anzuzeigen."
-
-#: app/components/header.tsx:71
-#: app/components/header.tsx:82
-msgid "logo.swiss.confederation"
-msgstr "Logo der Schweizerischen Eidgenossenschaft"
-
-#: app/components/chart-footnotes.tsx:20
-msgid "metadata.dataset"
-msgstr "Datensatz"
-
-#: app/components/chart-footnotes.tsx:24
-msgid "metadata.source"
-msgstr "Quelle"
-
-#: app/components/publish-actions.tsx:156
-msgid "publication.embed.AEM"
-msgstr "Einbett-Code für AEM «Externe Applikation»:"
-
-#: app/components/publish-actions.tsx:151
-msgid "publication.embed.iframe"
-msgstr "Einbett-Code:"
-
-#: app/components/publish-actions.tsx:96
-msgid "publication.popup.share"
-msgstr "Teilen"
-
-#: app/components/publish-actions.tsx:121
-msgid "publication.share.chart.url"
-msgstr "Diagramm-URL:"
-
-#: app/components/publish-actions.tsx:113
-msgid "publication.share.mail.body"
-msgstr "Hier ist eine Visualisierung, die ich mit visualize.admin.ch erstellt habe"
-
-#: app/components/publish-actions.tsx:110
-msgid "publication.share.mail.subject"
-msgstr "visualize.admin.ch"
-
-#: app/configurator/components/stepper.tsx:115
-msgid "step.annotate"
-msgstr "Beschreiben"
-
-#: app/configurator/components/stepper.tsx:109
-msgid "step.dataset"
-msgstr "Datensatz"
-
-#: app/configurator/components/stepper.tsx:111
-msgid "step.visualization.type"
-msgstr "Diagrammtyp"
-
-#: app/components/footer.tsx:35
-msgid "footer.institution.name"
-msgstr "Bundesamt für Umwelt BAFU"
-
-#: app/components/chart-preview.tsx:63
-msgid "annotation.add.description"
-msgstr "[ Ohne Beschreibung ]"
-
-#: app/components/chart-preview.tsx:55
-msgid "annotation.add.title"
-msgstr "[ Ohne Titel ]"
-
-#: app/pages/v/[chartId].tsx:83
-msgid "button.copy.visualization"
-msgstr "Diese Visualisierung kopieren"
-
-#: app/configurator/components/ui-helpers.tsx:312
-msgid "controls.chart.type.pie"
-msgstr "Kreis"
-
-#: app/configurator/components/filters.tsx:54
-msgid "controls.filter.select.none"
-msgstr "Alle abwählen"
-
-#: app/configurator/components/empty-right-panel.tsx:9
-msgid "controls.hint.configuring.chart"
-msgstr "Bitte eine Designoption oder Datendimension auswählen, um diese zu bearbeiten."
-
-#: app/configurator/components/empty-right-panel.tsx:14
-msgid "controls.hint.describing.chart"
-msgstr "Bitte ein Beschreibungsfeld auswählen, um dieses zu bearbeiten."
-
-#: app/configurator/components/ui-helpers.tsx:319
-msgid "controls.language.english"
-msgstr "Englisch"
-
-#: app/configurator/components/ui-helpers.tsx:323
-msgid "controls.language.french"
-msgstr "Französisch"
-
-#: app/configurator/components/ui-helpers.tsx:321
-msgid "controls.language.german"
-msgstr "Deutsch"
-
-#: app/configurator/components/ui-helpers.tsx:325
-msgid "controls.language.italian"
-msgstr "Italienisch"
-
-#: app/configurator/components/dataset-metadata.tsx:40
-msgid "dataset.metadata.date.created"
-msgstr "Erstellungsdatum"
-
-#: app/configurator/components/dataset-metadata.tsx:30
-msgid "dataset.metadata.source"
-msgstr "Quelle"
-
-#: app/configurator/components/dataset-metadata.tsx:17
-msgid "dataset.metadata.title"
-msgstr "Titel"
-
-#: app/configurator/components/dataset-selector.tsx:34
-msgid "dataset.order.newest"
-msgstr "Neueste"
-
-#: app/configurator/components/dataset-selector.tsx:26
-msgid "dataset.order.relevance"
-msgstr "Relevanz"
-
-#: app/configurator/components/dataset-selector.tsx:30
-msgid "dataset.order.title"
-msgstr "Titel"
-
-#: app/configurator/components/dataset-selector.tsx:79
-msgid "dataset.results"
-msgstr "{0, plural, =0 {Keine Treffer} =1 {# Treffer} other {# Treffer}}"
-
-#: app/configurator/components/dataset-selector.tsx:89
-msgid "dataset.sortby"
-msgstr "Sortieren nach"
-
-#: app/components/hint.tsx:105
-msgid "hint.nodata.message"
-msgstr "Keine Daten für die aktuelle Filterauswahl."
-
-#: app/components/hint.tsx:102
-msgid "hint.nodata.title"
-msgstr "Keine Daten"
-
-#: app/components/publish-actions.tsx:99
-msgid "publication.share.linktitle.facebook"
-msgstr "Teilen via Facebook"
-
-#: app/components/publish-actions.tsx:107
-msgid "publication.share.linktitle.mail"
-msgstr "Versenden via E-Mail"
-
-#: app/components/publish-actions.tsx:103
-msgid "publication.share.linktitle.twitter"
-msgstr "Teilen via Twitter"
-
-#: app/components/publish-actions.tsx:168
-#: app/components/publish-actions.tsx:171
-msgid "button.hint.click.to.copy"
-msgstr "Kopieren"
-
-#: app/components/publish-actions.tsx:194
-msgid "button.hint.copied"
-msgstr "Kopiert!"
-
-#: app/components/chart-footnotes.tsx:49
-msgid "metadata.link.created.with.visualize"
-msgstr "Erstellt mit visualize.admin.ch"
-
-#: app/components/form.tsx:145
-msgid "controls.search.clear"
-msgstr "Suche zurücksetzen"
-
-#: app/configurator/components/dataset-selector.tsx:37
-msgid "dataset.search.label"
-msgstr "Datensätze suchen"
-
-#: app/components/hint.tsx:147
-msgid "hint.only.negative.data.message"
-msgstr "Negative Datenwerte können mit diesem Diagrammtyp nicht dargestellt werden."
-
-#: app/components/hint.tsx:144
-msgid "hint.only.negative.data.title"
-msgstr "Negative Werte"
-
-#: app/configurator/components/chart-controls/color-palette.tsx:135
-#: app/configurator/components/chart-controls/color-palette.tsx:140
-msgid "controls.color.palette.reset"
-msgstr "Farbpalette zurücksetzen"
-
-#: app/configurator/components/field.tsx:144
-msgid "controls.dimension.none"
-msgstr "Keine"
-
-#: app/configurator/components/chart-options-selector.tsx:142
-msgid "controls.section.sorting"
-msgstr "Sortieren"
-
-#: app/configurator/components/chart-options-selector.tsx:116
-#: app/configurator/components/chart-options-selector.tsx:122
-msgid "controls.sorting.byDimensionLabel"
-msgstr "Name"
-
-#: app/configurator/components/ui-helpers.tsx:260
-msgid "controls.sorting.byDimensionLabel.ascending"
-msgstr "A → Z"
-
-#: app/configurator/components/ui-helpers.tsx:269
-msgid "controls.sorting.byDimensionLabel.descending"
-msgstr "Z → A"
-
-#: app/configurator/components/chart-options-selector.tsx:118
-msgid "controls.sorting.byMeasure"
-msgstr "Messwert"
-
-#: app/configurator/components/ui-helpers.tsx:293
-msgid "controls.sorting.byMeasure.ascending"
-msgstr "1 → 9"
-
-#: app/configurator/components/ui-helpers.tsx:299
-msgid "controls.sorting.byMeasure.descending"
-msgstr "9 → 1"
-
-#: app/configurator/components/chart-options-selector.tsx:120
-msgid "controls.sorting.byTotalSize"
-msgstr "Gesamtgrösse"
-
-#: app/configurator/components/ui-helpers.tsx:273
-msgid "controls.sorting.byTotalSize.ascending"
-msgstr "Kleinste zuerst"
-
-#: app/configurator/components/ui-helpers.tsx:285
-msgid "controls.sorting.byTotalSize.largestBottom"
-msgstr "Grösste unten"
-
-#: app/configurator/components/ui-helpers.tsx:277
-msgid "controls.sorting.byTotalSize.largestFirst"
-msgstr "Grösste zuerst"
-
-#: app/configurator/components/ui-helpers.tsx:282
-msgid "controls.sorting.byTotalSize.largestTop"
-msgstr "Kleinste unten"
-
-#: app/configurator/components/chart-controls/color-picker.tsx:100
-msgid "controls.colorpicker.open"
-msgstr "Farbwähler öffnen"
-
-#: app/configurator/components/ui-helpers.tsx:251
-#: app/configurator/table/table-chart-sorting-options.tsx:173
-msgid "controls.sorting.sortBy"
-msgstr "Sortieren nach"
-
-#: app/configurator/components/ui-helpers.tsx:232
-msgid "controls.axis.vertical"
-msgstr "Vertikale Achse"
-
-#: app/charts/table/table.tsx:136
-msgid "chart.published.toggle.mobile.view"
-msgstr "Kompakte Ansicht"
-
-#: app/charts/table/table.tsx:177
-msgid "chart.table.number.of.lines"
-msgstr "Anzahl Zeilen"
-
-#: app/configurator/table/table-chart-options.tsx:109
-msgid "columnStyle.bar"
-msgstr "Säulendiagramm"
-
-#: app/configurator/table/table-chart-options.tsx:95
-msgid "columnStyle.categories"
-msgstr "Kategorien"
-
-#: app/configurator/table/table-chart-options.tsx:105
-msgid "columnStyle.heatmap"
-msgstr "Wärmebildkarte"
-
-#: app/configurator/table/table-chart-options.tsx:91
-#: app/configurator/table/table-chart-options.tsx:101
-msgid "columnStyle.text"
-msgstr "Schrift"
-
-#: app/configurator/table/table-chart-options.tsx:206
-msgid "columnStyle.textStyle.bold"
-msgstr "Fett"
-
-#: app/configurator/table/table-chart-options.tsx:199
-msgid "columnStyle.textStyle.regular"
-msgstr "Normal"
-
-#: app/configurator/interactive-filters/editor-time-brush.tsx:113
-msgid "controls..interactiveFilters.time.defaultSettings"
-msgstr "Standardeinstellung"
-
-#: app/configurator/components/ui-helpers.tsx:314
-msgid "controls.chart.type.table"
-msgstr "Tabelle"
-
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:43
-msgid "controls.interactive.filters.dataFilter"
-msgstr "Datenfilter"
-
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:136
-msgid "controls.interactiveFilters.dataFilters.toggledataFilters"
-msgstr "Datenfilter anzeigen"
-
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:34
-msgid "controls.interactiveFilters.legend.toggleInteractiveLegend"
-msgstr "Filterbare Legende anzeigen"
-
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:106
-msgid "controls.interactiveFilters.time.noTimeDimension"
-msgstr "Keine Zeitdimension verfügbar!"
-
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:95
-msgid "controls.interactiveFilters.time.toggleTimeFilter"
-msgstr "Zeitfilter anzeigen"
-
-#: app/configurator/components/chart-controls/control-tab.tsx:101
-msgid "controls.option.isActive"
-msgstr "Ein"
-
-#: app/configurator/components/chart-controls/control-tab.tsx:99
-msgid "controls.option.isNotActive"
-msgstr "Aus"
-
-#: app/configurator/table/table-chart-configurator.tsx:63
-msgid "controls.section.columns"
-msgstr "Spalten"
-
-#: app/configurator/table/table-chart-options.tsx:130
-msgid "controls.section.columnstyle"
-msgstr "Spaltenstil"
-
-#: app/configurator/table/table-chart-configurator.tsx:61
-msgid "controls.section.groups"
-msgstr "Gruppierungen"
-
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:31
-msgid "controls.section.interactive.filters"
-msgstr "Interaktive Filter hinzufügen"
-
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:53
-msgid "controls.section.interactiveFilters.dataFilters"
-msgstr "Datenfilter"
-
-#: app/configurator/table/table-chart-options.tsx:239
-msgid "controls.section.tableSettings"
-msgstr "Tabelleneinstellungen"
-
-#: app/configurator/table/table-chart-sorting-options.tsx:202
-msgid "controls.section.tableSorting"
-msgstr "Tabellensortierung"
-
-#: app/configurator/table/table-chart-configurator.tsx:53
-msgid "controls.section.tableoptions"
-msgstr "Tabellenoptionen"
-
-#: app/configurator/table/table-chart-options.tsx:133
-msgid "controls.select.columnStyle"
-msgstr "Spaltenstil"
-
-#: app/configurator/table/table-chart-options.tsx:227
-msgid "controls.select.columnStyle.barColorBackground"
-msgstr "Hintergrundfarbe"
-
-#: app/configurator/table/table-chart-options.tsx:224
-msgid "controls.select.columnStyle.barColorNegative"
-msgstr "Negative Balkenfarbe"
-
-#: app/configurator/table/table-chart-options.tsx:221
-msgid "controls.select.columnStyle.barColorPositive"
-msgstr "Positive Balkenfarbe"
-
-#: app/configurator/table/table-chart-options.tsx:230
-msgid "controls.select.columnStyle.barShowBackground"
-msgstr "Hintergrundfarbe anzeigen"
-
-#: app/configurator/table/table-chart-options.tsx:213
-msgid "controls.select.columnStyle.columnColor"
-msgstr "Spaltenfarbe"
-
-#: app/configurator/table/table-chart-options.tsx:210
-msgid "controls.select.columnStyle.textColor"
-msgstr "Schriftfarbe"
-
-#: app/configurator/table/table-chart-options.tsx:196
-msgid "controls.select.columnStyle.textStyle"
-msgstr "Schriftstil"
-
-#: app/configurator/table/table-chart-sorting-options.tsx:131
-msgid "controls.sorting.addDimension"
-msgstr "Dimension hinzufügen"
-
-#: app/configurator/table/table-chart-sorting-options.tsx:70
-msgid "controls.sorting.removeOption"
-msgstr "Sortierung entfernen"
-
-#: app/configurator/table/table-chart-sorting-options.tsx:109
-msgid "controls.sorting.selectDimension"
-msgstr "Wählen Sie eine Dimension aus …"
-
-#: app/configurator/table/table-chart-options.tsx:119
-msgid "controls.table.column.group"
-msgstr "Gruppieren"
-
-#: app/configurator/table/table-chart-options.tsx:125
-msgid "controls.table.column.hide"
-msgstr "Spalte ausblenden"
-
-#: app/configurator/table/table-chart-options.tsx:120
-msgid "controls.table.column.hidefilter"
-msgstr "Spalte ausblenden und filtern"
-
-#: app/configurator/table/table-chart-configurator.tsx:56
-msgid "controls.table.settings"
-msgstr "Einstellungen"
-
-#: app/configurator/table/table-chart-configurator.tsx:57
-msgid "controls.table.sorting"
-msgstr "Sortierung"
-
-#: app/configurator/table/table-chart-options.tsx:242
-msgid "controls.tableSettings.showSearch"
-msgstr "Suche anzeigen"
-
-#: app/charts/shared/chart-data-filters.tsx:31
-msgid "interactive.data.filters.hide"
-msgstr "Filter ausblenden"
-
-#: app/charts/shared/chart-data-filters.tsx:31
-msgid "interactive.data.filters.show"
-msgstr "Filter anzeigen"
-
-#: app/configurator/components/chart-controls/drag-and-drop-tab.tsx:27
-msgid "table.column.no"
-msgstr "Spalte {0}"
-
 #: app/charts/map/chart-map-prototype.tsx:146
 msgid "chart.map.control.data.filters"
 msgstr "Datenfilter"
-
-#: app/charts/map/chart-map-prototype.tsx:162
-msgid "chart.map.warning.prototype"
-msgstr "Diese Karte ist ein Prototyp und kann nicht publiziert werden."
-
-#: app/configurator/components/ui-helpers.tsx:316
-msgid "controls.chart.type.map"
-msgstr "Karte"
-
-#: app/configurator/components/chart-type-selector.tsx:106
-msgid "controls.select.chart.type.experimental"
-msgstr "Experimentelle Features"
-
-#: app/configurator/components/chart-type-selector.tsx:111
-msgid "controls.select.chart.type.experimental.description"
-msgstr "Vorschau von zukünftigen Features mit limitierten Daten auf einer separaten Seite."
-
-#: app/configurator/components/dataset-selector.tsx:70
-msgid "dataset.includeDrafts"
-msgstr "Entwurfs-Datensätze anzeigen"
-
-#: app/components/chart-preview.tsx:39
-#: app/components/chart-published.tsx:37
-#: app/configurator/components/dataset-preview.tsx:25
-msgid "dataset.publicationStatus.draft.warning"
-msgstr "Achtung, dieser Datensatz ist im Entwurfs-Stadium.<0/><1>Diese Grafik nicht für Berichte verwenden.</1>"
-
-#: app/configurator/components/dataset-selector.tsx:163
-msgid "dataset.tag.draft"
-msgstr "Entwurf"
-
-#: app/components/hint.tsx:126
-msgid "hint.dataloadingerror.message"
-msgstr "Die Daten konnten nicht geladen werden."
-
-#: app/components/hint.tsx:123
-msgid "hint.dataloadingerror.title"
-msgstr "Daten-Ladefehler"
-
-#: app/configurator/components/ui-helpers.tsx:240
-msgid "controls.color"
-msgstr "Farbe"
-
-#: app/configurator/components/chart-controls/control-tab.tsx:12
-msgid "controls.color.add"
-msgstr "Hinzufügen …"
-
-#: app/configurator/components/chart-configurator.tsx:22
-msgid "controls.section.chart.options"
-msgstr "Diagramm-Einstellungen"
-
-#: app/configurator/components/chart-configurator.tsx:31
-msgid "controls.section.data.filters"
-msgstr "Filter"
-
-#: app/configurator/components/stepper.tsx:113
-msgid "step.visualize"
-msgstr "Visualisieren"
 
 #: app/charts/map/chart-map-prototype.tsx:136
 msgid "chart.map.control.layers"
@@ -651,6 +85,14 @@ msgstr "Flächen anzeigen"
 #: app/charts/map/prototype-right-controls.tsx:37
 msgid "chart.map.layers.area.color.palette"
 msgstr "Farbpalette"
+
+#: app/charts/map/prototype-right-controls.tsx:51
+msgid "chart.map.layers.area.discretization.continuous"
+msgstr "Kontinuierlich"
+
+#: app/charts/map/prototype-right-controls.tsx:59
+msgid "chart.map.layers.area.discretization.discrete"
+msgstr "Diskret"
 
 #: app/charts/map/prototype-right-controls.tsx:68
 msgid "chart.map.layers.area.discretization.jenks"
@@ -704,31 +146,603 @@ msgstr "Proportionale Symbole anzeigen"
 msgid "chart.map.layers.symbol.select.measure"
 msgstr "Messwert auswählen"
 
-#: app/configurator/components/chart-options-selector.tsx:102
-msgid "controls.select.column.layout"
-msgstr "Spaltenstil"
+#: app/charts/map/chart-map-prototype.tsx:162
+msgid "chart.map.warning.prototype"
+msgstr "Diese Karte ist ein Prototyp und kann nicht publiziert werden."
 
-#: app/charts/map/prototype-right-controls.tsx:51
-msgid "chart.map.layers.area.discretization.continuous"
-msgstr "Kontinuierlich"
+#: app/charts/table/table.tsx:136
+msgid "chart.published.toggle.mobile.view"
+msgstr "Kompakte Ansicht"
 
-#: app/charts/map/prototype-right-controls.tsx:59
-msgid "chart.map.layers.area.discretization.discrete"
-msgstr "Diskret"
+#: app/charts/table/table.tsx:177
+msgid "chart.table.number.of.lines"
+msgstr "Anzahl Zeilen"
 
-#: app/components/data-download.tsx:46
-msgid "button.download.runsparqlquery"
-msgstr "SPARQL-Abfrage ausführen"
+#: app/configurator/table/table-chart-options.tsx:109
+msgid "columnStyle.bar"
+msgstr "Säulendiagramm"
+
+#: app/configurator/table/table-chart-options.tsx:95
+msgid "columnStyle.categories"
+msgstr "Kategorien"
+
+#: app/configurator/table/table-chart-options.tsx:105
+msgid "columnStyle.heatmap"
+msgstr "Wärmebildkarte"
+
+#: app/configurator/table/table-chart-options.tsx:91
+#: app/configurator/table/table-chart-options.tsx:101
+msgid "columnStyle.text"
+msgstr "Schrift"
+
+#: app/configurator/table/table-chart-options.tsx:206
+msgid "columnStyle.textStyle.bold"
+msgstr "Fett"
+
+#: app/configurator/table/table-chart-options.tsx:199
+msgid "columnStyle.textStyle.regular"
+msgstr "Normal"
+
+#: app/configurator/interactive-filters/editor-time-brush.tsx:113
+msgid "controls..interactiveFilters.time.defaultSettings"
+msgstr "Standardeinstellung"
+
+#: app/configurator/components/ui-helpers.tsx:222
+msgid "controls.axis.horizontal"
+msgstr "Horizontale Achse"
+
+#: app/configurator/components/ui-helpers.tsx:232
+msgid "controls.axis.vertical"
+msgstr "Vertikale Achse"
+
+#: app/configurator/components/ui-helpers.tsx:308
+msgid "controls.chart.type.area"
+msgstr "Flächen"
+
+#: app/configurator/components/ui-helpers.tsx:304
+msgid "controls.chart.type.bar"
+msgstr "Balken"
+
+#: app/configurator/components/ui-helpers.tsx:302
+msgid "controls.chart.type.column"
+msgstr "Säulen"
+
+#: app/configurator/components/ui-helpers.tsx:306
+msgid "controls.chart.type.line"
+msgstr "Linien"
+
+#: app/configurator/components/ui-helpers.tsx:316
+msgid "controls.chart.type.map"
+msgstr "Karte"
+
+#: app/configurator/components/ui-helpers.tsx:312
+msgid "controls.chart.type.pie"
+msgstr "Kreis"
+
+#: app/configurator/components/ui-helpers.tsx:310
+msgid "controls.chart.type.scatterplot"
+msgstr "Scatterplot"
+
+#: app/configurator/components/ui-helpers.tsx:314
+msgid "controls.chart.type.table"
+msgstr "Tabelle"
+
+#: app/configurator/components/ui-helpers.tsx:240
+msgid "controls.color"
+msgstr "Farbe"
+
+#: app/configurator/components/chart-controls/control-tab.tsx:12
+msgid "controls.color.add"
+msgstr "Hinzufügen …"
+
+#: app/configurator/components/chart-controls/color-palette.tsx:40
+msgid "controls.color.palette"
+msgstr "Farbpalette"
+
+#: app/configurator/components/chart-controls/color-palette.tsx:135
+#: app/configurator/components/chart-controls/color-palette.tsx:140
+msgid "controls.color.palette.reset"
+msgstr "Farbpalette zurücksetzen"
+
+#: app/configurator/components/chart-controls/color-picker.tsx:100
+msgid "controls.colorpicker.open"
+msgstr "Farbwähler öffnen"
+
+#: app/configurator/components/ui-helpers.tsx:249
+msgid "controls.column.grouped"
+msgstr "gruppiert"
+
+#: app/configurator/components/ui-helpers.tsx:247
+msgid "controls.column.stacked"
+msgstr "gestapelt"
+
+#: app/configurator/components/ui-helpers.tsx:244
+msgid "controls.description"
+msgstr "Beschreibung hinzufügen"
+
+#: app/configurator/components/field.tsx:165
+msgid "controls.dimension.none"
+msgstr "Keine"
+
+#: app/configurator/components/field.tsx:31
+msgid "controls.dimensionvalue.none"
+msgstr "Kein Filter"
+
+#: app/configurator/components/filters.tsx:50
+msgid "controls.filter.select.all"
+msgstr "Alle auswählen"
+
+#: app/configurator/components/filters.tsx:54
+msgid "controls.filter.select.none"
+msgstr "Alle abwählen"
 
 #: app/configurator/interactive-filters/editor-time-interval-brush.tsx:89
 msgid "controls.filters.time.range"
 msgstr "Zeitspanne"
 
+#: app/configurator/components/empty-right-panel.tsx:9
+msgid "controls.hint.configuring.chart"
+msgstr "Bitte eine Designoption oder Datendimension auswählen, um diese zu bearbeiten."
+
+#: app/configurator/components/empty-right-panel.tsx:14
+msgid "controls.hint.describing.chart"
+msgstr "Bitte ein Beschreibungsfeld auswählen, um dieses zu bearbeiten."
+
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:43
+msgid "controls.interactive.filters.dataFilter"
+msgstr "Datenfilter"
+
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:136
+msgid "controls.interactiveFilters.dataFilters.toggledataFilters"
+msgstr "Datenfilter anzeigen"
+
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:34
+msgid "controls.interactiveFilters.legend.toggleInteractiveLegend"
+msgstr "Filterbare Legende anzeigen"
+
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:106
+msgid "controls.interactiveFilters.time.noTimeDimension"
+msgstr "Keine Zeitdimension verfügbar!"
+
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:95
+msgid "controls.interactiveFilters.time.toggleTimeFilter"
+msgstr "Zeitfilter anzeigen"
+
+#: app/configurator/components/ui-helpers.tsx:319
+msgid "controls.language.english"
+msgstr "Englisch"
+
+#: app/configurator/components/ui-helpers.tsx:323
+msgid "controls.language.french"
+msgstr "Französisch"
+
+#: app/configurator/components/ui-helpers.tsx:321
+msgid "controls.language.german"
+msgstr "Deutsch"
+
+#: app/configurator/components/ui-helpers.tsx:325
+msgid "controls.language.italian"
+msgstr "Italienisch"
+
+#: app/configurator/components/ui-helpers.tsx:225
+msgid "controls.measure"
+msgstr "Messwert"
+
+#: app/configurator/components/chart-controls/control-tab.tsx:101
+msgid "controls.option.isActive"
+msgstr "Ein"
+
+#: app/configurator/components/chart-controls/control-tab.tsx:99
+msgid "controls.option.isNotActive"
+msgstr "Aus"
+
+#: app/components/form.tsx:153
+msgid "controls.search.clear"
+msgstr "Suche zurücksetzen"
+
+#: app/configurator/components/chart-configurator.tsx:23
+msgid "controls.section.chart.options"
+msgstr "Diagramm-Einstellungen"
+
+#: app/configurator/table/table-chart-configurator.tsx:63
+msgid "controls.section.columns"
+msgstr "Spalten"
+
+#: app/configurator/table/table-chart-options.tsx:130
+msgid "controls.section.columnstyle"
+msgstr "Spaltenstil"
+
+#: app/configurator/components/chart-configurator.tsx:32
+msgid "controls.section.data.filters"
+msgstr "Filter"
+
+#: app/configurator/components/chart-annotator.tsx:12
+msgid "controls.section.description"
+msgstr "Titel & Beschreibung"
+
+#: app/configurator/components/chart-options-selector.tsx:95
+#: app/configurator/components/chart-options-selector.tsx:99
+#: app/configurator/table/table-chart-options.tsx:182
+#: app/configurator/table/table-chart-options.tsx:186
+msgid "controls.section.filter"
+msgstr "Filter"
+
+#: app/configurator/table/table-chart-configurator.tsx:61
+msgid "controls.section.groups"
+msgstr "Gruppierungen"
+
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:31
+msgid "controls.section.interactive.filters"
+msgstr "Interaktive Filter hinzufügen"
+
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:53
+msgid "controls.section.interactiveFilters.dataFilters"
+msgstr "Datenfilter"
+
+#: app/configurator/components/chart-options-selector.tsx:150
+msgid "controls.section.sorting"
+msgstr "Sortieren"
+
+#: app/configurator/table/table-chart-options.tsx:239
+msgid "controls.section.tableSettings"
+msgstr "Tabelleneinstellungen"
+
+#: app/configurator/table/table-chart-sorting-options.tsx:202
+msgid "controls.section.tableSorting"
+msgstr "Tabellensortierung"
+
+#: app/configurator/table/table-chart-configurator.tsx:53
+msgid "controls.section.tableoptions"
+msgstr "Tabellenoptionen"
+
+#: app/configurator/components/chart-type-selector.tsx:87
+#: app/configurator/components/chart-type-selector.tsx:90
+msgid "controls.select.chart.type"
+msgstr "Diagrammtyp"
+
+#: app/configurator/components/chart-type-selector.tsx:106
+msgid "controls.select.chart.type.experimental"
+msgstr "Experimentelle Features"
+
+#: app/configurator/components/chart-type-selector.tsx:111
+msgid "controls.select.chart.type.experimental.description"
+msgstr "Vorschau von zukünftigen Features mit limitierten Daten auf einer separaten Seite."
+
+#: app/configurator/components/chart-options-selector.tsx:110
+msgid "controls.select.column.layout"
+msgstr "Spaltenstil"
+
+#: app/configurator/table/table-chart-options.tsx:133
+msgid "controls.select.columnStyle"
+msgstr "Spaltenstil"
+
+#: app/configurator/table/table-chart-options.tsx:227
+msgid "controls.select.columnStyle.barColorBackground"
+msgstr "Hintergrundfarbe"
+
+#: app/configurator/table/table-chart-options.tsx:224
+msgid "controls.select.columnStyle.barColorNegative"
+msgstr "Negative Balkenfarbe"
+
+#: app/configurator/table/table-chart-options.tsx:221
+msgid "controls.select.columnStyle.barColorPositive"
+msgstr "Positive Balkenfarbe"
+
+#: app/configurator/table/table-chart-options.tsx:230
+msgid "controls.select.columnStyle.barShowBackground"
+msgstr "Hintergrundfarbe anzeigen"
+
+#: app/configurator/table/table-chart-options.tsx:213
+msgid "controls.select.columnStyle.columnColor"
+msgstr "Spaltenfarbe"
+
+#: app/configurator/table/table-chart-options.tsx:210
+msgid "controls.select.columnStyle.textColor"
+msgstr "Schriftfarbe"
+
+#: app/configurator/table/table-chart-options.tsx:196
+msgid "controls.select.columnStyle.textStyle"
+msgstr "Schriftstil"
+
+#: app/configurator/components/chart-options-selector.tsx:57
+#: app/configurator/components/chart-options-selector.tsx:59
+msgid "controls.select.dimension"
+msgstr "Dimension auswählen"
+
+#: app/configurator/components/chart-options-selector.tsx:58
+msgid "controls.select.measure"
+msgstr "Messwert auswählen"
+
+#: app/configurator/components/field.tsx:35
+#: app/configurator/components/field.tsx:169
+msgid "controls.select.optional"
+msgstr "optional"
+
+#: app/configurator/table/table-chart-sorting-options.tsx:131
+msgid "controls.sorting.addDimension"
+msgstr "Dimension hinzufügen"
+
+#: app/configurator/components/chart-options-selector.tsx:124
+#: app/configurator/components/chart-options-selector.tsx:130
+msgid "controls.sorting.byDimensionLabel"
+msgstr "Name"
+
+#: app/configurator/components/ui-helpers.tsx:260
+msgid "controls.sorting.byDimensionLabel.ascending"
+msgstr "A → Z"
+
+#: app/configurator/components/ui-helpers.tsx:269
+msgid "controls.sorting.byDimensionLabel.descending"
+msgstr "Z → A"
+
+#: app/configurator/components/chart-options-selector.tsx:126
+msgid "controls.sorting.byMeasure"
+msgstr "Messwert"
+
+#: app/configurator/components/ui-helpers.tsx:293
+msgid "controls.sorting.byMeasure.ascending"
+msgstr "1 → 9"
+
+#: app/configurator/components/ui-helpers.tsx:299
+msgid "controls.sorting.byMeasure.descending"
+msgstr "9 → 1"
+
+#: app/configurator/components/chart-options-selector.tsx:128
+msgid "controls.sorting.byTotalSize"
+msgstr "Gesamtgrösse"
+
+#: app/configurator/components/ui-helpers.tsx:273
+msgid "controls.sorting.byTotalSize.ascending"
+msgstr "Kleinste zuerst"
+
+#: app/configurator/components/ui-helpers.tsx:285
+msgid "controls.sorting.byTotalSize.largestBottom"
+msgstr "Grösste unten"
+
+#: app/configurator/components/ui-helpers.tsx:277
+msgid "controls.sorting.byTotalSize.largestFirst"
+msgstr "Grösste zuerst"
+
+#: app/configurator/components/ui-helpers.tsx:282
+msgid "controls.sorting.byTotalSize.largestTop"
+msgstr "Kleinste unten"
+
+#: app/configurator/table/table-chart-sorting-options.tsx:70
+msgid "controls.sorting.removeOption"
+msgstr "Sortierung entfernen"
+
+#: app/configurator/table/table-chart-sorting-options.tsx:109
+msgid "controls.sorting.selectDimension"
+msgstr "Wählen Sie eine Dimension aus …"
+
+#: app/configurator/components/ui-helpers.tsx:251
+#: app/configurator/table/table-chart-sorting-options.tsx:173
+msgid "controls.sorting.sortBy"
+msgstr "Sortieren nach"
+
+#: app/configurator/table/table-chart-options.tsx:119
+msgid "controls.table.column.group"
+msgstr "Gruppieren"
+
+#: app/configurator/table/table-chart-options.tsx:125
+msgid "controls.table.column.hide"
+msgstr "Spalte ausblenden"
+
+#: app/configurator/table/table-chart-options.tsx:120
+msgid "controls.table.column.hidefilter"
+msgstr "Spalte ausblenden und filtern"
+
+#: app/configurator/table/table-chart-configurator.tsx:56
+msgid "controls.table.settings"
+msgstr "Einstellungen"
+
+#: app/configurator/table/table-chart-configurator.tsx:57
+msgid "controls.table.sorting"
+msgstr "Sortierung"
+
+#: app/configurator/table/table-chart-options.tsx:242
+msgid "controls.tableSettings.showSearch"
+msgstr "Suche anzeigen"
+
+#: app/configurator/components/ui-helpers.tsx:242
+msgid "controls.title"
+msgstr "Titel hinzufügen"
+
+#: app/configurator/components/dataset-selector.tsx:70
+msgid "dataset.includeDrafts"
+msgstr "Entwurfs-Datensätze anzeigen"
+
+#: app/configurator/components/dataset-metadata.tsx:40
+msgid "dataset.metadata.date.created"
+msgstr "Erstellungsdatum"
+
 #: app/configurator/components/dataset-metadata.tsx:22
 msgid "dataset.metadata.description"
 msgstr "Beschreibung"
+
+#: app/configurator/components/dataset-metadata.tsx:30
+msgid "dataset.metadata.source"
+msgstr "Quelle"
+
+#: app/configurator/components/dataset-metadata.tsx:17
+msgid "dataset.metadata.title"
+msgstr "Titel"
 
 #: app/configurator/components/dataset-metadata.tsx:48
 msgid "dataset.metadata.version"
 msgstr "Version"
 
+#: app/configurator/components/dataset-selector.tsx:34
+msgid "dataset.order.newest"
+msgstr "Neueste"
+
+#: app/configurator/components/dataset-selector.tsx:26
+msgid "dataset.order.relevance"
+msgstr "Relevanz"
+
+#: app/configurator/components/dataset-selector.tsx:30
+msgid "dataset.order.title"
+msgstr "Titel"
+
+#: app/components/chart-preview.tsx:39
+#: app/components/chart-published.tsx:37
+#: app/configurator/components/dataset-preview.tsx:25
+msgid "dataset.publicationStatus.draft.warning"
+msgstr "Achtung, dieser Datensatz ist im Entwurfs-Stadium.<0/><1>Diese Grafik nicht für Berichte verwenden.</1>"
+
+#: app/configurator/components/dataset-selector.tsx:79
+msgid "dataset.results"
+msgstr "{0, plural, =0 {Keine Treffer} =1 {# Treffer} other {# Treffer}}"
+
+#: app/configurator/components/dataset-selector.tsx:37
+msgid "dataset.search.label"
+msgstr "Datensätze suchen"
+
+#: app/configurator/components/dataset-selector.tsx:89
+msgid "dataset.sortby"
+msgstr "Sortieren nach"
+
+#: app/configurator/components/dataset-selector.tsx:163
+msgid "dataset.tag.draft"
+msgstr "Entwurf"
+
+#: app/configurator/components/dataset-preview.tsx:55
+msgid "datatable.showing.first.rows"
+msgstr "Die ersten 10 Zeilen werden angezeigt"
+
+#: app/components/footer.tsx:35
+msgid "footer.institution.name"
+msgstr "Bundesamt für Umwelt BAFU"
+
+#: app/pages/v/[chartId].tsx:69
+msgid "hint.create.your.own.chart"
+msgstr "Sie können diese Visualisierung kopieren oder mit Schweizer Open Government Data eine neue Visualisierung erstellen."
+
+#: app/components/hint.tsx:126
+msgid "hint.dataloadingerror.message"
+msgstr "Die Daten konnten nicht geladen werden."
+
+#: app/components/hint.tsx:123
+msgid "hint.dataloadingerror.title"
+msgstr "Daten-Ladefehler"
+
+#: app/pages/v/[chartId].tsx:65
+msgid "hint.how.to.share"
+msgstr "Sie können diese Visualisierung teilen oder sie einbetten. Zudem können Sie eine neue Visualisierung erstellen oder die gezeigte Visualisierung kopieren."
+
+#: app/components/hint.tsx:54
+msgid "hint.loading.data"
+msgstr "Lade Daten …"
+
+#: app/configurator/components/chart-type-selector.tsx:94
+msgid "hint.no.visualization.with.dataset"
+msgstr "Mit dem ausgewählten Datensatz kann keine Visualisierung erstellt werden."
+
+#: app/components/hint.tsx:105
+msgid "hint.nodata.message"
+msgstr "Keine Daten für die aktuelle Filterauswahl."
+
+#: app/components/hint.tsx:102
+msgid "hint.nodata.title"
+msgstr "Keine Daten"
+
+#: app/components/hint.tsx:147
+msgid "hint.only.negative.data.message"
+msgstr "Negative Datenwerte können mit diesem Diagrammtyp nicht dargestellt werden."
+
+#: app/components/hint.tsx:144
+msgid "hint.only.negative.data.title"
+msgstr "Negative Werte"
+
+#: app/components/hint.tsx:167
+msgid "hint.publication.success"
+msgstr "Die Visualisierung ist jetzt veröffentlicht. Sie können sie teilen oder einbetten, indem Sie die URL kopieren oder das Menü unten verwenden."
+
+#: app/components/hint.tsx:80
+msgid "hint.select.dataset"
+msgstr "Datensatz auswählen"
+
+#: app/components/hint.tsx:83
+msgid "hint.select.dataset.to.preview"
+msgstr "Bitte Datensatz auswählen, um eine Vorschau anzuzeigen."
+
+#: app/charts/shared/chart-data-filters.tsx:31
+msgid "interactive.data.filters.hide"
+msgstr "Filter ausblenden"
+
+#: app/charts/shared/chart-data-filters.tsx:31
+msgid "interactive.data.filters.show"
+msgstr "Filter anzeigen"
+
+#: app/components/header.tsx:71
+#: app/components/header.tsx:82
+msgid "logo.swiss.confederation"
+msgstr "Logo der Schweizerischen Eidgenossenschaft"
+
+#: app/components/chart-footnotes.tsx:20
+msgid "metadata.dataset"
+msgstr "Datensatz"
+
+#: app/components/chart-footnotes.tsx:49
+msgid "metadata.link.created.with.visualize"
+msgstr "Erstellt mit visualize.admin.ch"
+
+#: app/components/chart-footnotes.tsx:24
+msgid "metadata.source"
+msgstr "Quelle"
+
+#: app/components/publish-actions.tsx:156
+msgid "publication.embed.AEM"
+msgstr "Einbett-Code für AEM «Externe Applikation»:"
+
+#: app/components/publish-actions.tsx:151
+msgid "publication.embed.iframe"
+msgstr "Einbett-Code:"
+
+#: app/components/publish-actions.tsx:96
+msgid "publication.popup.share"
+msgstr "Teilen"
+
+#: app/components/publish-actions.tsx:121
+msgid "publication.share.chart.url"
+msgstr "Diagramm-URL:"
+
+#: app/components/publish-actions.tsx:99
+msgid "publication.share.linktitle.facebook"
+msgstr "Teilen via Facebook"
+
+#: app/components/publish-actions.tsx:107
+msgid "publication.share.linktitle.mail"
+msgstr "Versenden via E-Mail"
+
+#: app/components/publish-actions.tsx:103
+msgid "publication.share.linktitle.twitter"
+msgstr "Teilen via Twitter"
+
+#: app/components/publish-actions.tsx:113
+msgid "publication.share.mail.body"
+msgstr "Hier ist eine Visualisierung, die ich mit visualize.admin.ch erstellt habe"
+
+#: app/components/publish-actions.tsx:110
+msgid "publication.share.mail.subject"
+msgstr "visualize.admin.ch"
+
+#: app/configurator/components/stepper.tsx:115
+msgid "step.annotate"
+msgstr "Beschreiben"
+
+#: app/configurator/components/stepper.tsx:109
+msgid "step.dataset"
+msgstr "Datensatz"
+
+#: app/configurator/components/stepper.tsx:111
+msgid "step.visualization.type"
+msgstr "Diagrammtyp"
+
+#: app/configurator/components/stepper.tsx:113
+msgid "step.visualize"
+msgstr "Visualisieren"
+
+#: app/configurator/components/chart-controls/drag-and-drop-tab.tsx:27
+msgid "table.column.no"
+msgstr "Spalte {0}"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -6,14 +6,45 @@ msgstr ""
 "X-Generator: POEditor.com\n"
 "Project-Id-Version: visualize.admin.ch\n"
 "Language: en\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: app/components/chart-preview.tsx:63
+msgid "annotation.add.description"
+msgstr "[ No Description ]"
+
+#: app/components/chart-preview.tsx:55
+msgid "annotation.add.title"
+msgstr "[ No Title ]"
+
+#: app/pages/v/[chartId].tsx:83
+msgid "button.copy.visualization"
+msgstr "Copy This Visualization"
 
 #: app/components/data-download.tsx:73
 msgid "button.download.data"
 msgstr "Download data"
 
+#: app/components/data-download.tsx:46
+msgid "button.download.runsparqlquery"
+msgstr "Run SPARQL query"
+
 #: app/components/publish-actions.tsx:146
 msgid "button.embed"
 msgstr "Embed"
+
+#: app/components/publish-actions.tsx:168
+#: app/components/publish-actions.tsx:171
+msgid "button.hint.click.to.copy"
+msgstr "Click to copy"
+
+#: app/components/publish-actions.tsx:194
+msgid "button.hint.copied"
+msgstr "Copied!"
 
 #: app/pages/v/[chartId].tsx:78
 msgid "button.new.visualization"
@@ -35,606 +66,9 @@ msgstr "Publish"
 msgid "button.share"
 msgstr "Share"
 
-#: app/configurator/components/ui-helpers.tsx:222
-msgid "controls.axis.horizontal"
-msgstr "Horizontal Axis"
-
-#: app/configurator/components/ui-helpers.tsx:308
-msgid "controls.chart.type.area"
-msgstr "Areas"
-
-#: app/configurator/components/ui-helpers.tsx:304
-msgid "controls.chart.type.bar"
-msgstr "Bars"
-
-#: app/configurator/components/ui-helpers.tsx:302
-msgid "controls.chart.type.column"
-msgstr "Columns"
-
-#: app/configurator/components/ui-helpers.tsx:306
-msgid "controls.chart.type.line"
-msgstr "Lines"
-
-#: app/configurator/components/ui-helpers.tsx:310
-msgid "controls.chart.type.scatterplot"
-msgstr "Scatterplot"
-
-#: app/configurator/components/chart-controls/color-palette.tsx:40
-msgid "controls.color.palette"
-msgstr "Color palette"
-
-#: app/configurator/components/ui-helpers.tsx:249
-msgid "controls.column.grouped"
-msgstr "Grouped"
-
-#: app/configurator/components/ui-helpers.tsx:247
-msgid "controls.column.stacked"
-msgstr "Stacked"
-
-#: app/configurator/components/ui-helpers.tsx:244
-msgid "controls.description"
-msgstr "Description"
-
-#: app/configurator/components/filters.tsx:50
-msgid "controls.filter.select.all"
-msgstr "Select all"
-
-#: app/configurator/components/ui-helpers.tsx:225
-msgid "controls.measure"
-msgstr "Measure"
-
-#: app/configurator/components/chart-annotator.tsx:12
-msgid "controls.section.description"
-msgstr "Title & Description"
-
-#: app/configurator/components/chart-options-selector.tsx:87
-#: app/configurator/components/chart-options-selector.tsx:91
-#: app/configurator/table/table-chart-options.tsx:182
-#: app/configurator/table/table-chart-options.tsx:186
-msgid "controls.section.filter"
-msgstr "Filter"
-
-#: app/configurator/components/chart-type-selector.tsx:87
-#: app/configurator/components/chart-type-selector.tsx:90
-msgid "controls.select.chart.type"
-msgstr "Chart Type"
-
-#: app/configurator/components/ui-helpers.tsx:331
-#: app/configurator/components/ui-helpers.tsx:333
-msgid "controls.select.dimension"
-msgstr "Select a dimension"
-
-#: app/configurator/components/ui-helpers.tsx:332
-msgid "controls.select.measure"
-msgstr "Select a measure"
-
-#: app/configurator/components/ui-helpers.tsx:242
-msgid "controls.title"
-msgstr "Title"
-
-#: app/configurator/components/dataset-preview.tsx:55
-msgid "datatable.showing.first.rows"
-msgstr "Showing first 10 rows"
-
-#: app/pages/v/[chartId].tsx:69
-msgid "hint.create.your.own.chart"
-msgstr "Create your own version of this visualization by copying it, or start from scratch and make a new visualization using Swiss Open Government Data."
-
-#: app/pages/v/[chartId].tsx:65
-msgid "hint.how.to.share"
-msgstr "You can share this visualization by copying the URL or by embedding it on your own website. You can also create a new visualization from scratch or start by copying the visualization above."
-
-#: app/components/hint.tsx:54
-msgid "hint.loading.data"
-msgstr "Loading data..."
-
-#: app/configurator/components/chart-type-selector.tsx:94
-msgid "hint.no.visualization.with.dataset"
-msgstr "No visualization can be created with the selected dataset."
-
-#: app/components/hint.tsx:167
-msgid "hint.publication.success"
-msgstr "Your visualization is now published. Share it by copying the URL or use the Embed menu below."
-
-#: app/components/hint.tsx:80
-msgid "hint.select.dataset"
-msgstr "Select a dataset"
-
-#: app/components/hint.tsx:83
-msgid "hint.select.dataset.to.preview"
-msgstr "Select a dataset to preview its structure and content."
-
-#: app/components/header.tsx:71
-#: app/components/header.tsx:82
-msgid "logo.swiss.confederation"
-msgstr "Logo of the Swiss Confederation"
-
-#: app/components/chart-footnotes.tsx:20
-msgid "metadata.dataset"
-msgstr "Dataset"
-
-#: app/components/chart-footnotes.tsx:24
-msgid "metadata.source"
-msgstr "Source"
-
-#: app/components/publish-actions.tsx:156
-msgid "publication.embed.AEM"
-msgstr "Embed Code for AEM \"External Application\":"
-
-#: app/components/publish-actions.tsx:151
-msgid "publication.embed.iframe"
-msgstr "Embed Code:"
-
-#: app/components/publish-actions.tsx:96
-msgid "publication.popup.share"
-msgstr "Share"
-
-#: app/components/publish-actions.tsx:121
-msgid "publication.share.chart.url"
-msgstr "Chart URL:"
-
-#: app/components/publish-actions.tsx:113
-msgid "publication.share.mail.body"
-msgstr "Here is a visualization I created using visualize.admin.ch"
-
-#: app/components/publish-actions.tsx:110
-msgid "publication.share.mail.subject"
-msgstr "visualize.admin.ch"
-
-#: app/configurator/components/stepper.tsx:115
-msgid "step.annotate"
-msgstr "Annotate"
-
-#: app/configurator/components/stepper.tsx:109
-msgid "step.dataset"
-msgstr "Dataset"
-
-#: app/configurator/components/stepper.tsx:111
-msgid "step.visualization.type"
-msgstr "Chart Type"
-
-#: app/components/footer.tsx:35
-msgid "footer.institution.name"
-msgstr "Federal Office for the Environment FOEN"
-
-#: app/components/chart-preview.tsx:63
-msgid "annotation.add.description"
-msgstr "[ No Description ]"
-
-#: app/components/chart-preview.tsx:55
-msgid "annotation.add.title"
-msgstr "[ No Title ]"
-
-#: app/pages/v/[chartId].tsx:83
-msgid "button.copy.visualization"
-msgstr "Copy This Visualization"
-
-#: app/configurator/components/ui-helpers.tsx:312
-msgid "controls.chart.type.pie"
-msgstr "Pie"
-
-#: app/configurator/components/filters.tsx:54
-msgid "controls.filter.select.none"
-msgstr "Select none"
-
-#: app/configurator/components/empty-right-panel.tsx:9
-msgid "controls.hint.configuring.chart"
-msgstr "Select a design element or a data dimension to modify its options."
-
-#: app/configurator/components/empty-right-panel.tsx:14
-msgid "controls.hint.describing.chart"
-msgstr "Select an annotation field to modify its content."
-
-#: app/configurator/components/ui-helpers.tsx:319
-msgid "controls.language.english"
-msgstr "English"
-
-#: app/configurator/components/ui-helpers.tsx:323
-msgid "controls.language.french"
-msgstr "French"
-
-#: app/configurator/components/ui-helpers.tsx:321
-msgid "controls.language.german"
-msgstr "German"
-
-#: app/configurator/components/ui-helpers.tsx:325
-msgid "controls.language.italian"
-msgstr "Italian"
-
-#: app/configurator/components/dataset-metadata.tsx:40
-msgid "dataset.metadata.date.created"
-msgstr "Date created"
-
-#: app/configurator/components/dataset-metadata.tsx:30
-msgid "dataset.metadata.source"
-msgstr "Source"
-
-#: app/configurator/components/dataset-metadata.tsx:17
-msgid "dataset.metadata.title"
-msgstr "Title"
-
-#: app/configurator/components/dataset-selector.tsx:34
-msgid "dataset.order.newest"
-msgstr "Newest"
-
-#: app/configurator/components/dataset-selector.tsx:26
-msgid "dataset.order.relevance"
-msgstr "Relevance"
-
-#: app/configurator/components/dataset-selector.tsx:30
-msgid "dataset.order.title"
-msgstr "Title"
-
-#: app/configurator/components/dataset-selector.tsx:79
-msgid "dataset.results"
-msgstr "{0, plural, =0 {No results} =1 {# result} other {# results}}"
-
-#: app/configurator/components/dataset-selector.tsx:89
-msgid "dataset.sortby"
-msgstr "Sort by"
-
-#: app/components/hint.tsx:105
-msgid "hint.nodata.message"
-msgstr "No data for your filter selection."
-
-#: app/components/hint.tsx:102
-msgid "hint.nodata.title"
-msgstr "No data"
-
-#: app/components/publish-actions.tsx:99
-msgid "publication.share.linktitle.facebook"
-msgstr "Share on Facebook"
-
-#: app/components/publish-actions.tsx:107
-msgid "publication.share.linktitle.mail"
-msgstr "Share via Email"
-
-#: app/components/publish-actions.tsx:103
-msgid "publication.share.linktitle.twitter"
-msgstr "Share on Twitter"
-
-#: app/components/publish-actions.tsx:168
-#: app/components/publish-actions.tsx:171
-msgid "button.hint.click.to.copy"
-msgstr "Click to copy"
-
-#: app/components/publish-actions.tsx:194
-msgid "button.hint.copied"
-msgstr "Copied!"
-
-#: app/components/chart-footnotes.tsx:49
-msgid "metadata.link.created.with.visualize"
-msgstr "Created with visualize.admin.ch"
-
-#: app/components/form.tsx:145
-msgid "controls.search.clear"
-msgstr "Clear search field"
-
-#: app/configurator/components/dataset-selector.tsx:37
-msgid "dataset.search.label"
-msgstr "Search datasets"
-
-#: app/components/hint.tsx:147
-msgid "hint.only.negative.data.message"
-msgstr "Negative data values cannot be displayed with this chart type."
-
-#: app/components/hint.tsx:144
-msgid "hint.only.negative.data.title"
-msgstr "Negative Values"
-
-#: app/configurator/components/chart-controls/color-palette.tsx:135
-#: app/configurator/components/chart-controls/color-palette.tsx:140
-msgid "controls.color.palette.reset"
-msgstr "Reset color palette"
-
-#: app/configurator/components/field.tsx:144
-msgid "controls.dimension.none"
-msgstr "None"
-
-#: app/configurator/components/chart-options-selector.tsx:142
-msgid "controls.section.sorting"
-msgstr "Sort"
-
-#: app/configurator/components/chart-options-selector.tsx:116
-#: app/configurator/components/chart-options-selector.tsx:122
-msgid "controls.sorting.byDimensionLabel"
-msgstr "Name"
-
-#: app/configurator/components/ui-helpers.tsx:260
-msgid "controls.sorting.byDimensionLabel.ascending"
-msgstr "A → Z"
-
-#: app/configurator/components/ui-helpers.tsx:269
-msgid "controls.sorting.byDimensionLabel.descending"
-msgstr "Z → A"
-
-#: app/configurator/components/chart-options-selector.tsx:118
-msgid "controls.sorting.byMeasure"
-msgstr "Measure"
-
-#: app/configurator/components/ui-helpers.tsx:293
-msgid "controls.sorting.byMeasure.ascending"
-msgstr "1 → 9"
-
-#: app/configurator/components/ui-helpers.tsx:299
-msgid "controls.sorting.byMeasure.descending"
-msgstr "9 → 1"
-
-#: app/configurator/components/chart-options-selector.tsx:120
-msgid "controls.sorting.byTotalSize"
-msgstr "Total size"
-
-#: app/configurator/components/ui-helpers.tsx:273
-msgid "controls.sorting.byTotalSize.ascending"
-msgstr "Largest last"
-
-#: app/configurator/components/ui-helpers.tsx:285
-msgid "controls.sorting.byTotalSize.largestBottom"
-msgstr "Largest bottom"
-
-#: app/configurator/components/ui-helpers.tsx:277
-msgid "controls.sorting.byTotalSize.largestFirst"
-msgstr "Largest first"
-
-#: app/configurator/components/ui-helpers.tsx:282
-msgid "controls.sorting.byTotalSize.largestTop"
-msgstr "Largest top"
-
-#: app/configurator/components/chart-controls/color-picker.tsx:100
-msgid "controls.colorpicker.open"
-msgstr "Open Color Picker"
-
-#: app/configurator/components/ui-helpers.tsx:251
-#: app/configurator/table/table-chart-sorting-options.tsx:173
-msgid "controls.sorting.sortBy"
-msgstr "Sort by"
-
-#: app/configurator/components/ui-helpers.tsx:232
-msgid "controls.axis.vertical"
-msgstr "Vertical Axis"
-
-#: app/charts/table/table.tsx:136
-msgid "chart.published.toggle.mobile.view"
-msgstr "Compact view"
-
-#: app/charts/table/table.tsx:177
-msgid "chart.table.number.of.lines"
-msgstr "Total number of lines:"
-
-#: app/configurator/table/table-chart-options.tsx:109
-msgid "columnStyle.bar"
-msgstr "Bar Chart"
-
-#: app/configurator/table/table-chart-options.tsx:95
-msgid "columnStyle.categories"
-msgstr "Categories"
-
-#: app/configurator/table/table-chart-options.tsx:105
-msgid "columnStyle.heatmap"
-msgstr "Heat Map"
-
-#: app/configurator/table/table-chart-options.tsx:91
-#: app/configurator/table/table-chart-options.tsx:101
-msgid "columnStyle.text"
-msgstr "Text"
-
-#: app/configurator/table/table-chart-options.tsx:206
-msgid "columnStyle.textStyle.bold"
-msgstr "Bold"
-
-#: app/configurator/table/table-chart-options.tsx:199
-msgid "columnStyle.textStyle.regular"
-msgstr "Regular"
-
-#: app/configurator/interactive-filters/editor-time-brush.tsx:113
-msgid "controls..interactiveFilters.time.defaultSettings"
-msgstr "Default Settings"
-
-#: app/configurator/components/ui-helpers.tsx:314
-msgid "controls.chart.type.table"
-msgstr "Table"
-
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:43
-msgid "controls.interactive.filters.dataFilter"
-msgstr "Data Filters"
-
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:136
-msgid "controls.interactiveFilters.dataFilters.toggledataFilters"
-msgstr "Show data filters"
-
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:34
-msgid "controls.interactiveFilters.legend.toggleInteractiveLegend"
-msgstr "Show legend filter"
-
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:106
-msgid "controls.interactiveFilters.time.noTimeDimension"
-msgstr "There is no time dimension!"
-
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:95
-msgid "controls.interactiveFilters.time.toggleTimeFilter"
-msgstr "Show time filter"
-
-#: app/configurator/components/chart-controls/control-tab.tsx:101
-msgid "controls.option.isActive"
-msgstr "On"
-
-#: app/configurator/components/chart-controls/control-tab.tsx:99
-msgid "controls.option.isNotActive"
-msgstr "Off"
-
-#: app/configurator/table/table-chart-configurator.tsx:63
-msgid "controls.section.columns"
-msgstr "Columns"
-
-#: app/configurator/table/table-chart-options.tsx:130
-msgid "controls.section.columnstyle"
-msgstr "Column Style"
-
-#: app/configurator/table/table-chart-configurator.tsx:61
-msgid "controls.section.groups"
-msgstr "Groups"
-
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:31
-msgid "controls.section.interactive.filters"
-msgstr "Interactive Filters"
-
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:53
-msgid "controls.section.interactiveFilters.dataFilters"
-msgstr "Data Filters"
-
-#: app/configurator/table/table-chart-options.tsx:239
-msgid "controls.section.tableSettings"
-msgstr "Table Settings"
-
-#: app/configurator/table/table-chart-sorting-options.tsx:202
-msgid "controls.section.tableSorting"
-msgstr "Table Sorting"
-
-#: app/configurator/table/table-chart-configurator.tsx:53
-msgid "controls.section.tableoptions"
-msgstr "Table Options"
-
-#: app/configurator/table/table-chart-options.tsx:133
-msgid "controls.select.columnStyle"
-msgstr "Column Style"
-
-#: app/configurator/table/table-chart-options.tsx:227
-msgid "controls.select.columnStyle.barColorBackground"
-msgstr "Background color"
-
-#: app/configurator/table/table-chart-options.tsx:224
-msgid "controls.select.columnStyle.barColorNegative"
-msgstr "Negative bar color"
-
-#: app/configurator/table/table-chart-options.tsx:221
-msgid "controls.select.columnStyle.barColorPositive"
-msgstr "Positive bar color"
-
-#: app/configurator/table/table-chart-options.tsx:230
-msgid "controls.select.columnStyle.barShowBackground"
-msgstr "Show bar background"
-
-#: app/configurator/table/table-chart-options.tsx:213
-msgid "controls.select.columnStyle.columnColor"
-msgstr "Column Color"
-
-#: app/configurator/table/table-chart-options.tsx:210
-msgid "controls.select.columnStyle.textColor"
-msgstr "Text Color"
-
-#: app/configurator/table/table-chart-options.tsx:196
-msgid "controls.select.columnStyle.textStyle"
-msgstr "Text Style"
-
-#: app/configurator/table/table-chart-sorting-options.tsx:131
-msgid "controls.sorting.addDimension"
-msgstr "Add dimension"
-
-#: app/configurator/table/table-chart-sorting-options.tsx:70
-msgid "controls.sorting.removeOption"
-msgstr "Remove sorting dimension"
-
-#: app/configurator/table/table-chart-sorting-options.tsx:109
-msgid "controls.sorting.selectDimension"
-msgstr "Select a dimension …"
-
-#: app/configurator/table/table-chart-options.tsx:119
-msgid "controls.table.column.group"
-msgstr "Use as group"
-
-#: app/configurator/table/table-chart-options.tsx:125
-msgid "controls.table.column.hide"
-msgstr "Hide column"
-
-#: app/configurator/table/table-chart-options.tsx:120
-msgid "controls.table.column.hidefilter"
-msgstr "Hide and filter column"
-
-#: app/configurator/table/table-chart-configurator.tsx:56
-msgid "controls.table.settings"
-msgstr "Settings"
-
-#: app/configurator/table/table-chart-configurator.tsx:57
-msgid "controls.table.sorting"
-msgstr "Sorting"
-
-#: app/configurator/table/table-chart-options.tsx:242
-msgid "controls.tableSettings.showSearch"
-msgstr "Show search field"
-
-#: app/charts/shared/chart-data-filters.tsx:31
-msgid "interactive.data.filters.hide"
-msgstr "Hide Filters"
-
-#: app/charts/shared/chart-data-filters.tsx:31
-msgid "interactive.data.filters.show"
-msgstr "Show Filters"
-
-#: app/configurator/components/chart-controls/drag-and-drop-tab.tsx:27
-msgid "table.column.no"
-msgstr "Column {0}"
-
 #: app/charts/map/chart-map-prototype.tsx:146
 msgid "chart.map.control.data.filters"
 msgstr "Data Filters"
-
-#: app/charts/map/chart-map-prototype.tsx:162
-msgid "chart.map.warning.prototype"
-msgstr "This map is a prototype and can't be published."
-
-#: app/configurator/components/ui-helpers.tsx:316
-msgid "controls.chart.type.map"
-msgstr "Map"
-
-#: app/configurator/components/chart-type-selector.tsx:106
-msgid "controls.select.chart.type.experimental"
-msgstr "Experimental Features"
-
-#: app/configurator/components/chart-type-selector.tsx:111
-msgid "controls.select.chart.type.experimental.description"
-msgstr "Preview upcoming features with a limited subset of data on a separate page."
-
-#: app/configurator/components/dataset-selector.tsx:70
-msgid "dataset.includeDrafts"
-msgstr "Include draft datasets"
-
-#: app/components/chart-preview.tsx:39
-#: app/components/chart-published.tsx:37
-#: app/configurator/components/dataset-preview.tsx:25
-msgid "dataset.publicationStatus.draft.warning"
-msgstr "Careful, this dataset is only a draft.<0/><1>Don't use for reporting!</1>"
-
-#: app/configurator/components/dataset-selector.tsx:163
-msgid "dataset.tag.draft"
-msgstr "Draft"
-
-#: app/components/hint.tsx:126
-msgid "hint.dataloadingerror.message"
-msgstr "The data could not be loaded."
-
-#: app/components/hint.tsx:123
-msgid "hint.dataloadingerror.title"
-msgstr "Data loading error"
-
-#: app/configurator/components/ui-helpers.tsx:240
-msgid "controls.color"
-msgstr "Color"
-
-#: app/configurator/components/chart-controls/control-tab.tsx:12
-msgid "controls.color.add"
-msgstr "Add ..."
-
-#: app/configurator/components/chart-configurator.tsx:22
-msgid "controls.section.chart.options"
-msgstr "Chart Options"
-
-#: app/configurator/components/chart-configurator.tsx:31
-msgid "controls.section.data.filters"
-msgstr "Filters"
-
-#: app/configurator/components/stepper.tsx:113
-msgid "step.visualize"
-msgstr "Visualize"
 
 #: app/charts/map/chart-map-prototype.tsx:136
 msgid "chart.map.control.layers"
@@ -651,6 +85,14 @@ msgstr "Show data areas"
 #: app/charts/map/prototype-right-controls.tsx:37
 msgid "chart.map.layers.area.color.palette"
 msgstr "Color palette"
+
+#: app/charts/map/prototype-right-controls.tsx:51
+msgid "chart.map.layers.area.discretization.continuous"
+msgstr "Continuous"
+
+#: app/charts/map/prototype-right-controls.tsx:59
+msgid "chart.map.layers.area.discretization.discrete"
+msgstr "Discrete"
 
 #: app/charts/map/prototype-right-controls.tsx:68
 msgid "chart.map.layers.area.discretization.jenks"
@@ -704,31 +146,603 @@ msgstr "Show proportional symbols"
 msgid "chart.map.layers.symbol.select.measure"
 msgstr "Select a measure"
 
-#: app/configurator/components/chart-options-selector.tsx:102
-msgid "controls.select.column.layout"
-msgstr "Column layout"
+#: app/charts/map/chart-map-prototype.tsx:162
+msgid "chart.map.warning.prototype"
+msgstr "This map is a prototype and can't be published."
 
-#: app/charts/map/prototype-right-controls.tsx:51
-msgid "chart.map.layers.area.discretization.continuous"
-msgstr "Continuous"
+#: app/charts/table/table.tsx:136
+msgid "chart.published.toggle.mobile.view"
+msgstr "Compact view"
 
-#: app/charts/map/prototype-right-controls.tsx:59
-msgid "chart.map.layers.area.discretization.discrete"
-msgstr "Discrete"
+#: app/charts/table/table.tsx:177
+msgid "chart.table.number.of.lines"
+msgstr "Total number of lines:"
 
-#: app/components/data-download.tsx:46
-msgid "button.download.runsparqlquery"
-msgstr "Run SPARQL query"
+#: app/configurator/table/table-chart-options.tsx:109
+msgid "columnStyle.bar"
+msgstr "Bar Chart"
+
+#: app/configurator/table/table-chart-options.tsx:95
+msgid "columnStyle.categories"
+msgstr "Categories"
+
+#: app/configurator/table/table-chart-options.tsx:105
+msgid "columnStyle.heatmap"
+msgstr "Heat Map"
+
+#: app/configurator/table/table-chart-options.tsx:91
+#: app/configurator/table/table-chart-options.tsx:101
+msgid "columnStyle.text"
+msgstr "Text"
+
+#: app/configurator/table/table-chart-options.tsx:206
+msgid "columnStyle.textStyle.bold"
+msgstr "Bold"
+
+#: app/configurator/table/table-chart-options.tsx:199
+msgid "columnStyle.textStyle.regular"
+msgstr "Regular"
+
+#: app/configurator/interactive-filters/editor-time-brush.tsx:113
+msgid "controls..interactiveFilters.time.defaultSettings"
+msgstr "Default Settings"
+
+#: app/configurator/components/ui-helpers.tsx:222
+msgid "controls.axis.horizontal"
+msgstr "Horizontal Axis"
+
+#: app/configurator/components/ui-helpers.tsx:232
+msgid "controls.axis.vertical"
+msgstr "Vertical Axis"
+
+#: app/configurator/components/ui-helpers.tsx:308
+msgid "controls.chart.type.area"
+msgstr "Areas"
+
+#: app/configurator/components/ui-helpers.tsx:304
+msgid "controls.chart.type.bar"
+msgstr "Bars"
+
+#: app/configurator/components/ui-helpers.tsx:302
+msgid "controls.chart.type.column"
+msgstr "Columns"
+
+#: app/configurator/components/ui-helpers.tsx:306
+msgid "controls.chart.type.line"
+msgstr "Lines"
+
+#: app/configurator/components/ui-helpers.tsx:316
+msgid "controls.chart.type.map"
+msgstr "Map"
+
+#: app/configurator/components/ui-helpers.tsx:312
+msgid "controls.chart.type.pie"
+msgstr "Pie"
+
+#: app/configurator/components/ui-helpers.tsx:310
+msgid "controls.chart.type.scatterplot"
+msgstr "Scatterplot"
+
+#: app/configurator/components/ui-helpers.tsx:314
+msgid "controls.chart.type.table"
+msgstr "Table"
+
+#: app/configurator/components/ui-helpers.tsx:240
+msgid "controls.color"
+msgstr "Color"
+
+#: app/configurator/components/chart-controls/control-tab.tsx:12
+msgid "controls.color.add"
+msgstr "Add ..."
+
+#: app/configurator/components/chart-controls/color-palette.tsx:40
+msgid "controls.color.palette"
+msgstr "Color palette"
+
+#: app/configurator/components/chart-controls/color-palette.tsx:135
+#: app/configurator/components/chart-controls/color-palette.tsx:140
+msgid "controls.color.palette.reset"
+msgstr "Reset color palette"
+
+#: app/configurator/components/chart-controls/color-picker.tsx:100
+msgid "controls.colorpicker.open"
+msgstr "Open Color Picker"
+
+#: app/configurator/components/ui-helpers.tsx:249
+msgid "controls.column.grouped"
+msgstr "Grouped"
+
+#: app/configurator/components/ui-helpers.tsx:247
+msgid "controls.column.stacked"
+msgstr "Stacked"
+
+#: app/configurator/components/ui-helpers.tsx:244
+msgid "controls.description"
+msgstr "Description"
+
+#: app/configurator/components/field.tsx:165
+msgid "controls.dimension.none"
+msgstr "None"
+
+#: app/configurator/components/field.tsx:31
+msgid "controls.dimensionvalue.none"
+msgstr "No Filter"
+
+#: app/configurator/components/filters.tsx:50
+msgid "controls.filter.select.all"
+msgstr "Select all"
+
+#: app/configurator/components/filters.tsx:54
+msgid "controls.filter.select.none"
+msgstr "Select none"
 
 #: app/configurator/interactive-filters/editor-time-interval-brush.tsx:89
 msgid "controls.filters.time.range"
 msgstr "Time Range"
 
+#: app/configurator/components/empty-right-panel.tsx:9
+msgid "controls.hint.configuring.chart"
+msgstr "Select a design element or a data dimension to modify its options."
+
+#: app/configurator/components/empty-right-panel.tsx:14
+msgid "controls.hint.describing.chart"
+msgstr "Select an annotation field to modify its content."
+
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:43
+msgid "controls.interactive.filters.dataFilter"
+msgstr "Data Filters"
+
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:136
+msgid "controls.interactiveFilters.dataFilters.toggledataFilters"
+msgstr "Show data filters"
+
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:34
+msgid "controls.interactiveFilters.legend.toggleInteractiveLegend"
+msgstr "Show legend filter"
+
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:106
+msgid "controls.interactiveFilters.time.noTimeDimension"
+msgstr "There is no time dimension!"
+
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:95
+msgid "controls.interactiveFilters.time.toggleTimeFilter"
+msgstr "Show time filter"
+
+#: app/configurator/components/ui-helpers.tsx:319
+msgid "controls.language.english"
+msgstr "English"
+
+#: app/configurator/components/ui-helpers.tsx:323
+msgid "controls.language.french"
+msgstr "French"
+
+#: app/configurator/components/ui-helpers.tsx:321
+msgid "controls.language.german"
+msgstr "German"
+
+#: app/configurator/components/ui-helpers.tsx:325
+msgid "controls.language.italian"
+msgstr "Italian"
+
+#: app/configurator/components/ui-helpers.tsx:225
+msgid "controls.measure"
+msgstr "Measure"
+
+#: app/configurator/components/chart-controls/control-tab.tsx:101
+msgid "controls.option.isActive"
+msgstr "On"
+
+#: app/configurator/components/chart-controls/control-tab.tsx:99
+msgid "controls.option.isNotActive"
+msgstr "Off"
+
+#: app/components/form.tsx:153
+msgid "controls.search.clear"
+msgstr "Clear search field"
+
+#: app/configurator/components/chart-configurator.tsx:23
+msgid "controls.section.chart.options"
+msgstr "Chart Options"
+
+#: app/configurator/table/table-chart-configurator.tsx:63
+msgid "controls.section.columns"
+msgstr "Columns"
+
+#: app/configurator/table/table-chart-options.tsx:130
+msgid "controls.section.columnstyle"
+msgstr "Column Style"
+
+#: app/configurator/components/chart-configurator.tsx:32
+msgid "controls.section.data.filters"
+msgstr "Filters"
+
+#: app/configurator/components/chart-annotator.tsx:12
+msgid "controls.section.description"
+msgstr "Title & Description"
+
+#: app/configurator/components/chart-options-selector.tsx:95
+#: app/configurator/components/chart-options-selector.tsx:99
+#: app/configurator/table/table-chart-options.tsx:182
+#: app/configurator/table/table-chart-options.tsx:186
+msgid "controls.section.filter"
+msgstr "Filter"
+
+#: app/configurator/table/table-chart-configurator.tsx:61
+msgid "controls.section.groups"
+msgstr "Groups"
+
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:31
+msgid "controls.section.interactive.filters"
+msgstr "Interactive Filters"
+
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:53
+msgid "controls.section.interactiveFilters.dataFilters"
+msgstr "Data Filters"
+
+#: app/configurator/components/chart-options-selector.tsx:150
+msgid "controls.section.sorting"
+msgstr "Sort"
+
+#: app/configurator/table/table-chart-options.tsx:239
+msgid "controls.section.tableSettings"
+msgstr "Table Settings"
+
+#: app/configurator/table/table-chart-sorting-options.tsx:202
+msgid "controls.section.tableSorting"
+msgstr "Table Sorting"
+
+#: app/configurator/table/table-chart-configurator.tsx:53
+msgid "controls.section.tableoptions"
+msgstr "Table Options"
+
+#: app/configurator/components/chart-type-selector.tsx:87
+#: app/configurator/components/chart-type-selector.tsx:90
+msgid "controls.select.chart.type"
+msgstr "Chart Type"
+
+#: app/configurator/components/chart-type-selector.tsx:106
+msgid "controls.select.chart.type.experimental"
+msgstr "Experimental Features"
+
+#: app/configurator/components/chart-type-selector.tsx:111
+msgid "controls.select.chart.type.experimental.description"
+msgstr "Preview upcoming features with a limited subset of data on a separate page."
+
+#: app/configurator/components/chart-options-selector.tsx:110
+msgid "controls.select.column.layout"
+msgstr "Column layout"
+
+#: app/configurator/table/table-chart-options.tsx:133
+msgid "controls.select.columnStyle"
+msgstr "Column Style"
+
+#: app/configurator/table/table-chart-options.tsx:227
+msgid "controls.select.columnStyle.barColorBackground"
+msgstr "Background color"
+
+#: app/configurator/table/table-chart-options.tsx:224
+msgid "controls.select.columnStyle.barColorNegative"
+msgstr "Negative bar color"
+
+#: app/configurator/table/table-chart-options.tsx:221
+msgid "controls.select.columnStyle.barColorPositive"
+msgstr "Positive bar color"
+
+#: app/configurator/table/table-chart-options.tsx:230
+msgid "controls.select.columnStyle.barShowBackground"
+msgstr "Show bar background"
+
+#: app/configurator/table/table-chart-options.tsx:213
+msgid "controls.select.columnStyle.columnColor"
+msgstr "Column Color"
+
+#: app/configurator/table/table-chart-options.tsx:210
+msgid "controls.select.columnStyle.textColor"
+msgstr "Text Color"
+
+#: app/configurator/table/table-chart-options.tsx:196
+msgid "controls.select.columnStyle.textStyle"
+msgstr "Text Style"
+
+#: app/configurator/components/chart-options-selector.tsx:57
+#: app/configurator/components/chart-options-selector.tsx:59
+msgid "controls.select.dimension"
+msgstr "Select a dimension"
+
+#: app/configurator/components/chart-options-selector.tsx:58
+msgid "controls.select.measure"
+msgstr "Select a measure"
+
+#: app/configurator/components/field.tsx:35
+#: app/configurator/components/field.tsx:169
+msgid "controls.select.optional"
+msgstr "optional"
+
+#: app/configurator/table/table-chart-sorting-options.tsx:131
+msgid "controls.sorting.addDimension"
+msgstr "Add dimension"
+
+#: app/configurator/components/chart-options-selector.tsx:124
+#: app/configurator/components/chart-options-selector.tsx:130
+msgid "controls.sorting.byDimensionLabel"
+msgstr "Name"
+
+#: app/configurator/components/ui-helpers.tsx:260
+msgid "controls.sorting.byDimensionLabel.ascending"
+msgstr "A → Z"
+
+#: app/configurator/components/ui-helpers.tsx:269
+msgid "controls.sorting.byDimensionLabel.descending"
+msgstr "Z → A"
+
+#: app/configurator/components/chart-options-selector.tsx:126
+msgid "controls.sorting.byMeasure"
+msgstr "Measure"
+
+#: app/configurator/components/ui-helpers.tsx:293
+msgid "controls.sorting.byMeasure.ascending"
+msgstr "1 → 9"
+
+#: app/configurator/components/ui-helpers.tsx:299
+msgid "controls.sorting.byMeasure.descending"
+msgstr "9 → 1"
+
+#: app/configurator/components/chart-options-selector.tsx:128
+msgid "controls.sorting.byTotalSize"
+msgstr "Total size"
+
+#: app/configurator/components/ui-helpers.tsx:273
+msgid "controls.sorting.byTotalSize.ascending"
+msgstr "Largest last"
+
+#: app/configurator/components/ui-helpers.tsx:285
+msgid "controls.sorting.byTotalSize.largestBottom"
+msgstr "Largest bottom"
+
+#: app/configurator/components/ui-helpers.tsx:277
+msgid "controls.sorting.byTotalSize.largestFirst"
+msgstr "Largest first"
+
+#: app/configurator/components/ui-helpers.tsx:282
+msgid "controls.sorting.byTotalSize.largestTop"
+msgstr "Largest top"
+
+#: app/configurator/table/table-chart-sorting-options.tsx:70
+msgid "controls.sorting.removeOption"
+msgstr "Remove sorting dimension"
+
+#: app/configurator/table/table-chart-sorting-options.tsx:109
+msgid "controls.sorting.selectDimension"
+msgstr "Select a dimension …"
+
+#: app/configurator/components/ui-helpers.tsx:251
+#: app/configurator/table/table-chart-sorting-options.tsx:173
+msgid "controls.sorting.sortBy"
+msgstr "Sort by"
+
+#: app/configurator/table/table-chart-options.tsx:119
+msgid "controls.table.column.group"
+msgstr "Use as group"
+
+#: app/configurator/table/table-chart-options.tsx:125
+msgid "controls.table.column.hide"
+msgstr "Hide column"
+
+#: app/configurator/table/table-chart-options.tsx:120
+msgid "controls.table.column.hidefilter"
+msgstr "Hide and filter column"
+
+#: app/configurator/table/table-chart-configurator.tsx:56
+msgid "controls.table.settings"
+msgstr "Settings"
+
+#: app/configurator/table/table-chart-configurator.tsx:57
+msgid "controls.table.sorting"
+msgstr "Sorting"
+
+#: app/configurator/table/table-chart-options.tsx:242
+msgid "controls.tableSettings.showSearch"
+msgstr "Show search field"
+
+#: app/configurator/components/ui-helpers.tsx:242
+msgid "controls.title"
+msgstr "Title"
+
+#: app/configurator/components/dataset-selector.tsx:70
+msgid "dataset.includeDrafts"
+msgstr "Include draft datasets"
+
+#: app/configurator/components/dataset-metadata.tsx:40
+msgid "dataset.metadata.date.created"
+msgstr "Date created"
+
 #: app/configurator/components/dataset-metadata.tsx:22
 msgid "dataset.metadata.description"
 msgstr "Description"
+
+#: app/configurator/components/dataset-metadata.tsx:30
+msgid "dataset.metadata.source"
+msgstr "Source"
+
+#: app/configurator/components/dataset-metadata.tsx:17
+msgid "dataset.metadata.title"
+msgstr "Title"
 
 #: app/configurator/components/dataset-metadata.tsx:48
 msgid "dataset.metadata.version"
 msgstr "Version"
 
+#: app/configurator/components/dataset-selector.tsx:34
+msgid "dataset.order.newest"
+msgstr "Newest"
+
+#: app/configurator/components/dataset-selector.tsx:26
+msgid "dataset.order.relevance"
+msgstr "Relevance"
+
+#: app/configurator/components/dataset-selector.tsx:30
+msgid "dataset.order.title"
+msgstr "Title"
+
+#: app/components/chart-preview.tsx:39
+#: app/components/chart-published.tsx:37
+#: app/configurator/components/dataset-preview.tsx:25
+msgid "dataset.publicationStatus.draft.warning"
+msgstr "Careful, this dataset is only a draft.<0/><1>Don't use for reporting!</1>"
+
+#: app/configurator/components/dataset-selector.tsx:79
+msgid "dataset.results"
+msgstr "{0, plural, =0 {No results} =1 {# result} other {# results}}"
+
+#: app/configurator/components/dataset-selector.tsx:37
+msgid "dataset.search.label"
+msgstr "Search datasets"
+
+#: app/configurator/components/dataset-selector.tsx:89
+msgid "dataset.sortby"
+msgstr "Sort by"
+
+#: app/configurator/components/dataset-selector.tsx:163
+msgid "dataset.tag.draft"
+msgstr "Draft"
+
+#: app/configurator/components/dataset-preview.tsx:55
+msgid "datatable.showing.first.rows"
+msgstr "Showing first 10 rows"
+
+#: app/components/footer.tsx:35
+msgid "footer.institution.name"
+msgstr "Federal Office for the Environment FOEN"
+
+#: app/pages/v/[chartId].tsx:69
+msgid "hint.create.your.own.chart"
+msgstr "Create your own version of this visualization by copying it, or start from scratch and make a new visualization using Swiss Open Government Data."
+
+#: app/components/hint.tsx:126
+msgid "hint.dataloadingerror.message"
+msgstr "The data could not be loaded."
+
+#: app/components/hint.tsx:123
+msgid "hint.dataloadingerror.title"
+msgstr "Data loading error"
+
+#: app/pages/v/[chartId].tsx:65
+msgid "hint.how.to.share"
+msgstr "You can share this visualization by copying the URL or by embedding it on your own website. You can also create a new visualization from scratch or start by copying the visualization above."
+
+#: app/components/hint.tsx:54
+msgid "hint.loading.data"
+msgstr "Loading data..."
+
+#: app/configurator/components/chart-type-selector.tsx:94
+msgid "hint.no.visualization.with.dataset"
+msgstr "No visualization can be created with the selected dataset."
+
+#: app/components/hint.tsx:105
+msgid "hint.nodata.message"
+msgstr "No data for your filter selection."
+
+#: app/components/hint.tsx:102
+msgid "hint.nodata.title"
+msgstr "No data"
+
+#: app/components/hint.tsx:147
+msgid "hint.only.negative.data.message"
+msgstr "Negative data values cannot be displayed with this chart type."
+
+#: app/components/hint.tsx:144
+msgid "hint.only.negative.data.title"
+msgstr "Negative Values"
+
+#: app/components/hint.tsx:167
+msgid "hint.publication.success"
+msgstr "Your visualization is now published. Share it by copying the URL or use the Embed menu below."
+
+#: app/components/hint.tsx:80
+msgid "hint.select.dataset"
+msgstr "Select a dataset"
+
+#: app/components/hint.tsx:83
+msgid "hint.select.dataset.to.preview"
+msgstr "Select a dataset to preview its structure and content."
+
+#: app/charts/shared/chart-data-filters.tsx:31
+msgid "interactive.data.filters.hide"
+msgstr "Hide Filters"
+
+#: app/charts/shared/chart-data-filters.tsx:31
+msgid "interactive.data.filters.show"
+msgstr "Show Filters"
+
+#: app/components/header.tsx:71
+#: app/components/header.tsx:82
+msgid "logo.swiss.confederation"
+msgstr "Logo of the Swiss Confederation"
+
+#: app/components/chart-footnotes.tsx:20
+msgid "metadata.dataset"
+msgstr "Dataset"
+
+#: app/components/chart-footnotes.tsx:49
+msgid "metadata.link.created.with.visualize"
+msgstr "Created with visualize.admin.ch"
+
+#: app/components/chart-footnotes.tsx:24
+msgid "metadata.source"
+msgstr "Source"
+
+#: app/components/publish-actions.tsx:156
+msgid "publication.embed.AEM"
+msgstr "Embed Code for AEM \"External Application\":"
+
+#: app/components/publish-actions.tsx:151
+msgid "publication.embed.iframe"
+msgstr "Embed Code:"
+
+#: app/components/publish-actions.tsx:96
+msgid "publication.popup.share"
+msgstr "Share"
+
+#: app/components/publish-actions.tsx:121
+msgid "publication.share.chart.url"
+msgstr "Chart URL:"
+
+#: app/components/publish-actions.tsx:99
+msgid "publication.share.linktitle.facebook"
+msgstr "Share on Facebook"
+
+#: app/components/publish-actions.tsx:107
+msgid "publication.share.linktitle.mail"
+msgstr "Share via Email"
+
+#: app/components/publish-actions.tsx:103
+msgid "publication.share.linktitle.twitter"
+msgstr "Share on Twitter"
+
+#: app/components/publish-actions.tsx:113
+msgid "publication.share.mail.body"
+msgstr "Here is a visualization I created using visualize.admin.ch"
+
+#: app/components/publish-actions.tsx:110
+msgid "publication.share.mail.subject"
+msgstr "visualize.admin.ch"
+
+#: app/configurator/components/stepper.tsx:115
+msgid "step.annotate"
+msgstr "Annotate"
+
+#: app/configurator/components/stepper.tsx:109
+msgid "step.dataset"
+msgstr "Dataset"
+
+#: app/configurator/components/stepper.tsx:111
+msgid "step.visualization.type"
+msgstr "Chart Type"
+
+#: app/configurator/components/stepper.tsx:113
+msgid "step.visualize"
+msgstr "Visualize"
+
+#: app/configurator/components/chart-controls/drag-and-drop-tab.tsx:27
+msgid "table.column.no"
+msgstr "Column {0}"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -6,14 +6,45 @@ msgstr ""
 "X-Generator: POEditor.com\n"
 "Project-Id-Version: visualize.admin.ch\n"
 "Language: fr\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: app/components/chart-preview.tsx:63
+msgid "annotation.add.description"
+msgstr "[ Pas de description ]"
+
+#: app/components/chart-preview.tsx:55
+msgid "annotation.add.title"
+msgstr "[ Pas de titre ]"
+
+#: app/pages/v/[chartId].tsx:83
+msgid "button.copy.visualization"
+msgstr "Copier cette visualisation"
 
 #: app/components/data-download.tsx:73
 msgid "button.download.data"
 msgstr "Télécharger les données"
 
+#: app/components/data-download.tsx:46
+msgid "button.download.runsparqlquery"
+msgstr "Lancer la requête SPARQL"
+
 #: app/components/publish-actions.tsx:146
 msgid "button.embed"
 msgstr "Intégrer"
+
+#: app/components/publish-actions.tsx:168
+#: app/components/publish-actions.tsx:171
+msgid "button.hint.click.to.copy"
+msgstr "Cliquer pour copier"
+
+#: app/components/publish-actions.tsx:194
+msgid "button.hint.copied"
+msgstr "Copié!"
 
 #: app/pages/v/[chartId].tsx:78
 msgid "button.new.visualization"
@@ -35,606 +66,9 @@ msgstr "Publier"
 msgid "button.share"
 msgstr "Partager"
 
-#: app/configurator/components/ui-helpers.tsx:222
-msgid "controls.axis.horizontal"
-msgstr "Axe horizontal"
-
-#: app/configurator/components/ui-helpers.tsx:308
-msgid "controls.chart.type.area"
-msgstr "Surfaces"
-
-#: app/configurator/components/ui-helpers.tsx:304
-msgid "controls.chart.type.bar"
-msgstr "Barres"
-
-#: app/configurator/components/ui-helpers.tsx:302
-msgid "controls.chart.type.column"
-msgstr "Colonnes"
-
-#: app/configurator/components/ui-helpers.tsx:306
-msgid "controls.chart.type.line"
-msgstr "Lignes"
-
-#: app/configurator/components/ui-helpers.tsx:310
-msgid "controls.chart.type.scatterplot"
-msgstr "Nuage de points"
-
-#: app/configurator/components/chart-controls/color-palette.tsx:40
-msgid "controls.color.palette"
-msgstr "Couleurs"
-
-#: app/configurator/components/ui-helpers.tsx:249
-msgid "controls.column.grouped"
-msgstr "groupées"
-
-#: app/configurator/components/ui-helpers.tsx:247
-msgid "controls.column.stacked"
-msgstr "empilées"
-
-#: app/configurator/components/ui-helpers.tsx:244
-msgid "controls.description"
-msgstr "Description"
-
-#: app/configurator/components/filters.tsx:50
-msgid "controls.filter.select.all"
-msgstr "Tout sélectionner"
-
-#: app/configurator/components/ui-helpers.tsx:225
-msgid "controls.measure"
-msgstr "Variable mesurée"
-
-#: app/configurator/components/chart-annotator.tsx:12
-msgid "controls.section.description"
-msgstr "Titre & description"
-
-#: app/configurator/components/chart-options-selector.tsx:87
-#: app/configurator/components/chart-options-selector.tsx:91
-#: app/configurator/table/table-chart-options.tsx:182
-#: app/configurator/table/table-chart-options.tsx:186
-msgid "controls.section.filter"
-msgstr "Filtre"
-
-#: app/configurator/components/chart-type-selector.tsx:87
-#: app/configurator/components/chart-type-selector.tsx:90
-msgid "controls.select.chart.type"
-msgstr "Type de graphique"
-
-#: app/configurator/components/ui-helpers.tsx:331
-#: app/configurator/components/ui-helpers.tsx:333
-msgid "controls.select.dimension"
-msgstr "Sélectionner une dimension"
-
-#: app/configurator/components/ui-helpers.tsx:332
-msgid "controls.select.measure"
-msgstr "Sélectionner une variable"
-
-#: app/configurator/components/ui-helpers.tsx:242
-msgid "controls.title"
-msgstr "Titre"
-
-#: app/configurator/components/dataset-preview.tsx:55
-msgid "datatable.showing.first.rows"
-msgstr "Seules les 10 premières lignes sont affichées"
-
-#: app/pages/v/[chartId].tsx:69
-msgid "hint.create.your.own.chart"
-msgstr "Créez votre propre visualisation à partie de celle-ci en la copiant, ou bien créez une nouvelle visualization avec les données ouvertes de l'administration publique suisse."
-
-#: app/pages/v/[chartId].tsx:65
-msgid "hint.how.to.share"
-msgstr "Vous pouvez partager cette visualisation en copiant l'URL ou en l'intégrant sur votre site Web. Vous pouvez également créer une toute nouvelle visualisation, ou bien copier et modifier la visualisation ci-dessus."
-
-#: app/components/hint.tsx:54
-msgid "hint.loading.data"
-msgstr "Chargement des données..."
-
-#: app/configurator/components/chart-type-selector.tsx:94
-msgid "hint.no.visualization.with.dataset"
-msgstr "Aucune visualisation ne peut être créée avec le jeu de données sélectionné."
-
-#: app/components/hint.tsx:167
-msgid "hint.publication.success"
-msgstr "Votre visualisation est à présent publiée. Partagez-là en copiant l'URL ou en utilisant les options d'intégration."
-
-#: app/components/hint.tsx:80
-msgid "hint.select.dataset"
-msgstr "Sélectionner un jeu de données"
-
-#: app/components/hint.tsx:83
-msgid "hint.select.dataset.to.preview"
-msgstr "Sélectionner un jeu de données pour prévisualiser sa structure et son contenu."
-
-#: app/components/header.tsx:71
-#: app/components/header.tsx:82
-msgid "logo.swiss.confederation"
-msgstr "Logo de la Confédération Suisse"
-
-#: app/components/chart-footnotes.tsx:20
-msgid "metadata.dataset"
-msgstr "Jeu de données"
-
-#: app/components/chart-footnotes.tsx:24
-msgid "metadata.source"
-msgstr "Source"
-
-#: app/components/publish-actions.tsx:156
-msgid "publication.embed.AEM"
-msgstr "Code pour intégrer sur AEM comme \"External Application\":"
-
-#: app/components/publish-actions.tsx:151
-msgid "publication.embed.iframe"
-msgstr "Code pour intégrer:"
-
-#: app/components/publish-actions.tsx:96
-msgid "publication.popup.share"
-msgstr "Partager"
-
-#: app/components/publish-actions.tsx:121
-msgid "publication.share.chart.url"
-msgstr "URL du graphique:"
-
-#: app/components/publish-actions.tsx:113
-msgid "publication.share.mail.body"
-msgstr "Voici une visualisation que j'ai créée sur visualize.admin.ch"
-
-#: app/components/publish-actions.tsx:110
-msgid "publication.share.mail.subject"
-msgstr "visualize.admin.ch"
-
-#: app/configurator/components/stepper.tsx:115
-msgid "step.annotate"
-msgstr "Annoter"
-
-#: app/configurator/components/stepper.tsx:109
-msgid "step.dataset"
-msgstr "Données"
-
-#: app/configurator/components/stepper.tsx:111
-msgid "step.visualization.type"
-msgstr "Type de graphique"
-
-#: app/components/footer.tsx:35
-msgid "footer.institution.name"
-msgstr "Office fédéral de l'environnement OFEV"
-
-#: app/components/chart-preview.tsx:63
-msgid "annotation.add.description"
-msgstr "[ Pas de description ]"
-
-#: app/components/chart-preview.tsx:55
-msgid "annotation.add.title"
-msgstr "[ Pas de titre ]"
-
-#: app/pages/v/[chartId].tsx:83
-msgid "button.copy.visualization"
-msgstr "Copier cette visualisation"
-
-#: app/configurator/components/ui-helpers.tsx:312
-msgid "controls.chart.type.pie"
-msgstr "Secteurs"
-
-#: app/configurator/components/filters.tsx:54
-msgid "controls.filter.select.none"
-msgstr "Tout déselectionner"
-
-#: app/configurator/components/empty-right-panel.tsx:9
-msgid "controls.hint.configuring.chart"
-msgstr "Sélectionnez un élément de design ou une dimension du jeu de données pour modifier leurs options."
-
-#: app/configurator/components/empty-right-panel.tsx:14
-msgid "controls.hint.describing.chart"
-msgstr "Sélectionnez une des annotations proposées pour la modifier."
-
-#: app/configurator/components/ui-helpers.tsx:319
-msgid "controls.language.english"
-msgstr "Anglais"
-
-#: app/configurator/components/ui-helpers.tsx:323
-msgid "controls.language.french"
-msgstr "Français"
-
-#: app/configurator/components/ui-helpers.tsx:321
-msgid "controls.language.german"
-msgstr "Allemand"
-
-#: app/configurator/components/ui-helpers.tsx:325
-msgid "controls.language.italian"
-msgstr "Italien"
-
-#: app/configurator/components/dataset-metadata.tsx:40
-msgid "dataset.metadata.date.created"
-msgstr "Date de création"
-
-#: app/configurator/components/dataset-metadata.tsx:30
-msgid "dataset.metadata.source"
-msgstr "Source"
-
-#: app/configurator/components/dataset-metadata.tsx:17
-msgid "dataset.metadata.title"
-msgstr "Titre"
-
-#: app/configurator/components/dataset-selector.tsx:34
-msgid "dataset.order.newest"
-msgstr "Le plus récent"
-
-#: app/configurator/components/dataset-selector.tsx:26
-msgid "dataset.order.relevance"
-msgstr "Le plus pertinent"
-
-#: app/configurator/components/dataset-selector.tsx:30
-msgid "dataset.order.title"
-msgstr "Titre"
-
-#: app/configurator/components/dataset-selector.tsx:79
-msgid "dataset.results"
-msgstr "{0, plural, =0 {Aucun résultat} =1 {# résultat} other {# résultats}}"
-
-#: app/configurator/components/dataset-selector.tsx:89
-msgid "dataset.sortby"
-msgstr "Trier par"
-
-#: app/components/hint.tsx:105
-msgid "hint.nodata.message"
-msgstr "Il n'y a pas de données correspondant aux filtres sélectionnés."
-
-#: app/components/hint.tsx:102
-msgid "hint.nodata.title"
-msgstr "Aucune donnée"
-
-#: app/components/publish-actions.tsx:99
-msgid "publication.share.linktitle.facebook"
-msgstr "Partager sur Facebook"
-
-#: app/components/publish-actions.tsx:107
-msgid "publication.share.linktitle.mail"
-msgstr "Partager par courriel"
-
-#: app/components/publish-actions.tsx:103
-msgid "publication.share.linktitle.twitter"
-msgstr "Partager sur Twitter"
-
-#: app/components/publish-actions.tsx:168
-#: app/components/publish-actions.tsx:171
-msgid "button.hint.click.to.copy"
-msgstr "Cliquer pour copier"
-
-#: app/components/publish-actions.tsx:194
-msgid "button.hint.copied"
-msgstr "Copié!"
-
-#: app/components/chart-footnotes.tsx:49
-msgid "metadata.link.created.with.visualize"
-msgstr "Créé avec visualize.admin.ch"
-
-#: app/components/form.tsx:145
-msgid "controls.search.clear"
-msgstr "Effacer la recherche"
-
-#: app/configurator/components/dataset-selector.tsx:37
-msgid "dataset.search.label"
-msgstr "Chercher un jeu de données"
-
-#: app/components/hint.tsx:147
-msgid "hint.only.negative.data.message"
-msgstr "Ce type de graphique ne permet pas de représenter des données négatives."
-
-#: app/components/hint.tsx:144
-msgid "hint.only.negative.data.title"
-msgstr "Valeurs négatives"
-
-#: app/configurator/components/chart-controls/color-palette.tsx:135
-#: app/configurator/components/chart-controls/color-palette.tsx:140
-msgid "controls.color.palette.reset"
-msgstr "Réinitialiser la palette de couleurs"
-
-#: app/configurator/components/field.tsx:144
-msgid "controls.dimension.none"
-msgstr "Aucune"
-
-#: app/configurator/components/chart-options-selector.tsx:142
-msgid "controls.section.sorting"
-msgstr "Trier"
-
-#: app/configurator/components/chart-options-selector.tsx:116
-#: app/configurator/components/chart-options-selector.tsx:122
-msgid "controls.sorting.byDimensionLabel"
-msgstr "Nom"
-
-#: app/configurator/components/ui-helpers.tsx:260
-msgid "controls.sorting.byDimensionLabel.ascending"
-msgstr "A → Z"
-
-#: app/configurator/components/ui-helpers.tsx:269
-msgid "controls.sorting.byDimensionLabel.descending"
-msgstr "Z → A"
-
-#: app/configurator/components/chart-options-selector.tsx:118
-msgid "controls.sorting.byMeasure"
-msgstr "Mesure"
-
-#: app/configurator/components/ui-helpers.tsx:293
-msgid "controls.sorting.byMeasure.ascending"
-msgstr "1 → 9"
-
-#: app/configurator/components/ui-helpers.tsx:299
-msgid "controls.sorting.byMeasure.descending"
-msgstr "9 → 1"
-
-#: app/configurator/components/chart-options-selector.tsx:120
-msgid "controls.sorting.byTotalSize"
-msgstr "Taille totale"
-
-#: app/configurator/components/ui-helpers.tsx:273
-msgid "controls.sorting.byTotalSize.ascending"
-msgstr "Croissant"
-
-#: app/configurator/components/ui-helpers.tsx:285
-msgid "controls.sorting.byTotalSize.largestBottom"
-msgstr "Décroissant de bas en haut"
-
-#: app/configurator/components/ui-helpers.tsx:277
-msgid "controls.sorting.byTotalSize.largestFirst"
-msgstr "Décroissant"
-
-#: app/configurator/components/ui-helpers.tsx:282
-msgid "controls.sorting.byTotalSize.largestTop"
-msgstr "Décroissant de haut en bas"
-
-#: app/configurator/components/chart-controls/color-picker.tsx:100
-msgid "controls.colorpicker.open"
-msgstr "Ouvrir la pipette à couleur"
-
-#: app/configurator/components/ui-helpers.tsx:251
-#: app/configurator/table/table-chart-sorting-options.tsx:173
-msgid "controls.sorting.sortBy"
-msgstr "Trier par"
-
-#: app/configurator/components/ui-helpers.tsx:232
-msgid "controls.axis.vertical"
-msgstr "Axe vertical"
-
-#: app/charts/table/table.tsx:136
-msgid "chart.published.toggle.mobile.view"
-msgstr "Vue compacte"
-
-#: app/charts/table/table.tsx:177
-msgid "chart.table.number.of.lines"
-msgstr "Nombre total de lignes:"
-
-#: app/configurator/table/table-chart-options.tsx:109
-msgid "columnStyle.bar"
-msgstr "Barres"
-
-#: app/configurator/table/table-chart-options.tsx:95
-msgid "columnStyle.categories"
-msgstr "Catégories"
-
-#: app/configurator/table/table-chart-options.tsx:105
-msgid "columnStyle.heatmap"
-msgstr "Heatmap"
-
-#: app/configurator/table/table-chart-options.tsx:91
-#: app/configurator/table/table-chart-options.tsx:101
-msgid "columnStyle.text"
-msgstr "Texte"
-
-#: app/configurator/table/table-chart-options.tsx:206
-msgid "columnStyle.textStyle.bold"
-msgstr "Gras"
-
-#: app/configurator/table/table-chart-options.tsx:199
-msgid "columnStyle.textStyle.regular"
-msgstr "Normal"
-
-#: app/configurator/interactive-filters/editor-time-brush.tsx:113
-msgid "controls..interactiveFilters.time.defaultSettings"
-msgstr "Paramètres d'origine"
-
-#: app/configurator/components/ui-helpers.tsx:314
-msgid "controls.chart.type.table"
-msgstr "Tableau"
-
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:43
-msgid "controls.interactive.filters.dataFilter"
-msgstr "Filtres de données"
-
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:136
-msgid "controls.interactiveFilters.dataFilters.toggledataFilters"
-msgstr "Afficher les filtres de données"
-
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:34
-msgid "controls.interactiveFilters.legend.toggleInteractiveLegend"
-msgstr "Afficher la légende filtrante"
-
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:106
-msgid "controls.interactiveFilters.time.noTimeDimension"
-msgstr "Il n'y a pas de dimension temporelle!"
-
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:95
-msgid "controls.interactiveFilters.time.toggleTimeFilter"
-msgstr "Afficher le filtre temporel"
-
-#: app/configurator/components/chart-controls/control-tab.tsx:101
-msgid "controls.option.isActive"
-msgstr "Actif"
-
-#: app/configurator/components/chart-controls/control-tab.tsx:99
-msgid "controls.option.isNotActive"
-msgstr "Inactif"
-
-#: app/configurator/table/table-chart-configurator.tsx:63
-msgid "controls.section.columns"
-msgstr "Colonnes"
-
-#: app/configurator/table/table-chart-options.tsx:130
-msgid "controls.section.columnstyle"
-msgstr "Style de la colonne"
-
-#: app/configurator/table/table-chart-configurator.tsx:61
-msgid "controls.section.groups"
-msgstr "Groupes"
-
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:31
-msgid "controls.section.interactive.filters"
-msgstr "Filtres interactifs"
-
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:53
-msgid "controls.section.interactiveFilters.dataFilters"
-msgstr "Filtres de données"
-
-#: app/configurator/table/table-chart-options.tsx:239
-msgid "controls.section.tableSettings"
-msgstr "Paramètres du tableau"
-
-#: app/configurator/table/table-chart-sorting-options.tsx:202
-msgid "controls.section.tableSorting"
-msgstr "Tri du tableau"
-
-#: app/configurator/table/table-chart-configurator.tsx:53
-msgid "controls.section.tableoptions"
-msgstr "Options du tableau"
-
-#: app/configurator/table/table-chart-options.tsx:133
-msgid "controls.select.columnStyle"
-msgstr "Style de la colonne"
-
-#: app/configurator/table/table-chart-options.tsx:227
-msgid "controls.select.columnStyle.barColorBackground"
-msgstr "Couleur de fond"
-
-#: app/configurator/table/table-chart-options.tsx:224
-msgid "controls.select.columnStyle.barColorNegative"
-msgstr "Couleur des valeurs négatives"
-
-#: app/configurator/table/table-chart-options.tsx:221
-msgid "controls.select.columnStyle.barColorPositive"
-msgstr "Couleur des valeurs positives"
-
-#: app/configurator/table/table-chart-options.tsx:230
-msgid "controls.select.columnStyle.barShowBackground"
-msgstr "Afficher la couleur de fond"
-
-#: app/configurator/table/table-chart-options.tsx:213
-msgid "controls.select.columnStyle.columnColor"
-msgstr "Couleur de la colonne"
-
-#: app/configurator/table/table-chart-options.tsx:210
-msgid "controls.select.columnStyle.textColor"
-msgstr "Couleur du texte"
-
-#: app/configurator/table/table-chart-options.tsx:196
-msgid "controls.select.columnStyle.textStyle"
-msgstr "Style du texte"
-
-#: app/configurator/table/table-chart-sorting-options.tsx:131
-msgid "controls.sorting.addDimension"
-msgstr "Ajouter une dimension"
-
-#: app/configurator/table/table-chart-sorting-options.tsx:70
-msgid "controls.sorting.removeOption"
-msgstr "Supprimer la dimension de tri"
-
-#: app/configurator/table/table-chart-sorting-options.tsx:109
-msgid "controls.sorting.selectDimension"
-msgstr "Sélectionner une dimension…"
-
-#: app/configurator/table/table-chart-options.tsx:119
-msgid "controls.table.column.group"
-msgstr "Grouper selon cette colonne"
-
-#: app/configurator/table/table-chart-options.tsx:125
-msgid "controls.table.column.hide"
-msgstr "Masquer la colonne"
-
-#: app/configurator/table/table-chart-options.tsx:120
-msgid "controls.table.column.hidefilter"
-msgstr "Masquer et filtrer cette colonne"
-
-#: app/configurator/table/table-chart-configurator.tsx:56
-msgid "controls.table.settings"
-msgstr "Paramètres"
-
-#: app/configurator/table/table-chart-configurator.tsx:57
-msgid "controls.table.sorting"
-msgstr "Tri"
-
-#: app/configurator/table/table-chart-options.tsx:242
-msgid "controls.tableSettings.showSearch"
-msgstr "Afficher le champ de recherche"
-
-#: app/charts/shared/chart-data-filters.tsx:31
-msgid "interactive.data.filters.hide"
-msgstr "Masquer les filtres"
-
-#: app/charts/shared/chart-data-filters.tsx:31
-msgid "interactive.data.filters.show"
-msgstr "Afficher les filtres"
-
-#: app/configurator/components/chart-controls/drag-and-drop-tab.tsx:27
-msgid "table.column.no"
-msgstr "Colonne {0}"
-
 #: app/charts/map/chart-map-prototype.tsx:146
 msgid "chart.map.control.data.filters"
 msgstr "Filtres de données"
-
-#: app/charts/map/chart-map-prototype.tsx:162
-msgid "chart.map.warning.prototype"
-msgstr "Il s'agit d'un prototype, il n'est pas encore possible de publier des cartes."
-
-#: app/configurator/components/ui-helpers.tsx:316
-msgid "controls.chart.type.map"
-msgstr "Carte"
-
-#: app/configurator/components/chart-type-selector.tsx:106
-msgid "controls.select.chart.type.experimental"
-msgstr "Fonctionnalités expérimentales"
-
-#: app/configurator/components/chart-type-selector.tsx:111
-msgid "controls.select.chart.type.experimental.description"
-msgstr "Voir le prototype de la carte avec un nombre limité de jeu de données (lien vers une nouvelle page)."
-
-#: app/configurator/components/dataset-selector.tsx:70
-msgid "dataset.includeDrafts"
-msgstr "Inclure les jeux de données à l'état d'ébauche"
-
-#: app/components/chart-preview.tsx:39
-#: app/components/chart-published.tsx:37
-#: app/configurator/components/dataset-preview.tsx:25
-msgid "dataset.publicationStatus.draft.warning"
-msgstr "Attention, ce jeu de données est à l'état d'ébauche.<0/><1>Ne l'utilisez pas pour une publication!</1>"
-
-#: app/configurator/components/dataset-selector.tsx:163
-msgid "dataset.tag.draft"
-msgstr "Ébauche"
-
-#: app/components/hint.tsx:126
-msgid "hint.dataloadingerror.message"
-msgstr "Les données n'ont pas pu être téléchargées."
-
-#: app/components/hint.tsx:123
-msgid "hint.dataloadingerror.title"
-msgstr "Problème de téléchargement des données"
-
-#: app/configurator/components/ui-helpers.tsx:240
-msgid "controls.color"
-msgstr "Couleur"
-
-#: app/configurator/components/chart-controls/control-tab.tsx:12
-msgid "controls.color.add"
-msgstr "Ajouter…"
-
-#: app/configurator/components/chart-configurator.tsx:22
-msgid "controls.section.chart.options"
-msgstr "Paramètres graphiques"
-
-#: app/configurator/components/chart-configurator.tsx:31
-msgid "controls.section.data.filters"
-msgstr "Filtres"
-
-#: app/configurator/components/stepper.tsx:113
-msgid "step.visualize"
-msgstr "Visualiser"
 
 #: app/charts/map/chart-map-prototype.tsx:136
 msgid "chart.map.control.layers"
@@ -651,6 +85,14 @@ msgstr "Ajouter des données"
 #: app/charts/map/prototype-right-controls.tsx:37
 msgid "chart.map.layers.area.color.palette"
 msgstr "Palette de couleurs"
+
+#: app/charts/map/prototype-right-controls.tsx:51
+msgid "chart.map.layers.area.discretization.continuous"
+msgstr "Continue"
+
+#: app/charts/map/prototype-right-controls.tsx:59
+msgid "chart.map.layers.area.discretization.discrete"
+msgstr "Discrète"
 
 #: app/charts/map/prototype-right-controls.tsx:68
 msgid "chart.map.layers.area.discretization.jenks"
@@ -704,31 +146,603 @@ msgstr "Ajouter des cercles proportionnels"
 msgid "chart.map.layers.symbol.select.measure"
 msgstr "Sélectionner une variable"
 
-#: app/configurator/components/chart-options-selector.tsx:102
-msgid "controls.select.column.layout"
-msgstr "Mise en forme de la colonne"
+#: app/charts/map/chart-map-prototype.tsx:162
+msgid "chart.map.warning.prototype"
+msgstr "Il s'agit d'un prototype, il n'est pas encore possible de publier des cartes."
 
-#: app/charts/map/prototype-right-controls.tsx:51
-msgid "chart.map.layers.area.discretization.continuous"
-msgstr "Continue"
+#: app/charts/table/table.tsx:136
+msgid "chart.published.toggle.mobile.view"
+msgstr "Vue compacte"
 
-#: app/charts/map/prototype-right-controls.tsx:59
-msgid "chart.map.layers.area.discretization.discrete"
-msgstr "Discrète"
+#: app/charts/table/table.tsx:177
+msgid "chart.table.number.of.lines"
+msgstr "Nombre total de lignes:"
 
-#: app/components/data-download.tsx:46
-msgid "button.download.runsparqlquery"
-msgstr "Lancer la requête SPARQL"
+#: app/configurator/table/table-chart-options.tsx:109
+msgid "columnStyle.bar"
+msgstr "Barres"
+
+#: app/configurator/table/table-chart-options.tsx:95
+msgid "columnStyle.categories"
+msgstr "Catégories"
+
+#: app/configurator/table/table-chart-options.tsx:105
+msgid "columnStyle.heatmap"
+msgstr "Heatmap"
+
+#: app/configurator/table/table-chart-options.tsx:91
+#: app/configurator/table/table-chart-options.tsx:101
+msgid "columnStyle.text"
+msgstr "Texte"
+
+#: app/configurator/table/table-chart-options.tsx:206
+msgid "columnStyle.textStyle.bold"
+msgstr "Gras"
+
+#: app/configurator/table/table-chart-options.tsx:199
+msgid "columnStyle.textStyle.regular"
+msgstr "Normal"
+
+#: app/configurator/interactive-filters/editor-time-brush.tsx:113
+msgid "controls..interactiveFilters.time.defaultSettings"
+msgstr "Paramètres d'origine"
+
+#: app/configurator/components/ui-helpers.tsx:222
+msgid "controls.axis.horizontal"
+msgstr "Axe horizontal"
+
+#: app/configurator/components/ui-helpers.tsx:232
+msgid "controls.axis.vertical"
+msgstr "Axe vertical"
+
+#: app/configurator/components/ui-helpers.tsx:308
+msgid "controls.chart.type.area"
+msgstr "Surfaces"
+
+#: app/configurator/components/ui-helpers.tsx:304
+msgid "controls.chart.type.bar"
+msgstr "Barres"
+
+#: app/configurator/components/ui-helpers.tsx:302
+msgid "controls.chart.type.column"
+msgstr "Colonnes"
+
+#: app/configurator/components/ui-helpers.tsx:306
+msgid "controls.chart.type.line"
+msgstr "Lignes"
+
+#: app/configurator/components/ui-helpers.tsx:316
+msgid "controls.chart.type.map"
+msgstr "Carte"
+
+#: app/configurator/components/ui-helpers.tsx:312
+msgid "controls.chart.type.pie"
+msgstr "Secteurs"
+
+#: app/configurator/components/ui-helpers.tsx:310
+msgid "controls.chart.type.scatterplot"
+msgstr "Nuage de points"
+
+#: app/configurator/components/ui-helpers.tsx:314
+msgid "controls.chart.type.table"
+msgstr "Tableau"
+
+#: app/configurator/components/ui-helpers.tsx:240
+msgid "controls.color"
+msgstr "Couleur"
+
+#: app/configurator/components/chart-controls/control-tab.tsx:12
+msgid "controls.color.add"
+msgstr "Ajouter…"
+
+#: app/configurator/components/chart-controls/color-palette.tsx:40
+msgid "controls.color.palette"
+msgstr "Couleurs"
+
+#: app/configurator/components/chart-controls/color-palette.tsx:135
+#: app/configurator/components/chart-controls/color-palette.tsx:140
+msgid "controls.color.palette.reset"
+msgstr "Réinitialiser la palette de couleurs"
+
+#: app/configurator/components/chart-controls/color-picker.tsx:100
+msgid "controls.colorpicker.open"
+msgstr "Ouvrir la pipette à couleur"
+
+#: app/configurator/components/ui-helpers.tsx:249
+msgid "controls.column.grouped"
+msgstr "groupées"
+
+#: app/configurator/components/ui-helpers.tsx:247
+msgid "controls.column.stacked"
+msgstr "empilées"
+
+#: app/configurator/components/ui-helpers.tsx:244
+msgid "controls.description"
+msgstr "Description"
+
+#: app/configurator/components/field.tsx:165
+msgid "controls.dimension.none"
+msgstr "Aucune"
+
+#: app/configurator/components/field.tsx:31
+msgid "controls.dimensionvalue.none"
+msgstr "Aucune filtre"
+
+#: app/configurator/components/filters.tsx:50
+msgid "controls.filter.select.all"
+msgstr "Tout sélectionner"
+
+#: app/configurator/components/filters.tsx:54
+msgid "controls.filter.select.none"
+msgstr "Tout déselectionner"
 
 #: app/configurator/interactive-filters/editor-time-interval-brush.tsx:89
 msgid "controls.filters.time.range"
 msgstr "Intervalle de temps"
 
+#: app/configurator/components/empty-right-panel.tsx:9
+msgid "controls.hint.configuring.chart"
+msgstr "Sélectionnez un élément de design ou une dimension du jeu de données pour modifier leurs options."
+
+#: app/configurator/components/empty-right-panel.tsx:14
+msgid "controls.hint.describing.chart"
+msgstr "Sélectionnez une des annotations proposées pour la modifier."
+
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:43
+msgid "controls.interactive.filters.dataFilter"
+msgstr "Filtres de données"
+
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:136
+msgid "controls.interactiveFilters.dataFilters.toggledataFilters"
+msgstr "Afficher les filtres de données"
+
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:34
+msgid "controls.interactiveFilters.legend.toggleInteractiveLegend"
+msgstr "Afficher la légende filtrante"
+
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:106
+msgid "controls.interactiveFilters.time.noTimeDimension"
+msgstr "Il n'y a pas de dimension temporelle!"
+
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:95
+msgid "controls.interactiveFilters.time.toggleTimeFilter"
+msgstr "Afficher le filtre temporel"
+
+#: app/configurator/components/ui-helpers.tsx:319
+msgid "controls.language.english"
+msgstr "Anglais"
+
+#: app/configurator/components/ui-helpers.tsx:323
+msgid "controls.language.french"
+msgstr "Français"
+
+#: app/configurator/components/ui-helpers.tsx:321
+msgid "controls.language.german"
+msgstr "Allemand"
+
+#: app/configurator/components/ui-helpers.tsx:325
+msgid "controls.language.italian"
+msgstr "Italien"
+
+#: app/configurator/components/ui-helpers.tsx:225
+msgid "controls.measure"
+msgstr "Variable mesurée"
+
+#: app/configurator/components/chart-controls/control-tab.tsx:101
+msgid "controls.option.isActive"
+msgstr "Actif"
+
+#: app/configurator/components/chart-controls/control-tab.tsx:99
+msgid "controls.option.isNotActive"
+msgstr "Inactif"
+
+#: app/components/form.tsx:153
+msgid "controls.search.clear"
+msgstr "Effacer la recherche"
+
+#: app/configurator/components/chart-configurator.tsx:23
+msgid "controls.section.chart.options"
+msgstr "Paramètres graphiques"
+
+#: app/configurator/table/table-chart-configurator.tsx:63
+msgid "controls.section.columns"
+msgstr "Colonnes"
+
+#: app/configurator/table/table-chart-options.tsx:130
+msgid "controls.section.columnstyle"
+msgstr "Style de la colonne"
+
+#: app/configurator/components/chart-configurator.tsx:32
+msgid "controls.section.data.filters"
+msgstr "Filtres"
+
+#: app/configurator/components/chart-annotator.tsx:12
+msgid "controls.section.description"
+msgstr "Titre & description"
+
+#: app/configurator/components/chart-options-selector.tsx:95
+#: app/configurator/components/chart-options-selector.tsx:99
+#: app/configurator/table/table-chart-options.tsx:182
+#: app/configurator/table/table-chart-options.tsx:186
+msgid "controls.section.filter"
+msgstr "Filtre"
+
+#: app/configurator/table/table-chart-configurator.tsx:61
+msgid "controls.section.groups"
+msgstr "Groupes"
+
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:31
+msgid "controls.section.interactive.filters"
+msgstr "Filtres interactifs"
+
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:53
+msgid "controls.section.interactiveFilters.dataFilters"
+msgstr "Filtres de données"
+
+#: app/configurator/components/chart-options-selector.tsx:150
+msgid "controls.section.sorting"
+msgstr "Trier"
+
+#: app/configurator/table/table-chart-options.tsx:239
+msgid "controls.section.tableSettings"
+msgstr "Paramètres du tableau"
+
+#: app/configurator/table/table-chart-sorting-options.tsx:202
+msgid "controls.section.tableSorting"
+msgstr "Tri du tableau"
+
+#: app/configurator/table/table-chart-configurator.tsx:53
+msgid "controls.section.tableoptions"
+msgstr "Options du tableau"
+
+#: app/configurator/components/chart-type-selector.tsx:87
+#: app/configurator/components/chart-type-selector.tsx:90
+msgid "controls.select.chart.type"
+msgstr "Type de graphique"
+
+#: app/configurator/components/chart-type-selector.tsx:106
+msgid "controls.select.chart.type.experimental"
+msgstr "Fonctionnalités expérimentales"
+
+#: app/configurator/components/chart-type-selector.tsx:111
+msgid "controls.select.chart.type.experimental.description"
+msgstr "Voir le prototype de la carte avec un nombre limité de jeu de données (lien vers une nouvelle page)."
+
+#: app/configurator/components/chart-options-selector.tsx:110
+msgid "controls.select.column.layout"
+msgstr "Mise en forme de la colonne"
+
+#: app/configurator/table/table-chart-options.tsx:133
+msgid "controls.select.columnStyle"
+msgstr "Style de la colonne"
+
+#: app/configurator/table/table-chart-options.tsx:227
+msgid "controls.select.columnStyle.barColorBackground"
+msgstr "Couleur de fond"
+
+#: app/configurator/table/table-chart-options.tsx:224
+msgid "controls.select.columnStyle.barColorNegative"
+msgstr "Couleur des valeurs négatives"
+
+#: app/configurator/table/table-chart-options.tsx:221
+msgid "controls.select.columnStyle.barColorPositive"
+msgstr "Couleur des valeurs positives"
+
+#: app/configurator/table/table-chart-options.tsx:230
+msgid "controls.select.columnStyle.barShowBackground"
+msgstr "Afficher la couleur de fond"
+
+#: app/configurator/table/table-chart-options.tsx:213
+msgid "controls.select.columnStyle.columnColor"
+msgstr "Couleur de la colonne"
+
+#: app/configurator/table/table-chart-options.tsx:210
+msgid "controls.select.columnStyle.textColor"
+msgstr "Couleur du texte"
+
+#: app/configurator/table/table-chart-options.tsx:196
+msgid "controls.select.columnStyle.textStyle"
+msgstr "Style du texte"
+
+#: app/configurator/components/chart-options-selector.tsx:57
+#: app/configurator/components/chart-options-selector.tsx:59
+msgid "controls.select.dimension"
+msgstr "Sélectionner une dimension"
+
+#: app/configurator/components/chart-options-selector.tsx:58
+msgid "controls.select.measure"
+msgstr "Sélectionner une variable"
+
+#: app/configurator/components/field.tsx:35
+#: app/configurator/components/field.tsx:169
+msgid "controls.select.optional"
+msgstr "optional"
+
+#: app/configurator/table/table-chart-sorting-options.tsx:131
+msgid "controls.sorting.addDimension"
+msgstr "Ajouter une dimension"
+
+#: app/configurator/components/chart-options-selector.tsx:124
+#: app/configurator/components/chart-options-selector.tsx:130
+msgid "controls.sorting.byDimensionLabel"
+msgstr "Nom"
+
+#: app/configurator/components/ui-helpers.tsx:260
+msgid "controls.sorting.byDimensionLabel.ascending"
+msgstr "A → Z"
+
+#: app/configurator/components/ui-helpers.tsx:269
+msgid "controls.sorting.byDimensionLabel.descending"
+msgstr "Z → A"
+
+#: app/configurator/components/chart-options-selector.tsx:126
+msgid "controls.sorting.byMeasure"
+msgstr "Mesure"
+
+#: app/configurator/components/ui-helpers.tsx:293
+msgid "controls.sorting.byMeasure.ascending"
+msgstr "1 → 9"
+
+#: app/configurator/components/ui-helpers.tsx:299
+msgid "controls.sorting.byMeasure.descending"
+msgstr "9 → 1"
+
+#: app/configurator/components/chart-options-selector.tsx:128
+msgid "controls.sorting.byTotalSize"
+msgstr "Taille totale"
+
+#: app/configurator/components/ui-helpers.tsx:273
+msgid "controls.sorting.byTotalSize.ascending"
+msgstr "Croissant"
+
+#: app/configurator/components/ui-helpers.tsx:285
+msgid "controls.sorting.byTotalSize.largestBottom"
+msgstr "Décroissant de bas en haut"
+
+#: app/configurator/components/ui-helpers.tsx:277
+msgid "controls.sorting.byTotalSize.largestFirst"
+msgstr "Décroissant"
+
+#: app/configurator/components/ui-helpers.tsx:282
+msgid "controls.sorting.byTotalSize.largestTop"
+msgstr "Décroissant de haut en bas"
+
+#: app/configurator/table/table-chart-sorting-options.tsx:70
+msgid "controls.sorting.removeOption"
+msgstr "Supprimer la dimension de tri"
+
+#: app/configurator/table/table-chart-sorting-options.tsx:109
+msgid "controls.sorting.selectDimension"
+msgstr "Sélectionner une dimension…"
+
+#: app/configurator/components/ui-helpers.tsx:251
+#: app/configurator/table/table-chart-sorting-options.tsx:173
+msgid "controls.sorting.sortBy"
+msgstr "Trier par"
+
+#: app/configurator/table/table-chart-options.tsx:119
+msgid "controls.table.column.group"
+msgstr "Grouper selon cette colonne"
+
+#: app/configurator/table/table-chart-options.tsx:125
+msgid "controls.table.column.hide"
+msgstr "Masquer la colonne"
+
+#: app/configurator/table/table-chart-options.tsx:120
+msgid "controls.table.column.hidefilter"
+msgstr "Masquer et filtrer cette colonne"
+
+#: app/configurator/table/table-chart-configurator.tsx:56
+msgid "controls.table.settings"
+msgstr "Paramètres"
+
+#: app/configurator/table/table-chart-configurator.tsx:57
+msgid "controls.table.sorting"
+msgstr "Tri"
+
+#: app/configurator/table/table-chart-options.tsx:242
+msgid "controls.tableSettings.showSearch"
+msgstr "Afficher le champ de recherche"
+
+#: app/configurator/components/ui-helpers.tsx:242
+msgid "controls.title"
+msgstr "Titre"
+
+#: app/configurator/components/dataset-selector.tsx:70
+msgid "dataset.includeDrafts"
+msgstr "Inclure les jeux de données à l'état d'ébauche"
+
+#: app/configurator/components/dataset-metadata.tsx:40
+msgid "dataset.metadata.date.created"
+msgstr "Date de création"
+
 #: app/configurator/components/dataset-metadata.tsx:22
 msgid "dataset.metadata.description"
 msgstr "Description"
+
+#: app/configurator/components/dataset-metadata.tsx:30
+msgid "dataset.metadata.source"
+msgstr "Source"
+
+#: app/configurator/components/dataset-metadata.tsx:17
+msgid "dataset.metadata.title"
+msgstr "Titre"
 
 #: app/configurator/components/dataset-metadata.tsx:48
 msgid "dataset.metadata.version"
 msgstr "Version"
 
+#: app/configurator/components/dataset-selector.tsx:34
+msgid "dataset.order.newest"
+msgstr "Le plus récent"
+
+#: app/configurator/components/dataset-selector.tsx:26
+msgid "dataset.order.relevance"
+msgstr "Le plus pertinent"
+
+#: app/configurator/components/dataset-selector.tsx:30
+msgid "dataset.order.title"
+msgstr "Titre"
+
+#: app/components/chart-preview.tsx:39
+#: app/components/chart-published.tsx:37
+#: app/configurator/components/dataset-preview.tsx:25
+msgid "dataset.publicationStatus.draft.warning"
+msgstr "Attention, ce jeu de données est à l'état d'ébauche.<0/><1>Ne l'utilisez pas pour une publication!</1>"
+
+#: app/configurator/components/dataset-selector.tsx:79
+msgid "dataset.results"
+msgstr "{0, plural, =0 {Aucun résultat} =1 {# résultat} other {# résultats}}"
+
+#: app/configurator/components/dataset-selector.tsx:37
+msgid "dataset.search.label"
+msgstr "Chercher un jeu de données"
+
+#: app/configurator/components/dataset-selector.tsx:89
+msgid "dataset.sortby"
+msgstr "Trier par"
+
+#: app/configurator/components/dataset-selector.tsx:163
+msgid "dataset.tag.draft"
+msgstr "Ébauche"
+
+#: app/configurator/components/dataset-preview.tsx:55
+msgid "datatable.showing.first.rows"
+msgstr "Seules les 10 premières lignes sont affichées"
+
+#: app/components/footer.tsx:35
+msgid "footer.institution.name"
+msgstr "Office fédéral de l'environnement OFEV"
+
+#: app/pages/v/[chartId].tsx:69
+msgid "hint.create.your.own.chart"
+msgstr "Créez votre propre visualisation à partie de celle-ci en la copiant, ou bien créez une nouvelle visualization avec les données ouvertes de l'administration publique suisse."
+
+#: app/components/hint.tsx:126
+msgid "hint.dataloadingerror.message"
+msgstr "Les données n'ont pas pu être téléchargées."
+
+#: app/components/hint.tsx:123
+msgid "hint.dataloadingerror.title"
+msgstr "Problème de téléchargement des données"
+
+#: app/pages/v/[chartId].tsx:65
+msgid "hint.how.to.share"
+msgstr "Vous pouvez partager cette visualisation en copiant l'URL ou en l'intégrant sur votre site Web. Vous pouvez également créer une toute nouvelle visualisation, ou bien copier et modifier la visualisation ci-dessus."
+
+#: app/components/hint.tsx:54
+msgid "hint.loading.data"
+msgstr "Chargement des données..."
+
+#: app/configurator/components/chart-type-selector.tsx:94
+msgid "hint.no.visualization.with.dataset"
+msgstr "Aucune visualisation ne peut être créée avec le jeu de données sélectionné."
+
+#: app/components/hint.tsx:105
+msgid "hint.nodata.message"
+msgstr "Il n'y a pas de données correspondant aux filtres sélectionnés."
+
+#: app/components/hint.tsx:102
+msgid "hint.nodata.title"
+msgstr "Aucune donnée"
+
+#: app/components/hint.tsx:147
+msgid "hint.only.negative.data.message"
+msgstr "Ce type de graphique ne permet pas de représenter des données négatives."
+
+#: app/components/hint.tsx:144
+msgid "hint.only.negative.data.title"
+msgstr "Valeurs négatives"
+
+#: app/components/hint.tsx:167
+msgid "hint.publication.success"
+msgstr "Votre visualisation est à présent publiée. Partagez-là en copiant l'URL ou en utilisant les options d'intégration."
+
+#: app/components/hint.tsx:80
+msgid "hint.select.dataset"
+msgstr "Sélectionner un jeu de données"
+
+#: app/components/hint.tsx:83
+msgid "hint.select.dataset.to.preview"
+msgstr "Sélectionner un jeu de données pour prévisualiser sa structure et son contenu."
+
+#: app/charts/shared/chart-data-filters.tsx:31
+msgid "interactive.data.filters.hide"
+msgstr "Masquer les filtres"
+
+#: app/charts/shared/chart-data-filters.tsx:31
+msgid "interactive.data.filters.show"
+msgstr "Afficher les filtres"
+
+#: app/components/header.tsx:71
+#: app/components/header.tsx:82
+msgid "logo.swiss.confederation"
+msgstr "Logo de la Confédération Suisse"
+
+#: app/components/chart-footnotes.tsx:20
+msgid "metadata.dataset"
+msgstr "Jeu de données"
+
+#: app/components/chart-footnotes.tsx:49
+msgid "metadata.link.created.with.visualize"
+msgstr "Créé avec visualize.admin.ch"
+
+#: app/components/chart-footnotes.tsx:24
+msgid "metadata.source"
+msgstr "Source"
+
+#: app/components/publish-actions.tsx:156
+msgid "publication.embed.AEM"
+msgstr "Code pour intégrer sur AEM comme \"External Application\":"
+
+#: app/components/publish-actions.tsx:151
+msgid "publication.embed.iframe"
+msgstr "Code pour intégrer:"
+
+#: app/components/publish-actions.tsx:96
+msgid "publication.popup.share"
+msgstr "Partager"
+
+#: app/components/publish-actions.tsx:121
+msgid "publication.share.chart.url"
+msgstr "URL du graphique:"
+
+#: app/components/publish-actions.tsx:99
+msgid "publication.share.linktitle.facebook"
+msgstr "Partager sur Facebook"
+
+#: app/components/publish-actions.tsx:107
+msgid "publication.share.linktitle.mail"
+msgstr "Partager par courriel"
+
+#: app/components/publish-actions.tsx:103
+msgid "publication.share.linktitle.twitter"
+msgstr "Partager sur Twitter"
+
+#: app/components/publish-actions.tsx:113
+msgid "publication.share.mail.body"
+msgstr "Voici une visualisation que j'ai créée sur visualize.admin.ch"
+
+#: app/components/publish-actions.tsx:110
+msgid "publication.share.mail.subject"
+msgstr "visualize.admin.ch"
+
+#: app/configurator/components/stepper.tsx:115
+msgid "step.annotate"
+msgstr "Annoter"
+
+#: app/configurator/components/stepper.tsx:109
+msgid "step.dataset"
+msgstr "Données"
+
+#: app/configurator/components/stepper.tsx:111
+msgid "step.visualization.type"
+msgstr "Type de graphique"
+
+#: app/configurator/components/stepper.tsx:113
+msgid "step.visualize"
+msgstr "Visualiser"
+
+#: app/configurator/components/chart-controls/drag-and-drop-tab.tsx:27
+msgid "table.column.no"
+msgstr "Colonne {0}"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -6,14 +6,45 @@ msgstr ""
 "X-Generator: POEditor.com\n"
 "Project-Id-Version: visualize.admin.ch\n"
 "Language: it\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: app/components/chart-preview.tsx:63
+msgid "annotation.add.description"
+msgstr "[ Nessuna descrizione ]"
+
+#: app/components/chart-preview.tsx:55
+msgid "annotation.add.title"
+msgstr "[ Nessun titolo ]"
+
+#: app/pages/v/[chartId].tsx:83
+msgid "button.copy.visualization"
+msgstr "Copia questa visualizzazione"
 
 #: app/components/data-download.tsx:73
 msgid "button.download.data"
 msgstr "Scarica i dati"
 
+#: app/components/data-download.tsx:46
+msgid "button.download.runsparqlquery"
+msgstr "Esegui query SPARQL"
+
 #: app/components/publish-actions.tsx:146
 msgid "button.embed"
 msgstr "Incorpora"
+
+#: app/components/publish-actions.tsx:168
+#: app/components/publish-actions.tsx:171
+msgid "button.hint.click.to.copy"
+msgstr "Clicca per copiare"
+
+#: app/components/publish-actions.tsx:194
+msgid "button.hint.copied"
+msgstr "Copiato!"
 
 #: app/pages/v/[chartId].tsx:78
 msgid "button.new.visualization"
@@ -35,369 +66,89 @@ msgstr "Pubblica"
 msgid "button.share"
 msgstr "Condividi"
 
-#: app/configurator/components/ui-helpers.tsx:222
-msgid "controls.axis.horizontal"
-msgstr "Asse orizzontale"
+#: app/charts/map/chart-map-prototype.tsx:146
+msgid "chart.map.control.data.filters"
+msgstr "Filtri di dati"
 
-#: app/configurator/components/ui-helpers.tsx:308
-msgid "controls.chart.type.area"
+#: app/charts/map/chart-map-prototype.tsx:136
+msgid "chart.map.control.layers"
+msgstr "Livelli"
+
+#: app/charts/map/chart-map-prototype.tsx:139
+msgid "chart.map.layers.area"
 msgstr "Aree"
 
-#: app/configurator/components/ui-helpers.tsx:304
-msgid "controls.chart.type.bar"
-msgstr "Barre"
-
-#: app/configurator/components/ui-helpers.tsx:302
-msgid "controls.chart.type.column"
-msgstr "Colonne"
-
-#: app/configurator/components/ui-helpers.tsx:306
-msgid "controls.chart.type.line"
-msgstr "Linee"
-
-#. or "Dispersione"
-#: app/configurator/components/ui-helpers.tsx:310
-msgid "controls.chart.type.scatterplot"
-msgstr "Scatterplot"
-
-#: app/configurator/components/chart-controls/color-palette.tsx:40
-msgid "controls.color.palette"
-msgstr "Palette di colori"
-
-#: app/configurator/components/ui-helpers.tsx:249
-msgid "controls.column.grouped"
-msgstr "raggruppate"
-
-#: app/configurator/components/ui-helpers.tsx:247
-msgid "controls.column.stacked"
-msgstr "impilate"
-
-#: app/configurator/components/ui-helpers.tsx:244
-msgid "controls.description"
-msgstr "Descrizione"
-
-#: app/configurator/components/filters.tsx:50
-msgid "controls.filter.select.all"
-msgstr "Seleziona tutti"
-
-#: app/configurator/components/ui-helpers.tsx:225
-msgid "controls.measure"
-msgstr "Misura"
-
-#: app/configurator/components/chart-annotator.tsx:12
-msgid "controls.section.description"
-msgstr "Titolo e descrizione"
-
-#: app/configurator/components/chart-options-selector.tsx:87
-#: app/configurator/components/chart-options-selector.tsx:91
-#: app/configurator/table/table-chart-options.tsx:182
-#: app/configurator/table/table-chart-options.tsx:186
-msgid "controls.section.filter"
-msgstr "Filtro"
-
-#: app/configurator/components/chart-type-selector.tsx:87
-#: app/configurator/components/chart-type-selector.tsx:90
-msgid "controls.select.chart.type"
-msgstr "Tipo di grafico"
-
-#: app/configurator/components/ui-helpers.tsx:331
-#: app/configurator/components/ui-helpers.tsx:333
-msgid "controls.select.dimension"
-msgstr "Seleziona una dimensione"
-
-#: app/configurator/components/ui-helpers.tsx:332
-msgid "controls.select.measure"
-msgstr "Seleziona una misura"
-
-#: app/configurator/components/ui-helpers.tsx:242
-msgid "controls.title"
-msgstr "Titolo"
-
-#: app/configurator/components/dataset-preview.tsx:55
-msgid "datatable.showing.first.rows"
-msgstr "Sono mostrate soltanto le prime 10 righe"
-
-#: app/pages/v/[chartId].tsx:69
-msgid "hint.create.your.own.chart"
-msgstr "Crea la tua versione di questa visualizzazione copiandola, oppure inizia da zero e crea una nuova visualizzazione utilizzando i dati aperti dell’amministrazione pubblica svizzera."
-
-#: app/pages/v/[chartId].tsx:65
-msgid "hint.how.to.share"
-msgstr "È possibile condividere questa visualizzazione copiando l'URL o incorporandola nel vostro sito Web. Puoi anche creare una nuova visualizzazione partendo da zero oppure copiando e modificando la visualizzazione sopra."
-
-#: app/components/hint.tsx:54
-msgid "hint.loading.data"
-msgstr "Caricamento dei dati..."
-
-#: app/configurator/components/chart-type-selector.tsx:94
-msgid "hint.no.visualization.with.dataset"
-msgstr "Nessuna visualizzazione può essere creata con il dataset selezionato."
-
-#: app/components/hint.tsx:167
-msgid "hint.publication.success"
-msgstr "La tua visualizzazione è ora pubblicata. Condividila copiando l'URL o utilizzando le opzioni di incorporamento."
-
-#: app/components/hint.tsx:80
-msgid "hint.select.dataset"
-msgstr "Seleziona un dataset"
-
-#: app/components/hint.tsx:83
-msgid "hint.select.dataset.to.preview"
-msgstr "Seleziona un dataset per vedere l'anteprima della sua struttura e del suo contenuto."
-
-#: app/components/header.tsx:71
-#: app/components/header.tsx:82
-msgid "logo.swiss.confederation"
-msgstr "Logo della Confederazione svizzera"
-
-#: app/components/chart-footnotes.tsx:20
-msgid "metadata.dataset"
-msgstr "Dataset"
-
-#: app/components/chart-footnotes.tsx:24
-msgid "metadata.source"
-msgstr "Fonte"
-
-#. I saw "External Application" was not translated in french. Did the same here.
-#: app/components/publish-actions.tsx:156
-msgid "publication.embed.AEM"
-msgstr "Codice da incorporare su AEM come \"External Application\":"
-
-#: app/components/publish-actions.tsx:151
-msgid "publication.embed.iframe"
-msgstr "Codice di incorporamento:"
-
-#: app/components/publish-actions.tsx:96
-msgid "publication.popup.share"
-msgstr "Condividi"
-
-#: app/components/publish-actions.tsx:121
-msgid "publication.share.chart.url"
-msgstr "URL del grafico:"
-
-#: app/components/publish-actions.tsx:113
-msgid "publication.share.mail.body"
-msgstr "Ecco una visualizzazione che ho creato usando visualize.admin.ch"
-
-#: app/components/publish-actions.tsx:110
-msgid "publication.share.mail.subject"
-msgstr "visualize.admin.ch"
-
-#: app/configurator/components/stepper.tsx:115
-msgid "step.annotate"
-msgstr "Annota"
-
-#: app/configurator/components/stepper.tsx:109
-msgid "step.dataset"
-msgstr "Dataset"
-
-#: app/configurator/components/stepper.tsx:111
-msgid "step.visualization.type"
-msgstr "Tipo di grafico"
-
-#: app/components/footer.tsx:35
-msgid "footer.institution.name"
-msgstr "Ufficio federale dell'ambiente UFAM"
-
-#: app/components/chart-preview.tsx:63
-msgid "annotation.add.description"
-msgstr "[ Nessuna descrizione ]"
-
-#: app/components/chart-preview.tsx:55
-msgid "annotation.add.title"
-msgstr "[ Nessun titolo ]"
-
-#: app/pages/v/[chartId].tsx:83
-msgid "button.copy.visualization"
-msgstr "Copia questa visualizzazione"
-
-#: app/configurator/components/ui-helpers.tsx:312
-msgid "controls.chart.type.pie"
-msgstr "Torta"
-
-#: app/configurator/components/filters.tsx:54
-msgid "controls.filter.select.none"
-msgstr "Deseleziona tutto"
-
-#: app/configurator/components/empty-right-panel.tsx:9
-msgid "controls.hint.configuring.chart"
-msgstr "Seleziona un elemento di design o una dimensione dei dati per modificarne le opzioni."
-
-#: app/configurator/components/empty-right-panel.tsx:14
-msgid "controls.hint.describing.chart"
-msgstr "Seleziona una delle annotazioni proposte per modificarla."
-
-#: app/configurator/components/ui-helpers.tsx:319
-msgid "controls.language.english"
-msgstr "Inglese"
-
-#: app/configurator/components/ui-helpers.tsx:323
-msgid "controls.language.french"
-msgstr "Francese"
-
-#: app/configurator/components/ui-helpers.tsx:321
-msgid "controls.language.german"
-msgstr "Tedesco"
-
-#: app/configurator/components/ui-helpers.tsx:325
-msgid "controls.language.italian"
-msgstr "Italiano"
-
-#: app/configurator/components/dataset-metadata.tsx:40
-msgid "dataset.metadata.date.created"
-msgstr "Data di creazione"
-
-#: app/configurator/components/dataset-metadata.tsx:30
-msgid "dataset.metadata.source"
-msgstr "Fonte"
-
-#: app/configurator/components/dataset-metadata.tsx:17
-msgid "dataset.metadata.title"
-msgstr "Titolo"
-
-#. alternative: "data" (literally sorting by date)
-#: app/configurator/components/dataset-selector.tsx:34
-msgid "dataset.order.newest"
-msgstr "Il più recente"
-
-#. alternative: "rilevanza"
-#: app/configurator/components/dataset-selector.tsx:26
-msgid "dataset.order.relevance"
-msgstr "Il più rilevante"
-
-#: app/configurator/components/dataset-selector.tsx:30
-msgid "dataset.order.title"
-msgstr "Titolo"
-
-#. Only translate what is marked XXXX ;-)
-#: app/configurator/components/dataset-selector.tsx:79
-msgid "dataset.results"
-msgstr "\n"
-"{0, plural, =0 {Nessun risultato} =1 {# risultato} other {# risultati}}"
-
-#: app/configurator/components/dataset-selector.tsx:89
-msgid "dataset.sortby"
-msgstr "Ordina per"
-
-#: app/components/hint.tsx:105
-msgid "hint.nodata.message"
-msgstr "Non ci sono dati corrispondenti ai filtri selezionati."
-
-#: app/components/hint.tsx:102
-msgid "hint.nodata.title"
-msgstr "Nessun dato"
-
-#: app/components/publish-actions.tsx:99
-msgid "publication.share.linktitle.facebook"
-msgstr "Condividi su Facebook"
-
-#: app/components/publish-actions.tsx:107
-msgid "publication.share.linktitle.mail"
-msgstr "Condividi via Email"
-
-#: app/components/publish-actions.tsx:103
-msgid "publication.share.linktitle.twitter"
-msgstr "Condividi su Twitter"
-
-#: app/components/publish-actions.tsx:168
-#: app/components/publish-actions.tsx:171
-msgid "button.hint.click.to.copy"
-msgstr "Clicca per copiare"
-
-#: app/components/publish-actions.tsx:194
-msgid "button.hint.copied"
-msgstr "Copiato!"
-
-#: app/components/chart-footnotes.tsx:49
-msgid "metadata.link.created.with.visualize"
-msgstr "Creato con visualize.admin.ch"
-
-#: app/components/form.tsx:145
-msgid "controls.search.clear"
-msgstr "Cancella la ricerca"
-
-#: app/configurator/components/dataset-selector.tsx:37
-msgid "dataset.search.label"
-msgstr "Cerca un dataset"
-
-#: app/components/hint.tsx:147
-msgid "hint.only.negative.data.message"
-msgstr "Dati con valori negativi non possono essere visualizzati con questo tipo di grafico."
-
-#: app/components/hint.tsx:144
-msgid "hint.only.negative.data.title"
-msgstr "Valori negativi"
-
-#: app/configurator/components/chart-controls/color-palette.tsx:135
-#: app/configurator/components/chart-controls/color-palette.tsx:140
-msgid "controls.color.palette.reset"
-msgstr "Ripristina la tavolozza dei colori"
-
-#: app/configurator/components/field.tsx:144
-msgid "controls.dimension.none"
-msgstr "Nessuno"
-
-#: app/configurator/components/chart-options-selector.tsx:142
-msgid "controls.section.sorting"
-msgstr "Ordina"
-
-#: app/configurator/components/chart-options-selector.tsx:116
-#: app/configurator/components/chart-options-selector.tsx:122
-msgid "controls.sorting.byDimensionLabel"
-msgstr "Nome"
-
-#: app/configurator/components/ui-helpers.tsx:260
-msgid "controls.sorting.byDimensionLabel.ascending"
-msgstr "A → Z"
-
-#: app/configurator/components/ui-helpers.tsx:269
-msgid "controls.sorting.byDimensionLabel.descending"
-msgstr "Z → A"
-
-#: app/configurator/components/chart-options-selector.tsx:118
-msgid "controls.sorting.byMeasure"
-msgstr "Misura"
-
-#: app/configurator/components/ui-helpers.tsx:293
-msgid "controls.sorting.byMeasure.ascending"
-msgstr "1 → 9"
-
-#: app/configurator/components/ui-helpers.tsx:299
-msgid "controls.sorting.byMeasure.descending"
-msgstr "9 → 1"
-
-#: app/configurator/components/chart-options-selector.tsx:120
-msgid "controls.sorting.byTotalSize"
-msgstr "Grandezza totale"
-
-#: app/configurator/components/ui-helpers.tsx:273
-msgid "controls.sorting.byTotalSize.ascending"
-msgstr "Il più grande per ultimo"
-
-#: app/configurator/components/ui-helpers.tsx:285
-msgid "controls.sorting.byTotalSize.largestBottom"
-msgstr "Il più grande sotto"
-
-#: app/configurator/components/ui-helpers.tsx:277
-msgid "controls.sorting.byTotalSize.largestFirst"
-msgstr "Il più grande per primo"
-
-#: app/configurator/components/ui-helpers.tsx:282
-msgid "controls.sorting.byTotalSize.largestTop"
-msgstr "Il più grande sopra"
-
-#: app/configurator/components/chart-controls/color-picker.tsx:100
-msgid "controls.colorpicker.open"
-msgstr "Apri il selettore di colore"
-
-#: app/configurator/components/ui-helpers.tsx:251
-#: app/configurator/table/table-chart-sorting-options.tsx:173
-msgid "controls.sorting.sortBy"
-msgstr "Ordina per"
-
-#: app/configurator/components/ui-helpers.tsx:232
-msgid "controls.axis.vertical"
-msgstr "Asse verticale"
+#: app/charts/map/prototype-right-controls.tsx:22
+msgid "chart.map.layers.area.add.data"
+msgstr "Mostra le aree"
+
+#: app/charts/map/prototype-right-controls.tsx:37
+msgid "chart.map.layers.area.color.palette"
+msgstr "Palette di colore"
+
+#: app/charts/map/prototype-right-controls.tsx:51
+msgid "chart.map.layers.area.discretization.continuous"
+msgstr "Continuo"
+
+#: app/charts/map/prototype-right-controls.tsx:59
+msgid "chart.map.layers.area.discretization.discrete"
+msgstr "Discreto"
+
+#: app/charts/map/prototype-right-controls.tsx:68
+msgid "chart.map.layers.area.discretization.jenks"
+msgstr "Jenks (interruzioni naturali)"
+
+#: app/charts/map/prototype-right-controls.tsx:54
+msgid "chart.map.layers.area.discretization.linear"
+msgstr "Interpolazione lineare"
+
+#: app/charts/map/prototype-right-controls.tsx:71
+msgid "chart.map.layers.area.discretization.number.class"
+msgstr "Numero di classi"
+
+#: app/charts/map/prototype-right-controls.tsx:65
+msgid "chart.map.layers.area.discretization.quantiles"
+msgstr "Quantili (distribuzione omogenea dei valori)"
+
+#: app/charts/map/prototype-right-controls.tsx:62
+msgid "chart.map.layers.area.discretization.quantize"
+msgstr "Intervalli uguali"
+
+#: app/charts/map/prototype-right-controls.tsx:27
+msgid "chart.map.layers.area.select.measure"
+msgstr "Seleziona una variabile"
+
+#: app/charts/map/chart-map-prototype.tsx:138
+msgid "chart.map.layers.base"
+msgstr "Livello di base"
+
+#: app/charts/map/prototype-right-controls.tsx:13
+msgid "chart.map.layers.base.lakes"
+msgstr "Laghi"
+
+#: app/charts/map/prototype-right-controls.tsx:12
+msgid "chart.map.layers.base.relief"
+msgstr "Rilievo"
+
+#: app/charts/map/prototype-right-controls.tsx:108
+msgid "chart.map.layers.no.selected"
+msgstr "Seleziona un livello da editare nel pannello di sinistra."
+
+#: app/charts/map/chart-map-prototype.tsx:140
+msgid "chart.map.layers.symbol"
+msgstr "Simboli"
+
+#: app/charts/map/prototype-right-controls.tsx:90
+msgid "chart.map.layers.symbol.add.symbols"
+msgstr "Mostra simboli proporzionali"
+
+#: app/charts/map/prototype-right-controls.tsx:97
+msgid "chart.map.layers.symbol.select.measure"
+msgstr "Seleziona una variabile"
+
+#: app/charts/map/chart-map-prototype.tsx:162
+msgid "chart.map.warning.prototype"
+msgstr "Questa mappa è un prototipo e non può essere pubblicata."
 
 #: app/charts/table/table.tsx:136
 msgid "chart.published.toggle.mobile.view"
@@ -436,9 +187,106 @@ msgstr "Regular"
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Impostazioni predefinite"
 
+#: app/configurator/components/ui-helpers.tsx:222
+msgid "controls.axis.horizontal"
+msgstr "Asse orizzontale"
+
+#: app/configurator/components/ui-helpers.tsx:232
+msgid "controls.axis.vertical"
+msgstr "Asse verticale"
+
+#: app/configurator/components/ui-helpers.tsx:308
+msgid "controls.chart.type.area"
+msgstr "Aree"
+
+#: app/configurator/components/ui-helpers.tsx:304
+msgid "controls.chart.type.bar"
+msgstr "Barre"
+
+#: app/configurator/components/ui-helpers.tsx:302
+msgid "controls.chart.type.column"
+msgstr "Colonne"
+
+#: app/configurator/components/ui-helpers.tsx:306
+msgid "controls.chart.type.line"
+msgstr "Linee"
+
+#: app/configurator/components/ui-helpers.tsx:316
+msgid "controls.chart.type.map"
+msgstr "Mappa"
+
+#: app/configurator/components/ui-helpers.tsx:312
+msgid "controls.chart.type.pie"
+msgstr "Torta"
+
+#: app/configurator/components/ui-helpers.tsx:310
+msgid "controls.chart.type.scatterplot"
+msgstr "Scatterplot"
+
 #: app/configurator/components/ui-helpers.tsx:314
 msgid "controls.chart.type.table"
 msgstr "Tabella"
+
+#: app/configurator/components/ui-helpers.tsx:240
+msgid "controls.color"
+msgstr "Colore"
+
+#: app/configurator/components/chart-controls/control-tab.tsx:12
+msgid "controls.color.add"
+msgstr "Aggiungi ..."
+
+#: app/configurator/components/chart-controls/color-palette.tsx:40
+msgid "controls.color.palette"
+msgstr "Palette di colori"
+
+#: app/configurator/components/chart-controls/color-palette.tsx:135
+#: app/configurator/components/chart-controls/color-palette.tsx:140
+msgid "controls.color.palette.reset"
+msgstr "Ripristina la tavolozza dei colori"
+
+#: app/configurator/components/chart-controls/color-picker.tsx:100
+msgid "controls.colorpicker.open"
+msgstr "Apri il selettore di colore"
+
+#: app/configurator/components/ui-helpers.tsx:249
+msgid "controls.column.grouped"
+msgstr "raggruppate"
+
+#: app/configurator/components/ui-helpers.tsx:247
+msgid "controls.column.stacked"
+msgstr "impilate"
+
+#: app/configurator/components/ui-helpers.tsx:244
+msgid "controls.description"
+msgstr "Descrizione"
+
+#: app/configurator/components/field.tsx:165
+msgid "controls.dimension.none"
+msgstr "Nessuno"
+
+#: app/configurator/components/field.tsx:31
+msgid "controls.dimensionvalue.none"
+msgstr "Nessun filtro"
+
+#: app/configurator/components/filters.tsx:50
+msgid "controls.filter.select.all"
+msgstr "Seleziona tutti"
+
+#: app/configurator/components/filters.tsx:54
+msgid "controls.filter.select.none"
+msgstr "Deseleziona tutto"
+
+#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:89
+msgid "controls.filters.time.range"
+msgstr "intervallo di tempo"
+
+#: app/configurator/components/empty-right-panel.tsx:9
+msgid "controls.hint.configuring.chart"
+msgstr "Seleziona un elemento di design o una dimensione dei dati per modificarne le opzioni."
+
+#: app/configurator/components/empty-right-panel.tsx:14
+msgid "controls.hint.describing.chart"
+msgstr "Seleziona una delle annotazioni proposte per modificarla."
 
 #: app/configurator/interactive-filters/interactive-filters-configurator.tsx:43
 msgid "controls.interactive.filters.dataFilter"
@@ -460,6 +308,26 @@ msgstr "Nessuna dimensione temporale disponibile!"
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Mostra i filtri temporali"
 
+#: app/configurator/components/ui-helpers.tsx:319
+msgid "controls.language.english"
+msgstr "Inglese"
+
+#: app/configurator/components/ui-helpers.tsx:323
+msgid "controls.language.french"
+msgstr "Francese"
+
+#: app/configurator/components/ui-helpers.tsx:321
+msgid "controls.language.german"
+msgstr "Tedesco"
+
+#: app/configurator/components/ui-helpers.tsx:325
+msgid "controls.language.italian"
+msgstr "Italiano"
+
+#: app/configurator/components/ui-helpers.tsx:225
+msgid "controls.measure"
+msgstr "Misura"
+
 #: app/configurator/components/chart-controls/control-tab.tsx:101
 msgid "controls.option.isActive"
 msgstr "Attivo"
@@ -468,6 +336,14 @@ msgstr "Attivo"
 msgid "controls.option.isNotActive"
 msgstr "Inattivo"
 
+#: app/components/form.tsx:153
+msgid "controls.search.clear"
+msgstr "Cancella la ricerca"
+
+#: app/configurator/components/chart-configurator.tsx:23
+msgid "controls.section.chart.options"
+msgstr "Opzioni del grafico"
+
 #: app/configurator/table/table-chart-configurator.tsx:63
 msgid "controls.section.columns"
 msgstr "Colonne"
@@ -475,6 +351,21 @@ msgstr "Colonne"
 #: app/configurator/table/table-chart-options.tsx:130
 msgid "controls.section.columnstyle"
 msgstr "Stile della colonna"
+
+#: app/configurator/components/chart-configurator.tsx:32
+msgid "controls.section.data.filters"
+msgstr "Filtri"
+
+#: app/configurator/components/chart-annotator.tsx:12
+msgid "controls.section.description"
+msgstr "Titolo e descrizione"
+
+#: app/configurator/components/chart-options-selector.tsx:95
+#: app/configurator/components/chart-options-selector.tsx:99
+#: app/configurator/table/table-chart-options.tsx:182
+#: app/configurator/table/table-chart-options.tsx:186
+msgid "controls.section.filter"
+msgstr "Filtro"
 
 #: app/configurator/table/table-chart-configurator.tsx:61
 msgid "controls.section.groups"
@@ -488,6 +379,10 @@ msgstr "Filtri interattivi"
 msgid "controls.section.interactiveFilters.dataFilters"
 msgstr "Filtri di dati"
 
+#: app/configurator/components/chart-options-selector.tsx:150
+msgid "controls.section.sorting"
+msgstr "Ordina"
+
 #: app/configurator/table/table-chart-options.tsx:239
 msgid "controls.section.tableSettings"
 msgstr "Impostazioni della tabella"
@@ -499,6 +394,23 @@ msgstr "Ordinamento della tabella"
 #: app/configurator/table/table-chart-configurator.tsx:53
 msgid "controls.section.tableoptions"
 msgstr "Opzioni della tabella"
+
+#: app/configurator/components/chart-type-selector.tsx:87
+#: app/configurator/components/chart-type-selector.tsx:90
+msgid "controls.select.chart.type"
+msgstr "Tipo di grafico"
+
+#: app/configurator/components/chart-type-selector.tsx:106
+msgid "controls.select.chart.type.experimental"
+msgstr "Funzionalità in sperimentazione"
+
+#: app/configurator/components/chart-type-selector.tsx:111
+msgid "controls.select.chart.type.experimental.description"
+msgstr "Guarda il prototipo della mappa con un numero limitato di dati (link ad una nuova pagina)."
+
+#: app/configurator/components/chart-options-selector.tsx:110
+msgid "controls.select.column.layout"
+msgstr "Layout a colonne"
 
 #: app/configurator/table/table-chart-options.tsx:133
 msgid "controls.select.columnStyle"
@@ -532,9 +444,68 @@ msgstr "Colore del testo"
 msgid "controls.select.columnStyle.textStyle"
 msgstr "Stile del testo"
 
+#: app/configurator/components/chart-options-selector.tsx:57
+#: app/configurator/components/chart-options-selector.tsx:59
+msgid "controls.select.dimension"
+msgstr "Seleziona una dimensione"
+
+#: app/configurator/components/chart-options-selector.tsx:58
+msgid "controls.select.measure"
+msgstr "Seleziona una misura"
+
+#: app/configurator/components/field.tsx:35
+#: app/configurator/components/field.tsx:169
+msgid "controls.select.optional"
+msgstr "facoltativo"
+
 #: app/configurator/table/table-chart-sorting-options.tsx:131
 msgid "controls.sorting.addDimension"
 msgstr "Aggiungi una dimensione"
+
+#: app/configurator/components/chart-options-selector.tsx:124
+#: app/configurator/components/chart-options-selector.tsx:130
+msgid "controls.sorting.byDimensionLabel"
+msgstr "Nome"
+
+#: app/configurator/components/ui-helpers.tsx:260
+msgid "controls.sorting.byDimensionLabel.ascending"
+msgstr "A → Z"
+
+#: app/configurator/components/ui-helpers.tsx:269
+msgid "controls.sorting.byDimensionLabel.descending"
+msgstr "Z → A"
+
+#: app/configurator/components/chart-options-selector.tsx:126
+msgid "controls.sorting.byMeasure"
+msgstr "Misura"
+
+#: app/configurator/components/ui-helpers.tsx:293
+msgid "controls.sorting.byMeasure.ascending"
+msgstr "1 → 9"
+
+#: app/configurator/components/ui-helpers.tsx:299
+msgid "controls.sorting.byMeasure.descending"
+msgstr "9 → 1"
+
+#: app/configurator/components/chart-options-selector.tsx:128
+msgid "controls.sorting.byTotalSize"
+msgstr "Grandezza totale"
+
+#: app/configurator/components/ui-helpers.tsx:273
+msgid "controls.sorting.byTotalSize.ascending"
+msgstr "Il più grande per ultimo"
+
+#: app/configurator/components/ui-helpers.tsx:285
+msgid "controls.sorting.byTotalSize.largestBottom"
+msgstr "Il più grande sotto"
+
+#: app/configurator/components/ui-helpers.tsx:277
+msgid "controls.sorting.byTotalSize.largestFirst"
+msgstr "Il più grande per primo"
+
+#: app/configurator/components/ui-helpers.tsx:282
+msgid "controls.sorting.byTotalSize.largestTop"
+msgstr "Il più grande sopra"
 
 #: app/configurator/table/table-chart-sorting-options.tsx:70
 msgid "controls.sorting.removeOption"
@@ -543,6 +514,11 @@ msgstr "Rimuovi l'ordinamento"
 #: app/configurator/table/table-chart-sorting-options.tsx:109
 msgid "controls.sorting.selectDimension"
 msgstr "Seleziona una dimensione ..."
+
+#: app/configurator/components/ui-helpers.tsx:251
+#: app/configurator/table/table-chart-sorting-options.tsx:173
+msgid "controls.sorting.sortBy"
+msgstr "Ordina per"
 
 #: app/configurator/table/table-chart-options.tsx:119
 msgid "controls.table.column.group"
@@ -568,41 +544,45 @@ msgstr "Ordinamento"
 msgid "controls.tableSettings.showSearch"
 msgstr "Mostra il campo di ricerca"
 
-#: app/charts/shared/chart-data-filters.tsx:31
-msgid "interactive.data.filters.hide"
-msgstr "Nascondi i filtri"
-
-#: app/charts/shared/chart-data-filters.tsx:31
-msgid "interactive.data.filters.show"
-msgstr "Mostra i filtri"
-
-#: app/configurator/components/chart-controls/drag-and-drop-tab.tsx:27
-msgid "table.column.no"
-msgstr "Colonna {0}"
-
-#: app/charts/map/chart-map-prototype.tsx:146
-msgid "chart.map.control.data.filters"
-msgstr "Filtri di dati"
-
-#: app/charts/map/chart-map-prototype.tsx:162
-msgid "chart.map.warning.prototype"
-msgstr "Questa mappa è un prototipo e non può essere pubblicata."
-
-#: app/configurator/components/ui-helpers.tsx:316
-msgid "controls.chart.type.map"
-msgstr "Mappa"
-
-#: app/configurator/components/chart-type-selector.tsx:106
-msgid "controls.select.chart.type.experimental"
-msgstr "Funzionalità in sperimentazione"
-
-#: app/configurator/components/chart-type-selector.tsx:111
-msgid "controls.select.chart.type.experimental.description"
-msgstr "Guarda il prototipo della mappa con un numero limitato di dati (link ad una nuova pagina)."
+#: app/configurator/components/ui-helpers.tsx:242
+msgid "controls.title"
+msgstr "Titolo"
 
 #: app/configurator/components/dataset-selector.tsx:70
 msgid "dataset.includeDrafts"
 msgstr "Includi la bozza del set di dati"
+
+#: app/configurator/components/dataset-metadata.tsx:40
+msgid "dataset.metadata.date.created"
+msgstr "Data di creazione"
+
+#: app/configurator/components/dataset-metadata.tsx:22
+msgid "dataset.metadata.description"
+msgstr "Descrizione"
+
+#: app/configurator/components/dataset-metadata.tsx:30
+msgid "dataset.metadata.source"
+msgstr "Fonte"
+
+#: app/configurator/components/dataset-metadata.tsx:17
+msgid "dataset.metadata.title"
+msgstr "Titolo"
+
+#: app/configurator/components/dataset-metadata.tsx:48
+msgid "dataset.metadata.version"
+msgstr "versione"
+
+#: app/configurator/components/dataset-selector.tsx:34
+msgid "dataset.order.newest"
+msgstr "Il più recente"
+
+#: app/configurator/components/dataset-selector.tsx:26
+msgid "dataset.order.relevance"
+msgstr "Il più rilevante"
+
+#: app/configurator/components/dataset-selector.tsx:30
+msgid "dataset.order.title"
+msgstr "Titolo"
 
 #: app/components/chart-preview.tsx:39
 #: app/components/chart-published.tsx:37
@@ -610,9 +590,35 @@ msgstr "Includi la bozza del set di dati"
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Attenzione, questo set di dati è una bozza.<0/><1>Non utilizzare questo grafico per un rapporto!</1>"
 
+#: app/configurator/components/dataset-selector.tsx:79
+msgid "dataset.results"
+msgstr ""
+"\n"
+"{0, plural, =0 {Nessun risultato} =1 {# risultato} other {# risultati}}"
+
+#: app/configurator/components/dataset-selector.tsx:37
+msgid "dataset.search.label"
+msgstr "Cerca un dataset"
+
+#: app/configurator/components/dataset-selector.tsx:89
+msgid "dataset.sortby"
+msgstr "Ordina per"
+
 #: app/configurator/components/dataset-selector.tsx:163
 msgid "dataset.tag.draft"
 msgstr "Bozza"
+
+#: app/configurator/components/dataset-preview.tsx:55
+msgid "datatable.showing.first.rows"
+msgstr "Sono mostrate soltanto le prime 10 righe"
+
+#: app/components/footer.tsx:35
+msgid "footer.institution.name"
+msgstr "Ufficio federale dell'ambiente UFAM"
+
+#: app/pages/v/[chartId].tsx:69
+msgid "hint.create.your.own.chart"
+msgstr "Crea la tua versione di questa visualizzazione copiandola, oppure inizia da zero e crea una nuova visualizzazione utilizzando i dati aperti dell’amministrazione pubblica svizzera."
 
 #: app/components/hint.tsx:126
 msgid "hint.dataloadingerror.message"
@@ -622,120 +628,123 @@ msgstr "I dati non possono essere caricati."
 msgid "hint.dataloadingerror.title"
 msgstr "Problema di caricamento dei dati"
 
-#: app/configurator/components/ui-helpers.tsx:240
-msgid "controls.color"
-msgstr "Colore"
+#: app/pages/v/[chartId].tsx:65
+msgid "hint.how.to.share"
+msgstr "È possibile condividere questa visualizzazione copiando l'URL o incorporandola nel vostro sito Web. Puoi anche creare una nuova visualizzazione partendo da zero oppure copiando e modificando la visualizzazione sopra."
 
-#: app/configurator/components/chart-controls/control-tab.tsx:12
-msgid "controls.color.add"
-msgstr "Aggiungi ..."
+#: app/components/hint.tsx:54
+msgid "hint.loading.data"
+msgstr "Caricamento dei dati..."
 
-#: app/configurator/components/chart-configurator.tsx:22
-msgid "controls.section.chart.options"
-msgstr "Opzioni del grafico"
+#: app/configurator/components/chart-type-selector.tsx:94
+msgid "hint.no.visualization.with.dataset"
+msgstr "Nessuna visualizzazione può essere creata con il dataset selezionato."
 
-#: app/configurator/components/chart-configurator.tsx:31
-msgid "controls.section.data.filters"
-msgstr "Filtri"
+#: app/components/hint.tsx:105
+msgid "hint.nodata.message"
+msgstr "Non ci sono dati corrispondenti ai filtri selezionati."
+
+#: app/components/hint.tsx:102
+msgid "hint.nodata.title"
+msgstr "Nessun dato"
+
+#: app/components/hint.tsx:147
+msgid "hint.only.negative.data.message"
+msgstr "Dati con valori negativi non possono essere visualizzati con questo tipo di grafico."
+
+#: app/components/hint.tsx:144
+msgid "hint.only.negative.data.title"
+msgstr "Valori negativi"
+
+#: app/components/hint.tsx:167
+msgid "hint.publication.success"
+msgstr "La tua visualizzazione è ora pubblicata. Condividila copiando l'URL o utilizzando le opzioni di incorporamento."
+
+#: app/components/hint.tsx:80
+msgid "hint.select.dataset"
+msgstr "Seleziona un dataset"
+
+#: app/components/hint.tsx:83
+msgid "hint.select.dataset.to.preview"
+msgstr "Seleziona un dataset per vedere l'anteprima della sua struttura e del suo contenuto."
+
+#: app/charts/shared/chart-data-filters.tsx:31
+msgid "interactive.data.filters.hide"
+msgstr "Nascondi i filtri"
+
+#: app/charts/shared/chart-data-filters.tsx:31
+msgid "interactive.data.filters.show"
+msgstr "Mostra i filtri"
+
+#: app/components/header.tsx:71
+#: app/components/header.tsx:82
+msgid "logo.swiss.confederation"
+msgstr "Logo della Confederazione svizzera"
+
+#: app/components/chart-footnotes.tsx:20
+msgid "metadata.dataset"
+msgstr "Dataset"
+
+#: app/components/chart-footnotes.tsx:49
+msgid "metadata.link.created.with.visualize"
+msgstr "Creato con visualize.admin.ch"
+
+#: app/components/chart-footnotes.tsx:24
+msgid "metadata.source"
+msgstr "Fonte"
+
+#: app/components/publish-actions.tsx:156
+msgid "publication.embed.AEM"
+msgstr "Codice da incorporare su AEM come \"External Application\":"
+
+#: app/components/publish-actions.tsx:151
+msgid "publication.embed.iframe"
+msgstr "Codice di incorporamento:"
+
+#: app/components/publish-actions.tsx:96
+msgid "publication.popup.share"
+msgstr "Condividi"
+
+#: app/components/publish-actions.tsx:121
+msgid "publication.share.chart.url"
+msgstr "URL del grafico:"
+
+#: app/components/publish-actions.tsx:99
+msgid "publication.share.linktitle.facebook"
+msgstr "Condividi su Facebook"
+
+#: app/components/publish-actions.tsx:107
+msgid "publication.share.linktitle.mail"
+msgstr "Condividi via Email"
+
+#: app/components/publish-actions.tsx:103
+msgid "publication.share.linktitle.twitter"
+msgstr "Condividi su Twitter"
+
+#: app/components/publish-actions.tsx:113
+msgid "publication.share.mail.body"
+msgstr "Ecco una visualizzazione che ho creato usando visualize.admin.ch"
+
+#: app/components/publish-actions.tsx:110
+msgid "publication.share.mail.subject"
+msgstr "visualize.admin.ch"
+
+#: app/configurator/components/stepper.tsx:115
+msgid "step.annotate"
+msgstr "Annota"
+
+#: app/configurator/components/stepper.tsx:109
+msgid "step.dataset"
+msgstr "Dataset"
+
+#: app/configurator/components/stepper.tsx:111
+msgid "step.visualization.type"
+msgstr "Tipo di grafico"
 
 #: app/configurator/components/stepper.tsx:113
 msgid "step.visualize"
 msgstr "Visualizzare"
 
-#: app/charts/map/chart-map-prototype.tsx:136
-msgid "chart.map.control.layers"
-msgstr "Livelli"
-
-#: app/charts/map/chart-map-prototype.tsx:139
-msgid "chart.map.layers.area"
-msgstr "Aree"
-
-#: app/charts/map/prototype-right-controls.tsx:22
-msgid "chart.map.layers.area.add.data"
-msgstr "Mostra le aree"
-
-#: app/charts/map/prototype-right-controls.tsx:37
-msgid "chart.map.layers.area.color.palette"
-msgstr "Palette di colore"
-
-#: app/charts/map/prototype-right-controls.tsx:68
-msgid "chart.map.layers.area.discretization.jenks"
-msgstr "Jenks (interruzioni naturali)"
-
-#: app/charts/map/prototype-right-controls.tsx:54
-msgid "chart.map.layers.area.discretization.linear"
-msgstr "Interpolazione lineare"
-
-#: app/charts/map/prototype-right-controls.tsx:71
-msgid "chart.map.layers.area.discretization.number.class"
-msgstr "Numero di classi"
-
-#: app/charts/map/prototype-right-controls.tsx:65
-msgid "chart.map.layers.area.discretization.quantiles"
-msgstr "Quantili (distribuzione omogenea dei valori)"
-
-#. Translated as in french.
-#: app/charts/map/prototype-right-controls.tsx:62
-msgid "chart.map.layers.area.discretization.quantize"
-msgstr "Intervalli uguali"
-
-#: app/charts/map/prototype-right-controls.tsx:27
-msgid "chart.map.layers.area.select.measure"
-msgstr "Seleziona una variabile"
-
-#: app/charts/map/chart-map-prototype.tsx:138
-msgid "chart.map.layers.base"
-msgstr "Livello di base"
-
-#: app/charts/map/prototype-right-controls.tsx:13
-msgid "chart.map.layers.base.lakes"
-msgstr "Laghi"
-
-#: app/charts/map/prototype-right-controls.tsx:12
-msgid "chart.map.layers.base.relief"
-msgstr "Rilievo"
-
-#: app/charts/map/prototype-right-controls.tsx:108
-msgid "chart.map.layers.no.selected"
-msgstr "Seleziona un livello da editare nel pannello di sinistra."
-
-#: app/charts/map/chart-map-prototype.tsx:140
-msgid "chart.map.layers.symbol"
-msgstr "Simboli"
-
-#: app/charts/map/prototype-right-controls.tsx:90
-msgid "chart.map.layers.symbol.add.symbols"
-msgstr "Mostra simboli proporzionali"
-
-#: app/charts/map/prototype-right-controls.tsx:97
-msgid "chart.map.layers.symbol.select.measure"
-msgstr "Seleziona una variabile"
-
-#: app/configurator/components/chart-options-selector.tsx:102
-msgid "controls.select.column.layout"
-msgstr "Layout a colonne"
-
-#: app/charts/map/prototype-right-controls.tsx:51
-msgid "chart.map.layers.area.discretization.continuous"
-msgstr "Continuo"
-
-#: app/charts/map/prototype-right-controls.tsx:59
-msgid "chart.map.layers.area.discretization.discrete"
-msgstr "Discreto"
-
-#: app/components/data-download.tsx:46
-msgid "button.download.runsparqlquery"
-msgstr "Esegui query SPARQL"
-
-#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:89
-msgid "controls.filters.time.range"
-msgstr "intervallo di tempo"
-
-#: app/configurator/components/dataset-metadata.tsx:22
-msgid "dataset.metadata.description"
-msgstr "Descrizione"
-
-#: app/configurator/components/dataset-metadata.tsx:48
-msgid "dataset.metadata.version"
-msgstr "versione"
-
+#: app/configurator/components/chart-controls/drag-and-drop-tab.tsx:27
+msgid "table.column.no"
+msgstr "Colonna {0}"

--- a/app/rdf/parse.ts
+++ b/app/rdf/parse.ts
@@ -130,6 +130,10 @@ export const parseCubeDimension = ({
     dataType?.equals(ns.xsd.decimal) ||
     false;
 
+  const isKeyDimension = dim
+    .out(ns.rdf.type)
+    .terms.some((t) => t.equals(ns.cube.KeyDimension));
+
   return {
     cube,
     dimension: dim,
@@ -139,6 +143,7 @@ export const parseCubeDimension = ({
       iri: dim.path?.value!,
       isLiteral,
       isNumerical,
+      isKeyDimension,
       hasUndefinedValues,
       dataType: dataType?.value,
       name: dim.out(ns.schema.name, outOpts).value ?? dim.path?.value!,

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -22,7 +22,7 @@ import * as ns from "./namespace";
 import { getQueryLocales, parseCube, parseCubeDimension } from "./parse";
 import { loadResourceLabels } from "./query-labels";
 
-const NULL_DIMENSION_VALUE = "NULL";
+const DIMENSION_VALUE_UNDEFINED = ns.cube.Undefined.value;
 
 /** Adds a suffix to an iri to mark its label */
 const labelDimensionIri = (iri: string) => `${iri}/__label__`;
@@ -288,7 +288,7 @@ const getCubeDimensionValuesWithLabels = async ({
       ? dimensionValueLiterals.map((v) => {
           return ns.cube.Undefined.equals(v.datatype)
             ? {
-                value: NULL_DIMENSION_VALUE, // We use a known string here because actual null does not work as value in UI inputs.
+                value: DIMENSION_VALUE_UNDEFINED, // We use a known string here because actual null does not work as value in UI inputs.
                 label: "–",
               }
             : {
@@ -465,7 +465,7 @@ const buildFilters = ({
     const toRDFValue = (value: string): NamedNode | Literal => {
       return dataType
         ? parsedCubeDimension.data.hasUndefinedValues &&
-          value === NULL_DIMENSION_VALUE
+          value === DIMENSION_VALUE_UNDEFINED
           ? rdf.literal("", ns.cube.Undefined)
           : rdf.literal(value, dataType)
         : rdf.namedNode(value);


### PR DESCRIPTION
Adds support for `cube:KeyDimensions`:

- Only Key Dimensions will be automatically set as filters. This should prevent cases where filters on redundant dimensions result in queries that return no data. NB: this only works if the cube is modeled correctly!
- Optional filter menus (only non-key dimensions can be optional) now include a "No Filter" option to deselect filters

Note that this does not yet address #73 or #79