### PR TITLE
Properly check for undefined data points in the area chart generator

### DIFF
--- a/app/charts/area/areas.tsx
+++ b/app/charts/area/areas.tsx
@@ -1,5 +1,6 @@
 import { area } from "d3";
 import { memo } from "react";
+import { isNumber } from "../../configurator/components/ui-helpers";
 import { useTheme } from "../../themes";
 import { useChartState } from "../shared/use-chart-state";
 import { AreasState } from "./areas-state";
@@ -9,7 +10,7 @@ export const Areas = () => {
     useChartState() as AreasState;
   const theme = useTheme();
   const areaGenerator = area<$FixMe>()
-    .defined((d) => d[0] !== null && d[1] !== null)
+    .defined((d) => isNumber(d[0]) && isNumber(d[1]))
     .x((d) => xScale(getX(d.data)))
     .y0((d) => yScale(d[0]))
     .y1((d) => yScale(d[1]));

--- a/app/charts/area/areas.tsx
+++ b/app/charts/area/areas.tsx
@@ -21,7 +21,7 @@ export const Areas = () => {
           <Area
             key={`${d.key}-${i}`}
             path={areaGenerator(d) as string}
-            color={segments.length > 1 ? colors(d.key) : theme.colors.primary}
+            color={colors(d.key)}
           />
         );
       })}


### PR DESCRIPTION
Currently, when we would like to create a stacked area chart, which is based on a dataset that contains some missing values, we could see e.g. this:

<img width="912" alt="Screenshot 2021-10-19 at 11 47 21" src="https://user-images.githubusercontent.com/52032047/137885899-19aa41af-4df0-4766-b56f-904fbf257714.png">

Repro: https://dev.visualize.admin.ch/en/v/Jcy9ujD2SmCX

This happens due to the fact, that the D3's stack method generates `NaN` values, when there is no data for some category in a given point of time, and in the area generator we check for `null`, which doesn't work.

This PR fixes that by checking if a value is a number.

Chart after fixing:

<img width="609" alt="Screenshot 2021-10-19 at 11 50 19" src="https://user-images.githubusercontent.com/52032047/137886325-605bf12a-0cb3-4a9f-9ec0-0ae8837ff570.png">