### PR TITLE
Fix non-table filtering issue

### DIFF
--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -111,13 +111,24 @@ describe("deriveFiltersFromField", () => {
     __typename: "NominalDimension",
   } as DimensionMetaDataFragment;
 
-  const _applyDimensionToFilters = (
-    filters: any,
-    isField: boolean,
-    isHidden: boolean,
-    isGrouped: boolean
-  ) =>
-    applyDimensionToFilters(filters, dimension, isField, isHidden, isGrouped);
+  const _applyDimensionToFilters = ({
+    initialFiltersState,
+    isField,
+    isHidden,
+    isGrouped,
+  }: {
+    initialFiltersState: any;
+    isField: boolean;
+    isHidden: boolean;
+    isGrouped: boolean;
+  }) =>
+    applyDimensionToFilters({
+      filters: initialFiltersState,
+      dimension,
+      isField,
+      isHidden,
+      isGrouped,
+    });
 
   it("non-table: should remove single value filter when a dimension is used as a field", () => {
     const initialFiltersState = {
@@ -128,7 +139,12 @@ describe("deriveFiltersFromField", () => {
     };
     const expectedFiltersState = {};
 
-    _applyDimensionToFilters(initialFiltersState, true, false, false);
+    _applyDimensionToFilters({
+      initialFiltersState,
+      isField: true,
+      isHidden: false,
+      isGrouped: false,
+    });
     expect(initialFiltersState).toEqual(expectedFiltersState);
   });
 
@@ -141,7 +157,12 @@ describe("deriveFiltersFromField", () => {
       },
     };
 
-    _applyDimensionToFilters(initialFiltersState, true, true, false);
+    _applyDimensionToFilters({
+      initialFiltersState,
+      isField: true,
+      isHidden: true,
+      isGrouped: false,
+    });
     expect(initialFiltersState).toEqual(expectedFiltersState);
   });
 
@@ -159,7 +180,12 @@ describe("deriveFiltersFromField", () => {
       },
     };
 
-    _applyDimensionToFilters(initialFiltersState, true, true, false);
+    _applyDimensionToFilters({
+      initialFiltersState,
+      isField: true,
+      isHidden: true,
+      isGrouped: false,
+    });
     expect(initialFiltersState).toEqual(expectedFiltersState);
   });
 
@@ -178,7 +204,12 @@ describe("deriveFiltersFromField", () => {
       },
     };
 
-    _applyDimensionToFilters(initialFiltersState, true, true, false);
+    _applyDimensionToFilters({
+      initialFiltersState,
+      isField: true,
+      isHidden: true,
+      isGrouped: false,
+    });
     expect(initialFiltersState).toEqual(expectedFiltersState);
   });
 
@@ -196,7 +227,12 @@ describe("deriveFiltersFromField", () => {
       },
     };
 
-    _applyDimensionToFilters(initialFiltersState, true, false, true);
+    _applyDimensionToFilters({
+      initialFiltersState,
+      isField: true,
+      isHidden: false,
+      isGrouped: true,
+    });
     expect(initialFiltersState).toEqual(expectedFiltersState);
   });
 
@@ -214,7 +250,12 @@ describe("deriveFiltersFromField", () => {
       },
     };
 
