### PR TITLE
Consider user-selected color in line and area charts for one-element selections

### DIFF
--- a/app/charts/area/areas.tsx
+++ b/app/charts/area/areas.tsx
@@ -20,7 +20,7 @@ export const Areas = () => {
           <Area
             key={`${d.key}-${i}`}
             path={areaGenerator(d) as string}
-            color={segments.length > 1 ? colors(d.key) : theme.colors.primary}
+            color={colors(d.key)}
           />
         );
       })}

--- a/app/charts/line/lines.tsx
+++ b/app/charts/line/lines.tsx
@@ -1,9 +1,9 @@
-import { useChartState } from "../shared/use-chart-state";
 import { line } from "d3";
-import { Observation } from "../../domain/data";
-import { LinesState } from "./lines-state";
-import { useTheme } from "../../themes";
 import { Fragment, memo } from "react";
+import { Observation } from "../../domain/data";
+import { useTheme } from "../../themes";
+import { useChartState } from "../shared/use-chart-state";
+import { LinesState } from "./lines-state";
 
 export const Lines = () => {
   const { getX, xScale, getY, yScale, grouped, colors, bounds } =
@@ -23,11 +23,7 @@ export const Lines = () => {
             <Line
               key={index}
               path={lineGenerator(observation[1]) as string}
-              color={
-                Array.from(grouped).length > 1
-                  ? colors(observation[0])
-                  : theme.colors.primary
-              }
+              color={colors(observation[0])}
             />
           </Fragment>
         );


### PR DESCRIPTION
Closes #171.

This PR makes the line and area charts consider user-selected colors when the selection is one-element long.

@herrstucki I'm not sure why the current behavior wasn't allowing that, as this was explicitly coded in the app – let me know if you think it shouldn't be changed :)