### PR TITLE
Rename env variables for clarity

### DIFF
--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -4,28 +4,31 @@ import NextLink from "next/link";
 import { forwardRef, ReactNode } from "react";
 import contentRoutes from "../content-routes.json";
 import { useLocale } from "../locales/use-locale";
-import { COMMIT, GITHUB_REPO, VERSION } from "../domain/env";
+import { BUILD_COMMIT, BUILD_GITHUB_REPO, BUILD_VERSION } from "../domain/env";
 
 const Version = () => {
   let commitLink = null;
 
-  if (GITHUB_REPO && COMMIT) {
+  if (BUILD_GITHUB_REPO && BUILD_COMMIT) {
     commitLink = (
       <>
         (
-        <Link variant="primary" href={`${GITHUB_REPO}/commit/${COMMIT}`}>
-          {COMMIT.substr(0, 7)}
+        <Link
+          variant="primary"
+          href={`${BUILD_GITHUB_REPO}/commit/${BUILD_COMMIT}`}
+        >
+          {BUILD_COMMIT.substr(0, 7)}
         </Link>
         )
       </>
     );
-  } else if (COMMIT) {
-    commitLink = `(${COMMIT.substr(0, 7)})`;
+  } else if (BUILD_COMMIT) {
+    commitLink = `(${BUILD_COMMIT.substr(0, 7)})`;
   }
 
   return (
     <>
-      {VERSION} {commitLink}
+      {BUILD_VERSION} {commitLink}
     </>
   );
 };

--- a/app/domain/env.ts
+++ b/app/domain/env.ts
@@ -1,43 +1,49 @@
 declare global {
   interface Window {
-    __runtimeEnv__: Record<string, string | undefined>;
+    __clientEnv__: Record<string, string | undefined>;
   }
 }
 
-const runtimeEnv =
-  typeof window !== "undefined" ? window.__runtimeEnv__ : undefined;
+/**
+ * Client and server-side **RUNTIME** variables
+ *
+ * These values are exposed in pages/_document.tsx to the browser or read from process.env on the server-side.
+ * Note: we can't destructure process.env because it's mangled in the Next.js runtime
+ */
 
-// These values are exposed in pages/_document.tsx to the browser or read from process.env on the server-side.
-// Note: we can't destructure process.env because it's mangled in the Next.js runtime
+const clientEnv =
+  typeof window !== "undefined" ? window.__clientEnv__ : undefined;
 
 export const PUBLIC_URL = (
-  runtimeEnv?.PUBLIC_URL ??
+  clientEnv?.PUBLIC_URL ??
   process.env.PUBLIC_URL ??
   ""
 ).replace(/\/$/, "");
 
 export const SPARQL_ENDPOINT =
-  runtimeEnv?.SPARQL_ENDPOINT ??
+  clientEnv?.SPARQL_ENDPOINT ??
   process.env.SPARQL_ENDPOINT ??
   "https://int.lindas.admin.ch/query";
 
 export const SPARQL_EDITOR =
-  runtimeEnv?.SPARQL_EDITOR ?? process.env.SPARQL_EDITOR;
+  clientEnv?.SPARQL_EDITOR ?? process.env.SPARQL_EDITOR;
 
 export const GRAPHQL_ENDPOINT =
-  runtimeEnv?.GRAPHQL_ENDPOINT ??
-  process.env.GRAPHQL_ENDPOINT ??
-  "/api/graphql";
+  clientEnv?.GRAPHQL_ENDPOINT ?? process.env.GRAPHQL_ENDPOINT ?? "/api/graphql";
 
 export const GA_TRACKING_ID =
-  runtimeEnv?.GA_TRACKING_ID ?? process.env.GA_TRACKING_ID;
+  clientEnv?.GA_TRACKING_ID ?? process.env.GA_TRACKING_ID;
 
-// Server-side-only values (not exposed through window)
+/**
+ * Server-side-only **RUNTIME** variables (not exposed through window)
+ */
 
 export const DATABASE_URL = process.env.DATABASE_URL;
 
-// Build-time env vars
+/**
+ * Variables set at **BUILD TIME** through `NEXT_PUBLIC_*` variables. Available on the client and server.
+ */
 
-export const VERSION = process.env.NEXT_PUBLIC_VERSION;
-export const COMMIT = process.env.NEXT_PUBLIC_COMMIT;
-export const GITHUB_REPO = process.env.NEXT_PUBLIC_GITHUB_REPO;
+export const BUILD_VERSION = process.env.NEXT_PUBLIC_VERSION;
+export const BUILD_COMMIT = process.env.NEXT_PUBLIC_COMMIT;
+export const BUILD_GITHUB_REPO = process.env.NEXT_PUBLIC_GITHUB_REPO;

--- a/app/pages/_document.tsx
+++ b/app/pages/_document.tsx
@@ -7,7 +7,7 @@ import Document, {
 } from "next/document";
 import { parseLocaleString } from "../locales/locales";
 
-const runtimeEnv = {
+const clientEnv = {
   GA_TRACKING_ID: process.env.GA_TRACKING_ID,
   SPARQL_EDITOR: process.env.SPARQL_EDITOR,
   SPARQL_ENDPOINT: process.env.SPARQL_ENDPOINT,
@@ -42,18 +42,18 @@ class MyDocument extends Document<{ locale: string }> {
         <Head>
           <script
             dangerouslySetInnerHTML={{
-              __html: `window.__runtimeEnv__=${JSON.stringify(runtimeEnv)}`,
+              __html: `window.__clientEnv__=${JSON.stringify(clientEnv)}`,
             }}
           />
-          {runtimeEnv.GA_TRACKING_ID && (
+          {clientEnv.GA_TRACKING_ID && (
             <>
               <script
                 async
-                src={`https://www.googletagmanager.com/gtag/js?id=${runtimeEnv.GA_TRACKING_ID}`}
+                src={`https://www.googletagmanager.com/gtag/js?id=${clientEnv.GA_TRACKING_ID}`}
               />
               <script
                 dangerouslySetInnerHTML={{
-                  __html: `window.dataLayer = window.dataLayer || [];function gtag() {window.dataLayer.push(arguments);};gtag("js", new Date());gtag("config", "${runtimeEnv.GA_TRACKING_ID}", {anonymize_ip:true});`,
+                  __html: `window.dataLayer = window.dataLayer || [];function gtag() {window.dataLayer.push(arguments);};gtag("js", new Date());gtag("config", "${clientEnv.GA_TRACKING_ID}", {anonymize_ip:true});`,
                 }}
               ></script>
             </>


### PR DESCRIPTION
Follow-up on #194. Rename env variables to make it more clear which are available in the client, server and which are set during build time.