### PR TITLE
feat: Disable an ability to add temporal interactive filters

### DIFF
--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -129,9 +129,6 @@ const DataFilterDropdown = ({
   if (data?.dataCubeByIri?.dimensionByIri) {
     const dimension = data?.dataCubeByIri?.dimensionByIri;
 
-    // TODO: Un-disable temporal fields
-    const disabled = dimension.__typename === "TemporalDimension";
-
     const configFilter = chartConfig.filters[dimension.iri];
     const configFilterValue =
       configFilter && configFilter.type === "single"
@@ -143,9 +140,7 @@ const DataFilterDropdown = ({
       configFilterValue ??
       FIELD_VALUE_NONE;
 
-    const options = disabled
-      ? [{ value, label: formatDateAuto(value) }]
-      : dimension.isKeyDimension
+    const options = dimension.isKeyDimension
       ? dimension.values
       : [
           {
@@ -173,7 +168,6 @@ const DataFilterDropdown = ({
           label={dimension.label}
           options={options}
           value={value}
-          disabled={disabled}
           onChange={setDataFilter}
         />
       </Flex>

--- a/app/configurator/interactive-filters/interactive-filters-config-options.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-config-options.tsx
@@ -1,12 +1,6 @@
 import { t, Trans } from "@lingui/macro";
 import { extent } from "d3";
-import React, {
-  ChangeEvent,
-  ReactNode,
-  useCallback,
-  useEffect,
-  useRef,
-} from "react";
+import React, { ChangeEvent, useCallback, useEffect, useRef } from "react";
 import { Box } from "theme-ui";
 import { getFieldComponentIri, getFieldComponentIris } from "../../charts";
 import { Checkbox } from "../../components/form";
@@ -30,8 +24,8 @@ import {
   useInteractiveFiltersToggle,
   useInteractiveTimeFiltersToggle,
 } from "./interactive-filters-config-actions";
-import { InteractveFilterType } from "./interactive-filters-configurator";
 import { toggleInteractiveFilterDataDimension } from "./interactive-filters-config-state";
+import { InteractveFilterType } from "./interactive-filters-configurator";
 
 export const InteractiveFiltersOptions = ({
   state,
@@ -256,9 +250,12 @@ const InteractiveDataFilterOptions = ({
     const mappedIris = getFieldComponentIris(state.chartConfig.fields);
 
     // Dimensions that are not encoded in the visualization
-    const unMappedDimensions = data?.dataCubeByIri.dimensions.filter(
-      (dim) => !mappedIris.has(dim.iri)
-    );
+    // excluding temporal dimensions
+    const unMappedDimensionsWithoutTemporalDimensions =
+      data?.dataCubeByIri.dimensions.filter(
+        (dim) =>
+          !mappedIris.has(dim.iri) && dim.__typename !== "TemporalDimension"
+      );
 
     return (
       <>
@@ -270,10 +267,10 @@ const InteractiveDataFilterOptions = ({
           path="dataFilters"
           defaultChecked={false}
           disabled={false}
-          dimensions={unMappedDimensions}
+          dimensions={unMappedDimensionsWithoutTemporalDimensions}
         ></InteractiveDataFiltersToggle>
         <Box sx={{ my: 3 }}>
-          {unMappedDimensions.map((d, i) => (
+          {unMappedDimensionsWithoutTemporalDimensions.map((d, i) => (
             <InteractiveDataFilterOptionsCheckbox
               key={i}
               label={d.label}


### PR DESCRIPTION
Closes #117.

As per conversation with @herrstucki, we decided to disable temporal interactive filters completely, as the whole approach probably needs some adjustments – both selects, inputs or sliders wouldn't be very convenient for selecting a single date when there is **a lot** of possible values.

This PR disables the ability to add temporal interactive filters when creating a chart – so the existing charts will still contain these filters for the time being.

In case there is a need to hide this type of filters in the current charts, let me know and I'll also introduce the changes.