### PR TITLE
Add Git Hash To Version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,7 @@ build:
     - medium
   script:
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
-    - docker build -t $MAIN_IMAGE_TAG .
+    - docker build --build-arg COMMIT=$CI_COMMIT_SHA -t $MAIN_IMAGE_TAG .
     - docker push $MAIN_IMAGE_TAG
   only:
     - main
@@ -35,7 +35,7 @@ release:
     - medium
   script:
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
-    - docker build -t $RELEASE_IMAGE_TAG -t $CI_REGISTRY_IMAGE:$(./scripts/get-package-version.sh) .
+    - docker build --build-arg COMMIT=$CI_COMMIT_SHA -t $RELEASE_IMAGE_TAG -t $CI_REGISTRY_IMAGE:$(./scripts/get-package-version.sh) .
     - docker push $RELEASE_IMAGE_TAG
     - docker push $CI_REGISTRY_IMAGE:$(./scripts/get-package-version.sh)
   only:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM node:12
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
+# build with `docker build --build-arg COMMIT=$(git rev-parse HEAD)`
+ARG COMMIT
+
 # Build app
 COPY package.json yarn.lock ./
 COPY app/package.json ./app/
@@ -10,9 +13,11 @@ RUN yarn install --frozen-lockfile
 
 ENV NODE_ENV production
 ENV NODE_OPTIONS=--max_old_space_size=2048
+ENV NEXT_PUBLIC_COMMIT=$COMMIT
 ENV PORT 3000
 
 COPY ./ ./
+
 RUN yarn build
 
 # Install only prod dependencies and start app

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ COPY app/package.json ./app/
 RUN yarn install --frozen-lockfile
 
 ENV NODE_ENV production
+ENV NODE_OPTIONS=--max_old_space_size=2048
 ENV PORT 3000
 
 COPY ./ ./

--- a/app/.env.development
+++ b/app/.env.development
@@ -2,5 +2,3 @@ DATABASE_URL=postgres://postgres:password@localhost:5432/visualization_tool
 SPARQL_ENDPOINT=https://int.lindas.admin.ch/query
 SPARQL_EDITOR=https://int.lindas.admin.ch/sparql/
 NEXT_PUBLIC_GRAPHQL_ENDPOINT=/api/graphql
-NEXT_PUBLIC_COMMIT=main
-NEXT_PUBLIC_GITHUB_REPO=https://github.com/visualize-admin/visualization-tool

--- a/app/.env.development
+++ b/app/.env.development
@@ -2,3 +2,5 @@ DATABASE_URL=postgres://postgres:password@localhost:5432/visualization_tool
 SPARQL_ENDPOINT=https://int.lindas.admin.ch/query
 SPARQL_EDITOR=https://int.lindas.admin.ch/sparql/
 NEXT_PUBLIC_GRAPHQL_ENDPOINT=/api/graphql
+NEXT_PUBLIC_COMMIT=main
+NEXT_PUBLIC_GITHUB_REPO=https://github.com/visualize-admin/visualization-tool

--- a/app/.env.development
+++ b/app/.env.development
@@ -1,4 +1,4 @@
 DATABASE_URL=postgres://postgres:password@localhost:5432/visualization_tool
-SPARQL_ENDPOINT=https://int.lindas.admin.ch/query
-SPARQL_EDITOR=https://int.lindas.admin.ch/sparql/
-NEXT_PUBLIC_GRAPHQL_ENDPOINT=/api/graphql
+SPARQL_ENDPOINT=https://lindas.admin.ch/query
+SPARQL_EDITOR=https://lindas.admin.ch/sparql/
+GRAPHQL_ENDPOINT=/api/graphql