-    _applyDimensionToFilters(initialFiltersState, false, false, false);
+    _applyDimensionToFilters({
+      initialFiltersState,
+      isField: false,
+      isHidden: false,
+      isGrouped: false,
+    });
     expect(initialFiltersState).toEqual(expectedFiltersState);
   });
 });

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -113,11 +113,13 @@ describe("deriveFiltersFromField", () => {
 
   const _applyDimensionToFilters = (
     filters: any,
+    isField: boolean,
     isHidden: boolean,
     isGrouped: boolean
-  ) => applyDimensionToFilters(filters, dimension, isHidden, isGrouped);
+  ) =>
+    applyDimensionToFilters(filters, dimension, isField, isHidden, isGrouped);
 
-  it("should remove single value filter", () => {
+  it("non-table: should remove single value filter when a dimension is used as a field", () => {
     const initialFiltersState = {
       "https://environment.ld.admin.ch/foen/ubd0104/parametertype": {
         type: "single",
@@ -126,11 +128,11 @@ describe("deriveFiltersFromField", () => {
     };
     const expectedFiltersState = {};
 
-    _applyDimensionToFilters(initialFiltersState, false, false);
+    _applyDimensionToFilters(initialFiltersState, true, false, false);
     expect(initialFiltersState).toEqual(expectedFiltersState);
   });
 
-  it("should add single value filter for empty filter if hidden and not grouped", () => {
+  it("table: should add single value filter for empty filter if hidden and not grouped", () => {
     const initialFiltersState = {};
     const expectedFiltersState = {
       "https://environment.ld.admin.ch/foen/ubd0104/parametertype": {
@@ -139,11 +141,11 @@ describe("deriveFiltersFromField", () => {
       },
     };
 
-    _applyDimensionToFilters(initialFiltersState, true, false);
+    _applyDimensionToFilters(initialFiltersState, true, true, false);
     expect(initialFiltersState).toEqual(expectedFiltersState);
   });
 
-  it("should add single value filter for multi filter if hidden and not grouped", () => {
+  it("table: should add single value filter for multi filter if hidden and not grouped", () => {
     const initialFiltersState = {
       "https://environment.ld.admin.ch/foen/ubd0104/parametertype": {
         type: "multi",
@@ -157,11 +159,11 @@ describe("deriveFiltersFromField", () => {
       },
     };
 
-    _applyDimensionToFilters(initialFiltersState, true, false);
+    _applyDimensionToFilters(initialFiltersState, true, true, false);
     expect(initialFiltersState).toEqual(expectedFiltersState);
   });
 
-  it("should add single value filter for range filter if hidden", () => {
+  it("table: should add single value filter for range filter if hidden", () => {
     const initialFiltersState = {
       "https://environment.ld.admin.ch/foen/ubd0104/parametertype": {
         from: "2007-05-21",
@@ -176,11 +178,11 @@ describe("deriveFiltersFromField", () => {
       },
     };
 
-    _applyDimensionToFilters(initialFiltersState, true, false);
+    _applyDimensionToFilters(initialFiltersState, true, true, false);
     expect(initialFiltersState).toEqual(expectedFiltersState);
   });
 
-  it("should not modify filters for multi filter if not hidden and grouped", () => {
+  it("table: should not modify filters for multi filter if not hidden and grouped", () => {
     const initialFiltersState = {
       "https://environment.ld.admin.ch/foen/ubd0104/parametertype": {
         type: "multi",
@@ -194,7 +196,25 @@ describe("deriveFiltersFromField", () => {
       },
     };
 
-    _applyDimensionToFilters(initialFiltersState, false, true);
+    _applyDimensionToFilters(initialFiltersState, true, false, true);
+    expect(initialFiltersState).toEqual(expectedFiltersState);
+  });
+
+  it("non-table: should not modify filters if dimension is not used as a field", () => {
+    const initialFiltersState = {
+      "https://environment.ld.admin.ch/foen/ubd0104/parametertype": {
+        type: "multi",
+        values: { "E.coli": false, Enterokokken: true },
+      },
+    };
+    const expectedFiltersState = {
+      "https://environment.ld.admin.ch/foen/ubd0104/parametertype": {
+        type: "multi",
+        values: { "E.coli": false, Enterokokken: true },
+      },
+    };
+
+    _applyDimensionToFilters(initialFiltersState, false, false, false);
     expect(initialFiltersState).toEqual(expectedFiltersState);
   });
 });

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -277,7 +277,8 @@ export const applyTableDimensionToFilters = ({
         }
         break;
       default:
-        throw new Error();
+        const _exhaustiveCheck: never = currentFilter;
+        return _exhaustiveCheck;
     }
   } else {
     if (shouldBecomeSingleFilter && dimension.isKeyDimension) {
@@ -332,7 +333,8 @@ export const applyNonTableDimensionToFilters = ({
         }
         break;
       default:
-        throw new Error();
+        const _exhaustiveCheck: never = currentFilter;
+        return _exhaustiveCheck;
     }
   } else {
     if (!isField && dimension.isKeyDimension) {

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -221,26 +221,32 @@ const deriveFiltersFromFields = produce(
     const isHidden = (iri: string) => hiddenFieldIris.has(iri);
 
     dimensions.forEach((dimension) =>
-      applyDimensionToFilters(
+      applyDimensionToFilters({
         filters,
         dimension,
-        isField(dimension.iri),
-        isHidden(dimension.iri),
-        isGrouped(dimension.iri)
-      )
+        isField: isField(dimension.iri),
+        isHidden: isHidden(dimension.iri),
+        isGrouped: isGrouped(dimension.iri),
+      })
     );
 
     return chartConfig;
   }
 );
 
-export const applyDimensionToFilters = (
-  filters: Filters,
-  dimension: DimensionMetaDataFragment,
-  isField: boolean,
-  isHidden: boolean,
-  isGrouped: boolean
-) => {
+export const applyDimensionToFilters = ({
+  filters,
+  dimension,
+  isField,
+  isHidden,
+  isGrouped,
+}: {
+  filters: Filters;
+  dimension: DimensionMetaDataFragment;
+  isField: boolean;
+  isHidden: boolean;
+  isGrouped: boolean;
+}) => {
   if (dimension.isKeyDimension) {
     const f = filters[dimension.iri];
 

--- a/app/configurator/table/table-chart-options.tsx
+++ b/app/configurator/table/table-chart-options.tsx
@@ -327,7 +327,7 @@ export const TableColumnOptions = ({
             <legend style={{ display: "none" }}>
               <Trans id="controls.section.filter">Filter</Trans>
             </legend>
-            {component.isKeyDimension && isHidden ? (
+            {component.isKeyDimension && isHidden && !isGroup ? (
               <DataFilterSelectTime
                 dimensionIri={component.iri}
                 label={component.label}


### PR DESCRIPTION
I have not considered all possible situations in #191 – I assumed that we don't need to differentiate between tables and other charts when dealing with filters, but in fact we do.

This PR fixes an issue currently available on DEV, when using a given dimension as a segment,  which removes currently applied single filter, and this behavior is not desired in this case.

I have also added some comments, to not forget in the future what's going on here (along with another test) 😆