### PR TITLE
feat: Consider InteractiveFilters during data download

### DIFF
--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -16,7 +16,7 @@ export const useQueryFilters = ({
   interactiveFiltersIsActive,
 }: {
   chartConfig: ChartConfig;
-  interactiveFiltersIsActive: boolean;
+  interactiveFiltersIsActive: boolean | undefined;
 }): Filters | FilterValueSingle => {
   const [IFstate] = useInteractiveFilters();
   const { filters } = chartConfig;

--- a/app/components/chart-filters-list.tsx
+++ b/app/components/chart-filters-list.tsx
@@ -1,5 +1,5 @@
 import { Fragment } from "react";
-import { Text, Box } from "theme-ui";
+import { Box, Text } from "theme-ui";
 import { useQueryFilters } from "../charts/shared/chart-helpers";
 import { ChartConfig } from "../configurator";
 import { useFormatFullDateAuto } from "../configurator/components/ui-helpers";
@@ -23,7 +23,7 @@ export const ChartFiltersList = ({
   const queryFilters = useQueryFilters({
     chartConfig,
     interactiveFiltersIsActive:
-      chartConfig.interactiveFiltersConfig?.dataFilters.active ?? false,
+      chartConfig.interactiveFiltersConfig?.dataFilters.active,
   });
   if (data?.dataCubeByIri) {
     const {

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -205,13 +205,11 @@ const Chart = ({
   dataSet: string;
   chartConfig: ChartConfig;
 }) => {
-  const interactiveFiltersIsActive =
-    chartConfig.interactiveFiltersConfig?.dataFilters.active ?? false;
-
   // Combine filters from config + interactive filters
   const queryFilters = useQueryFilters({
     chartConfig,
-    interactiveFiltersIsActive,
+    interactiveFiltersIsActive:
+      chartConfig.interactiveFiltersConfig?.dataFilters.active,
   });
 
   return (

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -152,13 +152,11 @@ const Chart = ({
   dataSet: string;
   chartConfig: ChartConfig;
 }) => {
-  const interactiveFiltersIsActive =
-    chartConfig.interactiveFiltersConfig?.dataFilters.active ?? false;
-
   // Combine filters from config + interactive filters
   const queryFilters = useQueryFilters({
     chartConfig,
-    interactiveFiltersIsActive,
+    interactiveFiltersIsActive:
+      chartConfig.interactiveFiltersConfig?.dataFilters.active,
   });
 
   return (

--- a/app/components/data-download.tsx
+++ b/app/components/data-download.tsx
@@ -36,7 +36,7 @@ export const DataDownload = memo(
     const filters = useQueryFilters({
       chartConfig,
       interactiveFiltersIsActive:
-        chartConfig.interactiveFiltersConfig?.dataFilters.active ?? false,
+        chartConfig.interactiveFiltersConfig?.dataFilters.active,
     });
 
     const [{ data }] = useDataCubeObservationsQuery({


### PR DESCRIPTION
Closes #142.

Currently, interactive filters do not affect the data that is being downloaded, and that might be confusing for users. This PR fixes that, so the `stuff_visible_on_the_chart` is always equal to the `stuff_downloaded_to_csv`.

PS. Not sure if we should change this yet, as @herrstucki didn't have a chance to go through the #142 and the current behavior might be the expected behavior.