### PR TITLE
fix: Ability to use integer as filters

### DIFF
--- a/app/configurator/config-types.ts
+++ b/app/configurator/config-types.ts
@@ -27,7 +27,7 @@ export type FilterValueMulti = t.TypeOf<typeof FilterValueMulti>;
 const FilterValueSingle = t.type(
   {
     type: t.literal("single"),
-    value: t.string,
+    value: t.union([t.string, t.number]),
   },
   "FilterValueSingle"
 );


### PR DESCRIPTION
Fixes #168

The parser for single filter now accepts strings and integers since some datasets have integers in their columns. 