### PR TITLE
Fix Column Chart display bugs

### DIFF
--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -26,11 +26,10 @@ import {
 } from "../../configurator/components/ui-helpers";
 import { Observation, ObservationValue } from "../../domain/data";
 import { sortByIndex } from "../../lib/array";
-import { estimateTextWidth } from "../../lib/estimate-text-width";
 import { useLocale } from "../../locales/use-locale";
-import { BRUSH_BOTTOM_SPACE } from "../shared/brush";
 import { getLabelWithUnit, usePreparedData } from "../shared/chart-helpers";
 import { TooltipInfo } from "../shared/interaction/tooltip";
+import { useChartPadding } from "../shared/padding";
 import { ChartContext, ChartProps } from "../shared/use-chart-state";
 import { InteractionProvider } from "../shared/use-interaction";
 import { useInteractiveFilters } from "../shared/use-interactive-filters";
@@ -258,16 +257,15 @@ const useGroupedColumnsState = ({
     ];
   });
 
-  // Dimensions
-  const left = interactiveFiltersConfig?.time.active
-    ? estimateTextWidth(formatNumber(entireMaxValue))
-    : Math.max(
-        estimateTextWidth(formatNumber(yScale.domain()[0])),
-        estimateTextWidth(formatNumber(yScale.domain()[1]))
-      );
-  const bottom = interactiveFiltersConfig?.time.active
-    ? (max(bandDomain, (d) => estimateTextWidth(d)) || 70) + BRUSH_BOTTOM_SPACE
-    : max(bandDomain, (d) => estimateTextWidth(d)) || 70;
+  const { left, bottom } = useChartPadding(
+    yScale,
+    width,
+    aspectRatio,
+    interactiveFiltersConfig,
+    formatNumber,
+    bandDomain
+  );
+
   const margins = {
     top: 50,
     right: 40,

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -225,8 +225,7 @@ const useGroupedColumnsState = ({
 
   // y
   const minValue = Math.min(mkNumber(min(preparedData, (d) => getY(d))), 0);
-  const maxValue = max(preparedData, (d) => getY(d)) as number;
-  const entireMaxValue = max(sortedData, getY) as number;
+  const maxValue = Math.max(max(preparedData, (d) => getY(d)) as number, 0);
 
   const yScale = scaleLinear()
     .domain([mkNumber(minValue), mkNumber(maxValue)])

--- a/app/charts/column/columns-grouped.tsx
+++ b/app/charts/column/columns-grouped.tsx
@@ -1,6 +1,6 @@
-import { memo } from "react";
 import { useChartState } from "../shared/use-chart-state";
 import { GroupedColumnsState } from "./columns-grouped-state";
+import { Column } from "./rendering-utils";
 
 export const ColumnsGrouped = () => {
   const {
@@ -19,45 +19,22 @@ export const ColumnsGrouped = () => {
     <g transform={`translate(${margins.left} ${margins.top})`}>
       {grouped.map((segment) => (
         <g key={segment[0]} transform={`translate(${xScale(segment[0])}, 0)`}>
-          {segment[1].map((d, i) => (
-            <Column
-              key={i}
-              x={xScaleIn(getSegment(d)) as number}
-              y={yScale(Math.max(0, getY(d) ?? NaN))}
-              width={xScaleIn.bandwidth()}
-              height={Math.abs(yScale(getY(d) ?? NaN) - yScale(0))}
-              color={colors(getSegment(d))}
-            />
-          ))}
+          {segment[1].map((d, i) => {
+            const y = getY(d) ?? NaN;
+
+            return (
+              <Column
+                key={i}
+                x={xScaleIn(getSegment(d)) as number}
+                y={yScale(Math.max(y, 0))}
+                width={xScaleIn.bandwidth()}
+                height={Math.abs(yScale(y) - yScale(0))}
+                color={colors(getSegment(d))}
+              />
+            );
+          })}
         </g>
       ))}
     </g>
   );
 };
-
-const Column = memo(
-  ({
-    x,
-    y,
-    width,
-    height,
-    color,
-  }: {
-    x: number;
-    y: number;
-    width: number;
-    height: number;
-    color: string;
-  }) => {
-    return (
-      <rect
-        x={x}
-        y={y}
-        width={width}
-        height={height}
-        stroke="none"
-        fill={color}
-      />
-    );
-  }
-);

--- a/app/charts/column/columns-simple.tsx
+++ b/app/charts/column/columns-simple.tsx
@@ -1,32 +1,26 @@
-import { memo } from "react";
 import { useTheme } from "../../themes";
 import { useChartState } from "../shared/use-chart-state";
 import { ColumnsState } from "./columns-state";
+import { Column } from "./rendering-utils";
 
 export const Columns = () => {
-  const {
-    preparedData,
-    bounds,
-    getX,
-    xScale,
-    getY,
-    yScale,
-  } = useChartState() as ColumnsState;
+  const { preparedData, bounds, getX, xScale, getY, yScale } =
+    useChartState() as ColumnsState;
   const theme = useTheme();
   const { margins } = bounds;
 
   return (
     <g transform={`translate(${margins.left} ${margins.top})`}>
       {preparedData.map((d, i) => {
+        const y = getY(d) ?? NaN;
+
         return (
           <Column
             key={i}
             x={xScale(getX(d)) as number}
             width={xScale.bandwidth()}
-            // y={yScale(getY(d))}
-            y={yScale(Math.max(0, getY(d) ?? NaN))}
-            // height={yScale(0) - yScale(getY(d))}
-            height={Math.abs(yScale(getY(d) ?? 0) - yScale(0))}
+            y={yScale(Math.max(y, 0))}
+            height={Math.abs(yScale(y) - yScale(0))}
             color={
               (getY(d) ?? NaN) <= 0
                 ? theme.colors.secondary
@@ -38,30 +32,3 @@ export const Columns = () => {
     </g>
   );
 };
-
-const Column = memo(
-  ({
-    x,
-    y,
-    width,
-    height,
-    color,
-  }: {
-    x: number;
-    y: number;
-    width: number;
-    height: number;
-    color: string;
-  }) => {
-    return (
-      <rect
-        x={x}
-        y={y}
-        width={width}
-        height={height}
-        fill={color}
-        stroke="none"
-      />
-    );
-  }
-);

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -31,15 +31,14 @@ import {
 import { Observation, ObservationValue } from "../../domain/data";
 import { DimensionMetaDataFragment } from "../../graphql/query-hooks";
 import { sortByIndex } from "../../lib/array";
-import { estimateTextWidth } from "../../lib/estimate-text-width";
 import { useLocale } from "../../locales/use-locale";
-import { BRUSH_BOTTOM_SPACE } from "../shared/brush";
 import {
   getLabelWithUnit,
   getWideData,
   usePreparedData,
 } from "../shared/chart-helpers";
 import { TooltipInfo } from "../shared/interaction/tooltip";
+import { useChartPadding } from "../shared/padding";
 import { ChartContext, ChartProps } from "../shared/use-chart-state";
 import { InteractionProvider } from "../shared/use-interaction";
 import { useInteractiveFilters } from "../shared/use-interactive-filters";
@@ -292,16 +291,15 @@ const useColumnsStackedState = ({
     }[]
   );
 
-  // Dimensions
-  const left = interactiveFiltersConfig?.time.active
-    ? estimateTextWidth(formatNumber(entireMaxTotalValue))
-    : Math.max(
-        estimateTextWidth(formatNumber(yScale.domain()[0])),
-        estimateTextWidth(formatNumber(yScale.domain()[1]))
-      );
-  const bottom = interactiveFiltersConfig?.time.active
-    ? (max(bandDomain, (d) => estimateTextWidth(d)) || 70) + BRUSH_BOTTOM_SPACE
-    : max(bandDomain, (d) => estimateTextWidth(d)) || 70;
+  const { left, bottom } = useChartPadding(
+    yScale,
+    width,
+    aspectRatio,
+    interactiveFiltersConfig,
+    formatNumber,
+    bandDomain
+  );
+
   const margins = {
     top: 50,
     right: 40,

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -250,16 +250,19 @@ const useColumnsStackedState = ({
   const xEntireScale = scaleTime().domain(xEntireDomainAsTime);
 
   // y
-  const minTotal = Math.min(
-    min<$FixMe, number>(chartWideData, (d) => d.total) as number,
-    0
+  const minTotal = min<$FixMe, number>(chartWideData, (d) =>
+    segments
+      .map((s) => d[s])
+      .filter((d) => d < 0)
+      .reduce((a, b) => a + b, 0)
   );
-  const maxTotal = max<$FixMe, number>(chartWideData, (d) => d.total) as number;
+  const maxTotal = max<$FixMe, number>(chartWideData, (d) =>
+    segments
+      .map((s) => d[s])
+      .filter((d) => d >= 0)
+      .reduce((a, b) => a + b, 0)
+  );
   const yStackDomain = [minTotal, maxTotal] as [number, number];
-  const entireMaxTotalValue = max<$FixMe, number>(
-    allDataWide,
-    (d) => d.total
-  ) as number;
 
   const yMeasure = measures.find((d) => d.iri === fields.y.componentIri);
 

--- a/app/charts/column/columns-stacked.tsx
+++ b/app/charts/column/columns-stacked.tsx
@@ -1,11 +1,12 @@
-import { memo } from "react";
 import { useChartState } from "../shared/use-chart-state";
 import { StackedColumnsState } from "./columns-stacked-state";
+import { Column } from "./rendering-utils";
 
 export const ColumnsStacked = () => {
   const { bounds, getX, xScale, yScale, colors, series } =
     useChartState() as StackedColumnsState;
   const { margins } = bounds;
+
   return (
     <g transform={`translate(${margins.left} ${margins.top})`}>
       {series.map((sv) => (
@@ -15,8 +16,8 @@ export const ColumnsStacked = () => {
               <Column
                 key={`${getX(segment.data)}-${i}`}
                 x={xScale(getX(segment.data)) as number}
-                width={xScale.bandwidth()}
                 y={yScale(segment[1])}
+                width={xScale.bandwidth()}
                 height={yScale(segment[0]) - yScale(segment[1])}
               />
             );
@@ -26,17 +27,3 @@ export const ColumnsStacked = () => {
     </g>
   );
 };
-
-const Column = memo(function Column({
-  x,
-  y,
-  width,
-  height,
-}: {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-}) {
-  return <rect x={x} y={y} width={width} height={height} stroke="none" />;
-});

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -150,7 +150,7 @@ const useColumnsState = ({
 
   // y
   const minValue = Math.min(min(preparedData, (d) => getY(d)) ?? 0, 0);
-  const maxValue = max(preparedData, (d) => getY(d)) ?? 0;
+  const maxValue = Math.max(max(preparedData, (d) => getY(d)) ?? 0, 0);
   const entireMaxValue = max(sortedData, getY) as number;
 
   const yScale = scaleLinear()

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -1,6 +1,5 @@
 import {
   ascending,
-  axisLeft,
   descending,
   extent,
   max,
@@ -25,7 +24,6 @@ import {
 } from "../../configurator/components/ui-helpers";
 import { Observation } from "../../domain/data";
 import { TimeUnit } from "../../graphql/query-hooks";
-
 import { getLabelWithUnit, usePreparedData } from "../shared/chart-helpers";
 import { TooltipInfo } from "../shared/interaction/tooltip";
 import { useChartPadding } from "../shared/padding";
@@ -171,7 +169,6 @@ const useColumnsState = ({
     yScale,
     width,
     aspectRatio,
-    entireMaxValue,
     interactiveFiltersConfig,
     formatNumber,
     bandDomain

--- a/app/charts/column/rendering-utils.tsx
+++ b/app/charts/column/rendering-utils.tsx
@@ -1,0 +1,28 @@
+import { memo } from "react";
+
+export const Column = memo(
+  ({
+    x,
+    y,
+    width,
+    height,
+    color,
+  }: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    color?: string;
+  }) => {
+    return (
+      <rect
+        x={x}
+        y={y}
+        width={width}
+        height={height}
+        fill={color}
+        stroke="none"
+      />
+    );
+  }
+);

--- a/app/charts/shared/padding.tsx
+++ b/app/charts/shared/padding.tsx
@@ -9,7 +9,6 @@ const computeChartPadding = (
   yScale: d3.ScaleLinear<number, number>,
   width: number,
   aspectRatio: number,
-  entireMaxValue: number,
   interactiveFiltersConfig: ChartProps["interactiveFiltersConfig"],
   formatNumber: (n: number) => string,
   bandDomain?: string[]
@@ -20,9 +19,9 @@ const computeChartPadding = (
   // Width * aspectRatio is taken as an approximation of chartHeight
   // since we do not have access to chartHeight yet.
   const fakeTicks = yScale.ticks(getTickNumber(width * aspectRatio));
-  const left = interactiveFiltersConfig?.time.active
-    ? estimateTextWidth(formatNumber(entireMaxValue))
-    : Math.max(...fakeTicks.map((x) => estimateTextWidth(`${x}`)));
+  const left = Math.max(
+    ...fakeTicks.map((x) => estimateTextWidth(`${formatNumber(x)}`))
+  );
 
   let bottom = interactiveFiltersConfig?.time.active ? BRUSH_BOTTOM_SPACE : 40;
   if (bandDomain && bandDomain.length) {
@@ -35,7 +34,6 @@ export const useChartPadding = (
   yScale: d3.ScaleLinear<number, number>,
   width: number,
   aspectRatio: number,
-  entireMaxValue: number,
   interactiveFiltersConfig: ChartProps["interactiveFiltersConfig"],
   formatNumber: (n: number) => string,
   bandDomain?: string[]
@@ -46,17 +44,17 @@ export const useChartPadding = (
         yScale,
         width,
         aspectRatio,
-        entireMaxValue,
         interactiveFiltersConfig,
-        formatNumber
+        formatNumber,
+        bandDomain
       ),
     [
       yScale,
       width,
       aspectRatio,
-      entireMaxValue,
       interactiveFiltersConfig,
       formatNumber,
+      bandDomain,
     ]
   );
 };


### PR DESCRIPTION
Closes #166, #190.

This PR:
- fixes cropped Y axis ticks for column charts,
- introduces a "start with 0" constraint for Y axes with negative scales, which fixes bars that were overlapping axis titles,
- fixes min and max Y scale ranges for stacked column charts (previously, it was taking min and max of total, which was a sum of all positive and negative values in a given "column stack" – now it takes max(positive values in a stack) and min(negative values in a stack)),
- extracts a Column function (which was the same in 3 files) to a separate file.