### PR TITLE
Fix hidden grouped-by columns in the Table chart

### DIFF
--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -4,11 +4,11 @@ import {
   GenericFields,
   TableColumn,
 } from "../configurator";
-import { getCategoricalDimensions, getTimeDimensions } from "../domain/data";
 import { mapColorsToComponentValuesIris } from "../configurator/components/ui-helpers";
+import { getCategoricalDimensions, getTimeDimensions } from "../domain/data";
+import { DimensionMetaDataFragment } from "../graphql/query-hooks";
 import { DataCubeMetadata } from "../graphql/types";
 import { unreachableError } from "../lib/unreachable";
-import { DimensionMetaDataFragment } from "../graphql/query-hooks";
 
 export const enabledChartTypes: ChartType[] = [
   // "bar",
@@ -338,6 +338,14 @@ export const getPossibleChartType = ({
 export const getFieldComponentIris = (fields: GenericFields) => {
   return new Set(
     Object.values(fields).flatMap((f) => (f ? [f.componentIri] : []))
+  );
+};
+
+export const getGroupedFieldIris = (fields: GenericFields) => {
+  return new Set(
+    Object.values(fields).flatMap((f) =>
+      f && (f as $IntentionalAny).isGroup ? [f.componentIri] : []
+    )
   );
 };
 

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -235,7 +235,6 @@ export const getInitialConfig = ({
               index: i,
               isGroup: false,
               isHidden: false,
-              isFiltered: false,
               columnStyle: {
                 textStyle: "regular",
                 type: "text",
@@ -349,10 +348,10 @@ export const getGroupedFieldIris = (fields: GenericFields) => {
   );
 };
 
-export const getFilteredFieldIris = (fields: GenericFields) => {
+export const getHiddenFieldIris = (fields: GenericFields) => {
   return new Set(
     Object.values(fields).flatMap((f) =>
-      f && (f as $IntentionalAny).isFiltered ? [f.componentIri] : []
+      f && (f as $IntentionalAny).isHidden ? [f.componentIri] : []
     )
   );
 };

--- a/app/charts/table/table-state.tsx
+++ b/app/charts/table/table-state.tsx
@@ -207,7 +207,7 @@ const useTableState = ({
   const hiddenIris = useMemo(
     () =>
       orderedTableColumns
-        .filter((c) => c.isHidden || c.isFiltered)
+        .filter((c) => c.isHidden)
         .map((c) => getSlugifiedIri(c.componentIri)),
     [orderedTableColumns]
   );

--- a/app/configurator/components/chart-controls/drag-and-drop-tab.tsx
+++ b/app/configurator/components/chart-controls/drag-and-drop-tab.tsx
@@ -63,7 +63,7 @@ export const TabDropZone = ({
                 >
                   &nbsp;
                 </Box> */}
-                {items.map(({ componentIri, index, isFiltered }, i) => {
+                {items.map(({ componentIri, index, isHidden }, i) => {
                   return (
                     <Draggable
                       key={componentIri}
@@ -98,7 +98,7 @@ export const TabDropZone = ({
                                 </Trans>
                               }
                               isDragging={isDragging}
-                              disabled={isFiltered}
+                              disabled={isHidden}
                             />
                             <Box
                               sx={{

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -62,13 +62,18 @@ export const DimensionValuesMultiFilter = ({
 
   if (data?.dataCubeByIri?.dimensionByIri) {
     const dimension = data?.dataCubeByIri?.dimensionByIri;
-
     const activeFilter = getFilterValue(state, dimension.iri);
+    const activeFilterValues = activeFilter
+      ? activeFilter.type === "single"
+        ? [String(activeFilter.value)]
+        : activeFilter.type === "multi"
+        ? Object.keys(activeFilter.values)
+        : []
+      : [];
 
     const selectionState: SelectionState = !activeFilter
       ? "ALL_SELECTED"
-      : activeFilter.type === "multi" &&
-        Object.keys(activeFilter.values).length === 0
+      : activeFilterValues.length === 0
       ? "NONE_SELECTED"
       : "SOME_SELECTED";
 
@@ -110,7 +115,13 @@ export const DimensionValuesMultiFilter = ({
                 label={dv.label}
                 value={dv.value}
                 allValues={dimension.values.map((d) => d.value)}
-                checked={selectionState === "ALL_SELECTED" ? true : undefined}
+                checked={
+                  selectionState === "ALL_SELECTED"
+                    ? true
+                    : selectionState === "SOME_SELECTED"
+                    ? activeFilterValues?.includes(dv.value)
+                    : undefined
+                }
                 checkAction={selectionState === "NONE_SELECTED" ? "SET" : "ADD"}
                 color={color}
                 colorConfigPath={colorConfigPath}

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -119,7 +119,7 @@ export const DimensionValuesMultiFilter = ({
                   selectionState === "ALL_SELECTED"
                     ? true
                     : selectionState === "SOME_SELECTED"
-                    ? activeFilterValues?.includes(dv.value)
+                    ? activeFilterValues.includes(dv.value)
                     : undefined
                 }
                 checkAction={selectionState === "NONE_SELECTED" ? "SET" : "ADD"}

--- a/app/configurator/config-types.ts
+++ b/app/configurator/config-types.ts
@@ -393,7 +393,6 @@ const TableColumn = t.type({
   index: t.number,
   isGroup: t.boolean,
   isHidden: t.boolean,
-  isFiltered: t.boolean,
   columnStyle: ColumnStyle,
 });
 export type TableColumn = t.TypeOf<typeof TableColumn>;

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -1,6 +1,7 @@
 import { Client } from "@urql/core";
-import { deriveFiltersFromField } from ".";
+import { applyDimensionToFilters } from ".";
 import * as api from "../api";
+import { DimensionMetaDataFragment } from "../graphql/query-hooks";
 import bathingWaterMetadata from "../test/__fixtures/api/DataCubeMetadataWithComponentValues-bathingWater.json";
 import { data as fakeVizFixture } from "../test/__fixtures/prod/line-1.json";
 import {
@@ -108,21 +109,13 @@ describe("deriveFiltersFromField", () => {
     ],
     unit: null,
     __typename: "NominalDimension",
-  };
+  } as DimensionMetaDataFragment;
 
-  const deriveFilters = (
-    filtersState: any,
+  const _applyDimensionToFilters = (
+    filters: any,
     isHidden: boolean,
     isGrouped: boolean
-  ) =>
-    deriveFiltersFromField(
-      filtersState,
-      dimension.isKeyDimension,
-      dimension.iri,
-      dimension.values,
-      isHidden,
-      isGrouped
-    );
+  ) => applyDimensionToFilters(filters, dimension, isHidden, isGrouped);
 
   it("should remove single value filter", () => {
     const initialFiltersState = {
@@ -133,7 +126,7 @@ describe("deriveFiltersFromField", () => {
     };
     const expectedFiltersState = {};
 
-    deriveFilters(initialFiltersState, false, false);
+    _applyDimensionToFilters(initialFiltersState, false, false);
     expect(initialFiltersState).toEqual(expectedFiltersState);
   });
 
@@ -146,7 +139,7 @@ describe("deriveFiltersFromField", () => {
       },
     };
 
-    deriveFilters(initialFiltersState, true, false);
+    _applyDimensionToFilters(initialFiltersState, true, false);
     expect(initialFiltersState).toEqual(expectedFiltersState);
   });
 
@@ -164,7 +157,7 @@ describe("deriveFiltersFromField", () => {
       },
     };
 
-    deriveFilters(initialFiltersState, true, false);
+    _applyDimensionToFilters(initialFiltersState, true, false);
     expect(initialFiltersState).toEqual(expectedFiltersState);
   });
 
@@ -183,7 +176,7 @@ describe("deriveFiltersFromField", () => {
       },
     };
 
-    deriveFilters(initialFiltersState, true, false);
+    _applyDimensionToFilters(initialFiltersState, true, false);
     expect(initialFiltersState).toEqual(expectedFiltersState);
   });
 
@@ -201,7 +194,7 @@ describe("deriveFiltersFromField", () => {
       },
     };
 
-    deriveFilters(initialFiltersState, false, true);
+    _applyDimensionToFilters(initialFiltersState, false, true);
     expect(initialFiltersState).toEqual(expectedFiltersState);
   });
 });

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -1,13 +1,14 @@
 import { Client } from "@urql/core";
+import { deriveFiltersFromField } from ".";
+import * as api from "../api";
+import bathingWaterMetadata from "../test/__fixtures/api/DataCubeMetadataWithComponentValues-bathingWater.json";
+import { data as fakeVizFixture } from "../test/__fixtures/prod/line-1.json";
 import {
   getLocalStorageKey,
   initChartStateFromChart,
-  initChartStateFromLocalStorage,
   initChartStateFromCube,
+  initChartStateFromLocalStorage,
 } from "./configurator-state";
-import * as api from "../api";
-import { data as fakeVizFixture } from "../test/__fixtures/prod/line-1.json";
-import bathingWaterMetadata from "../test/__fixtures/api/DataCubeMetadataWithComponentValues-bathingWater.json";
 
 const mockedApi = api as jest.Mocked<typeof api>;
 
@@ -93,5 +94,114 @@ describe("initChartStateFromCube", () => {
         state: "SELECTING_CHART_TYPE",
       })
     );
+  });
+});
+
+describe("deriveFiltersFromField", () => {
+  const dimension = {
+    iri: "https://environment.ld.admin.ch/foen/ubd0104/parametertype",
+    label: "Parameter",
+    isKeyDimension: true,
+    values: [
+      { value: "E.coli", label: "E.coli" },
+      { value: "Enterokokken", label: "Enterokokken" },
+    ],
+    unit: null,
+    __typename: "NominalDimension",
+  };
+
+  const deriveFilters = (
+    filtersState: any,
+    isHidden: boolean,
+    isGrouped: boolean
+  ) =>
+    deriveFiltersFromField(
+      filtersState,
+      dimension.isKeyDimension,
+      dimension.iri,
+      dimension.values,
+      isHidden,
+      isGrouped
+    );
+
+  it("should remove single value filter", () => {
+    const initialFiltersState = {
+      "https://environment.ld.admin.ch/foen/ubd0104/parametertype": {
+        type: "single",
+        value: "E.coli",
+      },
+    };
+    const expectedFiltersState = {};
+
+    deriveFilters(initialFiltersState, false, false);
+    expect(initialFiltersState).toEqual(expectedFiltersState);
+  });
+
+  it("should add single value filter for empty filter if hidden and not grouped", () => {
+    const initialFiltersState = {};
+    const expectedFiltersState = {
+      "https://environment.ld.admin.ch/foen/ubd0104/parametertype": {
+        type: "single",
+        value: "E.coli",
+      },
+    };
+
+    deriveFilters(initialFiltersState, true, false);
+    expect(initialFiltersState).toEqual(expectedFiltersState);
+  });
+
+  it("should add single value filter for multi filter if hidden and not grouped", () => {
+    const initialFiltersState = {
+      "https://environment.ld.admin.ch/foen/ubd0104/parametertype": {
+        type: "multi",
+        values: { "E.coli": true, Enterokokken: true },
+      },
+    };
+    const expectedFiltersState = {
+      "https://environment.ld.admin.ch/foen/ubd0104/parametertype": {
+        type: "single",
+        value: "E.coli",
+      },
+    };
+
+    deriveFilters(initialFiltersState, true, false);
+    expect(initialFiltersState).toEqual(expectedFiltersState);
+  });
+
+  it("should add single value filter for range filter if hidden", () => {
+    const initialFiltersState = {
+      "https://environment.ld.admin.ch/foen/ubd0104/parametertype": {
+        from: "2007-05-21",
+        to: "2020-09-28",
+        type: "range",
+      },
+    };
+    const expectedFiltersState = {
+      "https://environment.ld.admin.ch/foen/ubd0104/parametertype": {
+        type: "single",
+        value: "2007-05-21",
+      },
+    };
+
+    deriveFilters(initialFiltersState, true, false);
+    expect(initialFiltersState).toEqual(expectedFiltersState);
+  });
+
+  it("should not modify filters for multi filter if not hidden and grouped", () => {
+    const initialFiltersState = {
+      "https://environment.ld.admin.ch/foen/ubd0104/parametertype": {
+        type: "multi",
+        values: { "E.coli": false, Enterokokken: true },
+      },
+    };
+    const expectedFiltersState = {
+      "https://environment.ld.admin.ch/foen/ubd0104/parametertype": {
+        type: "multi",
+        values: { "E.coli": false, Enterokokken: true },
+      },
+    };
+
+    deriveFilters(initialFiltersState, false, true);
+    expect(initialFiltersState).toEqual(expectedFiltersState);
   });
 });

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -1,4 +1,3 @@
-import { string } from "fp-ts";
 import produce from "immer";
 import setWith from "lodash/setWith";
 import { useRouter } from "next/router";
@@ -9,18 +8,17 @@ import {
   useContext,
   useEffect,
 } from "react";
-import { Client, createRequest, useClient } from "urql";
+import { Client, useClient } from "urql";
 import { Reducer, useImmerReducer } from "use-immer";
 import { fetchChartConfig, saveChartConfig } from "../api";
 import {
   getFieldComponentIris,
   getFilteredFieldIris,
+  getGroupedFieldIris,
   getInitialConfig,
   getPossibleChartType,
 } from "../charts";
 import {
-  DataCubeMetadataDocument,
-  DataCubeMetadataQuery,
   DataCubeMetadataWithComponentValuesDocument,
   DataCubeMetadataWithComponentValuesQuery,
 } from "../graphql/query-hooks";
@@ -28,13 +26,11 @@ import { DataCubeMetadata } from "../graphql/types";
 import { createChartId } from "../lib/create-chart-id";
 import { unreachableError } from "../lib/unreachable";
 import { useLocale } from "../locales/use-locale";
-import { getCube } from "../rdf/queries";
 import { mapColorsToComponentValuesIris } from "./components/ui-helpers";
 import {
   ChartConfig,
   ChartType,
   ConfiguratorState,
-  ConfiguratorStatePublishing,
   ConfiguratorStateSelectingDataSet,
   decodeConfiguratorState,
   FilterValue,
@@ -211,33 +207,45 @@ const deriveFiltersFromFields = produce(
     const { fields, filters } = chartConfig;
 
     const fieldDimensionIris = getFieldComponentIris(fields);
+    const groupedDimensionItis = getGroupedFieldIris(fields);
     const filteredFieldIris = getFilteredFieldIris(fields);
 
     const isField = (iri: string) => fieldDimensionIris.has(iri);
+    const isGrouped = (iri: string) => groupedDimensionItis.has(iri);
     const isPreFiltered = (iri: string) => filteredFieldIris.has(iri);
     const isFiltered = (iri: string) => !isField(iri) || isPreFiltered(iri);
 
     dimensions.forEach((dimension) => {
       const f = filters[dimension.iri];
+      const filtered = isFiltered(dimension.iri);
+      const grouped = isGrouped(dimension.iri);
+
       if (f !== undefined) {
         // Fix wrong filter type
-        if (!isFiltered(dimension.iri) && f.type === "single") {
-          // Remove filter
-          delete filters[dimension.iri];
-        } else if (isFiltered(dimension.iri) && f.type === "multi") {
+        if (f.type === "single") {
+          if (!filtered) {
+            delete filters[dimension.iri];
+          } else if (grouped) {
+            filters[dimension.iri] = {
+              type: "multi",
+              values: { [String(f.value)]: true },
+            };
+          }
+        } else if (f.type === "multi" && filtered && !grouped) {
           filters[dimension.iri] = {
             type: "single",
             value: Object.keys(f.values)[0],
           };
-        } else if (isFiltered(dimension.iri) && f.type === "range") {
+        } else if (f.type === "range" && filtered) {
           filters[dimension.iri] = {
             type: "single",
             value: f.from,
           };
         }
       } else {
-        // Add filter for this dim if it's not one of the selected multi filter fields
-        if (isFiltered(dimension.iri) && dimension.isKeyDimension) {
+        // Add filter for this dim if it's not one of the selected multi filter fields, but
+        // only when the dimension isn't grouped, as only then we need to switch to a single filter.
+        if (dimension.isKeyDimension && filtered && !grouped) {
           filters[dimension.iri] = {
             type: "single",
             value: dimension.values[0].value,

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -224,14 +224,7 @@ const deriveFiltersFromFields = produce(
         if (f !== undefined) {
           // Fix wrong filter type
           if (f.type === "single") {
-            if (!hidden) {
-              delete filters[dimension.iri];
-            } else if (grouped) {
-              filters[dimension.iri] = {
-                type: "multi",
-                values: { [String(f.value)]: true },
-              };
-            }
+            delete filters[dimension.iri];
           } else if (f.type === "multi") {
             if (hidden && !grouped) {
               filters[dimension.iri] = {

--- a/app/configurator/table/table-chart-options.tsx
+++ b/app/configurator/table/table-chart-options.tsx
@@ -35,18 +35,14 @@ import {
 } from "../config-types";
 import { useConfiguratorState } from "../configurator-state";
 import { TableSortingOptions } from "./table-chart-sorting-options";
-import {
-  updateIsFiltered,
-  updateIsGroup,
-  updateIsHidden,
-} from "./table-config-state";
+import { updateIsGroup, updateIsHidden } from "./table-config-state";
 
 const useTableColumnGroupHiddenField = ({
   path,
   field,
   metaData,
 }: {
-  path: "isGroup" | "isHidden" | "isFiltered";
+  path: "isGroup" | "isHidden";
   field: string;
   metaData: DataCubeMetadata;
 }): FieldProps => {
@@ -58,13 +54,7 @@ const useTableColumnGroupHiddenField = ({
         state.state === "CONFIGURING_CHART" &&
         state.chartConfig.chartType === "table"
       ) {
-        const updater =
-          path === "isGroup"
-            ? updateIsGroup
-            : path === "isHidden"
-            ? updateIsHidden
-            : updateIsFiltered;
-
+        const updater = path === "isGroup" ? updateIsGroup : updateIsHidden;
         const chartConfig = updater(state.chartConfig, {
           field,
           value: e.currentTarget.checked,
@@ -104,7 +94,7 @@ const ChartOptionGroupHiddenField = ({
 }: {
   label: string;
   field: string;
-  path: "isGroup" | "isHidden" | "isFiltered";
+  path: "isGroup" | "isHidden";
   defaultChecked?: boolean;
   disabled?: boolean;
   metaData: DataCubeMetadata;
@@ -169,7 +159,7 @@ export const TableColumnOptions = ({
     return <div>`No component ${activeField}`</div>;
   }
 
-  const { isGroup, isFiltered, isHidden } = chartConfig.fields[activeField];
+  const { isGroup, isHidden } = chartConfig.fields[activeField];
 
   const columnStyleOptions =
     component.__typename === "NominalDimension" ||
@@ -226,30 +216,18 @@ export const TableColumnOptions = ({
               metaData={metaData}
             />
           )}
-          {component.isKeyDimension ? (
-            <ChartOptionGroupHiddenField
-              label={t({
-                id: "controls.table.column.hidefilter",
-                message: "Hide and filter column",
-              })}
-              field={activeField}
-              path="isFiltered"
-              metaData={metaData}
-            />
-          ) : (
-            <ChartOptionGroupHiddenField
-              label={t({
-                id: "controls.table.column.hide",
-                message: "Hide column",
-              })}
-              field={activeField}
-              path="isHidden"
-              metaData={metaData}
-            />
-          )}
+          <ChartOptionGroupHiddenField
+            label={t({
+              id: "controls.table.column.hide",
+              message: "Hide column",
+            })}
+            field={activeField}
+            path="isHidden"
+            metaData={metaData}
+          />
         </ControlSectionContent>
       </ControlSection>
-      {!isFiltered && (!isHidden || isGroup) && (
+      {(isGroup || !isHidden) && (
         <ControlSection>
           <SectionTitle iconName={"formatting"}>
             <Trans id="controls.section.columnstyle">Column Style</Trans>
@@ -325,7 +303,7 @@ export const TableColumnOptions = ({
             <legend style={{ display: "none" }}>
               <Trans id="controls.section.filter">Filter</Trans>
             </legend>
-            {isFiltered && !isGroup ? (
+            {component.isKeyDimension && isHidden && !isGroup ? (
               <DimensionValuesSingleFilter
                 dataSetIri={metaData.iri}
                 dimensionIri={component.iri}
@@ -349,7 +327,7 @@ export const TableColumnOptions = ({
             <legend style={{ display: "none" }}>
               <Trans id="controls.section.filter">Filter</Trans>
             </legend>
-            {isFiltered ? (
+            {component.isKeyDimension && isHidden ? (
               <DataFilterSelectTime
                 dimensionIri={component.iri}
                 label={component.label}

--- a/app/configurator/table/table-chart-options.tsx
+++ b/app/configurator/table/table-chart-options.tsx
@@ -216,26 +216,26 @@ export const TableColumnOptions = ({
         </SectionTitle>
         <ControlSectionContent side="right">
           {component.__typename !== "Measure" && (
-              <ChartOptionGroupHiddenField
-                label={t({
-                  id: "controls.table.column.group",
-                  message: "Use to group",
-                })}
-                field={activeField}
-                path="isGroup"
-                metaData={metaData}
-              />
+            <ChartOptionGroupHiddenField
+              label={t({
+                id: "controls.table.column.group",
+                message: "Use to group",
+              })}
+              field={activeField}
+              path="isGroup"
+              metaData={metaData}
+            />
           )}
           {component.isKeyDimension ? (
-                <ChartOptionGroupHiddenField
-                  label={t({
-                    id: "controls.table.column.hidefilter",
-                    message: "Hide and filter column",
-                  })}
-                  field={activeField}
-                  path="isFiltered"
-                  metaData={metaData}
-                />
+            <ChartOptionGroupHiddenField
+              label={t({
+                id: "controls.table.column.hidefilter",
+                message: "Hide and filter column",
+              })}
+              field={activeField}
+              path="isFiltered"
+              metaData={metaData}
+            />
           ) : (
             <ChartOptionGroupHiddenField
               label={t({
@@ -325,7 +325,7 @@ export const TableColumnOptions = ({
             <legend style={{ display: "none" }}>
               <Trans id="controls.section.filter">Filter</Trans>
             </legend>
-            {isFiltered ? (
+            {isFiltered && !isGroup ? (
               <DimensionValuesSingleFilter
                 dataSetIri={metaData.iri}
                 dimensionIri={component.iri}

--- a/app/configurator/table/table-chart-options.tsx
+++ b/app/configurator/table/table-chart-options.tsx
@@ -222,7 +222,6 @@ export const TableColumnOptions = ({
                   message: "Use to group",
                 })}
                 field={activeField}
-                disabled={isFiltered}
                 path="isGroup"
                 metaData={metaData}
               />

--- a/app/configurator/table/table-chart-options.tsx
+++ b/app/configurator/table/table-chart-options.tsx
@@ -1,12 +1,6 @@
 import { t, Trans } from "@lingui/macro";
 import get from "lodash/get";
-import React, {
-  ChangeEvent,
-  ReactNode,
-  useCallback,
-  useEffect,
-  useRef,
-} from "react";
+import React, { ChangeEvent, useCallback, useEffect, useRef } from "react";
 import { Checkbox } from "../../components/form";
 import { DimensionMetaDataFragment } from "../../graphql/query-hooks";
 import { DataCubeMetadata } from "../../graphql/types";
@@ -221,8 +215,7 @@ export const TableColumnOptions = ({
           {component.label}
         </SectionTitle>
         <ControlSectionContent side="right">
-          {component.isKeyDimension && (
-            <>
+          {component.__typename !== "Measure" && (
               <ChartOptionGroupHiddenField
                 label={t({
                   id: "controls.table.column.group",
@@ -233,7 +226,8 @@ export const TableColumnOptions = ({
                 path="isGroup"
                 metaData={metaData}
               />
-              {!isGroup && (
+          )}
+          {component.isKeyDimension ? (
                 <ChartOptionGroupHiddenField
                   label={t({
                     id: "controls.table.column.hidefilter",
@@ -243,11 +237,7 @@ export const TableColumnOptions = ({
                   path="isFiltered"
                   metaData={metaData}
                 />
-              )}
-            </>
-          )}
-
-          {(!component.isKeyDimension || isGroup) && (
+          ) : (
             <ChartOptionGroupHiddenField
               label={t({
                 id: "controls.table.column.hide",

--- a/app/configurator/table/table-config-state.ts
+++ b/app/configurator/table/table-config-state.ts
@@ -23,13 +23,6 @@ export const moveFields = produce(
     let destinationFields =
       destination.droppableId === "columns" ? columnFields : groupFields;
 
-    // Reset isHidden prop if field is being grouped/ungrouped
-    if (source.droppableId !== destination.droppableId) {
-      const movedField = sourceFields[source.index];
-      movedField.isHidden = false;
-      // movedField.isFiltered = false;
-    }
-
     // Move from source to destination
     destinationFields.splice(
       destination.index,
@@ -71,9 +64,6 @@ export const updateIsGroup = produce(
 
     // Update field
     chartConfig.fields[field].isGroup = value;
-    // Reset other field states
-    chartConfig.fields[field].isHidden = false;
-    // chartConfig.fields[field].isFiltered = false;
 
     // Get fields _without_ field that is updated
     const fieldsArray = getOrderedTableColumns(chartConfig.fields);

--- a/app/configurator/table/table-config-state.ts
+++ b/app/configurator/table/table-config-state.ts
@@ -113,26 +113,6 @@ export const updateIsHidden = produce(
     return chartConfig;
   }
 );
-export const updateIsFiltered = produce(
-  (
-    chartConfig: TableConfig,
-    {
-      field,
-      value,
-    }: {
-      field: string;
-      value: boolean;
-    }
-  ): TableConfig => {
-    if (!chartConfig.fields[field]) {
-      return chartConfig;
-    }
-
-    chartConfig.fields[field].isFiltered = value;
-
-    return chartConfig;
-  }
-);
 
 export const addSortingOption = produce(
   (chartConfig: TableConfig, option: TableSortingOption): TableConfig => {

--- a/app/docs/fixtures.ts
+++ b/app/docs/fixtures.ts
@@ -830,7 +830,6 @@ export const tableConfig: TableConfig = {
       index: 1,
       isGroup: false,
       isHidden: false,
-      isFiltered: false,
       componentType: "NominalDimension",
       columnStyle: {
         type: "text",
@@ -845,7 +844,6 @@ export const tableConfig: TableConfig = {
       index: 7,
       isGroup: false,
       isHidden: false,
-      isFiltered: false,
       componentType: "NominalDimension",
       columnStyle: {
         type: "category",
@@ -873,7 +871,6 @@ export const tableConfig: TableConfig = {
       index: 3,
       isGroup: false,
       isHidden: false,
-      isFiltered: false,
       componentType: "NominalDimension",
       columnStyle: {
         type: "text",
@@ -888,7 +885,6 @@ export const tableConfig: TableConfig = {
       index: 4,
       isGroup: false,
       isHidden: false,
-      isFiltered: false,
       componentType: "NominalDimension",
       columnStyle: {
         type: "text",
@@ -903,7 +899,6 @@ export const tableConfig: TableConfig = {
       index: 5,
       isGroup: false,
       isHidden: false,
-      isFiltered: false,
       componentType: "NominalDimension",
       columnStyle: {
         type: "text",
@@ -918,7 +913,6 @@ export const tableConfig: TableConfig = {
       index: 6,
       isGroup: false,
       isHidden: false,
-      isFiltered: false,
       componentType: "Measure",
       columnStyle: {
         type: "text",
@@ -933,7 +927,6 @@ export const tableConfig: TableConfig = {
       index: 2,
       isGroup: false,
       isHidden: false,
-      isFiltered: false,
       componentType: "Measure",
       columnStyle: {
         type: "heatmap",
@@ -947,7 +940,6 @@ export const tableConfig: TableConfig = {
       index: 8,
       isGroup: false,
       isHidden: false,
-      isFiltered: false,
       componentType: "Measure",
       columnStyle: {
         type: "text",
@@ -962,7 +954,6 @@ export const tableConfig: TableConfig = {
       index: 9,
       isGroup: false,
       isHidden: false,
-      isFiltered: false,
       componentType: "Measure",
       columnStyle: {
         type: "text",
@@ -977,7 +968,6 @@ export const tableConfig: TableConfig = {
       index: 10,
       isGroup: false,
       isHidden: false,
-      isFiltered: false,
       componentType: "Measure",
       columnStyle: {
         type: "bar",
@@ -994,7 +984,6 @@ export const tableConfig: TableConfig = {
       index: 11,
       isGroup: false,
       isHidden: false,
-      isFiltered: false,
       componentType: "Measure",
       columnStyle: { type: "heatmap", palette: "turbo", textStyle: "regular" },
     },
@@ -1004,7 +993,6 @@ export const tableConfig: TableConfig = {
       index: 12,
       isGroup: false,
       isHidden: false,
-      isFiltered: false,
       componentType: "Measure",
       columnStyle: {
         type: "heatmap",
@@ -1018,7 +1006,6 @@ export const tableConfig: TableConfig = {
       index: 13,
       isGroup: false,
       isHidden: false,
-      isFiltered: false,
       componentType: "Measure",
       columnStyle: {
         type: "text",
@@ -1033,7 +1020,6 @@ export const tableConfig: TableConfig = {
       index: 14,
       isGroup: false,
       isHidden: false,
-      isFiltered: false,
       componentType: "Measure",
       columnStyle: {
         type: "text",


### PR DESCRIPTION
Closes #188.

This PR:
- keeps the hidden state when using a hidden column as a group (as suggested in the issue raised by @AnninaWalker),
- allows to hide/unhide key dimensions used as group-by columns,
- shows a "Use as group" checkbox for non-key dimensions that are not of a "Measure" type (previously anyway we could use them as grouping variables by drag&drop), but this might be more convenient and consistent with how it's dealt with in case of key dimensions.

@herrstucki previously it was coded to clear the "isHidden" prop, so let me know if you think it should be the way the PR proposes – but it feels more natural to keep the state IMO, as anyway I had to hide a column first and then use it as a group (the other way I see it could be to always clear the "isFiltered" prop when using a key dimension to group the data by and disable the ability to "Hide and filter column").