### PR TITLE
Replace examples on the home page

### DIFF
--- a/app/homepage/examples.tsx
+++ b/app/homepage/examples.tsx
@@ -32,7 +32,7 @@ export const Examples = ({
       <HomepageSection>{headline}</HomepageSection>
       <Example headline={example1Headline} description={example1Description}>
         <ChartPublished
-          dataSet="https://environment.ld.admin.ch/foen/ubd0037/3/"
+          dataSet="https://environment.ld.admin.ch/foen/ubd0037/2/"
           meta={{
             title: {
               de: "Lärmbelastung durch Verkehr",
@@ -133,293 +133,73 @@ export const Examples = ({
         reverse
       >
         <ChartPublished
-          dataSet="https://environment.ld.admin.ch/foen/ubd0066/3/"
+          dataSet="https://culture.ld.admin.ch/sfa/StateAccounts_Office/3/"
           meta={{
             title: {
-              de: "Schwermetallbelastung des Bodens",
-              fr: "Pollution des sols par les métaux lourds",
-              it: "Carico di metalli pesanti nel suolo",
-              en: "Heavy metal soil contamination",
+              de: "Entwicklung der Staatsrechnungen nach Ämtern",
+              en: "Evolution of state accounts by office",
+              fr: "Evolution des comptes d'état par office",
+              it: "Evoluzione dei conti dello stato per ufficio",
             },
             description: {
               de: "",
+              en: "",
               fr: "",
               it: "",
-              en: "",
             },
           }}
           chartConfig={{
-            chartType: "column",
             fields: {
               x: {
-                componentIri:
-                  "https://environment.ld.admin.ch/foen/ubd0066/samplingperiod",
+                componentIri: "http://www.w3.org/2006/time#Year",
               },
               y: {
-                componentIri:
-                  "https://environment.ld.admin.ch/foen/ubd0066/wert",
+                componentIri: "http://schema.org/amount",
               },
               segment: {
-                componentIri:
-                  "https://environment.ld.admin.ch/foen/ubd0066/station",
+                type: "stacked",
                 palette: "category10",
-                type: "grouped",
                 sorting: {
                   sortingType: "byDimensionLabel",
                   sortingOrder: "asc",
                 },
                 colorMapping: {
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/1_1":
-                    "#7f7f7f",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/2_1":
-                    "#bcbd22",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/3_1":
-                    "#17becf",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/4_1":
-                    "#ff7f0e",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/5_1":
-                    "#d62728",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/6_1":
-                    "#9467bd",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/7_1":
-                    "#8c564b",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/8_1":
-                    "#e377c2",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/9_1":
-                    "#bcbd22",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/10_1":
-                    "#7f7f7f",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/11_1":
-                    "#bcbd22",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/12_1":
-                    "#17becf",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/13_1":
+                  "https://culture.ld.admin.ch/sfa/StateAccounts_Office/3/OperationCharacter/OC1":
                     "#1f77b4",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/14_1":
+                  "https://culture.ld.admin.ch/sfa/StateAccounts_Office/3/OperationCharacter/OC2":
                     "#ff7f0e",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/15_1":
-                    "#2ca02c",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/16_1":
-                    "#d62728",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/17_1":
-                    "#9467bd",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/18_1":
-                    "#8c564b",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/19_1":
-                    "#e377c2",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/20_1":
-                    "#bcbd22",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/21_1":
-                    "#17becf",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/22_1":
-                    "#1f77b4",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/23_1":
-                    "#ff7f0e",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/24_1":
-                    "#2ca02c",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/25_1":
-                    "#d62728",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/26_1":
-                    "#9467bd",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/27_1":
-                    "#8c564b",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/28_1":
-                    "#e377c2",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/29_1":
-                    "#7f7f7f",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/30_1":
-                    "#17becf",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/31_1":
-                    "#1f77b4",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/32_1":
-                    "#ff7f0e",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/33_1":
-                    "#2ca02c",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/34_1":
-                    "#d62728",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/35_1":
-                    "#9467bd",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/36_1":
-                    "#8c564b",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/37_1":
-                    "#e377c2",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/38_1":
-                    "#7f7f7f",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/39_1":
-                    "#bcbd22",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/40_1":
-                    "#1f77b4",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/41_1":
-                    "#ff7f0e",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/42_1":
-                    "#2ca02c",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/42_2":
-                    "#d62728",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/43_1":
-                    "#9467bd",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/44_1":
-                    "#8c564b",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/45_1":
-                    "#e377c2",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/46_1":
-                    "#7f7f7f",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/47_1":
-                    "#bcbd22",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/48_1":
-                    "#17becf",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/49_1":
-                    "#1f77b4",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/50_1":
-                    "#2ca02c",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/51_1":
-                    "#d62728",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/52_1":
-                    "#bcbd22",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/53_1":
-                    "#8c564b",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/54_1":
-                    "#e377c2",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/55_1":
-                    "#7f7f7f",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/56_1":
-                    "#bcbd22",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/57_1":
-                    "#17becf",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/58_1":
-                    "#1f77b4",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/59_1":
-                    "#ff7f0e",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/59_2":
-                    "#2ca02c",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/60_1":
-                    "#9467bd",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/61_1":
-                    "#8c564b",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/62_1":
-                    "#e377c2",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/63_1":
-                    "#7f7f7f",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/64_1":
-                    "#bcbd22",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/65_1":
-                    "#17becf",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/66_1":
-                    "#1f77b4",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/67_1":
-                    "#ff7f0e",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/68_1":
-                    "#2ca02c",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/69_1":
-                    "#d62728",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/70_1":
-                    "#8c564b",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/71_1":
-                    "#e377c2",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/72_1":
-                    "#7f7f7f",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/73_1":
-                    "#bcbd22",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/74_1":
-                    "#17becf",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/75_1":
-                    "#1f77b4",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/76_1":
-                    "#ff7f0e",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/77_1":
-                    "#2ca02c",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/78_1":
-                    "#d62728",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/79_1":
-                    "#9467bd",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/80_1":
-                    "#e377c2",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/81_1":
-                    "#7f7f7f",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/82_1":
-                    "#bcbd22",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/83_1":
-                    "#17becf",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/84_1":
-                    "#1f77b4",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/85_1":
-                    "#ff7f0e",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/86_1":
-                    "#2ca02c",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/87_1":
-                    "#d62728",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/88_1":
-                    "#9467bd",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/89_1":
-                    "#8c564b",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/90_1":
-                    "#7f7f7f",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/91_1":
-                    "#bcbd22",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/92_1":
-                    "#17becf",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/92_2":
-                    "#1f77b4",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/93_1":
-                    "#ff7f0e",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/94_1":
-                    "#2ca02c",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/95_1":
-                    "#d62728",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/96_1":
-                    "#9467bd",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/97_1":
-                    "#8c564b",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/98_1":
-                    "#e377c2",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/99_1":
-                    "#7f7f7f",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/100_1":
-                    "#1f77b4",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/101_1":
-                    "#ff7f0e",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/102_1":
-                    "#2ca02c",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/103_1":
-                    "#d62728",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/104_1":
-                    "#9467bd",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/105_1":
-                    "#8c564b",
-                  "https://environment.ld.admin.ch/foen/ubd0066/Station/106_1":
-                    "#e377c2",
                 },
+                componentIri:
+                  "https://culture.ld.admin.ch/sfa/StateAccounts_Office/operationcharacter",
               },
             },
-            interactiveFiltersConfig: {
-              legend: {
-                active: true,
-                componentIri: "",
+            filters: {
+              "https://culture.ld.admin.ch/sfa/StateAccounts_Office/office": {
+                type: "single",
+                value:
+                  "https://culture.ld.admin.ch/sfa/StateAccounts_Office/3/Office/O7",
               },
+            },
+            chartType: "area",
+            interactiveFiltersConfig: {
               time: {
-                active: false,
+                active: true,
                 presets: {
-                  to: "",
-                  from: "",
+                  to: "2013-12-31T23:00:00.000Z",
+                  from: "1950-12-31T23:00:00.000Z",
                   type: "range",
                 },
+                componentIri: "",
+              },
+              legend: {
+                active: true,
                 componentIri: "",
               },
               dataFilters: {
                 active: true,
                 componentIris: [
-                  "https://environment.ld.admin.ch/foen/ubd0066/messparameter",
+                  "https://culture.ld.admin.ch/sfa/StateAccounts_Office/office",
                 ],
-              },
-            },
-            filters: {
-              "https://environment.ld.admin.ch/foen/ubd0066/landuse": {
-                type: "single",
-                value:
-                  "https://environment.ld.admin.ch/foen/ubd0066/Landuse/10",
-              },
-              "https://environment.ld.admin.ch/foen/ubd0066/messparameter": {
-                type: "single",
-                value: "https://ld.admin.ch/cube/dimension/el01/cu",
               },
             },
           }}

--- a/app/homepage/examples.tsx
+++ b/app/homepage/examples.tsx
@@ -41,10 +41,10 @@ export const Examples = ({
               en: "Traffic noise pollution",
             },
             description: {
-              de: "Anteil der Personen mit schädlichem oder lästigem Verkehrslärm am Wohnort, in der Schweiz, 2015",
-              fr: "Proportion des personnes exposées à leur domicile à un bruit nuisible ou incommodant dû au trafic, en Suisse, en 2015",
-              it: "Percentuale di persone esposte, al loro domicilio, a rumore dannoso o molesto generato dal traffico, in Svizzera, nel 2015",
-              en: "Proportion of people exposed at home to harmful or disturbing levels of traffic noise, in Switzerland, 2015",
+              de: "",
+              fr: "",
+              it: "",
+              en: "",
             },
           }}
           chartConfig={{
@@ -53,6 +53,10 @@ export const Examples = ({
               x: {
                 componentIri:
                   "https://environment.ld.admin.ch/foen/ubd0037/verkehrsart",
+                sorting: {
+                  sortingType: "byMeasure",
+                  sortingOrder: "desc",
+                },
               },
               y: {
                 componentIri:
@@ -69,15 +73,15 @@ export const Examples = ({
                 },
                 colorMapping: {
                   "https://environment.ld.admin.ch/foen/ubd0037/periode/D":
-                    "#1f77b4",
-                  "https://environment.ld.admin.ch/foen/ubd0037/periode/N":
                     "#ff7f0e",
+                  "https://environment.ld.admin.ch/foen/ubd0037/periode/N":
+                    "#1f77b4",
                 },
               },
             },
             interactiveFiltersConfig: {
               legend: {
-                active: true,
+                active: false,
                 componentIri: "",
               },
               time: {
@@ -92,7 +96,6 @@ export const Examples = ({
               dataFilters: {
                 active: true,
                 componentIris: [
-                  "https://environment.ld.admin.ch/foen/ubd0037/beurteilung",
                   "https://environment.ld.admin.ch/foen/ubd0037/gemeindetype",
                   "https://environment.ld.admin.ch/foen/ubd0037/laermbelasteteeinheit",
                 ],
@@ -130,39 +133,35 @@ export const Examples = ({
         reverse
       >
         <ChartPublished
-          dataSet="https://environment.ld.admin.ch/foen/ubd0104/3/"
+          dataSet="https://environment.ld.admin.ch/foen/ubd0066/3/"
           meta={{
             title: {
-              de: "E. coli und Enterokokken in Badegewässern",
-              fr: "E. coli et entérocoques dans les eaux de baignade",
-              it: "E. coli ed enterococchi nelle acque di balneazione",
-              en: "E. coli and enterococci in Bathing water",
+              de: "Schwermetallbelastung des Bodens",
+              fr: "Pollution des sols par les métaux lourds",
+              it: "Carico di metalli pesanti nel suolo",
+              en: "Heavy metal soil contamination",
             },
             description: {
-              de: "Konzentration von Escherichia coli und intestinalen Enterokokken an Badestellen, nach Beobachtungsprogramm, 2018",
-              fr: "Concentration en Escherichia coli et entérocoques intestinaux dans les sites de baignade, par programme d’observation, en 2018",
-              it: "Concentrazione di Escherichia coli ed enterococchi intestinali nei siti di balneazione, per programma di osservazione, nel 2018",
-              en: "Concentration of Escherichia coli and intestinal enterococci at bathing sites, by monitoring programme, 2018",
+              de: "",
+              fr: "",
+              it: "",
+              en: "",
             },
           }}
           chartConfig={{
-            chartType: "area",
+            chartType: "column",
             fields: {
               x: {
                 componentIri:
-                  "https://environment.ld.admin.ch/foen/ubd0104/dateofprobing",
-                sorting: {
-                  sortingType: "byDimensionLabel",
-                  sortingOrder: "asc",
-                },
+                  "https://environment.ld.admin.ch/foen/ubd0066/samplingperiod",
               },
               y: {
                 componentIri:
-                  "https://environment.ld.admin.ch/foen/ubd0104/value",
+                  "https://environment.ld.admin.ch/foen/ubd0066/wert",
               },
               segment: {
                 componentIri:
-                  "https://environment.ld.admin.ch/foen/ubd0104/station",
+                  "https://environment.ld.admin.ch/foen/ubd0066/station",
                 palette: "category10",
                 type: "grouped",
                 sorting: {
@@ -170,10 +169,224 @@ export const Examples = ({
                   sortingOrder: "asc",
                 },
                 colorMapping: {
-                  "https://environment.ld.admin.ch/foen/ubd0104/Station/CH24001":
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/1_1":
+                    "#7f7f7f",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/2_1":
+                    "#bcbd22",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/3_1":
+                    "#17becf",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/4_1":
                     "#ff7f0e",
-                  "https://environment.ld.admin.ch/foen/ubd0104/Station/CH24002":
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/5_1":
+                    "#d62728",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/6_1":
+                    "#9467bd",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/7_1":
+                    "#8c564b",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/8_1":
+                    "#e377c2",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/9_1":
+                    "#bcbd22",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/10_1":
+                    "#7f7f7f",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/11_1":
+                    "#bcbd22",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/12_1":
+                    "#17becf",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/13_1":
                     "#1f77b4",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/14_1":
+                    "#ff7f0e",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/15_1":
+                    "#2ca02c",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/16_1":
+                    "#d62728",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/17_1":
+                    "#9467bd",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/18_1":
+                    "#8c564b",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/19_1":
+                    "#e377c2",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/20_1":
+                    "#bcbd22",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/21_1":
+                    "#17becf",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/22_1":
+                    "#1f77b4",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/23_1":
+                    "#ff7f0e",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/24_1":
+                    "#2ca02c",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/25_1":
+                    "#d62728",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/26_1":
+                    "#9467bd",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/27_1":
+                    "#8c564b",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/28_1":
+                    "#e377c2",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/29_1":
+                    "#7f7f7f",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/30_1":
+                    "#17becf",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/31_1":
+                    "#1f77b4",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/32_1":
+                    "#ff7f0e",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/33_1":
+                    "#2ca02c",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/34_1":
+                    "#d62728",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/35_1":
+                    "#9467bd",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/36_1":
+                    "#8c564b",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/37_1":
+                    "#e377c2",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/38_1":
+                    "#7f7f7f",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/39_1":
+                    "#bcbd22",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/40_1":
+                    "#1f77b4",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/41_1":
+                    "#ff7f0e",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/42_1":
+                    "#2ca02c",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/42_2":
+                    "#d62728",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/43_1":
+                    "#9467bd",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/44_1":
+                    "#8c564b",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/45_1":
+                    "#e377c2",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/46_1":
+                    "#7f7f7f",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/47_1":
+                    "#bcbd22",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/48_1":
+                    "#17becf",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/49_1":
+                    "#1f77b4",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/50_1":
+                    "#2ca02c",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/51_1":
+                    "#d62728",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/52_1":
+                    "#bcbd22",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/53_1":
+                    "#8c564b",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/54_1":
+                    "#e377c2",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/55_1":
+                    "#7f7f7f",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/56_1":
+                    "#bcbd22",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/57_1":
+                    "#17becf",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/58_1":
+                    "#1f77b4",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/59_1":
+                    "#ff7f0e",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/59_2":
+                    "#2ca02c",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/60_1":
+                    "#9467bd",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/61_1":
+                    "#8c564b",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/62_1":
+                    "#e377c2",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/63_1":
+                    "#7f7f7f",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/64_1":
+                    "#bcbd22",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/65_1":
+                    "#17becf",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/66_1":
+                    "#1f77b4",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/67_1":
+                    "#ff7f0e",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/68_1":
+                    "#2ca02c",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/69_1":
+                    "#d62728",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/70_1":
+                    "#8c564b",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/71_1":
+                    "#e377c2",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/72_1":
+                    "#7f7f7f",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/73_1":
+                    "#bcbd22",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/74_1":
+                    "#17becf",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/75_1":
+                    "#1f77b4",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/76_1":
+                    "#ff7f0e",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/77_1":
+                    "#2ca02c",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/78_1":
+                    "#d62728",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/79_1":
+                    "#9467bd",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/80_1":
+                    "#e377c2",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/81_1":
+                    "#7f7f7f",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/82_1":
+                    "#bcbd22",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/83_1":
+                    "#17becf",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/84_1":
+                    "#1f77b4",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/85_1":
+                    "#ff7f0e",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/86_1":
+                    "#2ca02c",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/87_1":
+                    "#d62728",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/88_1":
+                    "#9467bd",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/89_1":
+                    "#8c564b",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/90_1":
+                    "#7f7f7f",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/91_1":
+                    "#bcbd22",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/92_1":
+                    "#17becf",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/92_2":
+                    "#1f77b4",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/93_1":
+                    "#ff7f0e",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/94_1":
+                    "#2ca02c",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/95_1":
+                    "#d62728",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/96_1":
+                    "#9467bd",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/97_1":
+                    "#8c564b",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/98_1":
+                    "#e377c2",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/99_1":
+                    "#7f7f7f",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/100_1":
+                    "#1f77b4",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/101_1":
+                    "#ff7f0e",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/102_1":
+                    "#2ca02c",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/103_1":
+                    "#d62728",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/104_1":
+                    "#9467bd",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/105_1":
+                    "#8c564b",
+                  "https://environment.ld.admin.ch/foen/ubd0066/Station/106_1":
+                    "#e377c2",
                 },
               },
             },
@@ -184,44 +397,30 @@ export const Examples = ({
               },
               time: {
                 active: false,
-                componentIri: "",
                 presets: {
+                  to: "",
+                  from: "",
                   type: "range",
-                  from: "2007-05-20T22:00:00.000Z",
-                  to: "2020-09-27T22:00:00.000Z",
                 },
+                componentIri: "",
               },
               dataFilters: {
                 active: true,
                 componentIris: [
-                  "https://environment.ld.admin.ch/foen/ubd0104/parametertype",
+                  "https://environment.ld.admin.ch/foen/ubd0066/messparameter",
                 ],
               },
             },
             filters: {
-              "https://environment.ld.admin.ch/foen/ubd0104/dateofprobing": {
-                type: "range",
-                from: "2018-01-01",
-                to: "2018-12-31",
-              },
-              "https://environment.ld.admin.ch/foen/ubd0104/parametertype": {
+              "https://environment.ld.admin.ch/foen/ubd0066/landuse": {
                 type: "single",
-                value: "E.coli",
+                value:
+                  "https://environment.ld.admin.ch/foen/ubd0066/Landuse/10",
               },
-              "https://environment.ld.admin.ch/foen/ubd0104/station": {
-                type: "multi",
-                values: {
-                  "https://environment.ld.admin.ch/foen/ubd0104/Station/CH24002":
-                    true,
-                  "https://environment.ld.admin.ch/foen/ubd0104/Station/CH24001":
-                    true,
-                },
+              "https://environment.ld.admin.ch/foen/ubd0066/messparameter": {
+                type: "single",
+                value: "https://ld.admin.ch/cube/dimension/el01/cu",
               },
-              "https://environment.ld.admin.ch/foen/ubd0104/monitoringprogramm":
-                {
-                  type: "single",
-                  value: "BAQUA_BE",
-                },
             },
           }}
           configKey={""}


### PR DESCRIPTION
Closes #82.

Side question: can I be sure that these examples will work when we publish to PROD? These datasets don't appear on that env and I'm not sure if we can fetch them from there.