### PR TITLE
Date Data Filter

### DIFF
--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -83,6 +83,7 @@ export const ChartDataFilters = ({
                 <DataFilterDropdown
                   key={d}
                   dataSetIri={dataSet}
+                  chartConfig={chartConfig}
                   dimensionIri={d}
                 />
               ))}
@@ -97,9 +98,11 @@ export const ChartDataFilters = ({
 const DataFilterDropdown = ({
   dimensionIri,
   dataSetIri,
+  chartConfig,
 }: {
   dimensionIri: string;
   dataSetIri: string;
+  chartConfig: ChartConfig;
 }) => {
   const [state, dispatch] = useInteractiveFilters();
   const formatDateAuto = useFormatFullDateAuto();
@@ -129,7 +132,16 @@ const DataFilterDropdown = ({
     // TODO: Un-disable temporal fields
     const disabled = dimension.__typename === "TemporalDimension";
 
-    const value = dataFilters[dimension.iri]?.value ?? FIELD_VALUE_NONE;
+    const configFilter = chartConfig.filters[dimension.iri];
+    const configFilterValue =
+      configFilter && configFilter.type === "single"
+        ? configFilter.value
+        : undefined;
+
+    const value =
+      dataFilters?.[dimension.iri]?.value ??
+      configFilterValue ??
+      FIELD_VALUE_NONE;
 
     const options = disabled
       ? [{ value, label: formatDateAuto(value) }]

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -6,6 +6,7 @@ import { ChartFiltersList } from "../../components/chart-filters-list";
 import { Select } from "../../components/form";
 import { Loading } from "../../components/hint";
 import { ChartConfig, InteractiveFiltersDataConfig } from "../../configurator";
+import { useFormatFullDateAuto } from "../../configurator/components/ui-helpers";
 import { FIELD_VALUE_NONE } from "../../configurator/constants";
 import { useDimensionValuesQuery } from "../../graphql/query-hooks";
 import { Icon } from "../../icons";
@@ -101,6 +102,7 @@ const DataFilterDropdown = ({
   dataSetIri: string;
 }) => {
   const [state, dispatch] = useInteractiveFilters();
+  const formatDateAuto = useFormatFullDateAuto();
   const { dataFilters } = state;
 
   const locale = useLocale();
@@ -124,7 +126,14 @@ const DataFilterDropdown = ({
   if (data?.dataCubeByIri?.dimensionByIri) {
     const dimension = data?.dataCubeByIri?.dimensionByIri;
 
-    const options = dimension.isKeyDimension
+    // TODO: Un-disable temporal fields
+    const disabled = dimension.__typename === "TemporalDimension";
+
+    const value = dataFilters[dimension.iri]?.value ?? FIELD_VALUE_NONE;
+
+    const options = disabled
+      ? [{ value, label: formatDateAuto(value) }]
+      : dimension.isKeyDimension
       ? dimension.values
       : [
           {
@@ -151,14 +160,8 @@ const DataFilterDropdown = ({
           id="interactiveDataFilter"
           label={dimension.label}
           options={options}
-          value={
-            dataFilters &&
-            dataFilters[dimension.iri] &&
-            dataFilters[dimension.iri].value
-              ? dataFilters[dimension.iri].value
-              : FIELD_VALUE_NONE
-          }
-          disabled={false}
+          value={value}
+          disabled={disabled}
           onChange={setDataFilter}
         />
       </Flex>

--- a/app/components/chart-filters-list.tsx
+++ b/app/components/chart-filters-list.tsx
@@ -36,11 +36,14 @@ export const ChartFiltersList = ({
       }
 
       const dimension = dimensions.find((d) => d.iri === iri);
-      const value = dimension?.values.find((v) => v.value === f.value);
-
       if (!dimension) {
         return [];
       }
+
+      const value =
+        dimension.__typename === "TemporalDimension"
+          ? { value: f.value, label: formatDateAuto(f.value) }
+          : dimension.values.find((v) => v.value === f.value);
 
       return [
         {
@@ -62,10 +65,7 @@ export const ChartFiltersList = ({
                 </Box>
 
                 <Box as="span" sx={{ fontWeight: "bold" }}>
-                  {value &&
-                    (dimension.__typename === "TemporalDimension"
-                      ? formatDateAuto(value.value)
-                      : value.label)}
+                  {value && value.label}
                 </Box>
                 {i < namedFilters.length - 1 && ", "}
               </Fragment>

--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -269,7 +269,7 @@ export const Input = ({
   label?: string | ReactNode;
   disabled?: boolean;
 } & FieldProps) => (
-  <Box sx={{ color: "monochrome700", fontSize: 4 }}>
+  <Box sx={{ color: "monochrome700", fontSize: 4, pb: 2 }}>
     {label && name && (
       <Label htmlFor={name} smaller>
         {label}

--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -149,22 +149,25 @@ export const Select = ({
   disabled,
   options,
   onChange,
+  sortOptions = true,
 }: {
   id: string;
   options: Option[];
   label?: ReactNode;
   disabled?: boolean;
+  sortOptions?: boolean;
 } & SelectProps) => {
   const locale = useLocale();
   const sortedOptions = useMemo(() => {
     const noneOptions = options.filter((o) => o.isNoneValue);
     const restOptions = options.filter((o) => !o.isNoneValue);
 
-    return [
-      ...noneOptions,
-      ...restOptions.sort((a, b) => a.label.localeCompare(b.label, locale)),
-    ];
-  }, [options, locale]);
+    if (sortOptions) {
+      restOptions.sort((a, b) => a.label.localeCompare(b.label, locale));
+    }
+
+    return [...noneOptions, ...restOptions];
+  }, [options, locale, sortOptions]);
 
   return (
     <Box sx={{ color: "monochrome700", pb: 2 }}>

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -11,7 +11,11 @@ import {
   ControlSectionContent,
   SectionTitle,
 } from "./chart-controls/section";
-import { DataFilterSelect, ControlTabField } from "./field";
+import {
+  DataFilterSelect,
+  ControlTabField,
+  DataFilterSelectTime,
+} from "./field";
 import { Loading } from "../../components/hint";
 import { Box } from "theme-ui";
 
@@ -59,25 +63,50 @@ export const ChartConfigurator = ({
           <ControlSectionContent side="left" aria-labelledby="controls-data">
             {requiredFilterDimensions.map((dimension, i) => (
               <Box sx={{ px: 2, mb: 2 }} key={dimension.iri}>
-                <DataFilterSelect
-                  dimensionIri={dimension.iri}
-                  label={dimension.label}
-                  options={dimension.values}
-                  disabled={false}
-                  id={`select-single-filter-${i}`}
-                />
+                {dimension.__typename === "TemporalDimension" ? (
+                  <DataFilterSelectTime
+                    dimensionIri={dimension.iri}
+                    label={dimension.label}
+                    from={dimension.values[0].value}
+                    to={dimension.values[1].value}
+                    timeUnit={dimension.timeUnit}
+                    timeFormat={dimension.timeFormat}
+                    disabled={false}
+                    id={`select-single-filter-${i}`}
+                  />
+                ) : (
+                  <DataFilterSelect
+                    dimensionIri={dimension.iri}
+                    label={dimension.label}
+                    options={dimension.values}
+                    disabled={false}
+                    id={`select-single-filter-${i}`}
+                  />
+                )}
               </Box>
             ))}
             {optionalFilterDimensions.map((dimension, i) => (
               <Box sx={{ px: 2, mb: 2 }} key={dimension.iri}>
-                <DataFilterSelect
-                  dimensionIri={dimension.iri}
-                  label={dimension.label}
-                  options={dimension.values}
-                  disabled={false}
-                  isOptional
-                  id={`select-single-filter-${i}`}
-                />
+                {dimension.__typename === "TemporalDimension" ? (
+                  <DataFilterSelectTime
+                    dimensionIri={dimension.iri}
+                    label={dimension.label}
+                    from={dimension.values[0].value}
+                    to={dimension.values[1].value}
+                    timeUnit={dimension.timeUnit}
+                    timeFormat={dimension.timeFormat}
+                    disabled={false}
+                    id={`select-single-filter-${i}`}
+                  />
+                ) : (
+                  <DataFilterSelect
+                    dimensionIri={dimension.iri}
+                    label={dimension.label}
+                    options={dimension.values}
+                    disabled={false}
+                    id={`select-single-filter-${i}`}
+                  />
+                )}
               </Box>
             ))}
           </ControlSectionContent>

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -96,6 +96,7 @@ export const ChartConfigurator = ({
                     timeUnit={dimension.timeUnit}
                     timeFormat={dimension.timeFormat}
                     disabled={false}
+                    isOptional
                     id={`select-single-filter-${i}`}
                   />
                 ) : (
@@ -104,6 +105,7 @@ export const ChartConfigurator = ({
                     label={dimension.label}
                     options={dimension.values}
                     disabled={false}
+                    isOptional
                     id={`select-single-filter-${i}`}
                   />
                 )}

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -187,11 +187,13 @@ export const DataFilterSelectTime = ({
     formatDateAuto,
   ]);
 
+  const fullLabel = isOptional ? `${label} (${optionalLabel})` : label;
+
   if (range <= 100) {
     return (
       <Select
         id={id}
-        label={isOptional ? `${label} (${optionalLabel})` : label}
+        label={fullLabel}
         disabled={disabled}
         options={allOptions}
         sortOptions={false}
@@ -203,7 +205,7 @@ export const DataFilterSelectTime = ({
   return (
     <TimeInput
       id={id}
-      label={isOptional ? `${label} (${optionalLabel})` : label}
+      label={fullLabel}
       value={fieldProps.value}
       timeFormat={timeFormat}
       onChange={fieldProps.onChange}
@@ -224,7 +226,9 @@ const TimeInput = ({
   timeFormat: string;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
 }) => {
-  const [inputValue, setInputValue] = useState(value);
+  const [inputValue, setInputValue] = useState(
+    value === FIELD_VALUE_NONE ? undefined : value
+  );
   const formatLocale = useTimeFormatLocale();
 
   const [parseDateValue, formatDateValue] = useMemo(
@@ -248,7 +252,7 @@ const TimeInput = ({
 
   return (
     <Input
-      id={id}
+      name={id}
       label={label}
       value={inputValue}
       onChange={onInputChange}

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -1,6 +1,6 @@
 import { t } from "@lingui/macro";
 import get from "lodash/get";
-import { ChangeEvent, ReactNode, useCallback, useMemo } from "react";
+import { ChangeEvent, ReactNode, useCallback, useMemo, useState } from "react";
 import { Box, Flex } from "theme-ui";
 import {
   Option,
@@ -12,7 +12,7 @@ import {
   useSingleFilterField,
 } from "..";
 import { Checkbox, Input, Label, Radio, Select } from "../../components/form";
-import { DimensionFieldsFragment } from "../../graphql/query-hooks";
+import { DimensionFieldsFragment, TimeUnit } from "../../graphql/query-hooks";
 import { DataCubeMetadata } from "../../graphql/types";
 import { IconName } from "../../icons";
 import {
@@ -23,7 +23,12 @@ import {
 import { FIELD_VALUE_NONE } from "../constants";
 import { ColorPickerMenu } from "./chart-controls/color-picker";
 import { AnnotatorTab, ControlTab } from "./chart-controls/control-tab";
-import { getPalette } from "./ui-helpers";
+import {
+  getPalette,
+  getTimeInterval,
+  useFormatFullDateAuto,
+  useTimeFormatLocale,
+} from "./ui-helpers";
 
 export const ControlTabField = ({
   component,
@@ -99,6 +104,155 @@ export const DataFilterSelect = ({
       options={allOptions}
       {...fieldProps}
     ></Select>
+  );
+};
+
+export const DataFilterSelectTime = ({
+  dimensionIri,
+  label,
+  from,
+  to,
+  timeUnit,
+  timeFormat,
+  id,
+  disabled,
+  isOptional,
+}: {
+  dimensionIri: string;
+  label: string;
+  from: string;
+  to: string;
+  timeUnit: TimeUnit;
+  timeFormat: string;
+  id: string;
+  disabled?: boolean;
+  isOptional?: boolean;
+}) => {
+  const fieldProps = useSingleFilterSelect({ dimensionIri });
+  const formatDateAuto = useFormatFullDateAuto();
+  const formatLocale = useTimeFormatLocale();
+
+  const formatDateValue = formatLocale.format(timeFormat);
+  const parseDateValue = formatLocale.parse(timeFormat);
+
+  const fromDate = parseDateValue(from);
+  const toDate = parseDateValue(to);
+  if (!fromDate || !toDate) {
+    throw Error(`Error parsing dates ${from}, ${to}`);
+  }
+  const timeInterval = getTimeInterval(timeUnit);
+  const range = timeInterval.count(fromDate, toDate) + 1;
+
+  const noneLabel = t({
+    id: "controls.dimensionvalue.none",
+    message: `No Filter`,
+  });
+
+  const optionalLabel = t({
+    id: "controls.select.optional",
+    message: `optional`,
+  });
+
+  const allOptions = useMemo(() => {
+    if (range > 100) {
+      return [];
+    }
+
+    const options = [...timeInterval.range(fromDate, toDate), toDate].map(
+      (d) => {
+        return {
+          value: formatDateValue(d),
+          label: formatDateAuto(d),
+        };
+      }
+    );
+    return isOptional
+      ? [
+          {
+            value: FIELD_VALUE_NONE,
+            label: noneLabel,
+            isNoneValue: true,
+          },
+          ...options,
+        ]
+      : options;
+  }, [
+    range,
+    timeInterval,
+    fromDate,
+    toDate,
+    isOptional,
+    noneLabel,
+    formatDateValue,
+    formatDateAuto,
+  ]);
+
+  if (range <= 100) {
+    return (
+      <Select
+        id={id}
+        label={isOptional ? `${label} (${optionalLabel})` : label}
+        disabled={disabled}
+        options={allOptions}
+        sortOptions={false}
+        {...fieldProps}
+      ></Select>
+    );
+  }
+
+  return (
+    <TimeInput
+      id={id}
+      label={isOptional ? `${label} (${optionalLabel})` : label}
+      value={fieldProps.value}
+      timeFormat={timeFormat}
+      onChange={fieldProps.onChange}
+    />
+  );
+};
+
+const TimeInput = ({
+  id,
+  label,
+  value,
+  timeFormat,
+  onChange,
+}: {
+  id: string;
+  label: string;
+  value: string | undefined;
+  timeFormat: string;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+}) => {
+  const [inputValue, setInputValue] = useState(value);
+  const formatLocale = useTimeFormatLocale();
+
+  const [parseDateValue, formatDateValue] = useMemo(
+    () => [formatLocale.parse(timeFormat), formatLocale.format(timeFormat)],
+    [timeFormat, formatLocale]
+  );
+
+  const onInputChange = useCallback<(e: ChangeEvent<HTMLInputElement>) => void>(
+    (e) => {
+      setInputValue(e.currentTarget.value);
+      const parsed = parseDateValue(e.currentTarget.value);
+      if (
+        parsed !== null &&
+        formatDateValue(parsed) === e.currentTarget.value
+      ) {
+        onChange(e);
+      }
+    },
+    [formatDateValue, onChange, parseDateValue]
+  );
+
+  return (
+    <Input
+      id={id}
+      label={label}
+      value={inputValue}
+      onChange={onInputChange}
+    ></Input>
   );
 };
 

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -1,4 +1,3 @@
-import { SelectProps } from "theme-ui";
 import get from "lodash/get";
 import {
   ChangeEvent,
@@ -6,6 +5,7 @@ import {
   SyntheticEvent,
   useCallback,
 } from "react";
+import { SelectProps } from "theme-ui";
 import { getFieldComponentIri } from "../charts";
 import { DataCubeMetadata } from "../graphql/types";
 import { ChartType } from "./config-types";
@@ -265,10 +265,15 @@ export const useSingleFilterSelect = ({
   dimensionIri,
 }: {
   dimensionIri: string;
-}): SelectProps => {
+}): {
+  value: string | undefined;
+  onChange: (e: ChangeEvent<HTMLSelectElement | HTMLInputElement>) => void;
+} => {
   const [state, dispatch] = useConfiguratorState();
 
-  const onChange = useCallback<(e: ChangeEvent<HTMLSelectElement>) => void>(
+  const onChange = useCallback<
+    (e: ChangeEvent<HTMLSelectElement | HTMLInputElement>) => void
+  >(
     (e) => {
       dispatch({
         type: "CHART_CONFIG_FILTER_SET_SINGLE",

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -220,6 +220,11 @@ const deriveFiltersFromFields = produce(
             type: "single",
             value: Object.keys(f.values)[0],
           };
+        } else if (isFiltered(dimension.iri) && f.type === "range") {
+          filters[dimension.iri] = {
+            type: "single",
+            value: f.from,
+          };
         }
       } else {
         // Add filter for this dim if it's not one of the selected multi filter fields

--- a/app/configurator/interactive-filters/editor-time-interval-brush.tsx
+++ b/app/configurator/interactive-filters/editor-time-interval-brush.tsx
@@ -120,7 +120,7 @@ export const EditorIntervalBrush = ({
 
   const [fromPx, toPx] = timeRange.map(timeScale);
 
-  // FIXME: fix dependency array
+  // FIXME: fix dependency array but don't include brush.move!
   useEffect(() => {
     const g = select(brushRef.current);
     (g as Selection<SVGGElement, unknown, null, undefined>).call(brush.move, [

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -95,6 +95,10 @@ query DataCubeMetadataWithComponentValues($iri: String!, $locale: String!) {
     publisher
     dimensions {
       ...dimensionFieldsWithValues
+      ... on TemporalDimension {
+        timeUnit
+        timeFormat
+      }
     }
     measures {
       ...dimensionFields
@@ -110,6 +114,10 @@ query DimensionValues(
   dataCubeByIri(iri: $dataCubeIri, locale: $locale) {
     dimensionByIri(iri: $dimensionIri) {
       ...dimensionFieldsWithValues
+      ... on TemporalDimension {
+        timeUnit
+        timeFormat
+      }
     }
   }
 }

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -269,7 +269,7 @@ export type DataCubeMetadataWithComponentValuesQuery = { __typename: 'Query', da
       { __typename: 'OrdinalDimension' }
       & DimensionFieldsWithValues_OrdinalDimension_Fragment
     ) | (
-      { __typename: 'TemporalDimension' }
+      { __typename: 'TemporalDimension', timeUnit: TimeUnit, timeFormat: string }
       & DimensionFieldsWithValues_TemporalDimension_Fragment
     ) | (
       { __typename: 'Measure' }
@@ -293,7 +293,7 @@ export type DimensionValuesQuery = { __typename: 'Query', dataCubeByIri?: Maybe<
       { __typename: 'OrdinalDimension' }
       & DimensionFieldsWithValues_OrdinalDimension_Fragment
     ) | (
-      { __typename: 'TemporalDimension' }
+      { __typename: 'TemporalDimension', timeUnit: TimeUnit, timeFormat: string }
       & DimensionFieldsWithValues_TemporalDimension_Fragment
     ) | (
       { __typename: 'Measure' }
@@ -453,6 +453,10 @@ export const DataCubeMetadataWithComponentValuesDocument = gql`
     publisher
     dimensions {
       ...dimensionFieldsWithValues
+      ... on TemporalDimension {
+        timeUnit
+        timeFormat
+      }
     }
     measures {
       ...dimensionFields
@@ -470,6 +474,10 @@ export const DimensionValuesDocument = gql`
   dataCubeByIri(iri: $dataCubeIri, locale: $locale) {
     dimensionByIri(iri: $dimensionIri) {
       ...dimensionFieldsWithValues
+      ... on TemporalDimension {
+        timeUnit
+        timeFormat
+      }
     }
   }
 }


### PR DESCRIPTION
Handle temporal dimensions correctly in data filters. The original problem was that the dimension is only annotated with the date range but not a list of dates. To select a filter on a temporal dimension, we have to interpolate in the right time unit.

This is implemented by showing a dropdown menu for 100 entries and less and an input field when there are more possible values. The input is matched on the ISO8601 format of the dimension's datatype (e.g. "2007" for years, "2007-01-01" for dates etc.).

It's not an optimal solution because users have to know or guess the right date … but it works for now. We will have to design and implement a better solution in the future, ideally one _that only allows to select dates which have observations_.

See #79 

