### PR TITLE
Use correct timeUnit to format dates above the chart

### DIFF
--- a/app/components/chart-filters-list.tsx
+++ b/app/components/chart-filters-list.tsx
@@ -44,7 +44,7 @@ export const ChartFiltersList = ({
         dimension.__typename === "TemporalDimension"
           ? {
               value: f.value,
-              label: timeFormatUnit(f.value, f.timeUnit),
+              label: timeFormatUnit(f.value, dimension.timeUnit),
             }
           : dimension.values.find((v) => v.value === f.value);
 


### PR DESCRIPTION
This PR fixes the issue mentioned in the comments in #117 (the year being formatted as DD-MM-YYYY).