### PR TITLE
fix: Use "cube" parameter instead of "dataset" when creating chart from existing dataset

### DIFF
--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -3,7 +3,7 @@ import {
   getLocalStorageKey,
   initChartStateFromChart,
   initChartStateFromLocalStorage,
-  initChartStateFromDataset,
+  initChartStateFromCube,
 } from "./configurator-state";
 import * as api from "../api";
 import { data as fakeVizFixture } from "../test/__fixtures/prod/5BmzFXXNtE1X.json";
@@ -68,7 +68,7 @@ describe("initChartFromLocalStorage", () => {
   });
 });
 
-describe("initChartStateFromDataset", () => {
+describe("initChartStateFromCube", () => {
   const setup = ({ cubeMetadata }: { cubeMetadata: object }) => {
     const client = new Client({
       url: "https://example.com/graphql",
@@ -83,7 +83,7 @@ describe("initChartStateFromDataset", () => {
   };
   it("should work init fields with existing dataset and go directly to 2nd step", async () => {
     const { client } = setup({ cubeMetadata: bathingWaterMetadata });
-    const res = await initChartStateFromDataset(
+    const res = await initChartStateFromCube(
       client,
       "https://environment.ld.admin.ch/foen/ubd0104/3/",
       "en"

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -799,7 +799,7 @@ export const initChartStateFromChart = async (
   }
 };
 
-export const initChartStateFromDataset = async (
+export const initChartStateFromCube = async (
   client: Client,
   datasetIri: DatasetIri,
   locale: string
@@ -882,10 +882,10 @@ const ConfiguratorStateProviderInternal = ({
         if (chartId === "new") {
           if (query.from && typeof query.from === "string") {
             newChartState = await initChartStateFromChart(query.from);
-          } else if (query.dataset && typeof query.dataset === "string") {
-            newChartState = await initChartStateFromDataset(
+          } else if (query.cube && typeof query.cube === "string") {
+            newChartState = await initChartStateFromCube(
               client,
-              query.dataset,
+              query.cube,
               locale
             );
           }


### PR DESCRIPTION
https://github.com/visualize-admin/visualization-tool/pull/150#issuecomment-956097226

> @ptbrowne Currently, the Cube Creator links to /create/new?cube=<versionHistoryIri> (as described in #87). So the param and the logic don't quite match yet 😅

Instead of using the "dataset" parameter in the URL, use the "cube" to match what the cube creator is using.
