### PR TITLE
fix: Automatic redirects to ChartConfigurator from ActionBar and DatasetList in docs

### DIFF
--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -774,11 +774,13 @@ const ConfiguratorStateProviderInternal = ({
   chartId,
   children,
   initialState = INITIAL_STATE,
+  allowDefaultRedirect = true,
 }: {
   key: string;
   chartId: string;
   children?: ReactNode;
   initialState?: ConfiguratorState;
+  allowDefaultRedirect?: boolean;
 }) => {
   const locale = useLocale();
   const stateAndDispatch = useImmerReducer(reducer, initialState);
@@ -824,7 +826,7 @@ const ConfiguratorStateProviderInternal = ({
               window.localStorage.removeItem(getLocalStorageKey(chartId));
             }
           } else {
-            if (!asPath.includes("/docs")) replace(`/create/new`);
+            if (allowDefaultRedirect) replace(`/create/new`);
           }
         }
       } catch {
@@ -833,7 +835,15 @@ const ConfiguratorStateProviderInternal = ({
       }
     };
     initialize();
-  }, [dispatch, chartId, replace, initialState, asPath, query, locale]);
+  }, [
+    dispatch,
+    chartId,
+    replace,
+    initialState,
+    allowDefaultRedirect,
+    query,
+    locale,
+  ]);
 
   useEffect(() => {
     try {
@@ -922,10 +932,12 @@ export const ConfiguratorStateProvider = ({
   chartId,
   children,
   initialState,
+  allowDefaultRedirect,
 }: {
   chartId: string;
   children?: ReactNode;
   initialState?: ConfiguratorState;
+  allowDefaultRedirect?: boolean;
 }) => {
   // Ensure that the state is reset by using the `chartId` as `key`
   return (
@@ -933,6 +945,7 @@ export const ConfiguratorStateProvider = ({
       key={chartId}
       chartId={chartId}
       initialState={initialState}
+      allowDefaultRedirect={allowDefaultRedirect}
     >
       {children}
     </ConfiguratorStateProviderInternal>

--- a/app/docs/action-bar.docs.tsx
+++ b/app/docs/action-bar.docs.tsx
@@ -1,8 +1,8 @@
 import { markdown, ReactSpecimen } from "catalog";
-import { ActionBar } from "../configurator/components/action-bar";
+import { Box, Text } from "theme-ui";
 import { ConfiguratorStateProvider } from "../configurator";
+import { ActionBar } from "../configurator/components/action-bar";
 import { states } from "./fixtures";
-import { Text, Box } from "theme-ui";
 
 export default () =>
   markdown`
@@ -23,7 +23,11 @@ import { ActionBar } from "./components/action-bar"
 ${states.map((state) => (
   <Box key={state.state} my={4} sx={{ width: "100%" }}>
     <Text>{state.state}</Text>
-    <ConfiguratorStateProvider chartId={state.state} initialState={state}>
+    <ConfiguratorStateProvider
+      chartId={state.state}
+      initialState={state}
+      allowDefaultRedirect={false}
+    >
       <ReactSpecimen>
         <ActionBar />
       </ReactSpecimen>

--- a/app/docs/dataset-list.docs.tsx
+++ b/app/docs/dataset-list.docs.tsx
@@ -12,6 +12,7 @@ export default () => markdown`
     <ConfiguratorStateProvider
       chartId={states[0].state}
       initialState={states[0]}
+      allowDefaultRedirect={false}
     >
       <ReactSpecimen span={2}>
         <div
@@ -40,6 +41,7 @@ export default () => markdown`
     <ConfiguratorStateProvider
       chartId={states[0].state}
       initialState={states[0]}
+      allowDefaultRedirect={false}
     >
       <ReactSpecimen span={2}>
         <div


### PR DESCRIPTION
Closes #102.

Currently, when we go to /docs -> Components -> Action Bar | Dataset List, we won't actually see the docs, but rather will be redirected to a chart configurator.

This behavior occurs due to some logic in a `ConfiguratorStateProvider`, which checks the `chartId` param and if it couldn't find it in the localStorage, it would redirect the user to /create/new.

I have changed this logic to first check, if the user is currently visiting the docs, and if they are, then the redirect won't happen. This fixes both the issue for ActionBar and DatasetList pages.