--- a/app/components/DebugPanel.tsx
+++ b/app/components/DebugPanel.tsx
@@ -51,7 +51,7 @@ const DebugConfigurator = () => {
         {SPARQL_EDITOR && (
           <Link
             variant="primary"
-            href={`https://int.lindas.admin.ch/sparql#query=${encodeURIComponent(
+            href={`${SPARQL_EDITOR}#query=${encodeURIComponent(
               `#pragma describe.strategy cbd
 DESCRIBE <${configuratorState.dataSet ?? ""}>`
             )}&requestMethod=POST`}

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -4,30 +4,28 @@ import NextLink from "next/link";
 import { forwardRef, ReactNode } from "react";
 import contentRoutes from "../content-routes.json";
 import { useLocale } from "../locales/use-locale";
+import { COMMIT, GITHUB_REPO, VERSION } from "../domain/env";
 
 const Version = () => {
   let commitLink = null;
 
-  if (process.env.NEXT_PUBLIC_GITHUB_REPO && process.env.NEXT_PUBLIC_COMMIT) {
+  if (GITHUB_REPO && COMMIT) {
     commitLink = (
       <>
         (
-        <Link
-          variant="primary"
-          href={`${process.env.NEXT_PUBLIC_GITHUB_REPO}/commit/${process.env.NEXT_PUBLIC_COMMIT}`}
-        >
-          {process.env.NEXT_PUBLIC_COMMIT.substr(0, 7)}
+        <Link variant="primary" href={`${GITHUB_REPO}/commit/${COMMIT}`}>
+          {COMMIT.substr(0, 7)}
         </Link>
         )
       </>
     );
-  } else if (process.env.NEXT_PUBLIC_COMMIT) {
-    commitLink = `(${process.env.NEXT_PUBLIC_COMMIT.substr(0, 7)})`;
+  } else if (COMMIT) {
+    commitLink = `(${COMMIT.substr(0, 7)})`;
   }
 
   return (
     <>
-      {process.env.NEXT_PUBLIC_VERSION} {commitLink}
+      {VERSION} {commitLink}
     </>
   );
 };

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -27,7 +27,7 @@ const Version = () => {
 
   return (
     <>
-      {process.env.VERSION} {commitLink}
+      {process.env.NEXT_PUBLIC_VERSION} {commitLink}
     </>
   );
 };

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -5,6 +5,33 @@ import { forwardRef, ReactNode } from "react";
 import contentRoutes from "../content-routes.json";
 import { useLocale } from "../locales/use-locale";
 
+const Version = () => {
+  let commitLink = null;
+
+  if (process.env.NEXT_PUBLIC_GITHUB_REPO && process.env.NEXT_PUBLIC_COMMIT) {
+    commitLink = (
+      <>
+        (
+        <Link
+          variant="primary"
+          href={`${process.env.NEXT_PUBLIC_GITHUB_REPO}/commit/${process.env.NEXT_PUBLIC_COMMIT}`}
+        >
+          {process.env.NEXT_PUBLIC_COMMIT.substr(0, 7)}
+        </Link>
+        )
+      </>
+    );
+  } else if (process.env.NEXT_PUBLIC_COMMIT) {
+    commitLink = `(${process.env.NEXT_PUBLIC_COMMIT.substr(0, 7)})`;
+  }
+
+  return (
+    <>
+      {process.env.VERSION} {commitLink}
+    </>
+  );
+};
+
 export const Footer = () => {
   const locale = useLocale();
 
@@ -89,7 +116,7 @@ export const Footer = () => {
               fontFamily: "body",
             }}
           >
-            {process.env.VERSION}
+            <Version />
           </Text>
           <NextLink
             href={contentRoutes.legal[locale].path}

--- a/app/db/pg-pool.ts
+++ b/app/db/pg-pool.ts
@@ -1,5 +1,6 @@
 import { Pool } from "pg";
+import { DATABASE_URL } from "../domain/env";
 
 export const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
+  connectionString: DATABASE_URL,
 });

--- a/app/domain/env.ts
+++ b/app/domain/env.ts
@@ -1,11 +1,36 @@
-import getConfig from "next/config";
+declare global {
+  interface Window {
+    __runtimeEnv__: Record<string, string | undefined>;
+  }
+}
 
-const config = getConfig();
+const runtimeEnv =
+  typeof window !== "undefined" ? window.__runtimeEnv__ : undefined;
 
-export const PUBLIC_URL = config?.publicRuntimeConfig?.PUBLIC_URL ?? "";
+// These values are exposed in pages/_document.tsx to the browser or read from process.env on the server-side.
+// Note: we can't destructure process.env because it's mangled in the Next.js runtime
+
+export const PUBLIC_URL =
+  runtimeEnv?.PUBLIC_URL ?? process.env.PUBLIC_URL ?? "";
+
 export const SPARQL_ENDPOINT =
-  process.env.SPARQL_ENDPOINT ?? "https://int.lindas.admin.ch/query";
-export const SPARQL_EDITOR = process.env.SPARQL_EDITOR;
+  runtimeEnv?.SPARQL_ENDPOINT ??
+  process.env.SPARQL_ENDPOINT ??
+  "https://int.lindas.admin.ch/query";
+
+export const SPARQL_EDITOR =
+  runtimeEnv?.SPARQL_EDITOR ?? process.env.SPARQL_EDITOR;
+
 export const GRAPHQL_ENDPOINT =
-  process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT ?? "/api/graphql";
-export const GA_TRACKING_ID = config?.publicRuntimeConfig?.GA_TRACKING_ID;
+  runtimeEnv?.GRAPHQL_ENDPOINT ??
+  process.env.GRAPHQL_ENDPOINT ??
+  "/api/graphql";
+
+export const GA_TRACKING_ID =
+  runtimeEnv?.GA_TRACKING_ID ?? process.env.GA_TRACKING_ID;
+
+// Build-time env vars
+
+export const VERSION = process.env.NEXT_PUBLIC_VERSION;
+export const COMMIT = process.env.NEXT_PUBLIC_COMMIT;
+export const GITHUB_REPO = process.env.NEXT_PUBLIC_GITHUB_REPO;

--- a/app/domain/env.ts
+++ b/app/domain/env.ts
@@ -32,6 +32,10 @@ export const GRAPHQL_ENDPOINT =
 export const GA_TRACKING_ID =
   runtimeEnv?.GA_TRACKING_ID ?? process.env.GA_TRACKING_ID;
 
+// Server-side-only values (not exposed through window)
+
+export const DATABASE_URL = process.env.DATABASE_URL;
+
 // Build-time env vars
 
 export const VERSION = process.env.NEXT_PUBLIC_VERSION;

--- a/app/domain/env.ts
+++ b/app/domain/env.ts
@@ -10,8 +10,11 @@ const runtimeEnv =
 // These values are exposed in pages/_document.tsx to the browser or read from process.env on the server-side.
 // Note: we can't destructure process.env because it's mangled in the Next.js runtime
 
-export const PUBLIC_URL =
-  runtimeEnv?.PUBLIC_URL ?? process.env.PUBLIC_URL ?? "";
+export const PUBLIC_URL = (
+  runtimeEnv?.PUBLIC_URL ??
+  process.env.PUBLIC_URL ??
+  ""
+).replace(/\/$/, "");
 
 export const SPARQL_ENDPOINT =
   runtimeEnv?.SPARQL_ENDPOINT ??

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -8,7 +8,12 @@ const withPreconstruct = require("@preconstruct/next");
 
 const { locales, defaultLocale } = require("./locales/locales.json");
 
-const VERSION = `v${pkg.version}`;
+// Populate build-time variables from package.json
+process.env.NEXT_PUBLIC_VERSION = `v${pkg.version}`;
+process.env.NEXT_PUBLIC_GITHUB_REPO = pkg.repository.url.replace(
+  /(\/|\.git)$/,
+  ""
+);
 
 const publicRuntimeConfig = {
   PUBLIC_URL: process.env.PUBLIC_URL
@@ -18,7 +23,9 @@ const publicRuntimeConfig = {
 };
 
 console.log("Starting with publicRuntimeConfig\n", publicRuntimeConfig);
-console.log("Version", VERSION);
+console.log("Version", process.env.NEXT_PUBLIC_VERSION);
+console.log("Commit", process.env.NEXT_PUBLIC_COMMIT);
+console.log("GitHub Repo", process.env.NEXT_PUBLIC_GITHUB_REPO);
 console.log("Extra Certs", process.env.NODE_EXTRA_CA_CERTS);
 
 module.exports = withPreconstruct(
@@ -27,11 +34,6 @@ module.exports = withPreconstruct(
       publicRuntimeConfig,
 
       ...(process.env.NETLIFY === "true" ? { target: "serverless" } : {}),
-
-      // Build-time env variables
-      env: {
-        VERSION,
-      },
 
       i18n: {
         locales,

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -15,26 +15,15 @@ process.env.NEXT_PUBLIC_GITHUB_REPO = pkg.repository.url.replace(
   ""
 );
 
-const publicRuntimeConfig = {
-  PUBLIC_URL: process.env.PUBLIC_URL
-    ? process.env.PUBLIC_URL.replace(/\/$/, "")
-    : "",
-  GA_TRACKING_ID: process.env.GA_TRACKING_ID,
-};
-
-console.log("Starting with publicRuntimeConfig\n", publicRuntimeConfig);
 console.log("Version", process.env.NEXT_PUBLIC_VERSION);
 console.log("Commit", process.env.NEXT_PUBLIC_COMMIT);
 console.log("GitHub Repo", process.env.NEXT_PUBLIC_GITHUB_REPO);
+
 console.log("Extra Certs", process.env.NODE_EXTRA_CA_CERTS);
 
 module.exports = withPreconstruct(
   withBundleAnalyzer(
     withMDX({
-      publicRuntimeConfig,
-
-      ...(process.env.NETLIFY === "true" ? { target: "serverless" } : {}),
-
       i18n: {
         locales,
         defaultLocale,

--- a/app/pages/_document.tsx
+++ b/app/pages/_document.tsx
@@ -5,8 +5,15 @@ import Document, {
   NextScript,
   DocumentContext,
 } from "next/document";
-import { GA_TRACKING_ID } from "../domain/env";
 import { parseLocaleString } from "../locales/locales";
+
+const runtimeEnv = {
+  GA_TRACKING_ID: process.env.GA_TRACKING_ID,
+  SPARQL_EDITOR: process.env.SPARQL_EDITOR,
+  SPARQL_ENDPOINT: process.env.SPARQL_ENDPOINT,
+  PUBLIC_URL: process.env.PUBLIC_URL,
+  GRAPHQL_ENDPOINT: process.env.GRAPHQL_ENDPOINT,
+};
 
 class MyDocument extends Document<{ locale: string }> {
   static async getInitialProps(ctx: DocumentContext) {
@@ -33,15 +40,20 @@ class MyDocument extends Document<{ locale: string }> {
         lang={this.props.locale}
       >
         <Head>
-          {GA_TRACKING_ID && (
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `window.__runtimeEnv__=${JSON.stringify(runtimeEnv)}`,
+            }}
+          />
+          {runtimeEnv.GA_TRACKING_ID && (
             <>
               <script
                 async
-                src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
+                src={`https://www.googletagmanager.com/gtag/js?id=${runtimeEnv.GA_TRACKING_ID}`}
               />
               <script
                 dangerouslySetInnerHTML={{
-                  __html: `window.dataLayer = window.dataLayer || [];function gtag() {window.dataLayer.push(arguments);};gtag("js", new Date());gtag("config", "${GA_TRACKING_ID}", {anonymize_ip:true});`,
+                  __html: `window.dataLayer = window.dataLayer || [];function gtag() {window.dataLayer.push(arguments);};gtag("js", new Date());gtag("config", "${runtimeEnv.GA_TRACKING_ID}", {anonymize_ip:true});`,
                 }}
               ></script>
             </>

--- a/app/pages/_document.tsx
+++ b/app/pages/_document.tsx
@@ -29,7 +29,7 @@ class MyDocument extends Document<{ locale: string }> {
   render() {
     return (
       <Html
-        data-app-version={`${process.env.VERSION}`}
+        data-app-version={`${process.env.NEXT_PUBLIC_VERSION}`}
         lang={this.props.locale}
       >
         <Head>

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev:rollup": "rollup -c rollup.config.js --watch",
     "db:migrate:dev": "DATABASE_URL=postgres://postgres:password@localhost:5432/visualization_tool scripts/db-migrate.js",
     "db:migrate": "scripts/db-migrate.js",
-    "build": "NODE_OPTIONS=--max_old_space_size=2048 yarn graphql:codegen && lingui compile && rollup -c rollup.config.js && next build ./app",
+    "build": "NODE_OPTIONS=--max_old_space_size=2048 NEXT_PUBLIC_COMMIT=$SOURCE_VERSION yarn graphql:codegen && lingui compile && rollup -c rollup.config.js && next build ./app",
     "build:npm": "yarn graphql:codegen && lingui compile && BABEL_ENV=NPM_PACKAGE preconstruct build",
     "start": "yarn db:migrate && GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE='' NO_PROXY='localhost,127.0.0.1' next start ./app -p $PORT",
     "lint": "lingui compile && tsc --noEmit -p ./app && tsc --noEmit -p ./embed",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev:rollup": "rollup -c rollup.config.js --watch",
     "db:migrate:dev": "DATABASE_URL=postgres://postgres:password@localhost:5432/visualization_tool scripts/db-migrate.js",
     "db:migrate": "scripts/db-migrate.js",
-    "build": "NODE_OPTIONS=--max_old_space_size=2048 NEXT_PUBLIC_COMMIT=$SOURCE_VERSION yarn graphql:codegen && lingui compile && rollup -c rollup.config.js && next build ./app",
+    "build": "yarn graphql:codegen && lingui compile && rollup -c rollup.config.js && next build ./app",
     "build:npm": "yarn graphql:codegen && lingui compile && BABEL_ENV=NPM_PACKAGE preconstruct build",
     "start": "yarn db:migrate && GLOBAL_AGENT_ENVIRONMENT_VARIABLE_NAMESPACE='' NO_PROXY='localhost,127.0.0.1' next start ./app -p $PORT",
     "lint": "lingui compile && tsc --noEmit -p ./app && tsc --noEmit -p ./embed",


### PR DESCRIPTION
Adds the Git hash and repo via `NEXT_PUBLIC_` build-time env vars, so they can be displayed along with the version number.

- [x] Display hash and link to GH repo if env vars are present
- [x] Set `NEXT_PUBLIC_COMMIT` during Docker build

Fixes #192
Fixes #167