### PR TITLE
Add missing data imputations for stacked area charts

### DIFF
--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -20,7 +20,7 @@ import {
   sum,
 } from "d3";
 import { ReactNode, useCallback, useMemo } from "react";
-import { AreaFields, ImputationType } from "../../configurator";
+import { AreaFields } from "../../configurator";
 import {
   getPalette,
   parseDate,
@@ -33,9 +33,9 @@ import { estimateTextWidth } from "../../lib/estimate-text-width";
 import { useLocale } from "../../locales/use-locale";
 import { BRUSH_BOTTOM_SPACE } from "../shared/brush";
 import {
-  getBaseWideData,
   getLabelWithUnit,
   getTemporalWideDataWithImputedValues,
+  getWideData,
   usePreparedData,
 } from "../shared/chart-helpers";
 import { TooltipInfo } from "../shared/interaction/tooltip";
@@ -69,14 +69,12 @@ const useAreasState = ({
   fields,
   dimensions,
   measures,
-  imputationType,
   interactiveFiltersConfig,
   aspectRatio,
 }: Pick<
   ChartProps,
   "data" | "dimensions" | "measures" | "interactiveFiltersConfig"
 > & {
-  imputationType: ImputationType;
   fields: AreaFields;
   aspectRatio: number;
 }): AreasState => {
@@ -131,7 +129,7 @@ const useAreasState = ({
     sortedData,
     (d) => d[fields.x.componentIri] as string
   );
-  const allDataWide = getBaseWideData({
+  const allDataWide = getWideData({
     groupedMap: allDataGroupedMap,
     getSegment,
     getY,
@@ -157,7 +155,7 @@ const useAreasState = ({
     groupedMap,
     xKey,
     segments: allSegments,
-    imputationType,
+    imputationType: fields.y.imputationType || "none",
     segmentKey,
     getSegment,
     getY,
@@ -374,14 +372,12 @@ const AreaChartProvider = ({
   measures,
   dimensions,
   interactiveFiltersConfig,
-  imputationType,
   aspectRatio,
   children,
 }: Pick<
   ChartProps,
   "data" | "fields" | "dimensions" | "measures" | "interactiveFiltersConfig"
 > & {
-  imputationType: ImputationType;
   children: ReactNode;
   aspectRatio: number;
 } & { fields: AreaFields }) => {
@@ -390,7 +386,6 @@ const AreaChartProvider = ({
     fields,
     dimensions,
     measures,
-    imputationType,
     interactiveFiltersConfig,
     aspectRatio,
   });
@@ -405,14 +400,12 @@ export const AreaChart = ({
   measures,
   dimensions,
   interactiveFiltersConfig,
-  imputationType,
   aspectRatio,
   children,
 }: Pick<
   ChartProps,
   "data" | "fields" | "dimensions" | "measures" | "interactiveFiltersConfig"
 > & {
-  imputationType: ImputationType;
   children: ReactNode;
   fields: AreaFields;
   aspectRatio: number;
@@ -425,7 +418,6 @@ export const AreaChart = ({
           fields={fields}
           dimensions={dimensions}
           measures={measures}
-          imputationType={imputationType}
           interactiveFiltersConfig={interactiveFiltersConfig}
           aspectRatio={aspectRatio}
         >

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -13,7 +13,6 @@ import {
   ScaleTime,
   scaleTime,
   stack,
-  stackOffsetDiverging,
   stackOrderAscending,
   stackOrderDescending,
   stackOrderReverse,
@@ -34,6 +33,7 @@ import { BRUSH_BOTTOM_SPACE } from "../shared/brush";
 import {
   getLabelWithUnit,
   getWideData,
+  stackOffsetDivergingPositiveZeros,
   useOptionalNumericVariable,
   usePreparedData,
   useSegment,
@@ -221,7 +221,7 @@ const useAreasState = ({
 
   const stacked = stack()
     .order(stackOrder)
-    .offset(stackOffsetDiverging)
+    .offset(stackOffsetDivergingPositiveZeros)
     .keys(segments);
 
   const series = stacked(chartWideData as { [key: string]: number }[]);

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -28,7 +28,7 @@ import {
   useFormatNumber,
   useTimeFormatUnit,
 } from "../../configurator/components/ui-helpers";
-import { Observation, ObservationValue } from "../../domain/data";
+import { Observation } from "../../domain/data";
 import { sortByIndex } from "../../lib/array";
 import { estimateTextWidth } from "../../lib/estimate-text-width";
 import { useLocale } from "../../locales/use-locale";
@@ -58,8 +58,8 @@ export interface AreasState {
   segments: string[];
   colors: ScaleOrdinal<string, string>;
   yAxisLabel: string;
-  chartWideData: ArrayLike<Record<string, ObservationValue>>;
-  allDataWide: ArrayLike<Record<string, ObservationValue>>;
+  chartWideData: ArrayLike<Observation>;
+  allDataWide: ArrayLike<Observation>;
   series: $FixMe[];
   getAnnotationInfo: (d: Observation) => TooltipInfo;
 }

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -20,7 +20,7 @@ import {
   sum,
 } from "d3";
 import { ReactNode, useCallback, useMemo } from "react";
-import { AreaFields } from "../../configurator";
+import { AreaFields, ImputationType } from "../../configurator";
 import {
   getPalette,
   parseDate,
@@ -69,12 +69,14 @@ const useAreasState = ({
   fields,
   dimensions,
   measures,
+  imputationType,
   interactiveFiltersConfig,
   aspectRatio,
 }: Pick<
   ChartProps,
   "data" | "dimensions" | "measures" | "interactiveFiltersConfig"
 > & {
+  imputationType: ImputationType;
   fields: AreaFields;
   aspectRatio: number;
 }): AreasState => {
@@ -356,12 +358,14 @@ const AreaChartProvider = ({
   measures,
   dimensions,
   interactiveFiltersConfig,
+  imputationType,
   aspectRatio,
   children,
 }: Pick<
   ChartProps,
   "data" | "fields" | "dimensions" | "measures" | "interactiveFiltersConfig"
 > & {
+  imputationType: ImputationType;
   children: ReactNode;
   aspectRatio: number;
 } & { fields: AreaFields }) => {
@@ -370,6 +374,7 @@ const AreaChartProvider = ({
     fields,
     dimensions,
     measures,
+    imputationType,
     interactiveFiltersConfig,
     aspectRatio,
   });
@@ -384,12 +389,14 @@ export const AreaChart = ({
   measures,
   dimensions,
   interactiveFiltersConfig,
+  imputationType,
   aspectRatio,
   children,
 }: Pick<
   ChartProps,
   "data" | "fields" | "dimensions" | "measures" | "interactiveFiltersConfig"
 > & {
+  imputationType: ImputationType;
   children: ReactNode;
   fields: AreaFields;
   aspectRatio: number;
@@ -402,6 +409,7 @@ export const AreaChart = ({
           fields={fields}
           dimensions={dimensions}
           measures={measures}
+          imputationType={imputationType}
           interactiveFiltersConfig={interactiveFiltersConfig}
           aspectRatio={aspectRatio}
         >

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -32,9 +32,10 @@ import { useLocale } from "../../locales/use-locale";
 import { BRUSH_BOTTOM_SPACE } from "../shared/brush";
 import {
   getLabelWithUnit,
+  useOptionalNumericVariable,
   usePreparedData,
   useSegment,
-  useTemporalX,
+  useTemporalVariable,
   useWideData,
 } from "../shared/chart-helpers";
 import { TooltipInfo } from "../shared/interaction/tooltip";
@@ -92,14 +93,11 @@ const useAreasState = ({
     throw Error(`Dimension <${fields.x.componentIri}> is not temporal!`);
   }
 
-  const hasSegment = fields.segment;
-
-  const getX = useTemporalX(fields.x.componentIri);
-  const getY = (d: Observation): number | null => {
-    const v = d[fields.y.componentIri];
-    return v !== null ? +v : null;
-  };
+  const getX = useTemporalVariable(fields.x.componentIri);
+  const getY = useOptionalNumericVariable(fields.y.componentIri);
   const getSegment = useSegment(fields.segment?.componentIri);
+
+  const hasSegment = fields.segment;
   const allSegments = [...new Set(data.map((d) => getSegment(d)))];
 
   const xKey = fields.x.componentIri;
@@ -116,7 +114,14 @@ const useAreasState = ({
         .sort((a, b) => ascending(getX(a), getX(b))),
     [data, getX]
   );
-  const allDataWide = useWideData({ data: sortedData, getSegment, getY, xKey });
+
+  const allDataWide = useWideData({
+    data: sortedData,
+    segments: allSegments,
+    getSegment,
+    getY,
+    xKey,
+  });
 
   // Data for chart
   const preparedData = usePreparedData({
@@ -135,7 +140,6 @@ const useAreasState = ({
     imputationType: fields.y.imputationType,
     getSegment,
     getY,
-    getX,
   });
 
   const yMeasure = measures.find((d) => d.iri === fields.y.componentIri);

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -34,6 +34,7 @@ import { estimateTextWidth } from "../../lib/estimate-text-width";
 import { useLocale } from "../../locales/use-locale";
 import { BRUSH_BOTTOM_SPACE } from "../shared/brush";
 import {
+  getWideData,
   getLabelWithUnit,
   getWideData,
   usePreparedData,
@@ -97,8 +98,6 @@ const useAreasState = ({
 
   const hasSegment = fields.segment;
 
-  const getGroups = (d: Observation): string =>
-    d[fields.x.componentIri] as string;
   const getX = useCallback(
     (d: Observation): Date => parseDate(`${d[fields.x.componentIri]}`),
     [fields.x.componentIri]
@@ -127,7 +126,10 @@ const useAreasState = ({
         .sort((a, b) => ascending(getX(a), getX(b))),
     [data, getX]
   );
-  const allDataGroupedMap = group(sortedData, getGroups);
+  const allDataGroupedMap = group(
+    sortedData,
+    (d) => d[fields.x.componentIri] as string
+  );
   const allDataWide = getWideData({
     groupedMap: allDataGroupedMap,
     getSegment,
@@ -145,7 +147,10 @@ const useAreasState = ({
     getSegment,
   });
 
-  const groupedMap = group(preparedData, getGroups);
+  const groupedMap = group(
+    preparedData,
+    (d) => d[fields.x.componentIri] as string
+  );
   const chartWideData = getWideData({ groupedMap, xKey, getSegment, getY });
 
   const yMeasure = measures.find((d) => d.iri === fields.y.componentIri);

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -24,7 +24,6 @@ import { AreaFields, ImputationType } from "../../configurator";
 import {
   getPalette,
   parseDate,
-  useFormatFullDateAuto,
   useFormatNumber,
   useTimeFormatUnit,
 } from "../../configurator/components/ui-helpers";
@@ -36,7 +35,7 @@ import { BRUSH_BOTTOM_SPACE } from "../shared/brush";
 import {
   getBaseWideData,
   getLabelWithUnit,
-  getWideData,
+  getTemporalWideDataWithImputedValues,
   usePreparedData,
 } from "../shared/chart-helpers";
 import { TooltipInfo } from "../shared/interaction/tooltip";
@@ -106,11 +105,13 @@ const useAreasState = ({
     const v = d[fields.y.componentIri];
     return v !== null ? +v : null;
   };
+  const segmentKey = fields.segment ? fields.segment.componentIri : "segment";
   const getSegment = useCallback(
     (d: Observation): string =>
       fields.segment ? (d[fields.segment.componentIri] as string) : "segment",
     [fields.segment]
   );
+  const allSegments = [...new Set(data.map((d) => getSegment(d)))];
 
   const xKey = fields.x.componentIri;
   const hasInteractiveTimeFilter = useMemo(
@@ -151,7 +152,17 @@ const useAreasState = ({
     preparedData,
     (d) => d[fields.x.componentIri] as string
   );
-  const chartWideData = getBaseWideData({ groupedMap, xKey, getSegment, getY });
+
+  const chartWideData = getTemporalWideDataWithImputedValues({
+    groupedMap,
+    xKey,
+    segments: allSegments,
+    imputationType,
+    segmentKey,
+    getSegment,
+    getY,
+    getX,
+  });
 
   const yMeasure = measures.find((d) => d.iri === fields.y.componentIri);
 

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -34,7 +34,7 @@ import { estimateTextWidth } from "../../lib/estimate-text-width";
 import { useLocale } from "../../locales/use-locale";
 import { BRUSH_BOTTOM_SPACE } from "../shared/brush";
 import {
-  getWideData,
+  getBaseWideData,
   getLabelWithUnit,
   getWideData,
   usePreparedData,
@@ -130,7 +130,7 @@ const useAreasState = ({
     sortedData,
     (d) => d[fields.x.componentIri] as string
   );
-  const allDataWide = getWideData({
+  const allDataWide = getBaseWideData({
     groupedMap: allDataGroupedMap,
     getSegment,
     getY,
@@ -151,7 +151,7 @@ const useAreasState = ({
     preparedData,
     (d) => d[fields.x.componentIri] as string
   );
-  const chartWideData = getWideData({ groupedMap, xKey, getSegment, getY });
+  const chartWideData = getBaseWideData({ groupedMap, xKey, getSegment, getY });
 
   const yMeasure = measures.find((d) => d.iri === fields.y.componentIri);
 

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -9,8 +9,7 @@ import {
 import {
   AreaConfig,
   AreaFields,
-  Filters,
-  FilterValueSingle,
+  ImputationType,
   InteractiveFiltersConfig,
 } from "../../configurator";
 import { isNumber } from "../../configurator/components/ui-helpers";
@@ -71,6 +70,7 @@ export const ChartAreasVisualization = ({
           measures={measures}
           fields={chartConfig.fields}
           interactiveFiltersConfig={chartConfig.interactiveFiltersConfig}
+          imputationType={chartConfig.imputationType}
         />
         {fetching && <LoadingOverlay />}
       </Box>
@@ -93,12 +93,14 @@ export const ChartAreas = memo(
     measures,
     fields,
     interactiveFiltersConfig,
+    imputationType,
   }: {
     observations: Observation[];
     dimensions: DimensionMetaDataFragment[];
     measures: DimensionMetaDataFragment[];
     fields: AreaFields;
     interactiveFiltersConfig: InteractiveFiltersConfig;
+    imputationType: ImputationType;
   }) => {
     return (
       <AreaChart
@@ -107,6 +109,7 @@ export const ChartAreas = memo(
         dimensions={dimensions}
         measures={measures}
         interactiveFiltersConfig={interactiveFiltersConfig}
+        imputationType={imputationType}
         aspectRatio={0.4}
       >
         <ChartContainer>

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -70,7 +70,7 @@ export const ChartAreasVisualization = ({
           measures={measures}
           fields={chartConfig.fields}
           interactiveFiltersConfig={chartConfig.interactiveFiltersConfig}
-          imputationType={chartConfig.imputationType}
+          imputationType={chartConfig.imputationType || "none"}
         />
         {fetching && <LoadingOverlay />}
       </Box>

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -9,7 +9,6 @@ import {
 import {
   AreaConfig,
   AreaFields,
-  ImputationType,
   InteractiveFiltersConfig,
 } from "../../configurator";
 import { isNumber } from "../../configurator/components/ui-helpers";
@@ -70,7 +69,6 @@ export const ChartAreasVisualization = ({
           measures={measures}
           fields={chartConfig.fields}
           interactiveFiltersConfig={chartConfig.interactiveFiltersConfig}
-          imputationType={chartConfig.imputationType || "none"}
         />
         {fetching && <LoadingOverlay />}
       </Box>
@@ -93,14 +91,12 @@ export const ChartAreas = memo(
     measures,
     fields,
     interactiveFiltersConfig,
-    imputationType,
   }: {
     observations: Observation[];
     dimensions: DimensionMetaDataFragment[];
     measures: DimensionMetaDataFragment[];
     fields: AreaFields;
     interactiveFiltersConfig: InteractiveFiltersConfig;
-    imputationType: ImputationType;
   }) => {
     return (
       <AreaChart
@@ -109,7 +105,6 @@ export const ChartAreas = memo(
         dimensions={dimensions}
         measures={measures}
         interactiveFiltersConfig={interactiveFiltersConfig}
-        imputationType={imputationType}
         aspectRatio={0.4}
       >
         <ChartContainer>

--- a/app/charts/bar/bars-grouped-state.tsx
+++ b/app/charts/bar/bars-grouped-state.tsx
@@ -16,7 +16,7 @@ import {
 import React, { ReactNode, useCallback, useMemo } from "react";
 import { BarFields, SortingOrder, SortingType } from "../../configurator";
 import { getPalette, mkNumber } from "../../configurator/components/ui-helpers";
-import { Observation, ObservationValue } from "../../domain/data";
+import { Observation } from "../../domain/data";
 import { sortByIndex } from "../../lib/array";
 import { useLocale } from "../../locales/use-locale";
 import { ChartContext, ChartProps } from "../shared/use-chart-state";
@@ -42,7 +42,7 @@ export interface GroupedBarsState {
   segments: string[];
   xAxisLabel: string;
   colors: ScaleOrdinal<string, string>;
-  grouped: [string, Record<string, ObservationValue>[]][];
+  grouped: [string, Observation[]][];
 }
 
 const useGroupedBarsState = ({

--- a/app/charts/bar/bars-grouped-state.tsx
+++ b/app/charts/bar/bars-grouped-state.tsx
@@ -19,6 +19,7 @@ import { getPalette, mkNumber } from "../../configurator/components/ui-helpers";
 import { Observation } from "../../domain/data";
 import { sortByIndex } from "../../lib/array";
 import { useLocale } from "../../locales/use-locale";
+import { useSegment } from "../shared/chart-helpers";
 import { ChartContext, ChartProps } from "../shared/use-chart-state";
 import { InteractionProvider } from "../shared/use-interaction";
 import { InteractiveFiltersProvider } from "../shared/use-interactive-filters";
@@ -64,13 +65,7 @@ const useGroupedBarsState = ({
     (d: Observation) => d[fields.y.componentIri] as string,
     [fields.y.componentIri]
   );
-  const getSegment = useCallback(
-    (d: Observation): string =>
-      fields.segment && fields.segment.componentIri
-        ? (d[fields.segment.componentIri] as string)
-        : "segment",
-    [fields.segment]
-  );
+  const getSegment = useSegment(fields.segment?.componentIri);
 
   const xAxisLabel =
     measures.find((d) => d.iri === fields.x.componentIri)?.label ??

--- a/app/charts/bar/bars-grouped-state.tsx
+++ b/app/charts/bar/bars-grouped-state.tsx
@@ -13,13 +13,17 @@ import {
   scaleOrdinal,
   sum,
 } from "d3";
-import React, { ReactNode, useCallback, useMemo } from "react";
+import React, { ReactNode, useMemo } from "react";
 import { BarFields, SortingOrder, SortingType } from "../../configurator";
 import { getPalette, mkNumber } from "../../configurator/components/ui-helpers";
 import { Observation } from "../../domain/data";
 import { sortByIndex } from "../../lib/array";
 import { useLocale } from "../../locales/use-locale";
-import { useSegment } from "../shared/chart-helpers";
+import {
+  useNumericVariable,
+  useSegment,
+  useStringVariable,
+} from "../shared/chart-helpers";
 import { ChartContext, ChartProps } from "../shared/use-chart-state";
 import { InteractionProvider } from "../shared/use-interaction";
 import { InteractiveFiltersProvider } from "../shared/use-interactive-filters";
@@ -57,14 +61,8 @@ const useGroupedBarsState = ({
   const locale = useLocale();
   const width = useWidth();
 
-  const getX = useCallback(
-    (d: Observation) => d[fields.x.componentIri] as number,
-    [fields.x.componentIri]
-  );
-  const getY = useCallback(
-    (d: Observation) => d[fields.y.componentIri] as string,
-    [fields.y.componentIri]
-  );
+  const getX = useNumericVariable(fields.x.componentIri);
+  const getY = useStringVariable(fields.y.componentIri);
   const getSegment = useSegment(fields.segment?.componentIri);
 
   const xAxisLabel =

--- a/app/charts/bar/bars-state.tsx
+++ b/app/charts/bar/bars-state.tsx
@@ -10,11 +10,15 @@ import {
   ScaleOrdinal,
   scaleOrdinal,
 } from "d3";
-import { ReactNode, useCallback, useMemo } from "react";
+import { ReactNode, useMemo } from "react";
 import { BarFields, SortingOrder, SortingType } from "../../configurator";
 import { getPalette, mkNumber } from "../../configurator/components/ui-helpers";
 import { Observation } from "../../domain/data";
-import { useSegment } from "../shared/chart-helpers";
+import {
+  useNumericVariable,
+  useSegment,
+  useStringVariable,
+} from "../shared/chart-helpers";
 import { ChartContext, ChartProps } from "../shared/use-chart-state";
 import { InteractionProvider } from "../shared/use-interaction";
 import { Bounds, Observer, useWidth } from "../shared/use-width";
@@ -48,15 +52,8 @@ const useBarsState = ({
 }): BarsState => {
   const width = useWidth();
 
-  const getX = useCallback(
-    (d: Observation) => d[fields.x.componentIri] as number,
-    [fields.x.componentIri]
-  );
-  const getY = useCallback(
-    (d: Observation) => d[fields.y.componentIri] as string,
-    [fields.y.componentIri]
-  );
-
+  const getX = useNumericVariable(fields.x.componentIri);
+  const getY = useStringVariable(fields.y.componentIri);
   const getSegment = useSegment(fields.segment?.componentIri);
 
   const xAxisLabel =

--- a/app/charts/bar/bars-state.tsx
+++ b/app/charts/bar/bars-state.tsx
@@ -1,5 +1,8 @@
-import { ascending, descending, max, min } from "d3";
 import {
+  ascending,
+  descending,
+  max,
+  min,
   scaleBand,
   ScaleBand,
   ScaleLinear,
@@ -7,20 +10,20 @@ import {
   ScaleOrdinal,
   scaleOrdinal,
 } from "d3";
-
 import { ReactNode, useCallback, useMemo } from "react";
 import { BarFields, SortingOrder, SortingType } from "../../configurator";
-import { Observation } from "../../domain/data";
 import { getPalette, mkNumber } from "../../configurator/components/ui-helpers";
-import {
-  BAR_HEIGHT,
-  BOTTOM_MARGIN_OFFSET,
-  LEFT_MARGIN_OFFSET,
-  BAR_SPACE_ON_TOP,
-} from "./constants";
+import { Observation } from "../../domain/data";
+import { useSegment } from "../shared/chart-helpers";
 import { ChartContext, ChartProps } from "../shared/use-chart-state";
 import { InteractionProvider } from "../shared/use-interaction";
 import { Bounds, Observer, useWidth } from "../shared/use-width";
+import {
+  BAR_HEIGHT,
+  BAR_SPACE_ON_TOP,
+  BOTTOM_MARGIN_OFFSET,
+  LEFT_MARGIN_OFFSET,
+} from "./constants";
 
 export interface BarsState {
   chartType: "bar";
@@ -54,13 +57,7 @@ const useBarsState = ({
     [fields.y.componentIri]
   );
 
-  const getSegment = useCallback(
-    (d: Observation): string =>
-      fields.segment && fields.segment.componentIri
-        ? (d[fields.segment.componentIri] as string)
-        : "segment",
-    [fields.segment]
-  );
+  const getSegment = useSegment(fields.segment?.componentIri);
 
   const xAxisLabel =
     measures.find((d) => d.iri === fields.x.componentIri)?.label ??
@@ -75,7 +72,7 @@ const useBarsState = ({
   }, [data, getX, getY, sortingType, sortingOrder]);
 
   // segments
-  const segments = Array.from(new Set(sortedData.map((d) => getSegment(d))));
+  const segments = [...new Set(sortedData.map((d) => getSegment(d)))];
   const colors = scaleOrdinal(getPalette(fields.segment?.palette)).domain(
     segments
   );

--- a/app/charts/chart-config-ui-options.ts
+++ b/app/charts/chart-config-ui-options.ts
@@ -1,4 +1,4 @@
-import { ChartType, SortingOrder } from "../configurator";
+import { ChartType, imputationTypes, SortingOrder } from "../configurator";
 
 /**
  * This module controls chart controls displayed in the UI.
@@ -14,7 +14,11 @@ export type DimensionType =
   | "Attribute";
 
 export type EncodingField = "x" | "y" | "segment";
-export type EncodingOption = "chartSubType" | "sorting" | "color";
+export type EncodingOption =
+  | "chartSubType"
+  | "sorting"
+  | "color"
+  | "imputationType";
 
 export type EncodingOptions =
   | undefined
@@ -165,7 +169,10 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
           { sortingType: "byDimensionLabel", sortingOrder: ["asc", "desc"] },
           { sortingType: "byTotalSize", sortingOrder: ["asc", "desc"] },
         ],
-        options: [{ field: "color", values: ["palette"] }],
+        options: [
+          { field: "color", values: ["palette"] },
+          { field: "imputationType", values: imputationTypes },
+        ],
       },
     ],
     interactiveFilters: ["legend", "time"],

--- a/app/charts/chart-config-ui-options.ts
+++ b/app/charts/chart-config-ui-options.ts
@@ -1,4 +1,5 @@
-import { ChartType, imputationTypes, SortingOrder } from "../configurator";
+import { ChartType, SortingOrder } from "../configurator";
+import { imputationTypes } from "../configurator/config-types";
 
 /**
  * This module controls chart controls displayed in the UI.

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -16,7 +16,7 @@ import {
   ScaleTime,
   sum,
 } from "d3";
-import React, { ReactNode, useCallback, useMemo } from "react";
+import React, { ReactNode, useMemo } from "react";
 import { ColumnFields, SortingOrder, SortingType } from "../../configurator";
 import {
   getPalette,
@@ -28,9 +28,11 @@ import { sortByIndex } from "../../lib/array";
 import { useLocale } from "../../locales/use-locale";
 import {
   getLabelWithUnit,
+  useOptionalNumericVariable,
   usePreparedData,
   useSegment,
-  useTemporalX,
+  useStringVariable,
+  useTemporalVariable,
 } from "../shared/chart-helpers";
 import { TooltipInfo } from "../shared/interaction/tooltip";
 import { useChartPadding } from "../shared/padding";
@@ -96,15 +98,9 @@ const useGroupedColumnsState = ({
 
   const xIsTime = xDimension.__typename === "TemporalDimension";
 
-  const getX = useCallback(
-    (d: Observation): string => `${d[fields.x.componentIri]}`,
-    [fields.x.componentIri]
-  );
-  const getXAsDate = useTemporalX(fields.x.componentIri);
-  const getY = (d: Observation): number | null => {
-    const v = d[fields.y.componentIri];
-    return v !== null ? +v : null;
-  };
+  const getX = useStringVariable(fields.x.componentIri);
+  const getXAsDate = useTemporalVariable(fields.x.componentIri);
+  const getY = useOptionalNumericVariable(fields.y.componentIri);
   const getSegment = useSegment(fields.segment?.componentIri);
 
   // Sort

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -21,13 +21,17 @@ import { ColumnFields, SortingOrder, SortingType } from "../../configurator";
 import {
   getPalette,
   mkNumber,
-  parseDate,
   useFormatNumber,
 } from "../../configurator/components/ui-helpers";
 import { Observation } from "../../domain/data";
 import { sortByIndex } from "../../lib/array";
 import { useLocale } from "../../locales/use-locale";
-import { getLabelWithUnit, usePreparedData } from "../shared/chart-helpers";
+import {
+  getLabelWithUnit,
+  usePreparedData,
+  useSegment,
+  useTemporalX,
+} from "../shared/chart-helpers";
 import { TooltipInfo } from "../shared/interaction/tooltip";
 import { useChartPadding } from "../shared/padding";
 import { ChartContext, ChartProps } from "../shared/use-chart-state";
@@ -96,21 +100,12 @@ const useGroupedColumnsState = ({
     (d: Observation): string => `${d[fields.x.componentIri]}`,
     [fields.x.componentIri]
   );
-  const getXAsDate = useCallback(
-    (d: Observation): Date => parseDate(`${d[fields.x.componentIri]}`),
-    [fields.x.componentIri]
-  );
+  const getXAsDate = useTemporalX(fields.x.componentIri);
   const getY = (d: Observation): number | null => {
     const v = d[fields.y.componentIri];
     return v !== null ? +v : null;
   };
-  const getSegment = useCallback(
-    (d: Observation): string =>
-      fields.segment && fields.segment.componentIri
-        ? `${d[fields.segment.componentIri]}`
-        : "segment",
-    [fields.segment]
-  );
+  const getSegment = useSegment(fields.segment?.componentIri);
 
   // Sort
   const xSortingType = fields.x.sorting?.sortingType;

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -24,7 +24,7 @@ import {
   parseDate,
   useFormatNumber,
 } from "../../configurator/components/ui-helpers";
-import { Observation, ObservationValue } from "../../domain/data";
+import { Observation } from "../../domain/data";
 import { sortByIndex } from "../../lib/array";
 import { useLocale } from "../../locales/use-locale";
 import { getLabelWithUnit, usePreparedData } from "../shared/chart-helpers";
@@ -60,7 +60,7 @@ export interface GroupedColumnsState {
   segments: string[];
   colors: ScaleOrdinal<string, string>;
   yAxisLabel: string;
-  grouped: [string, Record<string, ObservationValue>[]][];
+  grouped: [string, Observation[]][];
   getAnnotationInfo: (d: Observation) => TooltipInfo;
 }
 

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -33,8 +33,8 @@ import { DimensionMetaDataFragment } from "../../graphql/query-hooks";
 import { sortByIndex } from "../../lib/array";
 import { useLocale } from "../../locales/use-locale";
 import {
-  getBaseWideData,
   getLabelWithUnit,
+  getWideData,
   usePreparedData,
 } from "../shared/chart-helpers";
 import { TooltipInfo } from "../shared/interaction/tooltip";
@@ -131,7 +131,7 @@ const useColumnsStackedState = ({
   const sortingOrder = fields.x.sorting?.sortingOrder;
 
   const allDataGroupedMap = group(data, getX);
-  const allDataWide = getBaseWideData({
+  const allDataWide = getWideData({
     groupedMap: allDataGroupedMap,
     getSegment,
     getY,
@@ -165,7 +165,7 @@ const useColumnsStackedState = ({
   });
 
   const groupedMap = group(preparedData, getX);
-  const chartWideData = getBaseWideData({ groupedMap, xKey, getSegment, getY });
+  const chartWideData = getWideData({ groupedMap, xKey, getSegment, getY });
 
   //Ordered segments
   const segmentSortingType = fields.segment?.sorting?.sortingType;

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -33,8 +33,8 @@ import { DimensionMetaDataFragment } from "../../graphql/query-hooks";
 import { sortByIndex } from "../../lib/array";
 import { useLocale } from "../../locales/use-locale";
 import {
+  getBaseWideData,
   getLabelWithUnit,
-  getWideData,
   usePreparedData,
 } from "../shared/chart-helpers";
 import { TooltipInfo } from "../shared/interaction/tooltip";
@@ -131,7 +131,7 @@ const useColumnsStackedState = ({
   const sortingOrder = fields.x.sorting?.sortingOrder;
 
   const allDataGroupedMap = group(data, getX);
-  const allDataWide = getWideData({
+  const allDataWide = getBaseWideData({
     groupedMap: allDataGroupedMap,
     getSegment,
     getY,
@@ -165,7 +165,7 @@ const useColumnsStackedState = ({
   });
 
   const groupedMap = group(preparedData, getX);
-  const chartWideData = getWideData({ groupedMap, xKey, getSegment, getY });
+  const chartWideData = getBaseWideData({ groupedMap, xKey, getSegment, getY });
 
   //Ordered segments
   const segmentSortingType = fields.segment?.sorting?.sortingType;

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -28,7 +28,7 @@ import {
   parseDate,
   useFormatNumber,
 } from "../../configurator/components/ui-helpers";
-import { Observation, ObservationValue } from "../../domain/data";
+import { Observation } from "../../domain/data";
 import { DimensionMetaDataFragment } from "../../graphql/query-hooks";
 import { sortByIndex } from "../../lib/array";
 import { useLocale } from "../../locales/use-locale";
@@ -67,9 +67,9 @@ export interface StackedColumnsState {
   segments: string[];
   colors: ScaleOrdinal<string, string>;
   yAxisLabel: string;
-  chartWideData: ArrayLike<Record<string, ObservationValue>>;
-  allDataWide: ArrayLike<Record<string, ObservationValue>>;
-  grouped: [string, Record<string, ObservationValue>[]][];
+  chartWideData: ArrayLike<Observation>;
+  allDataWide: ArrayLike<Observation>;
+  grouped: [string, Observation[]][];
   series: $FixMe[];
   getAnnotationInfo: (d: Observation, orderedSegments: string[]) => TooltipInfo;
 }

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -18,13 +18,17 @@ import { ColumnFields, SortingOrder, SortingType } from "../../configurator";
 import {
   getPalette,
   mkNumber,
-  parseDate,
   useFormatNumber,
   useTimeFormatUnit,
 } from "../../configurator/components/ui-helpers";
 import { Observation } from "../../domain/data";
 import { TimeUnit } from "../../graphql/query-hooks";
-import { getLabelWithUnit, usePreparedData } from "../shared/chart-helpers";
+import {
+  getLabelWithUnit,
+  usePreparedData,
+  useSegment,
+  useTemporalX,
+} from "../shared/chart-helpers";
 import { TooltipInfo } from "../shared/interaction/tooltip";
 import { useChartPadding } from "../shared/padding";
 import { ChartContext, ChartProps } from "../shared/use-chart-state";
@@ -95,10 +99,7 @@ const useColumnsState = ({
     (d: Observation): string => `${d[fields.x.componentIri]}`,
     [fields.x.componentIri]
   );
-  const getXAsDate = useCallback(
-    (d: Observation): Date => parseDate(`${d[fields.x.componentIri]}`),
-    [fields.x.componentIri]
-  );
+  const getXAsDate = useTemporalX(fields.x.componentIri);
   const getY = useCallback(
     (d: Observation): number | null => {
       const v = d[fields.y.componentIri];
@@ -106,13 +107,7 @@ const useColumnsState = ({
     },
     [fields.y.componentIri]
   );
-  const getSegment = useCallback(
-    (d: Observation): string =>
-      fields.segment && fields.segment.componentIri
-        ? `${d[fields.segment.componentIri]}`
-        : "segment",
-    [fields.segment]
-  );
+  const getSegment = useSegment(fields.segment?.componentIri);
 
   const sortingType = fields.x.sorting?.sortingType;
   const sortingOrder = fields.x.sorting?.sortingOrder;

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -13,7 +13,7 @@ import {
   scaleTime,
   ScaleTime,
 } from "d3";
-import { ReactNode, useCallback, useMemo } from "react";
+import { ReactNode, useMemo } from "react";
 import { ColumnFields, SortingOrder, SortingType } from "../../configurator";
 import {
   getPalette,
@@ -25,9 +25,11 @@ import { Observation } from "../../domain/data";
 import { TimeUnit } from "../../graphql/query-hooks";
 import {
   getLabelWithUnit,
+  useOptionalNumericVariable,
   usePreparedData,
   useSegment,
-  useTemporalX,
+  useStringVariable,
+  useTemporalVariable,
 } from "../shared/chart-helpers";
 import { TooltipInfo } from "../shared/interaction/tooltip";
 import { useChartPadding } from "../shared/padding";
@@ -95,18 +97,9 @@ const useColumnsState = ({
       ? xDimension.timeUnit
       : undefined;
 
-  const getX = useCallback(
-    (d: Observation): string => `${d[fields.x.componentIri]}`,
-    [fields.x.componentIri]
-  );
-  const getXAsDate = useTemporalX(fields.x.componentIri);
-  const getY = useCallback(
-    (d: Observation): number | null => {
-      const v = d[fields.y.componentIri];
-      return v !== null ? +v : null;
-    },
-    [fields.y.componentIri]
-  );
+  const getX = useStringVariable(fields.x.componentIri);
+  const getXAsDate = useTemporalVariable(fields.x.componentIri);
+  const getY = useOptionalNumericVariable(fields.y.componentIri);
   const getSegment = useSegment(fields.segment?.componentIri);
 
   const sortingType = fields.x.sorting?.sortingType;

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -152,7 +152,7 @@ export const getInitialConfig = ({
           x: {
             componentIri: getTimeDimensions(dimensions)[0].iri,
           },
-          y: { componentIri: measures[0].iri },
+          y: { componentIri: measures[0].iri, imputationType: "none" },
         },
       };
     case "scatterplot":

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -154,7 +154,6 @@ export const getInitialConfig = ({
           },
           y: { componentIri: measures[0].iri },
         },
-        imputationType: "none",
       };
     case "scatterplot":
       return {

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -154,6 +154,7 @@ export const getInitialConfig = ({
           },
           y: { componentIri: measures[0].iri },
         },
+        imputationType: "none",
       };
     case "scatterplot":
       return {

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -25,11 +25,12 @@ import { useTheme } from "../../themes";
 import { BRUSH_BOTTOM_SPACE } from "../shared/brush";
 import {
   getLabelWithUnit,
+  getWideData,
   useOptionalNumericVariable,
   usePreparedData,
   useSegment,
+  useStringVariable,
   useTemporalVariable,
-  useWideData,
 } from "../shared/chart-helpers";
 import { TooltipInfo } from "../shared/interaction/tooltip";
 import { ChartContext, ChartProps } from "../shared/use-chart-state";
@@ -91,12 +92,8 @@ const useLinesState = ({
 
   const getX = useTemporalVariable(fields.x.componentIri);
   const getY = useOptionalNumericVariable(fields.y.componentIri);
+  const getGroups = useStringVariable(fields.x.componentIri);
   const getSegment = useSegment(fields.segment?.componentIri);
-
-  const allSegments = useMemo(
-    () => [...new Set(data.map((d) => getSegment(d)))],
-    [data, getSegment]
-  );
 
   const xKey = fields.x.componentIri;
 
@@ -104,12 +101,17 @@ const useLinesState = ({
     () => [...data].sort((a, b) => ascending(getX(a), getX(b))),
     [data, getX]
   );
-  const allDataWide = useWideData({
-    data: sortedData,
-    segments: allSegments,
-    getSegment,
-    getY,
+
+  const sortedDataGroupedByX = useMemo(
+    () => group(sortedData, getGroups),
+    [sortedData, getGroups]
+  );
+
+  const allDataWide = getWideData({
+    dataGroupedByX: sortedDataGroupedByX,
     xKey,
+    getY,
+    getSegment,
   });
 
   // All Data
@@ -122,13 +124,21 @@ const useLinesState = ({
     getSegment,
   });
 
-  const grouped = group(preparedData, getSegment);
-  const chartWideData = useWideData({
-    data: preparedData,
-    segments: allSegments,
-    getSegment,
-    getY,
+  const preparedDataGroupedBySegment = useMemo(
+    () => group(preparedData, getSegment),
+    [preparedData, getSegment]
+  );
+
+  const preparedDataGroupedByX = useMemo(
+    () => group(preparedData, getGroups),
+    [preparedData, getGroups]
+  );
+
+  const chartWideData = getWideData({
+    dataGroupedByX: preparedDataGroupedByX,
     xKey,
+    getY,
+    getSegment,
   });
 
   // x
@@ -279,7 +289,7 @@ const useLinesState = ({
     yAxisLabel,
     segments,
     colors,
-    grouped,
+    grouped: preparedDataGroupedBySegment,
     chartWideData,
     allDataWide,
     xKey,

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -16,8 +16,8 @@ import { LineFields } from "../../configurator";
 import {
   getPalette,
   parseDate,
-  useTimeFormatUnit,
   useFormatNumber,
+  useTimeFormatUnit,
 } from "../../configurator/components/ui-helpers";
 import { Observation } from "../../domain/data";
 import { sortByIndex } from "../../lib/array";
@@ -25,7 +25,7 @@ import { estimateTextWidth } from "../../lib/estimate-text-width";
 import { useTheme } from "../../themes";
 import { BRUSH_BOTTOM_SPACE } from "../shared/brush";
 import {
-  getWideData,
+  getBaseWideData,
   getLabelWithUnit,
   usePreparedData,
 } from "../shared/chart-helpers";
@@ -111,7 +111,7 @@ const useLinesState = ({
     sortedData,
     (d) => d[fields.x.componentIri] as string
   );
-  const allDataWide = getWideData({
+  const allDataWide = getBaseWideData({
     groupedMap: allDataGroupedMap,
     getSegment,
     getY,
@@ -133,7 +133,7 @@ const useLinesState = ({
     preparedData,
     (d) => d[fields.x.componentIri] as string
   );
-  const chartWideData = getWideData({ groupedMap, getSegment, getY, xKey });
+  const chartWideData = getBaseWideData({ groupedMap, getSegment, getY, xKey });
 
   // x
   const xDomain = extent(preparedData, (d) => getX(d)) as [Date, Date];

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -19,7 +19,7 @@ import {
   useTimeFormatUnit,
   useFormatNumber,
 } from "../../configurator/components/ui-helpers";
-import { Observation, ObservationValue } from "../../domain/data";
+import { Observation } from "../../domain/data";
 import { sortByIndex } from "../../lib/array";
 import { estimateTextWidth } from "../../lib/estimate-text-width";
 import { useTheme } from "../../themes";
@@ -52,8 +52,8 @@ export interface LinesState {
   xAxisLabel: string;
   yAxisLabel: string;
   grouped: Map<string, Observation[]>;
-  chartWideData: ArrayLike<Record<string, ObservationValue>>;
-  allDataWide: ArrayLike<Record<string, ObservationValue>>;
+  chartWideData: ArrayLike<Observation>;
+  allDataWide: ArrayLike<Observation>;
   xKey: string;
   getAnnotationInfo: (d: Observation) => TooltipInfo;
 }

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -25,8 +25,8 @@ import { estimateTextWidth } from "../../lib/estimate-text-width";
 import { useTheme } from "../../themes";
 import { BRUSH_BOTTOM_SPACE } from "../shared/brush";
 import {
-  getLabelWithUnit,
   getWideData,
+  getLabelWithUnit,
   usePreparedData,
 } from "../shared/chart-helpers";
 import { TooltipInfo } from "../shared/interaction/tooltip";
@@ -87,8 +87,6 @@ const useLinesState = ({
     throw Error(`Dimension <${fields.x.componentIri}> is not temporal!`);
   }
 
-  const getGroups = (d: Observation): string =>
-    d[fields.x.componentIri] as string;
   const getX = useCallback(
     (d: Observation): Date => parseDate(`${d[fields.x.componentIri]}`),
     [fields.x.componentIri]
@@ -109,7 +107,10 @@ const useLinesState = ({
     () => [...data].sort((a, b) => ascending(getX(a), getX(b))),
     [data, getX]
   );
-  const allDataGroupedMap = group(sortedData, getGroups);
+  const allDataGroupedMap = group(
+    sortedData,
+    (d) => d[fields.x.componentIri] as string
+  );
   const allDataWide = getWideData({
     groupedMap: allDataGroupedMap,
     getSegment,
@@ -128,7 +129,10 @@ const useLinesState = ({
   });
 
   const grouped = group(preparedData, getSegment);
-  const groupedMap = group(preparedData, getGroups);
+  const groupedMap = group(
+    preparedData,
+    (d) => d[fields.x.componentIri] as string
+  );
   const chartWideData = getWideData({ groupedMap, getSegment, getY, xKey });
 
   // x

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -25,8 +25,8 @@ import { estimateTextWidth } from "../../lib/estimate-text-width";
 import { useTheme } from "../../themes";
 import { BRUSH_BOTTOM_SPACE } from "../shared/brush";
 import {
-  getBaseWideData,
   getLabelWithUnit,
+  getWideData,
   usePreparedData,
 } from "../shared/chart-helpers";
 import { TooltipInfo } from "../shared/interaction/tooltip";
@@ -111,7 +111,7 @@ const useLinesState = ({
     sortedData,
     (d) => d[fields.x.componentIri] as string
   );
-  const allDataWide = getBaseWideData({
+  const allDataWide = getWideData({
     groupedMap: allDataGroupedMap,
     getSegment,
     getY,
@@ -133,7 +133,7 @@ const useLinesState = ({
     preparedData,
     (d) => d[fields.x.componentIri] as string
   );
-  const chartWideData = getBaseWideData({ groupedMap, getSegment, getY, xKey });
+  const chartWideData = getWideData({ groupedMap, getSegment, getY, xKey });
 
   // x
   const xDomain = extent(preparedData, (d) => getX(d)) as [Date, Date];

--- a/app/charts/pie/pie-state.tsx
+++ b/app/charts/pie/pie-state.tsx
@@ -8,14 +8,18 @@ import {
   ScaleOrdinal,
   scaleOrdinal,
 } from "d3";
-import React, { ReactNode, useCallback, useMemo } from "react";
+import React, { ReactNode, useMemo } from "react";
 import { PieFields, SortingOrder, SortingType } from "../../configurator";
 import {
   getPalette,
   useFormatNumber,
 } from "../../configurator/components/ui-helpers";
 import { Observation } from "../../domain/data";
-import { usePreparedData } from "../shared/chart-helpers";
+import {
+  useOptionalNumericVariable,
+  usePreparedData,
+  useSegment,
+} from "../shared/chart-helpers";
 import { TooltipInfo } from "../shared/interaction/tooltip";
 import { ChartContext, ChartProps } from "../shared/use-chart-state";
 import { InteractionProvider } from "../shared/use-interaction";
@@ -83,17 +87,8 @@ const usePieState = ({
     throw Error(`No dimension <${fields.y.componentIri}> in cube!`);
   }
 
-  const getY = useCallback(
-    (d: Observation): number | null => {
-      const v = d[fields.y.componentIri];
-      return v !== null ? +v : null;
-    },
-    [fields.y.componentIri]
-  );
-  const getX = useCallback(
-    (d: Observation): string => d[fields.segment.componentIri] as string,
-    [fields.segment.componentIri]
-  );
+  const getY = useOptionalNumericVariable(fields.y.componentIri);
+  const getX = useSegment(fields.segment.componentIri);
 
   // Sort data
   const sortingType = fields.segment.sorting?.sortingType;

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -7,7 +7,7 @@ import {
   ScaleOrdinal,
   scaleOrdinal,
 } from "d3";
-import React, { ReactNode, useCallback } from "react";
+import React, { ReactNode } from "react";
 import { ScatterPlotFields } from "../../configurator";
 import {
   getPalette,
@@ -16,7 +16,11 @@ import {
 } from "../../configurator/components/ui-helpers";
 import { Observation } from "../../domain/data";
 import { estimateTextWidth } from "../../lib/estimate-text-width";
-import { getLabelWithUnit, usePreparedData } from "../shared/chart-helpers";
+import {
+  getLabelWithUnit,
+  usePreparedData,
+  useSegment,
+} from "../shared/chart-helpers";
 import { TooltipInfo } from "../shared/interaction/tooltip";
 import { TooltipScatterplot } from "../shared/interaction/tooltip-content";
 import { ChartContext, ChartProps } from "../shared/use-chart-state";
@@ -68,11 +72,7 @@ const useScatterplotState = ({
     const v = d[fields.y.componentIri];
     return v !== null ? +v : null;
   };
-  const getSegment = useCallback(
-    (d: Observation): string =>
-      fields.segment ? (d[fields.segment.componentIri] as string) : "segment",
-    [fields.segment]
-  );
+  const getSegment = useSegment(fields.segment?.componentIri);
 
   // All data, sort by segment
   const sortedData = data.sort((a, b) =>

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -18,6 +18,7 @@ import { Observation } from "../../domain/data";
 import { estimateTextWidth } from "../../lib/estimate-text-width";
 import {
   getLabelWithUnit,
+  useOptionalNumericVariable,
   usePreparedData,
   useSegment,
 } from "../shared/chart-helpers";
@@ -64,14 +65,8 @@ const useScatterplotState = ({
   const width = useWidth();
   const formatNumber = useFormatNumber();
 
-  const getX = (d: Observation): number | null => {
-    const v = d[fields.x.componentIri];
-    return v !== null ? +v : null;
-  };
-  const getY = (d: Observation): number | null => {
-    const v = d[fields.y.componentIri];
-    return v !== null ? +v : null;
-  };
+  const getX = useOptionalNumericVariable(fields.x.componentIri);
+  const getY = useOptionalNumericVariable(fields.y.componentIri);
   const getSegment = useSegment(fields.segment?.componentIri);
 
   // All data, sort by segment

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -129,10 +129,42 @@ export const usePreparedData = ({
 };
 
 // retrieving variables
-export const useTemporalX = (xKey: string): ((d: Observation) => Date) => {
-  const getX = useCallback((d: Observation) => parseDate(`${d[xKey]}`), [xKey]);
+export const useNumericVariable = (
+  key: string
+): ((d: Observation) => number) => {
+  const getVariable = useCallback((d: Observation) => Number(d[key]), [key]);
 
-  return getX;
+  return getVariable;
+};
+
+export const useOptionalNumericVariable = (
+  key: string
+): ((d: Observation) => number | null) => {
+  const getVariable = useCallback(
+    (d: Observation) => (d[key] !== null ? Number(d[key]) : null),
+    [key]
+  );
+
+  return getVariable;
+};
+
+export const useStringVariable = (
+  key: string
+): ((d: Observation) => string) => {
+  const getVariable = useCallback((d: Observation) => `${d[key]}`, [key]);
+
+  return getVariable;
+};
+
+export const useTemporalVariable = (
+  key: string
+): ((d: Observation) => Date) => {
+  const getVariable = useCallback(
+    (d: Observation) => parseDate(`${d[key]}`),
+    [key]
+  );
+
+  return getVariable;
 };
 
 export const useSegment = (

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -128,7 +128,7 @@ export const usePreparedData = ({
 };
 
 // Helper to pivot a dataset to a wider format
-export const getBaseWideData = ({
+export const getWideData = ({
   xKey,
   groupedMap,
   getSegment,
@@ -187,7 +187,7 @@ export const getTemporalWideDataWithImputedValues = ({
 
   switch (imputationType) {
     case "none":
-      return getBaseWideData({ xKey, groupedMap, getSegment, getY });
+      return getWideData({ xKey, groupedMap, getSegment, getY });
     case "zeros":
       baseObservation = Object.assign(
         {},

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -1,6 +1,6 @@
 import { group, InternMap, sum } from "d3";
 import { omitBy } from "lodash";
-import { useCallback, useMemo } from "react";
+import { useMemo } from "react";
 import {
   ChartConfig,
   Filters,
@@ -321,23 +321,22 @@ export const useImputationNeeded = ({
   chartConfig: ChartConfig;
   data?: Array<Observation>;
 }) => {
-  const getSegment = useCallback(
-    (d: Observation): string =>
-      chartConfig.fields.segment
-        ? (d[chartConfig.fields.segment.componentIri] as string)
-        : "segment",
-    [chartConfig.fields.segment]
-  );
+  const imputationNeeded = useMemo(() => {
+    if (isAreaConfig(chartConfig) && data) {
+      const getSegment = (d: Observation): string =>
+        chartConfig.fields.segment
+          ? (d[chartConfig.fields.segment.componentIri] as string)
+          : "segment";
 
-  if (isAreaConfig(chartConfig) && data) {
-    return checkForMissingValuesInSegments(
-      group(
-        data,
-        (d: Observation) => d[chartConfig.fields.x.componentIri] as string
-      ),
-      [...new Set(data.map((d) => getSegment(d)))]
-    );
-  }
+      return checkForMissingValuesInSegments(
+        group(
+          data,
+          (d: Observation) => d[chartConfig.fields.x.componentIri] as string
+        ),
+        [...new Set(data.map((d) => getSegment(d)))]
+      );
+    }
+  }, [chartConfig, data]);
 
-  return false;
+  return imputationNeeded;
 };

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -1,9 +1,6 @@
 import { group, InternMap, sum } from "d3";
 import { omitBy } from "lodash";
-import {
-  useCallback,
-  useMemo
-} from "react";
+import { useCallback, useMemo } from "react";
 import {
   ChartConfig,
   Filters,
@@ -129,27 +126,36 @@ export const usePreparedData = ({
   return preparedData;
 };
 
-// Helper to pivot a dataset to a wider format (used in stacked charts)
-export const getWideData = ({
+// Helper to pivot a dataset to a wider format
+export const getBaseWideData = ({
   xKey,
   groupedMap,
   getSegment,
   getY,
 }: {
   xKey: string;
-  groupedMap: Map<string, Record<string, ObservationValue>[]>;
+  groupedMap: Map<string, Array<Observation>>;
   getSegment: (d: Observation) => string;
   getY: (d: Observation) => number | null;
 }): Array<Observation> => {
   const wideArray = [];
+
   for (const [key, values] of groupedMap) {
-    let obj: Observation = {
+    let observation: Observation = {
       [xKey]: key,
       total: sum(values, getY),
     };
 
     for (const value of values) {
-      obj[getSegment(value)] = getY(value);
+      observation[getSegment(value)] = getY(value);
+    }
+
+    wideArray.push(observation);
+  }
+
+  return wideArray;
+};
+
     }
 
     wideArray.push(obj);

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -344,24 +344,17 @@ export const useImputationNeeded = ({
   chartConfig: ChartConfig;
   data?: Array<Observation>;
 }): boolean => {
+  const getSegment = useSegment(chartConfig.fields.segment?.componentIri);
   const imputationNeeded = useMemo(() => {
     if (isAreaConfig(chartConfig) && data) {
-      const getSegment = (d: Observation): string =>
-        chartConfig.fields.segment
-          ? (d[chartConfig.fields.segment.componentIri] as string)
-          : "segment";
-
       return checkForMissingValuesInSegments(
-        group(
-          data,
-          (d: Observation) => d[chartConfig.fields.x.componentIri] as string
-        ),
+        group(data, (d) => d[chartConfig.fields.x.componentIri] as string),
         [...new Set(data.map((d) => getSegment(d)))]
       );
     } else {
       return false;
     }
-  }, [chartConfig, data]);
+  }, [chartConfig, data, getSegment]);
 
   return imputationNeeded;
 };

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -159,3 +159,5 @@ export const getLabelWithUnit = (
     ? `${dimension.label} (${dimension.unit})`
     : dimension.label;
 };
+
+

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -182,6 +182,28 @@ export const useSegment = (
   return getSegment;
 };
 
+// Stacking helpers.
+// Modified from d3 source code to treat 0s as positive values and stack them correctly
+// in area charts.
+export const stackOffsetDivergingPositiveZeros = (
+  series: any,
+  order: any
+): void => {
+  const n = series.length;
+
+  if (!(n > 0)) return;
+
+  for (let i, j = 0, d, dy, yp, yn, m = series[order[0]].length; j < m; ++j) {
+    for (yp = yn = 0, i = 0; i < n; ++i) {
+      if ((dy = (d = series[order[i]][j])[1] - d[0]) >= 0) {
+        (d[0] = yp), (d[1] = yp += dy);
+      } else {
+        (d[1] = yn), (d[0] = yn += dy);
+      }
+    }
+  }
+};
+
 // Helper to pivot a dataset to a wider format.
 // Currently, imputation is only applicable to temporal charts (specifically, stacked area charts).
 export const getWideData = ({

--- a/app/charts/shared/imputation.spec.tsx
+++ b/app/charts/shared/imputation.spec.tsx
@@ -1,0 +1,56 @@
+import {
+  imputeTemporalLinearSeries,
+  interpolateTemporalLinearValue,
+  interpolateZerosValue,
+} from "./imputation";
+
+describe("imputation", () => {
+  const previousValue = 10;
+  const nextValue = 20;
+
+  const previousDate = new Date(2020, 0, 0);
+  const currentDate = new Date(2020, 5, 11);
+  const nextDate = new Date(2021, 0, 0);
+
+  const expectedLinearlyInterpolatedValue =
+    previousValue +
+    ((nextValue - previousValue) *
+      (currentDate.getTime() - previousDate.getTime())) /
+      (nextDate.getTime() - previousDate.getTime());
+
+  it("should return zero", () => {
+    expect(interpolateZerosValue()).toEqual(0);
+  });
+
+  it("should return linearly interpolated value", () => {
+    const interpolatedValue = interpolateTemporalLinearValue({
+      previousValue,
+      nextValue,
+      previousTime: previousDate.getTime(),
+      currentTime: currentDate.getTime(),
+      nextTime: nextDate.getTime(),
+    });
+
+    expect(Math.round(interpolatedValue * 1e5) / 1e5).toEqual(
+      Math.round(expectedLinearlyInterpolatedValue * 1e5) / 1e5
+    );
+  });
+
+  it("should impute linearly interpolated value and leave present values intact", () => {
+    const dataToImpute = [
+      { date: previousDate, value: previousValue },
+      { date: currentDate, value: null },
+      { date: nextDate, value: nextValue },
+    ];
+
+    imputeTemporalLinearSeries({
+      dataSortedByX: dataToImpute,
+    });
+
+    expect(Math.round(dataToImpute[1].value! * 1e5) / 1e5).toEqual(
+      Math.round(expectedLinearlyInterpolatedValue * 1e5) / 1e5
+    );
+    expect(dataToImpute[0].value).toEqual(previousValue);
+    expect(dataToImpute[2].value).toEqual(nextValue);
+  });
+});

--- a/app/charts/shared/imputation.tsx
+++ b/app/charts/shared/imputation.tsx
@@ -4,7 +4,7 @@ export const interpolateZerosValue = () => {
   return 0;
 };
 
-const interpolateTemporalLinearValue = ({
+export const interpolateTemporalLinearValue = ({
   previousValue,
   nextValue,
   previousTime,

--- a/app/charts/shared/imputation.tsx
+++ b/app/charts/shared/imputation.tsx
@@ -1,0 +1,82 @@
+import { interpolate } from "d3-interpolate";
+
+export const interpolateZerosValue = () => {
+  return Number.MIN_VALUE;
+};
+
+export const interpolateTemporalLinearValue = ({
+  previousValue,
+  nextValue,
+  previousTime,
+  currentTime,
+  nextTime,
+}: {
+  previousValue: number;
+  nextValue: number;
+  previousTime: number;
+  currentTime: number;
+  nextTime: number;
+}) => {
+  return interpolate(
+    previousValue,
+    nextValue
+  )((currentTime - previousTime) / (nextTime - previousTime));
+};
+
+interface TemporalSeriesBeforeImputationEntry {
+  date: Date;
+  value: number | null;
+}
+
+interface TemporalSeriesAfterImputationEntry {
+  date: Date;
+  value: number;
+}
+
+export const imputeTemporalLinearSeries = ({
+  dataSortedByX,
+}: {
+  dataSortedByX: Array<TemporalSeriesBeforeImputationEntry>;
+}): Array<TemporalSeriesAfterImputationEntry> => {
+  const indexedData: Array<[TemporalSeriesBeforeImputationEntry, number]> =
+    dataSortedByX.map((d, i) => [d, i]);
+  const presentDataIndexes = indexedData
+    .filter((d) => d[0].value !== null)
+    .map((d) => d[1]);
+  const missingDataIndexes = indexedData
+    .filter((d) => d[0].value === null)
+    .map((d) => d[1]);
+
+  for (const missingDataIndex of missingDataIndexes) {
+    const nextIndex = presentDataIndexes.findIndex((d) => d > missingDataIndex);
+
+    if (nextIndex) {
+      const previousIndex = nextIndex - 1;
+
+      if (previousIndex >= 0) {
+        const previous = dataSortedByX[presentDataIndexes[previousIndex]];
+        const next = dataSortedByX[presentDataIndexes[nextIndex]];
+
+        dataSortedByX[missingDataIndex] = {
+          date: dataSortedByX[missingDataIndex].date,
+          value: interpolateTemporalLinearValue({
+            previousValue: previous.value!,
+            nextValue: next.value!,
+            previousTime: previous.date.getTime(),
+            nextTime: next.date.getTime(),
+            currentTime: dataSortedByX[missingDataIndex].date.getTime(),
+          }),
+        };
+
+        continue;
+      }
+    }
+
+    dataSortedByX[missingDataIndex] = {
+      date: dataSortedByX[missingDataIndex].date,
+      value: 0,
+    };
+  }
+
+  return dataSortedByX as Array<TemporalSeriesAfterImputationEntry>;
+};

--- a/app/charts/shared/imputation.tsx
+++ b/app/charts/shared/imputation.tsx
@@ -1,10 +1,10 @@
 import { interpolate } from "d3-interpolate";
 
 export const interpolateZerosValue = () => {
-  return Number.MIN_VALUE;
+  return 0;
 };
 
-export const interpolateTemporalLinearValue = ({
+const interpolateTemporalLinearValue = ({
   previousValue,
   nextValue,
   previousTime,
@@ -38,24 +38,29 @@ export const imputeTemporalLinearSeries = ({
 }: {
   dataSortedByX: Array<TemporalSeriesBeforeImputationEntry>;
 }): Array<TemporalSeriesAfterImputationEntry> => {
-  const indexedData: Array<[TemporalSeriesBeforeImputationEntry, number]> =
-    dataSortedByX.map((d, i) => [d, i]);
-  const presentDataIndexes = indexedData
-    .filter((d) => d[0].value !== null)
-    .map((d) => d[1]);
-  const missingDataIndexes = indexedData
-    .filter((d) => d[0].value === null)
-    .map((d) => d[1]);
+  const presentDataIndexes = [];
+  const missingDataIndexes = [];
+
+  for (let i = 0; i < dataSortedByX.length; i++) {
+    if (dataSortedByX[i].value !== null) {
+      presentDataIndexes.push(i);
+    } else {
+      missingDataIndexes.push(i);
+    }
+  }
 
   for (const missingDataIndex of missingDataIndexes) {
-    const nextIndex = presentDataIndexes.findIndex((d) => d > missingDataIndex);
+    const nextPresentDataIndex = presentDataIndexes.findIndex(
+      (d) => d > missingDataIndex
+    );
 
-    if (nextIndex) {
-      const previousIndex = nextIndex - 1;
+    if (nextPresentDataIndex) {
+      const previousPresentDataIndex = nextPresentDataIndex - 1;
 
-      if (previousIndex >= 0) {
-        const previous = dataSortedByX[presentDataIndexes[previousIndex]];
-        const next = dataSortedByX[presentDataIndexes[nextIndex]];
+      if (previousPresentDataIndex >= 0) {
+        const previous =
+          dataSortedByX[presentDataIndexes[previousPresentDataIndex]];
+        const next = dataSortedByX[presentDataIndexes[nextPresentDataIndex]];
 
         dataSortedByX[missingDataIndex] = {
           date: dataSortedByX[missingDataIndex].date,

--- a/app/charts/shared/imputation.tsx
+++ b/app/charts/shared/imputation.tsx
@@ -1,4 +1,5 @@
 import { interpolate } from "d3-interpolate";
+import { ChartConfig, isAreaConfig } from "../../configurator";
 
 export const interpolateZerosValue = () => {
   return 0;
@@ -84,4 +85,14 @@ export const imputeTemporalLinearSeries = ({
   }
 
   return dataSortedByX as Array<TemporalSeriesAfterImputationEntry>;
+};
+
+export const isUsingImputation = (chartConfig: ChartConfig): boolean => {
+  if (isAreaConfig(chartConfig)) {
+    const imputationType = chartConfig.fields.y.imputationType || "";
+
+    return ["zeros", "linear"].includes(imputationType);
+  }
+
+  return false;
 };

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -1,7 +1,5 @@
 import { Trans } from "@lingui/macro";
-import { omitBy } from "lodash";
 import * as React from "react";
-import { useEffect } from "react";
 import { Box, Flex, Text } from "theme-ui";
 import { ChartAreasVisualization } from "../charts/area/chart-area";
 import { ChartBarsVisualization } from "../charts/bar/chart-bar";
@@ -14,7 +12,17 @@ import { useQueryFilters } from "../charts/shared/chart-helpers";
 import { InteractiveFiltersProvider } from "../charts/shared/use-interactive-filters";
 import useSyncInteractiveFilters from "../charts/shared/use-sync-interactive-filters";
 import { ChartTableVisualization } from "../charts/table/chart-table";
-import { ChartConfig, useConfiguratorState } from "../configurator";
+import {
+  ChartConfig,
+  isAreaConfig,
+  isBarConfig,
+  isColumnConfig,
+  isLineConfig,
+  isPieConfig,
+  isScatterPlotConfig,
+  isTableConfig,
+  useConfiguratorState,
+} from "../configurator";
 import { useDataCubeMetadataQuery } from "../graphql/query-hooks";
 import { DataCubePublicationStatus } from "../graphql/resolver-types";
 import { useLocale } from "../locales/use-locale";
@@ -159,49 +167,49 @@ const Chart = ({
   return (
     <>
       {/* CHARTS */}
-      {chartConfig.chartType === "column" && (
+      {isColumnConfig(chartConfig) && (
         <ChartColumnsVisualization
           dataSetIri={dataSet}
           chartConfig={chartConfig}
           queryFilters={queryFilters}
         />
       )}
-      {chartConfig.chartType === "bar" && (
+      {isBarConfig(chartConfig) && (
         <ChartBarsVisualization
           dataSetIri={dataSet}
           chartConfig={chartConfig}
           queryFilters={queryFilters}
         />
       )}
-      {chartConfig.chartType === "line" && (
+      {isLineConfig(chartConfig) && (
         <ChartLinesVisualization
           dataSetIri={dataSet}
           chartConfig={chartConfig}
           queryFilters={queryFilters}
         />
       )}
-      {chartConfig.chartType === "area" && (
+      {isAreaConfig(chartConfig) && (
         <ChartAreasVisualization
           dataSetIri={dataSet}
           chartConfig={chartConfig}
           queryFilters={queryFilters}
         />
       )}
-      {chartConfig.chartType === "scatterplot" && (
+      {isScatterPlotConfig(chartConfig) && (
         <ChartScatterplotVisualization
           dataSetIri={dataSet}
           chartConfig={chartConfig}
           queryFilters={queryFilters}
         />
       )}
-      {chartConfig.chartType === "pie" && (
+      {isPieConfig(chartConfig) && (
         <ChartPieVisualization
           dataSetIri={dataSet}
           chartConfig={chartConfig}
           queryFilters={queryFilters}
         />
       )}
-      {chartConfig.chartType === "table" && (
+      {isTableConfig(chartConfig) && (
         <ChartTableVisualization
           dataSetIri={dataSet}
           chartConfig={chartConfig}

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -1,5 +1,4 @@
 import { Trans } from "@lingui/macro";
-import { omitBy } from "lodash";
 import * as React from "react";
 import { useEffect } from "react";
 import { Box, Flex, Text } from "theme-ui";
@@ -11,20 +10,20 @@ import { ChartPieVisualization } from "../charts/pie/chart-pie";
 import { ChartScatterplotVisualization } from "../charts/scatterplot/chart-scatterplot";
 import { ChartDataFilters } from "../charts/shared/chart-data-filters";
 import { QueryFilters, useQueryFilters } from "../charts/shared/chart-helpers";
+import { isUsingImputation } from "../charts/shared/imputation";
 import {
   InteractiveFiltersProvider,
   useInteractiveFilters,
 } from "../charts/shared/use-interactive-filters";
 import { ChartTableVisualization } from "../charts/table/chart-table";
-import { ChartConfig, ChartType, Meta } from "../configurator";
+import { ChartConfig, Meta } from "../configurator";
 import { parseDate } from "../configurator/components/ui-helpers";
-import { FIELD_VALUE_NONE } from "../configurator/constants";
 import { useDataCubeMetadataQuery } from "../graphql/query-hooks";
 import { DataCubePublicationStatus } from "../graphql/resolver-types";
 import { useLocale } from "../locales/use-locale";
 import { ChartErrorBoundary } from "./chart-error-boundary";
 import { ChartFootnotes } from "./chart-footnotes";
-import { HintRed } from "./hint";
+import { HintBlue, HintRed } from "./hint";
 
 export const ChartPublished = ({
   dataSet,
@@ -73,6 +72,16 @@ export const ChartPublished = ({
                 <strong>Don&apos;t use for reporting!</strong>
               </Trans>
             </HintRed>
+          </Box>
+        )}
+        {isUsingImputation(chartConfig) && (
+          <Box sx={{ mb: 4 }}>
+            <HintBlue iconName="hintWarning">
+              <Trans id="dataset.hasImputedValues">
+                Some data in this dataset is missing and has been interpolated
+                to fill the gaps.
+              </Trans>
+            </HintBlue>
           </Box>
         )}
         {meta.title[locale] !== "" && (

--- a/app/components/data-download.tsx
+++ b/app/components/data-download.tsx
@@ -4,7 +4,7 @@ import { saveAs } from "file-saver";
 import { memo, ReactNode, useMemo } from "react";
 import { Box, Button, Link } from "theme-ui";
 import { useQueryFilters } from "../charts/shared/chart-helpers";
-import { ChartConfig, ChartFields } from "../configurator";
+import { ChartConfig, ChartFields, isTableConfig } from "../configurator";
 import { Observation } from "../domain/data";
 import {
   DimensionMetaDataFragment,
@@ -28,7 +28,7 @@ export const DataDownload = memo(
     const measures =
       "y" in chartConfig.fields
         ? [chartConfig.fields.y.componentIri]
-        : chartConfig.chartType === "table"
+        : isTableConfig(chartConfig)
         ? Object.values(chartConfig.fields).flatMap((f) =>
             f.componentType === "Measure" && !f.isHidden ? [f.componentIri] : []
           )

--- a/app/components/hint.tsx
+++ b/app/components/hint.tsx
@@ -1,7 +1,7 @@
 import { keyframes } from "@emotion/react";
 import { Trans } from "@lingui/macro";
-import { Box, Flex, Text } from "theme-ui";
 import { ReactNode } from "react";
+import { Box, Flex, Text } from "theme-ui";
 import { Icon, IconName } from "../icons";
 
 export const Error = ({ children }: { children: ReactNode }) => (
@@ -247,16 +247,17 @@ export const Success = () => (
 export const HintBlue = ({
   iconName,
   children,
+  iconSize = 24,
 }: {
   iconName: IconName;
   children: ReactNode;
+  iconSize?: number;
 }) => (
   <Flex
     sx={{
       width: "auto",
       height: "auto",
-      m: 4,
-      p: 5,
+      p: 4,
       bg: "primaryLight",
       color: "primary",
       textAlign: "center",
@@ -264,8 +265,8 @@ export const HintBlue = ({
       alignItems: ["flex-start", "center"],
     }}
   >
-    <Box sx={{ width: 24, pr: 4 }}>
-      <Icon name={iconName} size={24} />
+    <Box sx={{ width: iconSize, pr: 4 }}>
+      <Icon name={iconName} size={iconSize} />
     </Box>
     <Text as="p" variant="paragraph1" sx={{ textAlign: "left", ml: 4 }}>
       {children}

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -7,6 +7,7 @@ import {
   ConfiguratorStateConfiguringChart,
   ImputationType,
   imputationTypes,
+  isAreaConfig,
   isTableConfig,
   SortingType,
   useConfiguratorState,
@@ -245,12 +246,13 @@ const EncodingOptionsPanel = ({
           // chartType={chartType}
         />
       )}
-      {encoding.options?.map((e) => e.field.includes("imputationType")) && (
-        <ChartImputationType
-          state={state}
-          disabled={!imputationNeeded}
-        ></ChartImputationType>
-      )}
+      {encoding.options?.map((e) => e.field.includes("imputationType")) &&
+        isAreaConfig(state.chartConfig) && (
+          <ChartImputationType
+            state={state}
+            disabled={!imputationNeeded}
+          ></ChartImputationType>
+        )}
       {encoding.filters && (
         <ControlSection>
           <SectionTitle disabled={!component} iconName="filter">

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -498,7 +498,7 @@ const ChartImputationType = ({
 
   const activeImputationType: ImputationType = get(
     state,
-    ["chartConfig", "imputationType"],
+    ["chartConfig", "fields", "y", "imputationType"],
     "none"
   );
 

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -1,6 +1,6 @@
 import { t, Trans } from "@lingui/macro";
 import get from "lodash/get";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { Box, Flex } from "theme-ui";
 import {
   ChartType,
@@ -47,14 +47,17 @@ export const ChartOptionsSelector = ({
   state: ConfiguratorStateConfiguringChart;
 }) => {
   const locale = useLocale();
-  const measures =
-    "y" in state.chartConfig.fields
-      ? [state.chartConfig.fields.y.componentIri]
-      : isTableConfig(state.chartConfig)
-      ? Object.values(state.chartConfig.fields).flatMap((f) =>
-          f.componentType === "Measure" && !f.isHidden ? [f.componentIri] : []
-        )
-      : [];
+  const measures = useMemo(
+    () =>
+      "y" in state.chartConfig.fields
+        ? [state.chartConfig.fields.y.componentIri]
+        : isTableConfig(state.chartConfig)
+        ? Object.values(state.chartConfig.fields).flatMap((f) =>
+            f.componentType === "Measure" && !f.isHidden ? [f.componentIri] : []
+          )
+        : [],
+    [state.chartConfig]
+  );
 
   const [{ data }] = useDataCubeObservationsQuery({
     variables: {

--- a/app/configurator/components/panel-left.tsx
+++ b/app/configurator/components/panel-left.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
-import { useConfiguratorState } from "..";
+import { isTableConfig, useConfiguratorState } from "..";
+import { ChartConfiguratorTable } from "../table/table-chart-configurator";
 import { ChartAnnotator } from "./chart-annotator";
 import { ChartConfigurator } from "./chart-configurator";
-import { ChartConfiguratorTable } from "../table/table-chart-configurator";
 import { ChartTypeSelector } from "./chart-type-selector";
 import { DataSetList } from "./dataset-selector";
 
@@ -19,7 +19,7 @@ export const PanelLeft = () => {
             <ChartTypeSelector state={state} />
           )}
           {state.state === "CONFIGURING_CHART" &&
-            (state.chartConfig.chartType === "table" ? (
+            (isTableConfig(state.chartConfig) ? (
               <ChartConfiguratorTable state={state} />
             ) : (
               <ChartConfigurator state={state} />

--- a/app/configurator/components/ui-helpers.ts
+++ b/app/configurator/components/ui-helpers.ts
@@ -432,6 +432,22 @@ const fieldLabels = {
     id: "controls.sorting.byMeasure.descending",
     message: "9 → 1",
   }),
+  "controls.imputation": defineMessage({
+    id: "controls.imputation",
+    message: "Imputation type",
+  }),
+  "controls.imputation.type.none": defineMessage({
+    id: "controls.imputation.type.none",
+    message: "-",
+  }),
+  "controls.imputation.type.zeros": defineMessage({
+    id: "controls.imputation.type.zeros",
+    message: "Zeros",
+  }),
+  "controls.imputation.type.linear": defineMessage({
+    id: "controls.imputation.type.linear",
+    message: "Linear interpolation",
+  }),
   "controls.chart.type.column": defineMessage({
     id: "controls.chart.type.column",
     message: "Columns",
@@ -515,13 +531,15 @@ export function getFieldLabel(field: string): string {
     case "description":
       return i18n._(fieldLabels["controls.description"]);
 
-    // Encoding Options  (right column)
+    // Encoding Options (right column)
     case "stacked":
       return i18n._(fieldLabels["controls.column.stacked"]);
     case "grouped":
       return i18n._(fieldLabels["controls.column.grouped"]);
     case "sortBy":
       return i18n._(fieldLabels["controls.sorting.sortBy"]);
+    case "imputation":
+      return i18n._(fieldLabels["controls.imputation"]);
 
     case "bar.stacked.byDimensionLabel.asc":
     case "bar.grouped.byDimensionLabel.asc":

--- a/app/configurator/config-types.ts
+++ b/app/configurator/config-types.ts
@@ -260,7 +260,10 @@ export const imputationTypes: ImputationType[] = ["none", "zeros", "linear"];
 const AreaFields = t.intersection([
   t.type({
     x: GenericField,
-    y: GenericField,
+    y: t.intersection([
+      GenericField,
+      t.partial({ imputationType: ImputationType }),
+    ]),
   }),
 
   t.partial({
@@ -281,19 +284,15 @@ const AreaFields = t.intersection([
     ]),
   }),
 ]);
-const AreaConfig = t.intersection(
-  [
-    t.type({
-      chartType: t.literal("area"),
-      filters: Filters,
-      interactiveFiltersConfig: InteractiveFiltersConfig,
-      fields: AreaFields,
-    }),
-    t.partial({ imputationType: ImputationType }),
-  ],
+const AreaConfig = t.type(
+  {
+    chartType: t.literal("area"),
+    filters: Filters,
+    interactiveFiltersConfig: InteractiveFiltersConfig,
+    fields: AreaFields,
+  },
   "AreaConfig"
 );
-
 export type AreaFields = t.TypeOf<typeof AreaFields>;
 export type AreaConfig = t.TypeOf<typeof AreaConfig>;
 

--- a/app/configurator/config-types.ts
+++ b/app/configurator/config-types.ts
@@ -517,6 +517,54 @@ export type ChartConfig = t.TypeOf<typeof ChartConfig>;
 
 export type ChartType = ChartConfig["chartType"];
 
+export const isAreaConfig = (
+  chartConfig: ChartConfig
+): chartConfig is AreaConfig => {
+  return chartConfig.chartType === "area";
+};
+
+export const isBarConfig = (
+  chartConfig: ChartConfig
+): chartConfig is BarConfig => {
+  return chartConfig.chartType === "bar";
+};
+
+export const isColumnConfig = (
+  chartConfig: ChartConfig
+): chartConfig is ColumnConfig => {
+  return chartConfig.chartType === "column";
+};
+
+export const isLineConfig = (
+  chartConfig: ChartConfig
+): chartConfig is LineConfig => {
+  return chartConfig.chartType === "line";
+};
+
+export const isScatterPlotConfig = (
+  chartConfig: ChartConfig
+): chartConfig is ScatterPlotConfig => {
+  return chartConfig.chartType === "scatterplot";
+};
+
+export const isPieConfig = (
+  chartConfig: ChartConfig
+): chartConfig is PieConfig => {
+  return chartConfig.chartType === "pie";
+};
+
+export const isTableConfig = (
+  chartConfig: ChartConfig
+): chartConfig is TableConfig => {
+  return chartConfig.chartType === "table";
+};
+
+export const isMapConfig = (
+  chartConfig: ChartConfig
+): chartConfig is MapConfig => {
+  return chartConfig.chartType === "map";
+};
+
 const Config = t.type(
   {
     dataSet: t.string,

--- a/app/configurator/config-types.ts
+++ b/app/configurator/config-types.ts
@@ -249,6 +249,14 @@ const LineConfig = t.type(
 export type LineFields = t.TypeOf<typeof LineFields>;
 export type LineConfig = t.TypeOf<typeof LineConfig>;
 
+const ImputationType = t.union([
+  t.literal("none"),
+  t.literal("zeros"),
+  t.literal("linear"),
+]);
+export type ImputationType = t.TypeOf<typeof ImputationType>;
+export const imputationTypes: ImputationType[] = ["none", "zeros", "linear"];
+
 const AreaFields = t.intersection([
   t.type({
     x: GenericField,
@@ -279,6 +287,7 @@ const AreaConfig = t.type(
     filters: Filters,
     interactiveFiltersConfig: InteractiveFiltersConfig,
     fields: AreaFields,
+    imputationType: ImputationType,
   },
   "AreaConfig"
 );

--- a/app/configurator/config-types.ts
+++ b/app/configurator/config-types.ts
@@ -281,14 +281,16 @@ const AreaFields = t.intersection([
     ]),
   }),
 ]);
-const AreaConfig = t.type(
-  {
-    chartType: t.literal("area"),
-    filters: Filters,
-    interactiveFiltersConfig: InteractiveFiltersConfig,
-    fields: AreaFields,
-    imputationType: ImputationType,
-  },
+const AreaConfig = t.intersection(
+  [
+    t.type({
+      chartType: t.literal("area"),
+      filters: Filters,
+      interactiveFiltersConfig: InteractiveFiltersConfig,
+      fields: AreaFields,
+    }),
+    t.partial({ imputationType: ImputationType }),
+  ],
   "AreaConfig"
 );
 

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import { Client, useClient } from "urql";
 import { Reducer, useImmerReducer } from "use-immer";
+import { ImputationType, isAreaConfig, isColumnConfig } from ".";
 import { fetchChartConfig, saveChartConfig } from "../api";
 import {
   getFieldComponentIris,
@@ -154,6 +155,7 @@ export type ConfiguratorStateAction =
       type: "CHART_CONFIG_FILTER_SET_NONE_MULTI";
       value: { dimensionIri: string };
     }
+  | { type: "IMPUTATION_TYPE_CHANGED"; value: { type: ImputationType } }
   | { type: "PUBLISH_FAILED" }
   | { type: "PUBLISHED"; value: string };
 
@@ -547,7 +549,7 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
             };
             // if x !== time, also deactivate interactive time filter
             if (
-              draft.chartConfig.chartType === "column" &&
+              isColumnConfig(draft.chartConfig) &&
               action.value.field === "x" &&
               component?.__typename !== "TemporalDimension" &&
               draft.chartConfig.interactiveFiltersConfig
@@ -778,6 +780,15 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
           to,
         };
       }
+      return draft;
+
+    case "IMPUTATION_TYPE_CHANGED":
+      if (draft.state === "CONFIGURING_CHART") {
+        if (isAreaConfig(draft.chartConfig)) {
+          draft.chartConfig.imputationType = action.value.type;
+        }
+      }
+
       return draft;
 
     // State transitions

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -858,7 +858,7 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
     case "IMPUTATION_TYPE_CHANGED":
       if (draft.state === "CONFIGURING_CHART") {
         if (isAreaConfig(draft.chartConfig)) {
-          draft.chartConfig.imputationType = action.value.type;
+          draft.chartConfig.fields.y.imputationType = action.value.type;
         }
       }
 

--- a/app/configurator/table/table-chart-options.tsx
+++ b/app/configurator/table/table-chart-options.tsx
@@ -31,6 +31,7 @@ import { FieldProps } from "../config-form";
 import {
   ColumnStyle,
   ConfiguratorStateConfiguringChart,
+  isTableConfig,
   TableConfig,
 } from "../config-types";
 import { useConfiguratorState } from "../configurator-state";
@@ -52,7 +53,7 @@ const useTableColumnGroupHiddenField = ({
     (e) => {
       if (
         state.state === "CONFIGURING_CHART" &&
-        state.chartConfig.chartType === "table"
+        isTableConfig(state.chartConfig)
       ) {
         const updater = path === "isGroup" ? updateIsGroup : updateIsHidden;
         const chartConfig = updater(state.chartConfig, {

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -294,18 +294,18 @@ msgstr "Bitte ein Beschreibungsfeld auswählen, um dieses zu bearbeiten."
 msgid "controls.imputation"
 msgstr ""
 
-#: app/configurator/components/chart-options-selector.tsx:474
+#: app/configurator/components/chart-options-selector.tsx:477
 #: app/configurator/components/ui-helpers.ts:447
 msgid "controls.imputation.type.linear"
 msgstr ""
 
-#: app/configurator/components/chart-options-selector.tsx:467
-#: app/configurator/components/chart-options-selector.tsx:479
+#: app/configurator/components/chart-options-selector.tsx:470
+#: app/configurator/components/chart-options-selector.tsx:482
 #: app/configurator/components/ui-helpers.ts:439
 msgid "controls.imputation.type.none"
 msgstr ""
 
-#: app/configurator/components/chart-options-selector.tsx:469
+#: app/configurator/components/chart-options-selector.tsx:472
 #: app/configurator/components/ui-helpers.ts:443
 msgid "controls.imputation.type.zeros"
 msgstr ""
@@ -382,8 +382,8 @@ msgstr "Filter"
 msgid "controls.section.description"
 msgstr "Titel & Beschreibung"
 
-#: app/configurator/components/chart-options-selector.tsx:259
-#: app/configurator/components/chart-options-selector.tsx:263
+#: app/configurator/components/chart-options-selector.tsx:262
+#: app/configurator/components/chart-options-selector.tsx:266
 #: app/configurator/table/table-chart-options.tsx:301
 #: app/configurator/table/table-chart-options.tsx:305
 #: app/configurator/table/table-chart-options.tsx:325
@@ -395,11 +395,11 @@ msgstr "Filter"
 msgid "controls.section.groups"
 msgstr "Gruppierungen"
 
-#: app/configurator/components/chart-options-selector.tsx:508
+#: app/configurator/components/chart-options-selector.tsx:511
 msgid "controls.section.imputation"
 msgstr ""
 
-#: app/configurator/components/chart-options-selector.tsx:513
+#: app/configurator/components/chart-options-selector.tsx:516
 msgid "controls.section.imputation.explanation"
 msgstr ""
 
@@ -411,7 +411,7 @@ msgstr "Interaktive Filter hinzufügen"
 msgid "controls.section.interactiveFilters.dataFilters"
 msgstr "Datenfilter"
 
-#: app/configurator/components/chart-options-selector.tsx:395
+#: app/configurator/components/chart-options-selector.tsx:398
 msgid "controls.section.sorting"
 msgstr "Sortieren"
 
@@ -440,7 +440,7 @@ msgstr "Experimentelle Features"
 msgid "controls.select.chart.type.experimental.description"
 msgstr "Vorschau von zukünftigen Features mit limitierten Daten auf einer separaten Seite."
 
-#: app/configurator/components/chart-options-selector.tsx:305
+#: app/configurator/components/chart-options-selector.tsx:308
 msgid "controls.select.column.layout"
 msgstr "Spaltenstil"
 
@@ -476,12 +476,12 @@ msgstr "Schriftfarbe"
 msgid "controls.select.columnStyle.textStyle"
 msgstr "Schriftstil"
 
-#: app/configurator/components/chart-options-selector.tsx:169
 #: app/configurator/components/chart-options-selector.tsx:171
+#: app/configurator/components/chart-options-selector.tsx:173
 msgid "controls.select.dimension"
 msgstr "Dimension auswählen"
 
-#: app/configurator/components/chart-options-selector.tsx:170
+#: app/configurator/components/chart-options-selector.tsx:172
 msgid "controls.select.measure"
 msgstr "Messwert auswählen"
 
@@ -495,8 +495,8 @@ msgstr "optional"
 msgid "controls.sorting.addDimension"
 msgstr "Dimension hinzufügen"
 
-#: app/configurator/components/chart-options-selector.tsx:346
-#: app/configurator/components/chart-options-selector.tsx:352
+#: app/configurator/components/chart-options-selector.tsx:349
+#: app/configurator/components/chart-options-selector.tsx:355
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Name"
 
@@ -508,7 +508,7 @@ msgstr "A → Z"
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
-#: app/configurator/components/chart-options-selector.tsx:348
+#: app/configurator/components/chart-options-selector.tsx:351
 msgid "controls.sorting.byMeasure"
 msgstr "Messwert"
 
@@ -520,7 +520,7 @@ msgstr "1 → 9"
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
-#: app/configurator/components/chart-options-selector.tsx:350
+#: app/configurator/components/chart-options-selector.tsx:353
 msgid "controls.sorting.byTotalSize"
 msgstr "Gesamtgrösse"
 
@@ -581,6 +581,10 @@ msgstr "Suche anzeigen"
 msgid "controls.title"
 msgstr "Titel hinzufügen"
 
+#: app/components/chart-published.tsx:80
+msgid "dataset.hasImputedValues"
+msgstr "Einige Daten in diesem Datensatz fehlen und wurden interpoliert, um die Lücken zu füllen."
+
 #: app/configurator/components/dataset-selector.tsx:103
 msgid "dataset.includeDrafts"
 msgstr "Entwurfs-Datensätze anzeigen"
@@ -626,12 +630,12 @@ msgid "dataset.order.title"
 msgstr "Titel"
 
 #: app/components/chart-preview.tsx:56
-#: app/components/chart-published.tsx:59
+#: app/components/chart-published.tsx:58
 #: app/configurator/components/dataset-preview.tsx:36
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Achtung, dieser Datensatz ist im Entwurfs-Stadium.<0/><1>Diese Grafik nicht für Berichte verwenden.</1>"
 
-#: app/components/chart-published.tsx:70
+#: app/components/chart-published.tsx:69
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Achtung, dieser Datensatz ist abgelaufen.<0/><1>Diese Grafik nicht für Berichte verwenden.</1>"
 

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -292,23 +292,23 @@ msgstr "Bitte ein Beschreibungsfeld auswählen, um dieses zu bearbeiten."
 
 #: app/configurator/components/ui-helpers.ts:435
 msgid "controls.imputation"
-msgstr ""
+msgstr "Imputationstyp"
 
 #: app/configurator/components/chart-options-selector.tsx:477
 #: app/configurator/components/ui-helpers.ts:447
 msgid "controls.imputation.type.linear"
-msgstr ""
+msgstr "Lineare Interpolation"
 
 #: app/configurator/components/chart-options-selector.tsx:470
 #: app/configurator/components/chart-options-selector.tsx:482
 #: app/configurator/components/ui-helpers.ts:439
 msgid "controls.imputation.type.none"
-msgstr ""
+msgstr "-"
 
 #: app/configurator/components/chart-options-selector.tsx:472
 #: app/configurator/components/ui-helpers.ts:443
 msgid "controls.imputation.type.zeros"
-msgstr ""
+msgstr "Nullen"
 
 #: app/configurator/interactive-filters/interactive-filters-configurator.tsx:92
 msgid "controls.interactive.filters.dataFilter"
@@ -397,11 +397,11 @@ msgstr "Gruppierungen"
 
 #: app/configurator/components/chart-options-selector.tsx:511
 msgid "controls.section.imputation"
-msgstr ""
+msgstr "Fehlende Werte"
 
 #: app/configurator/components/chart-options-selector.tsx:516
 msgid "controls.section.imputation.explanation"
-msgstr ""
+msgstr "Aufgrund der Natur des ausgewählten Diagrammtyps wurden einige fehlende Werte eingefügt. Entscheiden Sie sich für die Imputationslogik oder wechseln Sie zu einem anderen Diagrammtyp."
 
 #: app/configurator/interactive-filters/interactive-filters-configurator.tsx:63
 msgid "controls.section.interactive.filters"

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -13,11 +13,11 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/components/chart-preview.tsx:92
+#: app/components/chart-preview.tsx:95
 msgid "annotation.add.description"
 msgstr "[ Ohne Beschreibung ]"
 
-#: app/components/chart-preview.tsx:76
+#: app/components/chart-preview.tsx:79
 msgid "annotation.add.title"
 msgstr "[ Ohne Titel ]"
 
@@ -25,11 +25,11 @@ msgstr "[ Ohne Titel ]"
 msgid "button.copy.visualization"
 msgstr "Diese Visualisierung kopieren"
 
-#: app/components/data-download.tsx:124
+#: app/components/data-download.tsx:122
 msgid "button.download.data"
 msgstr "Daten herunterladen"
 
-#: app/components/data-download.tsx:73
+#: app/components/data-download.tsx:71
 msgid "button.download.runsparqlquery"
 msgstr "SPARQL-Abfrage ausführen"
 
@@ -158,28 +158,28 @@ msgstr "Kompakte Ansicht"
 msgid "chart.table.number.of.lines"
 msgstr "Anzahl Zeilen"
 
-#: app/configurator/table/table-chart-options.tsx:205
+#: app/configurator/table/table-chart-options.tsx:190
 msgid "columnStyle.bar"
 msgstr "Säulendiagramm"
 
-#: app/configurator/table/table-chart-options.tsx:191
+#: app/configurator/table/table-chart-options.tsx:176
 msgid "columnStyle.categories"
 msgstr "Kategorien"
 
-#: app/configurator/table/table-chart-options.tsx:201
+#: app/configurator/table/table-chart-options.tsx:186
 msgid "columnStyle.heatmap"
 msgstr "Wärmebildkarte"
 
-#: app/configurator/table/table-chart-options.tsx:187
-#: app/configurator/table/table-chart-options.tsx:197
+#: app/configurator/table/table-chart-options.tsx:172
+#: app/configurator/table/table-chart-options.tsx:182
 msgid "columnStyle.text"
 msgstr "Schrift"
 
-#: app/configurator/table/table-chart-options.tsx:416
+#: app/configurator/table/table-chart-options.tsx:384
 msgid "columnStyle.textStyle.bold"
 msgstr "Fett"
 
-#: app/configurator/table/table-chart-options.tsx:409
+#: app/configurator/table/table-chart-options.tsx:377
 msgid "columnStyle.textStyle.regular"
 msgstr "Normal"
 
@@ -187,47 +187,47 @@ msgstr "Normal"
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Standardeinstellung"
 
-#: app/configurator/components/ui-helpers.ts:328
+#: app/configurator/components/ui-helpers.ts:373
 msgid "controls.axis.horizontal"
 msgstr "Horizontale Achse"
 
-#: app/configurator/components/ui-helpers.ts:336
+#: app/configurator/components/ui-helpers.ts:381
 msgid "controls.axis.vertical"
 msgstr "Vertikale Achse"
 
-#: app/configurator/components/ui-helpers.ts:402
+#: app/configurator/components/ui-helpers.ts:463
 msgid "controls.chart.type.area"
 msgstr "Flächen"
 
-#: app/configurator/components/ui-helpers.ts:394
+#: app/configurator/components/ui-helpers.ts:455
 msgid "controls.chart.type.bar"
 msgstr "Balken"
 
-#: app/configurator/components/ui-helpers.ts:390
+#: app/configurator/components/ui-helpers.ts:451
 msgid "controls.chart.type.column"
 msgstr "Säulen"
 
-#: app/configurator/components/ui-helpers.ts:398
+#: app/configurator/components/ui-helpers.ts:459
 msgid "controls.chart.type.line"
 msgstr "Linien"
 
-#: app/configurator/components/ui-helpers.ts:418
+#: app/configurator/components/ui-helpers.ts:479
 msgid "controls.chart.type.map"
 msgstr "Karte"
 
-#: app/configurator/components/ui-helpers.ts:410
+#: app/configurator/components/ui-helpers.ts:471
 msgid "controls.chart.type.pie"
 msgstr "Kreis"
 
-#: app/configurator/components/ui-helpers.ts:406
+#: app/configurator/components/ui-helpers.ts:467
 msgid "controls.chart.type.scatterplot"
 msgstr "Scatterplot"
 
-#: app/configurator/components/ui-helpers.ts:414
+#: app/configurator/components/ui-helpers.ts:475
 msgid "controls.chart.type.table"
 msgstr "Tabelle"
 
-#: app/configurator/components/ui-helpers.ts:340
+#: app/configurator/components/ui-helpers.ts:385
 msgid "controls.color"
 msgstr "Farbe"
 
@@ -248,33 +248,33 @@ msgstr "Farbpalette zurücksetzen"
 msgid "controls.colorpicker.open"
 msgstr "Farbwähler öffnen"
 
-#: app/configurator/components/ui-helpers.ts:350
+#: app/configurator/components/ui-helpers.ts:395
 msgid "controls.column.grouped"
 msgstr "gruppiert"
 
-#: app/configurator/components/ui-helpers.ts:346
+#: app/configurator/components/ui-helpers.ts:391
 msgid "controls.column.stacked"
 msgstr "gestapelt"
 
-#: app/configurator/components/ui-helpers.ts:342
+#: app/configurator/components/ui-helpers.ts:387
 msgid "controls.description"
 msgstr "Beschreibung hinzufügen"
 
-#: app/configurator/components/field.tsx:517
+#: app/configurator/components/field.tsx:503
 msgid "controls.dimension.none"
 msgstr "Keine"
 
-#: app/charts/shared/chart-data-filters.tsx:124
-#: app/configurator/components/field.tsx:76
-#: app/configurator/components/field.tsx:146
+#: app/charts/shared/chart-data-filters.tsx:194
+#: app/configurator/components/field.tsx:77
+#: app/configurator/components/field.tsx:135
 msgid "controls.dimensionvalue.none"
 msgstr "Kein Filter"
 
-#: app/configurator/components/filters.tsx:84
+#: app/configurator/components/filters.tsx:89
 msgid "controls.filter.select.all"
 msgstr "Alle auswählen"
 
-#: app/configurator/components/filters.tsx:93
+#: app/configurator/components/filters.tsx:98
 msgid "controls.filter.select.none"
 msgstr "Alle abwählen"
 
@@ -290,43 +290,63 @@ msgstr "Bitte eine Designoption oder Datendimension auswählen, um diese zu bear
 msgid "controls.hint.describing.chart"
 msgstr "Bitte ein Beschreibungsfeld auswählen, um dieses zu bearbeiten."
 
+#: app/configurator/components/ui-helpers.ts:435
+msgid "controls.imputation"
+msgstr ""
+
+#: app/configurator/components/chart-options-selector.tsx:474
+#: app/configurator/components/ui-helpers.ts:447
+msgid "controls.imputation.type.linear"
+msgstr ""
+
+#: app/configurator/components/chart-options-selector.tsx:467
+#: app/configurator/components/chart-options-selector.tsx:479
+#: app/configurator/components/ui-helpers.ts:439
+msgid "controls.imputation.type.none"
+msgstr ""
+
+#: app/configurator/components/chart-options-selector.tsx:469
+#: app/configurator/components/ui-helpers.ts:443
+msgid "controls.imputation.type.zeros"
+msgstr ""
+
 #: app/configurator/interactive-filters/interactive-filters-configurator.tsx:92
 msgid "controls.interactive.filters.dataFilter"
 msgstr "Datenfilter"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:263
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:266
 msgid "controls.interactiveFilters.dataFilters.toggledataFilters"
 msgstr "Datenfilter anzeigen"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:63
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:64
 msgid "controls.interactiveFilters.legend.toggleInteractiveLegend"
 msgstr "Filterbare Legende anzeigen"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:198
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:199
 msgid "controls.interactiveFilters.time.noTimeDimension"
 msgstr "Keine Zeitdimension verfügbar!"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:172
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:173
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Zeitfilter anzeigen"
 
-#: app/configurator/components/ui-helpers.ts:422
+#: app/configurator/components/ui-helpers.ts:483
 msgid "controls.language.english"
 msgstr "Englisch"
 
-#: app/configurator/components/ui-helpers.ts:430
+#: app/configurator/components/ui-helpers.ts:491
 msgid "controls.language.french"
 msgstr "Französisch"
 
-#: app/configurator/components/ui-helpers.ts:426
+#: app/configurator/components/ui-helpers.ts:487
 msgid "controls.language.german"
 msgstr "Deutsch"
 
-#: app/configurator/components/ui-helpers.ts:434
+#: app/configurator/components/ui-helpers.ts:495
 msgid "controls.language.italian"
 msgstr "Italienisch"
 
-#: app/configurator/components/ui-helpers.ts:332
+#: app/configurator/components/ui-helpers.ts:377
 msgid "controls.measure"
 msgstr "Messwert"
 
@@ -350,7 +370,7 @@ msgstr "Diagramm-Einstellungen"
 msgid "controls.section.columns"
 msgstr "Spalten"
 
-#: app/configurator/table/table-chart-options.tsx:266
+#: app/configurator/table/table-chart-options.tsx:234
 msgid "controls.section.columnstyle"
 msgstr "Spaltenstil"
 
@@ -362,12 +382,12 @@ msgstr "Filter"
 msgid "controls.section.description"
 msgstr "Titel & Beschreibung"
 
-#: app/configurator/components/chart-options-selector.tsx:219
-#: app/configurator/components/chart-options-selector.tsx:223
-#: app/configurator/table/table-chart-options.tsx:333
-#: app/configurator/table/table-chart-options.tsx:337
-#: app/configurator/table/table-chart-options.tsx:357
-#: app/configurator/table/table-chart-options.tsx:361
+#: app/configurator/components/chart-options-selector.tsx:259
+#: app/configurator/components/chart-options-selector.tsx:263
+#: app/configurator/table/table-chart-options.tsx:301
+#: app/configurator/table/table-chart-options.tsx:305
+#: app/configurator/table/table-chart-options.tsx:325
+#: app/configurator/table/table-chart-options.tsx:329
 msgid "controls.section.filter"
 msgstr "Filter"
 
@@ -375,19 +395,27 @@ msgstr "Filter"
 msgid "controls.section.groups"
 msgstr "Gruppierungen"
 
+#: app/configurator/components/chart-options-selector.tsx:508
+msgid "controls.section.imputation"
+msgstr ""
+
+#: app/configurator/components/chart-options-selector.tsx:513
+msgid "controls.section.imputation.explanation"
+msgstr ""
+
 #: app/configurator/interactive-filters/interactive-filters-configurator.tsx:63
 msgid "controls.section.interactive.filters"
 msgstr "Interaktive Filter hinzufügen"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:94
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:95
 msgid "controls.section.interactiveFilters.dataFilters"
 msgstr "Datenfilter"
 
-#: app/configurator/components/chart-options-selector.tsx:355
+#: app/configurator/components/chart-options-selector.tsx:395
 msgid "controls.section.sorting"
 msgstr "Sortieren"
 
-#: app/configurator/table/table-chart-options.tsx:501
+#: app/configurator/table/table-chart-options.tsx:469
 msgid "controls.section.tableSettings"
 msgstr "Tabelleneinstellungen"
 
@@ -412,54 +440,54 @@ msgstr "Experimentelle Features"
 msgid "controls.select.chart.type.experimental.description"
 msgstr "Vorschau von zukünftigen Features mit limitierten Daten auf einer separaten Seite."
 
-#: app/configurator/components/chart-options-selector.tsx:265
+#: app/configurator/components/chart-options-selector.tsx:305
 msgid "controls.select.column.layout"
 msgstr "Spaltenstil"
 
-#: app/configurator/table/table-chart-options.tsx:271
+#: app/configurator/table/table-chart-options.tsx:239
 msgid "controls.select.columnStyle"
 msgstr "Spaltenstil"
 
-#: app/configurator/table/table-chart-options.tsx:476
+#: app/configurator/table/table-chart-options.tsx:444
 msgid "controls.select.columnStyle.barColorBackground"
 msgstr "Hintergrundfarbe"
 
-#: app/configurator/table/table-chart-options.tsx:468
+#: app/configurator/table/table-chart-options.tsx:436
 msgid "controls.select.columnStyle.barColorNegative"
 msgstr "Negative Balkenfarbe"
 
-#: app/configurator/table/table-chart-options.tsx:460
+#: app/configurator/table/table-chart-options.tsx:428
 msgid "controls.select.columnStyle.barColorPositive"
 msgstr "Positive Balkenfarbe"
 
-#: app/configurator/table/table-chart-options.tsx:484
+#: app/configurator/table/table-chart-options.tsx:452
 msgid "controls.select.columnStyle.barShowBackground"
 msgstr "Hintergrundfarbe anzeigen"
 
-#: app/configurator/table/table-chart-options.tsx:433
+#: app/configurator/table/table-chart-options.tsx:401
 msgid "controls.select.columnStyle.columnColor"
 msgstr "Spaltenfarbe"
 
-#: app/configurator/table/table-chart-options.tsx:425
+#: app/configurator/table/table-chart-options.tsx:393
 msgid "controls.select.columnStyle.textColor"
 msgstr "Schriftfarbe"
 
-#: app/configurator/table/table-chart-options.tsx:402
+#: app/configurator/table/table-chart-options.tsx:370
 msgid "controls.select.columnStyle.textStyle"
 msgstr "Schriftstil"
 
-#: app/configurator/components/chart-options-selector.tsx:135
-#: app/configurator/components/chart-options-selector.tsx:137
+#: app/configurator/components/chart-options-selector.tsx:169
+#: app/configurator/components/chart-options-selector.tsx:171
 msgid "controls.select.dimension"
 msgstr "Dimension auswählen"
 
-#: app/configurator/components/chart-options-selector.tsx:136
+#: app/configurator/components/chart-options-selector.tsx:170
 msgid "controls.select.measure"
 msgstr "Messwert auswählen"
 
-#: app/configurator/components/field.tsx:81
-#: app/configurator/components/field.tsx:151
-#: app/configurator/components/field.tsx:522
+#: app/configurator/components/field.tsx:82
+#: app/configurator/components/field.tsx:140
+#: app/configurator/components/field.tsx:508
 msgid "controls.select.optional"
 msgstr "optional"
 
@@ -467,48 +495,48 @@ msgstr "optional"
 msgid "controls.sorting.addDimension"
 msgstr "Dimension hinzufügen"
 
-#: app/configurator/components/chart-options-selector.tsx:306
-#: app/configurator/components/chart-options-selector.tsx:312
+#: app/configurator/components/chart-options-selector.tsx:346
+#: app/configurator/components/chart-options-selector.tsx:352
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Name"
 
-#: app/configurator/components/ui-helpers.ts:358
+#: app/configurator/components/ui-helpers.ts:403
 msgid "controls.sorting.byDimensionLabel.ascending"
 msgstr "A → Z"
 
-#: app/configurator/components/ui-helpers.ts:362
+#: app/configurator/components/ui-helpers.ts:407
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
-#: app/configurator/components/chart-options-selector.tsx:308
+#: app/configurator/components/chart-options-selector.tsx:348
 msgid "controls.sorting.byMeasure"
 msgstr "Messwert"
 
-#: app/configurator/components/ui-helpers.ts:382
+#: app/configurator/components/ui-helpers.ts:427
 msgid "controls.sorting.byMeasure.ascending"
 msgstr "1 → 9"
 
-#: app/configurator/components/ui-helpers.ts:386
+#: app/configurator/components/ui-helpers.ts:431
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
-#: app/configurator/components/chart-options-selector.tsx:310
+#: app/configurator/components/chart-options-selector.tsx:350
 msgid "controls.sorting.byTotalSize"
 msgstr "Gesamtgrösse"
 
-#: app/configurator/components/ui-helpers.ts:366
+#: app/configurator/components/ui-helpers.ts:411
 msgid "controls.sorting.byTotalSize.ascending"
 msgstr "Kleinste zuerst"
 
-#: app/configurator/components/ui-helpers.ts:378
+#: app/configurator/components/ui-helpers.ts:423
 msgid "controls.sorting.byTotalSize.largestBottom"
 msgstr "Grösste unten"
 
-#: app/configurator/components/ui-helpers.ts:370
+#: app/configurator/components/ui-helpers.ts:415
 msgid "controls.sorting.byTotalSize.largestFirst"
 msgstr "Grösste zuerst"
 
-#: app/configurator/components/ui-helpers.ts:374
+#: app/configurator/components/ui-helpers.ts:419
 msgid "controls.sorting.byTotalSize.largestTop"
 msgstr "Kleinste unten"
 
@@ -520,22 +548,22 @@ msgstr "Sortierung entfernen"
 msgid "controls.sorting.selectDimension"
 msgstr "Wählen Sie eine Dimension aus …"
 
-#: app/configurator/components/ui-helpers.ts:354
+#: app/configurator/components/ui-helpers.ts:399
 #: app/configurator/table/table-chart-sorting-options.tsx:305
 msgid "controls.sorting.sortBy"
 msgstr "Sortieren nach"
 
-#: app/configurator/table/table-chart-options.tsx:227
+#: app/configurator/table/table-chart-options.tsx:211
 msgid "controls.table.column.group"
 msgstr "Gruppieren"
 
-#: app/configurator/table/table-chart-options.tsx:252
+#: app/configurator/table/table-chart-options.tsx:221
 msgid "controls.table.column.hide"
 msgstr "Spalte ausblenden"
 
 #: app/configurator/table/table-chart-options.tsx:238
-msgid "controls.table.column.hidefilter"
-msgstr "Spalte ausblenden und filtern"
+#~ msgid "controls.table.column.hidefilter"
+#~ msgstr "Spalte ausblenden und filtern"
 
 #: app/configurator/table/table-chart-configurator.tsx:101
 msgid "controls.table.settings"
@@ -545,11 +573,11 @@ msgstr "Einstellungen"
 msgid "controls.table.sorting"
 msgstr "Sortierung"
 
-#: app/configurator/table/table-chart-options.tsx:505
+#: app/configurator/table/table-chart-options.tsx:473
 msgid "controls.tableSettings.showSearch"
 msgstr "Suche anzeigen"
 
-#: app/configurator/components/ui-helpers.ts:341
+#: app/configurator/components/ui-helpers.ts:386
 msgid "controls.title"
 msgstr "Titel hinzufügen"
 
@@ -597,13 +625,13 @@ msgstr "Relevanz"
 msgid "dataset.order.title"
 msgstr "Titel"
 
-#: app/components/chart-preview.tsx:53
-#: app/components/chart-published.tsx:58
-#: app/configurator/components/dataset-preview.tsx:35
+#: app/components/chart-preview.tsx:56
+#: app/components/chart-published.tsx:59
+#: app/configurator/components/dataset-preview.tsx:36
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Achtung, dieser Datensatz ist im Entwurfs-Stadium.<0/><1>Diese Grafik nicht für Berichte verwenden.</1>"
 
-#: app/components/chart-published.tsx:69
+#: app/components/chart-published.tsx:70
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Achtung, dieser Datensatz ist abgelaufen.<0/><1>Diese Grafik nicht für Berichte verwenden.</1>"
 
@@ -623,15 +651,15 @@ msgstr "Sortieren nach"
 msgid "dataset.tag.draft"
 msgstr "Entwurf"
 
-#: app/configurator/components/dataset-preview.tsx:85
+#: app/configurator/components/dataset-preview.tsx:86
 msgid "datatable.showing.first.rows"
 msgstr "Die ersten 10 Zeilen werden angezeigt"
 
-#: app/components/footer.tsx:38
+#: app/components/footer.tsx:66
 msgid "footer.institution.name"
 msgstr "Bundesamt für Umwelt BAFU"
 
-#: app/components/footer.tsx:33
+#: app/components/footer.tsx:61
 msgid "footer.institution.url"
 msgstr "https://www.bafu.admin.ch/bafu/de/home.html"
 
@@ -695,11 +723,11 @@ msgstr "Datensatz auswählen"
 msgid "hint.select.dataset.to.preview"
 msgstr "Bitte Datensatz auswählen, um eine Vorschau anzuzeigen."
 
-#: app/charts/shared/chart-data-filters.tsx:63
+#: app/charts/shared/chart-data-filters.tsx:67
 msgid "interactive.data.filters.hide"
 msgstr "Filter ausblenden"
 
-#: app/charts/shared/chart-data-filters.tsx:61
+#: app/charts/shared/chart-data-filters.tsx:65
 msgid "interactive.data.filters.show"
 msgstr "Filter anzeigen"
 

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -294,18 +294,18 @@ msgstr "Select an annotation field to modify its content."
 msgid "controls.imputation"
 msgstr "Imputation type"
 
-#: app/configurator/components/chart-options-selector.tsx:474
+#: app/configurator/components/chart-options-selector.tsx:477
 #: app/configurator/components/ui-helpers.ts:447
 msgid "controls.imputation.type.linear"
 msgstr "Linear interpolation"
 
-#: app/configurator/components/chart-options-selector.tsx:467
-#: app/configurator/components/chart-options-selector.tsx:479
+#: app/configurator/components/chart-options-selector.tsx:470
+#: app/configurator/components/chart-options-selector.tsx:482
 #: app/configurator/components/ui-helpers.ts:439
 msgid "controls.imputation.type.none"
 msgstr "-"
 
-#: app/configurator/components/chart-options-selector.tsx:469
+#: app/configurator/components/chart-options-selector.tsx:472
 #: app/configurator/components/ui-helpers.ts:443
 msgid "controls.imputation.type.zeros"
 msgstr "Zeros"
@@ -382,8 +382,8 @@ msgstr "Filters"
 msgid "controls.section.description"
 msgstr "Title & Description"
 
-#: app/configurator/components/chart-options-selector.tsx:259
-#: app/configurator/components/chart-options-selector.tsx:263
+#: app/configurator/components/chart-options-selector.tsx:262
+#: app/configurator/components/chart-options-selector.tsx:266
 #: app/configurator/table/table-chart-options.tsx:301
 #: app/configurator/table/table-chart-options.tsx:305
 #: app/configurator/table/table-chart-options.tsx:325
@@ -395,11 +395,11 @@ msgstr "Filter"
 msgid "controls.section.groups"
 msgstr "Groups"
 
-#: app/configurator/components/chart-options-selector.tsx:508
+#: app/configurator/components/chart-options-selector.tsx:511
 msgid "controls.section.imputation"
 msgstr "Missing values"
 
-#: app/configurator/components/chart-options-selector.tsx:513
+#: app/configurator/components/chart-options-selector.tsx:516
 msgid "controls.section.imputation.explanation"
 msgstr "Due to the nature of the selected chart type, some missing values have been introduced. Decide on the imputation logic or switch to another chart type."
 
@@ -411,7 +411,7 @@ msgstr "Interactive Filters"
 msgid "controls.section.interactiveFilters.dataFilters"
 msgstr "Data Filters"
 
-#: app/configurator/components/chart-options-selector.tsx:395
+#: app/configurator/components/chart-options-selector.tsx:398
 msgid "controls.section.sorting"
 msgstr "Sort"
 
@@ -440,7 +440,7 @@ msgstr "Experimental Features"
 msgid "controls.select.chart.type.experimental.description"
 msgstr "Preview upcoming features with a limited subset of data on a separate page."
 
-#: app/configurator/components/chart-options-selector.tsx:305
+#: app/configurator/components/chart-options-selector.tsx:308
 msgid "controls.select.column.layout"
 msgstr "Column layout"
 
@@ -476,12 +476,12 @@ msgstr "Text Color"
 msgid "controls.select.columnStyle.textStyle"
 msgstr "Text Style"
 
-#: app/configurator/components/chart-options-selector.tsx:169
 #: app/configurator/components/chart-options-selector.tsx:171
+#: app/configurator/components/chart-options-selector.tsx:173
 msgid "controls.select.dimension"
 msgstr "Select a dimension"
 
-#: app/configurator/components/chart-options-selector.tsx:170
+#: app/configurator/components/chart-options-selector.tsx:172
 msgid "controls.select.measure"
 msgstr "Select a measure"
 
@@ -495,8 +495,8 @@ msgstr "optional"
 msgid "controls.sorting.addDimension"
 msgstr "Add dimension"
 
-#: app/configurator/components/chart-options-selector.tsx:346
-#: app/configurator/components/chart-options-selector.tsx:352
+#: app/configurator/components/chart-options-selector.tsx:349
+#: app/configurator/components/chart-options-selector.tsx:355
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Name"
 
@@ -508,7 +508,7 @@ msgstr "A → Z"
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
-#: app/configurator/components/chart-options-selector.tsx:348
+#: app/configurator/components/chart-options-selector.tsx:351
 msgid "controls.sorting.byMeasure"
 msgstr "Measure"
 
@@ -520,7 +520,7 @@ msgstr "1 → 9"
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
-#: app/configurator/components/chart-options-selector.tsx:350
+#: app/configurator/components/chart-options-selector.tsx:353
 msgid "controls.sorting.byTotalSize"
 msgstr "Total size"
 
@@ -581,6 +581,10 @@ msgstr "Show search field"
 msgid "controls.title"
 msgstr "Title"
 
+#: app/components/chart-published.tsx:80
+msgid "dataset.hasImputedValues"
+msgstr "Some data in this dataset is missing and has been interpolated to fill the gaps."
+
 #: app/configurator/components/dataset-selector.tsx:103
 msgid "dataset.includeDrafts"
 msgstr "Include draft datasets"
@@ -626,12 +630,12 @@ msgid "dataset.order.title"
 msgstr "Title"
 
 #: app/components/chart-preview.tsx:56
-#: app/components/chart-published.tsx:59
+#: app/components/chart-published.tsx:58
 #: app/configurator/components/dataset-preview.tsx:36
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Careful, this dataset is only a draft.<0/><1>Don't use for reporting!</1>"
 
-#: app/components/chart-published.tsx:70
+#: app/components/chart-published.tsx:69
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Careful, the data for this chart has expired.<0/><1>Don't use for reporting!</1>"
 

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -13,11 +13,11 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/components/chart-preview.tsx:92
+#: app/components/chart-preview.tsx:95
 msgid "annotation.add.description"
 msgstr "[ No Description ]"
 
-#: app/components/chart-preview.tsx:76
+#: app/components/chart-preview.tsx:79
 msgid "annotation.add.title"
 msgstr "[ No Title ]"
 
@@ -25,11 +25,11 @@ msgstr "[ No Title ]"
 msgid "button.copy.visualization"
 msgstr "Copy This Visualization"
 
-#: app/components/data-download.tsx:124
+#: app/components/data-download.tsx:122
 msgid "button.download.data"
 msgstr "Download data"
 
-#: app/components/data-download.tsx:73
+#: app/components/data-download.tsx:71
 msgid "button.download.runsparqlquery"
 msgstr "Run SPARQL query"
 
@@ -158,28 +158,28 @@ msgstr "Compact view"
 msgid "chart.table.number.of.lines"
 msgstr "Total number of lines:"
 
-#: app/configurator/table/table-chart-options.tsx:205
+#: app/configurator/table/table-chart-options.tsx:190
 msgid "columnStyle.bar"
 msgstr "Bar Chart"
 
-#: app/configurator/table/table-chart-options.tsx:191
+#: app/configurator/table/table-chart-options.tsx:176
 msgid "columnStyle.categories"
 msgstr "Categories"
 
-#: app/configurator/table/table-chart-options.tsx:201
+#: app/configurator/table/table-chart-options.tsx:186
 msgid "columnStyle.heatmap"
 msgstr "Heat Map"
 
-#: app/configurator/table/table-chart-options.tsx:187
-#: app/configurator/table/table-chart-options.tsx:197
+#: app/configurator/table/table-chart-options.tsx:172
+#: app/configurator/table/table-chart-options.tsx:182
 msgid "columnStyle.text"
 msgstr "Text"
 
-#: app/configurator/table/table-chart-options.tsx:416
+#: app/configurator/table/table-chart-options.tsx:384
 msgid "columnStyle.textStyle.bold"
 msgstr "Bold"
 
-#: app/configurator/table/table-chart-options.tsx:409
+#: app/configurator/table/table-chart-options.tsx:377
 msgid "columnStyle.textStyle.regular"
 msgstr "Regular"
 
@@ -187,47 +187,47 @@ msgstr "Regular"
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Default Settings"
 
-#: app/configurator/components/ui-helpers.ts:328
+#: app/configurator/components/ui-helpers.ts:373
 msgid "controls.axis.horizontal"
 msgstr "Horizontal Axis"
 
-#: app/configurator/components/ui-helpers.ts:336
+#: app/configurator/components/ui-helpers.ts:381
 msgid "controls.axis.vertical"
 msgstr "Vertical Axis"
 
-#: app/configurator/components/ui-helpers.ts:402
+#: app/configurator/components/ui-helpers.ts:463
 msgid "controls.chart.type.area"
 msgstr "Areas"
 
-#: app/configurator/components/ui-helpers.ts:394
+#: app/configurator/components/ui-helpers.ts:455
 msgid "controls.chart.type.bar"
 msgstr "Bars"
 
-#: app/configurator/components/ui-helpers.ts:390
+#: app/configurator/components/ui-helpers.ts:451
 msgid "controls.chart.type.column"
 msgstr "Columns"
 
-#: app/configurator/components/ui-helpers.ts:398
+#: app/configurator/components/ui-helpers.ts:459
 msgid "controls.chart.type.line"
 msgstr "Lines"
 
-#: app/configurator/components/ui-helpers.ts:418
+#: app/configurator/components/ui-helpers.ts:479
 msgid "controls.chart.type.map"
 msgstr "Map"
 
-#: app/configurator/components/ui-helpers.ts:410
+#: app/configurator/components/ui-helpers.ts:471
 msgid "controls.chart.type.pie"
 msgstr "Pie"
 
-#: app/configurator/components/ui-helpers.ts:406
+#: app/configurator/components/ui-helpers.ts:467
 msgid "controls.chart.type.scatterplot"
 msgstr "Scatterplot"
 
-#: app/configurator/components/ui-helpers.ts:414
+#: app/configurator/components/ui-helpers.ts:475
 msgid "controls.chart.type.table"
 msgstr "Table"
 
-#: app/configurator/components/ui-helpers.ts:340
+#: app/configurator/components/ui-helpers.ts:385
 msgid "controls.color"
 msgstr "Color"
 
@@ -248,33 +248,33 @@ msgstr "Reset color palette"
 msgid "controls.colorpicker.open"
 msgstr "Open Color Picker"
 
-#: app/configurator/components/ui-helpers.ts:350
+#: app/configurator/components/ui-helpers.ts:395
 msgid "controls.column.grouped"
 msgstr "Grouped"
 
-#: app/configurator/components/ui-helpers.ts:346
+#: app/configurator/components/ui-helpers.ts:391
 msgid "controls.column.stacked"
 msgstr "Stacked"
 
-#: app/configurator/components/ui-helpers.ts:342
+#: app/configurator/components/ui-helpers.ts:387
 msgid "controls.description"
 msgstr "Description"
 
-#: app/configurator/components/field.tsx:517
+#: app/configurator/components/field.tsx:503
 msgid "controls.dimension.none"
 msgstr "None"
 
-#: app/charts/shared/chart-data-filters.tsx:124
-#: app/configurator/components/field.tsx:76
-#: app/configurator/components/field.tsx:146
+#: app/charts/shared/chart-data-filters.tsx:194
+#: app/configurator/components/field.tsx:77
+#: app/configurator/components/field.tsx:135
 msgid "controls.dimensionvalue.none"
 msgstr "No Filter"
 
-#: app/configurator/components/filters.tsx:84
+#: app/configurator/components/filters.tsx:89
 msgid "controls.filter.select.all"
 msgstr "Select all"
 
-#: app/configurator/components/filters.tsx:93
+#: app/configurator/components/filters.tsx:98
 msgid "controls.filter.select.none"
 msgstr "Select none"
 
@@ -290,43 +290,63 @@ msgstr "Select a design element or a data dimension to modify its options."
 msgid "controls.hint.describing.chart"
 msgstr "Select an annotation field to modify its content."
 
+#: app/configurator/components/ui-helpers.ts:435
+msgid "controls.imputation"
+msgstr "Imputation type"
+
+#: app/configurator/components/chart-options-selector.tsx:474
+#: app/configurator/components/ui-helpers.ts:447
+msgid "controls.imputation.type.linear"
+msgstr "Linear interpolation"
+
+#: app/configurator/components/chart-options-selector.tsx:467
+#: app/configurator/components/chart-options-selector.tsx:479
+#: app/configurator/components/ui-helpers.ts:439
+msgid "controls.imputation.type.none"
+msgstr "-"
+
+#: app/configurator/components/chart-options-selector.tsx:469
+#: app/configurator/components/ui-helpers.ts:443
+msgid "controls.imputation.type.zeros"
+msgstr "Zeros"
+
 #: app/configurator/interactive-filters/interactive-filters-configurator.tsx:92
 msgid "controls.interactive.filters.dataFilter"
 msgstr "Data Filters"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:263
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:266
 msgid "controls.interactiveFilters.dataFilters.toggledataFilters"
 msgstr "Show data filters"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:63
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:64
 msgid "controls.interactiveFilters.legend.toggleInteractiveLegend"
 msgstr "Show legend filter"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:198
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:199
 msgid "controls.interactiveFilters.time.noTimeDimension"
 msgstr "There is no time dimension!"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:172
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:173
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Show time filter"
 
-#: app/configurator/components/ui-helpers.ts:422
+#: app/configurator/components/ui-helpers.ts:483
 msgid "controls.language.english"
 msgstr "English"
 
-#: app/configurator/components/ui-helpers.ts:430
+#: app/configurator/components/ui-helpers.ts:491
 msgid "controls.language.french"
 msgstr "French"
 
-#: app/configurator/components/ui-helpers.ts:426
+#: app/configurator/components/ui-helpers.ts:487
 msgid "controls.language.german"
 msgstr "German"
 
-#: app/configurator/components/ui-helpers.ts:434
+#: app/configurator/components/ui-helpers.ts:495
 msgid "controls.language.italian"
 msgstr "Italian"
 
-#: app/configurator/components/ui-helpers.ts:332
+#: app/configurator/components/ui-helpers.ts:377
 msgid "controls.measure"
 msgstr "Measure"
 
@@ -350,7 +370,7 @@ msgstr "Chart Options"
 msgid "controls.section.columns"
 msgstr "Columns"
 
-#: app/configurator/table/table-chart-options.tsx:266
+#: app/configurator/table/table-chart-options.tsx:234
 msgid "controls.section.columnstyle"
 msgstr "Column Style"
 
@@ -362,12 +382,12 @@ msgstr "Filters"
 msgid "controls.section.description"
 msgstr "Title & Description"
 
-#: app/configurator/components/chart-options-selector.tsx:219
-#: app/configurator/components/chart-options-selector.tsx:223
-#: app/configurator/table/table-chart-options.tsx:333
-#: app/configurator/table/table-chart-options.tsx:337
-#: app/configurator/table/table-chart-options.tsx:357
-#: app/configurator/table/table-chart-options.tsx:361
+#: app/configurator/components/chart-options-selector.tsx:259
+#: app/configurator/components/chart-options-selector.tsx:263
+#: app/configurator/table/table-chart-options.tsx:301
+#: app/configurator/table/table-chart-options.tsx:305
+#: app/configurator/table/table-chart-options.tsx:325
+#: app/configurator/table/table-chart-options.tsx:329
 msgid "controls.section.filter"
 msgstr "Filter"
 
@@ -375,19 +395,27 @@ msgstr "Filter"
 msgid "controls.section.groups"
 msgstr "Groups"
 
+#: app/configurator/components/chart-options-selector.tsx:508
+msgid "controls.section.imputation"
+msgstr "Missing values"
+
+#: app/configurator/components/chart-options-selector.tsx:513
+msgid "controls.section.imputation.explanation"
+msgstr "Due to the nature of the selected chart type, some missing values have been introduced. Decide on the imputation logic or switch to another chart type."
+
 #: app/configurator/interactive-filters/interactive-filters-configurator.tsx:63
 msgid "controls.section.interactive.filters"
 msgstr "Interactive Filters"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:94
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:95
 msgid "controls.section.interactiveFilters.dataFilters"
 msgstr "Data Filters"
 
-#: app/configurator/components/chart-options-selector.tsx:355
+#: app/configurator/components/chart-options-selector.tsx:395
 msgid "controls.section.sorting"
 msgstr "Sort"
 
-#: app/configurator/table/table-chart-options.tsx:501
+#: app/configurator/table/table-chart-options.tsx:469
 msgid "controls.section.tableSettings"
 msgstr "Table Settings"
 
@@ -412,54 +440,54 @@ msgstr "Experimental Features"
 msgid "controls.select.chart.type.experimental.description"
 msgstr "Preview upcoming features with a limited subset of data on a separate page."
 
-#: app/configurator/components/chart-options-selector.tsx:265
+#: app/configurator/components/chart-options-selector.tsx:305
 msgid "controls.select.column.layout"
 msgstr "Column layout"
 
-#: app/configurator/table/table-chart-options.tsx:271
+#: app/configurator/table/table-chart-options.tsx:239
 msgid "controls.select.columnStyle"
 msgstr "Column Style"
 
-#: app/configurator/table/table-chart-options.tsx:476
+#: app/configurator/table/table-chart-options.tsx:444
 msgid "controls.select.columnStyle.barColorBackground"
 msgstr "Background color"
 
-#: app/configurator/table/table-chart-options.tsx:468
+#: app/configurator/table/table-chart-options.tsx:436
 msgid "controls.select.columnStyle.barColorNegative"
 msgstr "Negative bar color"
 
-#: app/configurator/table/table-chart-options.tsx:460
+#: app/configurator/table/table-chart-options.tsx:428
 msgid "controls.select.columnStyle.barColorPositive"
 msgstr "Positive bar color"
 
-#: app/configurator/table/table-chart-options.tsx:484
+#: app/configurator/table/table-chart-options.tsx:452
 msgid "controls.select.columnStyle.barShowBackground"
 msgstr "Show bar background"
 
-#: app/configurator/table/table-chart-options.tsx:433
+#: app/configurator/table/table-chart-options.tsx:401
 msgid "controls.select.columnStyle.columnColor"
 msgstr "Column Color"
 
-#: app/configurator/table/table-chart-options.tsx:425
+#: app/configurator/table/table-chart-options.tsx:393
 msgid "controls.select.columnStyle.textColor"
 msgstr "Text Color"
 
-#: app/configurator/table/table-chart-options.tsx:402
+#: app/configurator/table/table-chart-options.tsx:370
 msgid "controls.select.columnStyle.textStyle"
 msgstr "Text Style"
 
-#: app/configurator/components/chart-options-selector.tsx:135
-#: app/configurator/components/chart-options-selector.tsx:137
+#: app/configurator/components/chart-options-selector.tsx:169
+#: app/configurator/components/chart-options-selector.tsx:171
 msgid "controls.select.dimension"
 msgstr "Select a dimension"
 
-#: app/configurator/components/chart-options-selector.tsx:136
+#: app/configurator/components/chart-options-selector.tsx:170
 msgid "controls.select.measure"
 msgstr "Select a measure"
 
-#: app/configurator/components/field.tsx:81
-#: app/configurator/components/field.tsx:151
-#: app/configurator/components/field.tsx:522
+#: app/configurator/components/field.tsx:82
+#: app/configurator/components/field.tsx:140
+#: app/configurator/components/field.tsx:508
 msgid "controls.select.optional"
 msgstr "optional"
 
@@ -467,48 +495,48 @@ msgstr "optional"
 msgid "controls.sorting.addDimension"
 msgstr "Add dimension"
 
-#: app/configurator/components/chart-options-selector.tsx:306
-#: app/configurator/components/chart-options-selector.tsx:312
+#: app/configurator/components/chart-options-selector.tsx:346
+#: app/configurator/components/chart-options-selector.tsx:352
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Name"
 
-#: app/configurator/components/ui-helpers.ts:358
+#: app/configurator/components/ui-helpers.ts:403
 msgid "controls.sorting.byDimensionLabel.ascending"
 msgstr "A → Z"
 
-#: app/configurator/components/ui-helpers.ts:362
+#: app/configurator/components/ui-helpers.ts:407
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
-#: app/configurator/components/chart-options-selector.tsx:308
+#: app/configurator/components/chart-options-selector.tsx:348
 msgid "controls.sorting.byMeasure"
 msgstr "Measure"
 
-#: app/configurator/components/ui-helpers.ts:382
+#: app/configurator/components/ui-helpers.ts:427
 msgid "controls.sorting.byMeasure.ascending"
 msgstr "1 → 9"
 
-#: app/configurator/components/ui-helpers.ts:386
+#: app/configurator/components/ui-helpers.ts:431
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
-#: app/configurator/components/chart-options-selector.tsx:310
+#: app/configurator/components/chart-options-selector.tsx:350
 msgid "controls.sorting.byTotalSize"
 msgstr "Total size"
 
-#: app/configurator/components/ui-helpers.ts:366
+#: app/configurator/components/ui-helpers.ts:411
 msgid "controls.sorting.byTotalSize.ascending"
 msgstr "Largest last"
 
-#: app/configurator/components/ui-helpers.ts:378
+#: app/configurator/components/ui-helpers.ts:423
 msgid "controls.sorting.byTotalSize.largestBottom"
 msgstr "Largest bottom"
 
-#: app/configurator/components/ui-helpers.ts:370
+#: app/configurator/components/ui-helpers.ts:415
 msgid "controls.sorting.byTotalSize.largestFirst"
 msgstr "Largest first"
 
-#: app/configurator/components/ui-helpers.ts:374
+#: app/configurator/components/ui-helpers.ts:419
 msgid "controls.sorting.byTotalSize.largestTop"
 msgstr "Largest top"
 
@@ -520,22 +548,22 @@ msgstr "Remove sorting dimension"
 msgid "controls.sorting.selectDimension"
 msgstr "Select a dimension …"
 
-#: app/configurator/components/ui-helpers.ts:354
+#: app/configurator/components/ui-helpers.ts:399
 #: app/configurator/table/table-chart-sorting-options.tsx:305
 msgid "controls.sorting.sortBy"
 msgstr "Sort by"
 
-#: app/configurator/table/table-chart-options.tsx:227
+#: app/configurator/table/table-chart-options.tsx:211
 msgid "controls.table.column.group"
 msgstr "Use as group"
 
-#: app/configurator/table/table-chart-options.tsx:252
+#: app/configurator/table/table-chart-options.tsx:221
 msgid "controls.table.column.hide"
 msgstr "Hide column"
 
 #: app/configurator/table/table-chart-options.tsx:238
-msgid "controls.table.column.hidefilter"
-msgstr "Hide and filter column"
+#~ msgid "controls.table.column.hidefilter"
+#~ msgstr "Hide and filter column"
 
 #: app/configurator/table/table-chart-configurator.tsx:101
 msgid "controls.table.settings"
@@ -545,11 +573,11 @@ msgstr "Settings"
 msgid "controls.table.sorting"
 msgstr "Sorting"
 
-#: app/configurator/table/table-chart-options.tsx:505
+#: app/configurator/table/table-chart-options.tsx:473
 msgid "controls.tableSettings.showSearch"
 msgstr "Show search field"
 
-#: app/configurator/components/ui-helpers.ts:341
+#: app/configurator/components/ui-helpers.ts:386
 msgid "controls.title"
 msgstr "Title"
 
@@ -597,13 +625,13 @@ msgstr "Relevance"
 msgid "dataset.order.title"
 msgstr "Title"
 
-#: app/components/chart-preview.tsx:53
-#: app/components/chart-published.tsx:58
-#: app/configurator/components/dataset-preview.tsx:35
+#: app/components/chart-preview.tsx:56
+#: app/components/chart-published.tsx:59
+#: app/configurator/components/dataset-preview.tsx:36
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Careful, this dataset is only a draft.<0/><1>Don't use for reporting!</1>"
 
-#: app/components/chart-published.tsx:69
+#: app/components/chart-published.tsx:70
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Careful, the data for this chart has expired.<0/><1>Don't use for reporting!</1>"
 
@@ -623,15 +651,15 @@ msgstr "Sort by"
 msgid "dataset.tag.draft"
 msgstr "Draft"
 
-#: app/configurator/components/dataset-preview.tsx:85
+#: app/configurator/components/dataset-preview.tsx:86
 msgid "datatable.showing.first.rows"
 msgstr "Showing first 10 rows"
 
-#: app/components/footer.tsx:38
+#: app/components/footer.tsx:66
 msgid "footer.institution.name"
 msgstr "Federal Office for the Environment FOEN"
 
-#: app/components/footer.tsx:33
+#: app/components/footer.tsx:61
 msgid "footer.institution.url"
 msgstr "https://www.bafu.admin.ch/bafu/en/home.html"
 
@@ -695,11 +723,11 @@ msgstr "Select a dataset"
 msgid "hint.select.dataset.to.preview"
 msgstr "Select a dataset to preview its structure and content."
 
-#: app/charts/shared/chart-data-filters.tsx:63
+#: app/charts/shared/chart-data-filters.tsx:67
 msgid "interactive.data.filters.hide"
 msgstr "Hide Filters"
 
-#: app/charts/shared/chart-data-filters.tsx:61
+#: app/charts/shared/chart-data-filters.tsx:65
 msgid "interactive.data.filters.show"
 msgstr "Show Filters"
 

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -292,23 +292,23 @@ msgstr "Sélectionnez une des annotations proposées pour la modifier."
 
 #: app/configurator/components/ui-helpers.ts:435
 msgid "controls.imputation"
-msgstr ""
+msgstr "Type d'imputation"
 
 #: app/configurator/components/chart-options-selector.tsx:477
 #: app/configurator/components/ui-helpers.ts:447
 msgid "controls.imputation.type.linear"
-msgstr ""
+msgstr "Interpolation linéaire"
 
 #: app/configurator/components/chart-options-selector.tsx:470
 #: app/configurator/components/chart-options-selector.tsx:482
 #: app/configurator/components/ui-helpers.ts:439
 msgid "controls.imputation.type.none"
-msgstr ""
+msgstr "-"
 
 #: app/configurator/components/chart-options-selector.tsx:472
 #: app/configurator/components/ui-helpers.ts:443
 msgid "controls.imputation.type.zeros"
-msgstr ""
+msgstr "Zéros"
 
 #: app/configurator/interactive-filters/interactive-filters-configurator.tsx:92
 msgid "controls.interactive.filters.dataFilter"
@@ -397,11 +397,11 @@ msgstr "Groupes"
 
 #: app/configurator/components/chart-options-selector.tsx:511
 msgid "controls.section.imputation"
-msgstr ""
+msgstr "Valeurs manquantes"
 
 #: app/configurator/components/chart-options-selector.tsx:516
 msgid "controls.section.imputation.explanation"
-msgstr ""
+msgstr "En raison de la nature du type de graphique sélectionné, certaines valeurs manquantes ont été introduites. Décidez de la logique d'imputation ou passez à un autre type de graphique."
 
 #: app/configurator/interactive-filters/interactive-filters-configurator.tsx:63
 msgid "controls.section.interactive.filters"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -294,18 +294,18 @@ msgstr "Sélectionnez une des annotations proposées pour la modifier."
 msgid "controls.imputation"
 msgstr ""
 
-#: app/configurator/components/chart-options-selector.tsx:474
+#: app/configurator/components/chart-options-selector.tsx:477
 #: app/configurator/components/ui-helpers.ts:447
 msgid "controls.imputation.type.linear"
 msgstr ""
 
-#: app/configurator/components/chart-options-selector.tsx:467
-#: app/configurator/components/chart-options-selector.tsx:479
+#: app/configurator/components/chart-options-selector.tsx:470
+#: app/configurator/components/chart-options-selector.tsx:482
 #: app/configurator/components/ui-helpers.ts:439
 msgid "controls.imputation.type.none"
 msgstr ""
 
-#: app/configurator/components/chart-options-selector.tsx:469
+#: app/configurator/components/chart-options-selector.tsx:472
 #: app/configurator/components/ui-helpers.ts:443
 msgid "controls.imputation.type.zeros"
 msgstr ""
@@ -382,8 +382,8 @@ msgstr "Filtres"
 msgid "controls.section.description"
 msgstr "Titre & description"
 
-#: app/configurator/components/chart-options-selector.tsx:259
-#: app/configurator/components/chart-options-selector.tsx:263
+#: app/configurator/components/chart-options-selector.tsx:262
+#: app/configurator/components/chart-options-selector.tsx:266
 #: app/configurator/table/table-chart-options.tsx:301
 #: app/configurator/table/table-chart-options.tsx:305
 #: app/configurator/table/table-chart-options.tsx:325
@@ -395,11 +395,11 @@ msgstr "Filtre"
 msgid "controls.section.groups"
 msgstr "Groupes"
 
-#: app/configurator/components/chart-options-selector.tsx:508
+#: app/configurator/components/chart-options-selector.tsx:511
 msgid "controls.section.imputation"
 msgstr ""
 
-#: app/configurator/components/chart-options-selector.tsx:513
+#: app/configurator/components/chart-options-selector.tsx:516
 msgid "controls.section.imputation.explanation"
 msgstr ""
 
@@ -411,7 +411,7 @@ msgstr "Filtres interactifs"
 msgid "controls.section.interactiveFilters.dataFilters"
 msgstr "Filtres de données"
 
-#: app/configurator/components/chart-options-selector.tsx:395
+#: app/configurator/components/chart-options-selector.tsx:398
 msgid "controls.section.sorting"
 msgstr "Trier"
 
@@ -440,7 +440,7 @@ msgstr "Fonctionnalités expérimentales"
 msgid "controls.select.chart.type.experimental.description"
 msgstr "Voir le prototype de la carte avec un nombre limité de jeu de données (lien vers une nouvelle page)."
 
-#: app/configurator/components/chart-options-selector.tsx:305
+#: app/configurator/components/chart-options-selector.tsx:308
 msgid "controls.select.column.layout"
 msgstr "Mise en forme de la colonne"
 
@@ -476,12 +476,12 @@ msgstr "Couleur du texte"
 msgid "controls.select.columnStyle.textStyle"
 msgstr "Style du texte"
 
-#: app/configurator/components/chart-options-selector.tsx:169
 #: app/configurator/components/chart-options-selector.tsx:171
+#: app/configurator/components/chart-options-selector.tsx:173
 msgid "controls.select.dimension"
 msgstr "Sélectionner une dimension"
 
-#: app/configurator/components/chart-options-selector.tsx:170
+#: app/configurator/components/chart-options-selector.tsx:172
 msgid "controls.select.measure"
 msgstr "Sélectionner une variable"
 
@@ -495,8 +495,8 @@ msgstr "optionnel"
 msgid "controls.sorting.addDimension"
 msgstr "Ajouter une dimension"
 
-#: app/configurator/components/chart-options-selector.tsx:346
-#: app/configurator/components/chart-options-selector.tsx:352
+#: app/configurator/components/chart-options-selector.tsx:349
+#: app/configurator/components/chart-options-selector.tsx:355
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Nom"
 
@@ -508,7 +508,7 @@ msgstr "A → Z"
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
-#: app/configurator/components/chart-options-selector.tsx:348
+#: app/configurator/components/chart-options-selector.tsx:351
 msgid "controls.sorting.byMeasure"
 msgstr "Mesure"
 
@@ -520,7 +520,7 @@ msgstr "1 → 9"
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
-#: app/configurator/components/chart-options-selector.tsx:350
+#: app/configurator/components/chart-options-selector.tsx:353
 msgid "controls.sorting.byTotalSize"
 msgstr "Taille totale"
 
@@ -581,6 +581,10 @@ msgstr "Afficher le champ de recherche"
 msgid "controls.title"
 msgstr "Titre"
 
+#: app/components/chart-published.tsx:80
+msgid "dataset.hasImputedValues"
+msgstr "Certaines données de cet ensemble de données sont manquantes et ont été interpolées pour combler les lacunes."
+
 #: app/configurator/components/dataset-selector.tsx:103
 msgid "dataset.includeDrafts"
 msgstr "Inclure les jeux de données à l'état d'ébauche"
@@ -626,12 +630,12 @@ msgid "dataset.order.title"
 msgstr "Titre"
 
 #: app/components/chart-preview.tsx:56
-#: app/components/chart-published.tsx:59
+#: app/components/chart-published.tsx:58
 #: app/configurator/components/dataset-preview.tsx:36
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Attention, ce jeu de données est à l'état d'ébauche.<0/><1>Ne l'utilisez pas pour une publication!</1>"
 
-#: app/components/chart-published.tsx:70
+#: app/components/chart-published.tsx:69
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Attention, ce jeu de données est expiré.<0/><1>Ne l'utilisez pas pour une publication!</1>"
 

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -13,11 +13,11 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/components/chart-preview.tsx:92
+#: app/components/chart-preview.tsx:95
 msgid "annotation.add.description"
 msgstr "[ Pas de description ]"
 
-#: app/components/chart-preview.tsx:76
+#: app/components/chart-preview.tsx:79
 msgid "annotation.add.title"
 msgstr "[ Pas de titre ]"
 
@@ -25,11 +25,11 @@ msgstr "[ Pas de titre ]"
 msgid "button.copy.visualization"
 msgstr "Copier cette visualisation"
 
-#: app/components/data-download.tsx:124
+#: app/components/data-download.tsx:122
 msgid "button.download.data"
 msgstr "Télécharger les données"
 
-#: app/components/data-download.tsx:73
+#: app/components/data-download.tsx:71
 msgid "button.download.runsparqlquery"
 msgstr "Lancer la requête SPARQL"
 
@@ -158,28 +158,28 @@ msgstr "Vue compacte"
 msgid "chart.table.number.of.lines"
 msgstr "Nombre total de lignes:"
 
-#: app/configurator/table/table-chart-options.tsx:205
+#: app/configurator/table/table-chart-options.tsx:190
 msgid "columnStyle.bar"
 msgstr "Barres"
 
-#: app/configurator/table/table-chart-options.tsx:191
+#: app/configurator/table/table-chart-options.tsx:176
 msgid "columnStyle.categories"
 msgstr "Catégories"
 
-#: app/configurator/table/table-chart-options.tsx:201
+#: app/configurator/table/table-chart-options.tsx:186
 msgid "columnStyle.heatmap"
 msgstr "Heatmap"
 
-#: app/configurator/table/table-chart-options.tsx:187
-#: app/configurator/table/table-chart-options.tsx:197
+#: app/configurator/table/table-chart-options.tsx:172
+#: app/configurator/table/table-chart-options.tsx:182
 msgid "columnStyle.text"
 msgstr "Texte"
 
-#: app/configurator/table/table-chart-options.tsx:416
+#: app/configurator/table/table-chart-options.tsx:384
 msgid "columnStyle.textStyle.bold"
 msgstr "Gras"
 
-#: app/configurator/table/table-chart-options.tsx:409
+#: app/configurator/table/table-chart-options.tsx:377
 msgid "columnStyle.textStyle.regular"
 msgstr "Normal"
 
@@ -187,47 +187,47 @@ msgstr "Normal"
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Paramètres d'origine"
 
-#: app/configurator/components/ui-helpers.ts:328
+#: app/configurator/components/ui-helpers.ts:373
 msgid "controls.axis.horizontal"
 msgstr "Axe horizontal"
 
-#: app/configurator/components/ui-helpers.ts:336
+#: app/configurator/components/ui-helpers.ts:381
 msgid "controls.axis.vertical"
 msgstr "Axe vertical"
 
-#: app/configurator/components/ui-helpers.ts:402
+#: app/configurator/components/ui-helpers.ts:463
 msgid "controls.chart.type.area"
 msgstr "Surfaces"
 
-#: app/configurator/components/ui-helpers.ts:394
+#: app/configurator/components/ui-helpers.ts:455
 msgid "controls.chart.type.bar"
 msgstr "Barres"
 
-#: app/configurator/components/ui-helpers.ts:390
+#: app/configurator/components/ui-helpers.ts:451
 msgid "controls.chart.type.column"
 msgstr "Colonnes"
 
-#: app/configurator/components/ui-helpers.ts:398
+#: app/configurator/components/ui-helpers.ts:459
 msgid "controls.chart.type.line"
 msgstr "Lignes"
 
-#: app/configurator/components/ui-helpers.ts:418
+#: app/configurator/components/ui-helpers.ts:479
 msgid "controls.chart.type.map"
 msgstr "Carte"
 
-#: app/configurator/components/ui-helpers.ts:410
+#: app/configurator/components/ui-helpers.ts:471
 msgid "controls.chart.type.pie"
 msgstr "Secteurs"
 
-#: app/configurator/components/ui-helpers.ts:406
+#: app/configurator/components/ui-helpers.ts:467
 msgid "controls.chart.type.scatterplot"
 msgstr "Nuage de points"
 
-#: app/configurator/components/ui-helpers.ts:414
+#: app/configurator/components/ui-helpers.ts:475
 msgid "controls.chart.type.table"
 msgstr "Tableau"
 
-#: app/configurator/components/ui-helpers.ts:340
+#: app/configurator/components/ui-helpers.ts:385
 msgid "controls.color"
 msgstr "Couleur"
 
@@ -248,33 +248,33 @@ msgstr "Réinitialiser la palette de couleurs"
 msgid "controls.colorpicker.open"
 msgstr "Ouvrir la pipette à couleur"
 
-#: app/configurator/components/ui-helpers.ts:350
+#: app/configurator/components/ui-helpers.ts:395
 msgid "controls.column.grouped"
 msgstr "groupées"
 
-#: app/configurator/components/ui-helpers.ts:346
+#: app/configurator/components/ui-helpers.ts:391
 msgid "controls.column.stacked"
 msgstr "empilées"
 
-#: app/configurator/components/ui-helpers.ts:342
+#: app/configurator/components/ui-helpers.ts:387
 msgid "controls.description"
 msgstr "Description"
 
-#: app/configurator/components/field.tsx:517
+#: app/configurator/components/field.tsx:503
 msgid "controls.dimension.none"
 msgstr "Aucune"
 
-#: app/charts/shared/chart-data-filters.tsx:124
-#: app/configurator/components/field.tsx:76
-#: app/configurator/components/field.tsx:146
+#: app/charts/shared/chart-data-filters.tsx:194
+#: app/configurator/components/field.tsx:77
+#: app/configurator/components/field.tsx:135
 msgid "controls.dimensionvalue.none"
 msgstr "Aucune filtre"
 
-#: app/configurator/components/filters.tsx:84
+#: app/configurator/components/filters.tsx:89
 msgid "controls.filter.select.all"
 msgstr "Tout sélectionner"
 
-#: app/configurator/components/filters.tsx:93
+#: app/configurator/components/filters.tsx:98
 msgid "controls.filter.select.none"
 msgstr "Tout déselectionner"
 
@@ -290,43 +290,63 @@ msgstr "Sélectionnez un élément de design ou une dimension du jeu de données
 msgid "controls.hint.describing.chart"
 msgstr "Sélectionnez une des annotations proposées pour la modifier."
 
+#: app/configurator/components/ui-helpers.ts:435
+msgid "controls.imputation"
+msgstr ""
+
+#: app/configurator/components/chart-options-selector.tsx:474
+#: app/configurator/components/ui-helpers.ts:447
+msgid "controls.imputation.type.linear"
+msgstr ""
+
+#: app/configurator/components/chart-options-selector.tsx:467
+#: app/configurator/components/chart-options-selector.tsx:479
+#: app/configurator/components/ui-helpers.ts:439
+msgid "controls.imputation.type.none"
+msgstr ""
+
+#: app/configurator/components/chart-options-selector.tsx:469
+#: app/configurator/components/ui-helpers.ts:443
+msgid "controls.imputation.type.zeros"
+msgstr ""
+
 #: app/configurator/interactive-filters/interactive-filters-configurator.tsx:92
 msgid "controls.interactive.filters.dataFilter"
 msgstr "Filtres de données"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:263
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:266
 msgid "controls.interactiveFilters.dataFilters.toggledataFilters"
 msgstr "Afficher les filtres de données"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:63
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:64
 msgid "controls.interactiveFilters.legend.toggleInteractiveLegend"
 msgstr "Afficher la légende filtrante"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:198
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:199
 msgid "controls.interactiveFilters.time.noTimeDimension"
 msgstr "Il n'y a pas de dimension temporelle!"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:172
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:173
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Afficher le filtre temporel"
 
-#: app/configurator/components/ui-helpers.ts:422
+#: app/configurator/components/ui-helpers.ts:483
 msgid "controls.language.english"
 msgstr "Anglais"
 
-#: app/configurator/components/ui-helpers.ts:430
+#: app/configurator/components/ui-helpers.ts:491
 msgid "controls.language.french"
 msgstr "Français"
 
-#: app/configurator/components/ui-helpers.ts:426
+#: app/configurator/components/ui-helpers.ts:487
 msgid "controls.language.german"
 msgstr "Allemand"
 
-#: app/configurator/components/ui-helpers.ts:434
+#: app/configurator/components/ui-helpers.ts:495
 msgid "controls.language.italian"
 msgstr "Italien"
 
-#: app/configurator/components/ui-helpers.ts:332
+#: app/configurator/components/ui-helpers.ts:377
 msgid "controls.measure"
 msgstr "Variable mesurée"
 
@@ -350,7 +370,7 @@ msgstr "Paramètres graphiques"
 msgid "controls.section.columns"
 msgstr "Colonnes"
 
-#: app/configurator/table/table-chart-options.tsx:266
+#: app/configurator/table/table-chart-options.tsx:234
 msgid "controls.section.columnstyle"
 msgstr "Style de la colonne"
 
@@ -362,12 +382,12 @@ msgstr "Filtres"
 msgid "controls.section.description"
 msgstr "Titre & description"
 
-#: app/configurator/components/chart-options-selector.tsx:219
-#: app/configurator/components/chart-options-selector.tsx:223
-#: app/configurator/table/table-chart-options.tsx:333
-#: app/configurator/table/table-chart-options.tsx:337
-#: app/configurator/table/table-chart-options.tsx:357
-#: app/configurator/table/table-chart-options.tsx:361
+#: app/configurator/components/chart-options-selector.tsx:259
+#: app/configurator/components/chart-options-selector.tsx:263
+#: app/configurator/table/table-chart-options.tsx:301
+#: app/configurator/table/table-chart-options.tsx:305
+#: app/configurator/table/table-chart-options.tsx:325
+#: app/configurator/table/table-chart-options.tsx:329
 msgid "controls.section.filter"
 msgstr "Filtre"
 
@@ -375,19 +395,27 @@ msgstr "Filtre"
 msgid "controls.section.groups"
 msgstr "Groupes"
 
+#: app/configurator/components/chart-options-selector.tsx:508
+msgid "controls.section.imputation"
+msgstr ""
+
+#: app/configurator/components/chart-options-selector.tsx:513
+msgid "controls.section.imputation.explanation"
+msgstr ""
+
 #: app/configurator/interactive-filters/interactive-filters-configurator.tsx:63
 msgid "controls.section.interactive.filters"
 msgstr "Filtres interactifs"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:94
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:95
 msgid "controls.section.interactiveFilters.dataFilters"
 msgstr "Filtres de données"
 
-#: app/configurator/components/chart-options-selector.tsx:355
+#: app/configurator/components/chart-options-selector.tsx:395
 msgid "controls.section.sorting"
 msgstr "Trier"
 
-#: app/configurator/table/table-chart-options.tsx:501
+#: app/configurator/table/table-chart-options.tsx:469
 msgid "controls.section.tableSettings"
 msgstr "Paramètres du tableau"
 
@@ -412,54 +440,54 @@ msgstr "Fonctionnalités expérimentales"
 msgid "controls.select.chart.type.experimental.description"
 msgstr "Voir le prototype de la carte avec un nombre limité de jeu de données (lien vers une nouvelle page)."
 
-#: app/configurator/components/chart-options-selector.tsx:265
+#: app/configurator/components/chart-options-selector.tsx:305
 msgid "controls.select.column.layout"
 msgstr "Mise en forme de la colonne"
 
-#: app/configurator/table/table-chart-options.tsx:271
+#: app/configurator/table/table-chart-options.tsx:239
 msgid "controls.select.columnStyle"
 msgstr "Style de la colonne"
 
-#: app/configurator/table/table-chart-options.tsx:476
+#: app/configurator/table/table-chart-options.tsx:444
 msgid "controls.select.columnStyle.barColorBackground"
 msgstr "Couleur de fond"
 
-#: app/configurator/table/table-chart-options.tsx:468
+#: app/configurator/table/table-chart-options.tsx:436
 msgid "controls.select.columnStyle.barColorNegative"
 msgstr "Couleur des valeurs négatives"
 
-#: app/configurator/table/table-chart-options.tsx:460
+#: app/configurator/table/table-chart-options.tsx:428
 msgid "controls.select.columnStyle.barColorPositive"
 msgstr "Couleur des valeurs positives"
 
-#: app/configurator/table/table-chart-options.tsx:484
+#: app/configurator/table/table-chart-options.tsx:452
 msgid "controls.select.columnStyle.barShowBackground"
 msgstr "Afficher la couleur de fond"
 
-#: app/configurator/table/table-chart-options.tsx:433
+#: app/configurator/table/table-chart-options.tsx:401
 msgid "controls.select.columnStyle.columnColor"
 msgstr "Couleur de la colonne"
 
-#: app/configurator/table/table-chart-options.tsx:425
+#: app/configurator/table/table-chart-options.tsx:393
 msgid "controls.select.columnStyle.textColor"
 msgstr "Couleur du texte"
 
-#: app/configurator/table/table-chart-options.tsx:402
+#: app/configurator/table/table-chart-options.tsx:370
 msgid "controls.select.columnStyle.textStyle"
 msgstr "Style du texte"
 
-#: app/configurator/components/chart-options-selector.tsx:135
-#: app/configurator/components/chart-options-selector.tsx:137
+#: app/configurator/components/chart-options-selector.tsx:169
+#: app/configurator/components/chart-options-selector.tsx:171
 msgid "controls.select.dimension"
 msgstr "Sélectionner une dimension"
 
-#: app/configurator/components/chart-options-selector.tsx:136
+#: app/configurator/components/chart-options-selector.tsx:170
 msgid "controls.select.measure"
 msgstr "Sélectionner une variable"
 
-#: app/configurator/components/field.tsx:81
-#: app/configurator/components/field.tsx:151
-#: app/configurator/components/field.tsx:522
+#: app/configurator/components/field.tsx:82
+#: app/configurator/components/field.tsx:140
+#: app/configurator/components/field.tsx:508
 msgid "controls.select.optional"
 msgstr "optionnel"
 
@@ -467,48 +495,48 @@ msgstr "optionnel"
 msgid "controls.sorting.addDimension"
 msgstr "Ajouter une dimension"
 
-#: app/configurator/components/chart-options-selector.tsx:306
-#: app/configurator/components/chart-options-selector.tsx:312
+#: app/configurator/components/chart-options-selector.tsx:346
+#: app/configurator/components/chart-options-selector.tsx:352
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Nom"
 
-#: app/configurator/components/ui-helpers.ts:358
+#: app/configurator/components/ui-helpers.ts:403
 msgid "controls.sorting.byDimensionLabel.ascending"
 msgstr "A → Z"
 
-#: app/configurator/components/ui-helpers.ts:362
+#: app/configurator/components/ui-helpers.ts:407
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
-#: app/configurator/components/chart-options-selector.tsx:308
+#: app/configurator/components/chart-options-selector.tsx:348
 msgid "controls.sorting.byMeasure"
 msgstr "Mesure"
 
-#: app/configurator/components/ui-helpers.ts:382
+#: app/configurator/components/ui-helpers.ts:427
 msgid "controls.sorting.byMeasure.ascending"
 msgstr "1 → 9"
 
-#: app/configurator/components/ui-helpers.ts:386
+#: app/configurator/components/ui-helpers.ts:431
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
-#: app/configurator/components/chart-options-selector.tsx:310
+#: app/configurator/components/chart-options-selector.tsx:350
 msgid "controls.sorting.byTotalSize"
 msgstr "Taille totale"
 
-#: app/configurator/components/ui-helpers.ts:366
+#: app/configurator/components/ui-helpers.ts:411
 msgid "controls.sorting.byTotalSize.ascending"
 msgstr "Croissant"
 
-#: app/configurator/components/ui-helpers.ts:378
+#: app/configurator/components/ui-helpers.ts:423
 msgid "controls.sorting.byTotalSize.largestBottom"
 msgstr "Décroissant de bas en haut"
 
-#: app/configurator/components/ui-helpers.ts:370
+#: app/configurator/components/ui-helpers.ts:415
 msgid "controls.sorting.byTotalSize.largestFirst"
 msgstr "Décroissant"
 
-#: app/configurator/components/ui-helpers.ts:374
+#: app/configurator/components/ui-helpers.ts:419
 msgid "controls.sorting.byTotalSize.largestTop"
 msgstr "Décroissant de haut en bas"
 
@@ -520,22 +548,22 @@ msgstr "Supprimer la dimension de tri"
 msgid "controls.sorting.selectDimension"
 msgstr "Sélectionner une dimension…"
 
-#: app/configurator/components/ui-helpers.ts:354
+#: app/configurator/components/ui-helpers.ts:399
 #: app/configurator/table/table-chart-sorting-options.tsx:305
 msgid "controls.sorting.sortBy"
 msgstr "Trier par"
 
-#: app/configurator/table/table-chart-options.tsx:227
+#: app/configurator/table/table-chart-options.tsx:211
 msgid "controls.table.column.group"
 msgstr "Grouper selon cette colonne"
 
-#: app/configurator/table/table-chart-options.tsx:252
+#: app/configurator/table/table-chart-options.tsx:221
 msgid "controls.table.column.hide"
 msgstr "Masquer la colonne"
 
 #: app/configurator/table/table-chart-options.tsx:238
-msgid "controls.table.column.hidefilter"
-msgstr "Masquer et filtrer cette colonne"
+#~ msgid "controls.table.column.hidefilter"
+#~ msgstr "Masquer et filtrer cette colonne"
 
 #: app/configurator/table/table-chart-configurator.tsx:101
 msgid "controls.table.settings"
@@ -545,11 +573,11 @@ msgstr "Paramètres"
 msgid "controls.table.sorting"
 msgstr "Tri"
 
-#: app/configurator/table/table-chart-options.tsx:505
+#: app/configurator/table/table-chart-options.tsx:473
 msgid "controls.tableSettings.showSearch"
 msgstr "Afficher le champ de recherche"
 
-#: app/configurator/components/ui-helpers.ts:341
+#: app/configurator/components/ui-helpers.ts:386
 msgid "controls.title"
 msgstr "Titre"
 
@@ -597,13 +625,13 @@ msgstr "Le plus pertinent"
 msgid "dataset.order.title"
 msgstr "Titre"
 
-#: app/components/chart-preview.tsx:53
-#: app/components/chart-published.tsx:58
-#: app/configurator/components/dataset-preview.tsx:35
+#: app/components/chart-preview.tsx:56
+#: app/components/chart-published.tsx:59
+#: app/configurator/components/dataset-preview.tsx:36
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Attention, ce jeu de données est à l'état d'ébauche.<0/><1>Ne l'utilisez pas pour une publication!</1>"
 
-#: app/components/chart-published.tsx:69
+#: app/components/chart-published.tsx:70
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Attention, ce jeu de données est expiré.<0/><1>Ne l'utilisez pas pour une publication!</1>"
 
@@ -623,15 +651,15 @@ msgstr "Trier par"
 msgid "dataset.tag.draft"
 msgstr "Ébauche"
 
-#: app/configurator/components/dataset-preview.tsx:85
+#: app/configurator/components/dataset-preview.tsx:86
 msgid "datatable.showing.first.rows"
 msgstr "Seules les 10 premières lignes sont affichées"
 
-#: app/components/footer.tsx:38
+#: app/components/footer.tsx:66
 msgid "footer.institution.name"
 msgstr "Office fédéral de l'environnement OFEV"
 
-#: app/components/footer.tsx:33
+#: app/components/footer.tsx:61
 msgid "footer.institution.url"
 msgstr "https://www.bafu.admin.ch/bafu/fr/home.html"
 
@@ -695,11 +723,11 @@ msgstr "Sélectionner un jeu de données"
 msgid "hint.select.dataset.to.preview"
 msgstr "Sélectionner un jeu de données pour prévisualiser sa structure et son contenu."
 
-#: app/charts/shared/chart-data-filters.tsx:63
+#: app/charts/shared/chart-data-filters.tsx:67
 msgid "interactive.data.filters.hide"
 msgstr "Masquer les filtres"
 
-#: app/charts/shared/chart-data-filters.tsx:61
+#: app/charts/shared/chart-data-filters.tsx:65
 msgid "interactive.data.filters.show"
 msgstr "Afficher les filtres"
 

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -13,11 +13,11 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/components/chart-preview.tsx:92
+#: app/components/chart-preview.tsx:95
 msgid "annotation.add.description"
 msgstr "[ Nessuna descrizione ]"
 
-#: app/components/chart-preview.tsx:76
+#: app/components/chart-preview.tsx:79
 msgid "annotation.add.title"
 msgstr "[ Nessun titolo ]"
 
@@ -25,11 +25,11 @@ msgstr "[ Nessun titolo ]"
 msgid "button.copy.visualization"
 msgstr "Copia questa visualizzazione"
 
-#: app/components/data-download.tsx:124
+#: app/components/data-download.tsx:122
 msgid "button.download.data"
 msgstr "Scarica i dati"
 
-#: app/components/data-download.tsx:73
+#: app/components/data-download.tsx:71
 msgid "button.download.runsparqlquery"
 msgstr "Esegui query SPARQL"
 
@@ -158,28 +158,28 @@ msgstr "Vista compatta"
 msgid "chart.table.number.of.lines"
 msgstr "Numero totale di linee:"
 
-#: app/configurator/table/table-chart-options.tsx:205
+#: app/configurator/table/table-chart-options.tsx:190
 msgid "columnStyle.bar"
 msgstr "Grafico a barre"
 
-#: app/configurator/table/table-chart-options.tsx:191
+#: app/configurator/table/table-chart-options.tsx:176
 msgid "columnStyle.categories"
 msgstr "Categorie"
 
-#: app/configurator/table/table-chart-options.tsx:201
+#: app/configurator/table/table-chart-options.tsx:186
 msgid "columnStyle.heatmap"
 msgstr "Mappa di calore"
 
-#: app/configurator/table/table-chart-options.tsx:187
-#: app/configurator/table/table-chart-options.tsx:197
+#: app/configurator/table/table-chart-options.tsx:172
+#: app/configurator/table/table-chart-options.tsx:182
 msgid "columnStyle.text"
 msgstr "Testo"
 
-#: app/configurator/table/table-chart-options.tsx:416
+#: app/configurator/table/table-chart-options.tsx:384
 msgid "columnStyle.textStyle.bold"
 msgstr "Grassetto"
 
-#: app/configurator/table/table-chart-options.tsx:409
+#: app/configurator/table/table-chart-options.tsx:377
 msgid "columnStyle.textStyle.regular"
 msgstr "Regular"
 
@@ -187,47 +187,47 @@ msgstr "Regular"
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Impostazioni predefinite"
 
-#: app/configurator/components/ui-helpers.ts:328
+#: app/configurator/components/ui-helpers.ts:373
 msgid "controls.axis.horizontal"
 msgstr "Asse orizzontale"
 
-#: app/configurator/components/ui-helpers.ts:336
+#: app/configurator/components/ui-helpers.ts:381
 msgid "controls.axis.vertical"
 msgstr "Asse verticale"
 
-#: app/configurator/components/ui-helpers.ts:402
+#: app/configurator/components/ui-helpers.ts:463
 msgid "controls.chart.type.area"
 msgstr "Aree"
 
-#: app/configurator/components/ui-helpers.ts:394
+#: app/configurator/components/ui-helpers.ts:455
 msgid "controls.chart.type.bar"
 msgstr "Barre"
 
-#: app/configurator/components/ui-helpers.ts:390
+#: app/configurator/components/ui-helpers.ts:451
 msgid "controls.chart.type.column"
 msgstr "Colonne"
 
-#: app/configurator/components/ui-helpers.ts:398
+#: app/configurator/components/ui-helpers.ts:459
 msgid "controls.chart.type.line"
 msgstr "Linee"
 
-#: app/configurator/components/ui-helpers.ts:418
+#: app/configurator/components/ui-helpers.ts:479
 msgid "controls.chart.type.map"
 msgstr "Mappa"
 
-#: app/configurator/components/ui-helpers.ts:410
+#: app/configurator/components/ui-helpers.ts:471
 msgid "controls.chart.type.pie"
 msgstr "Torta"
 
-#: app/configurator/components/ui-helpers.ts:406
+#: app/configurator/components/ui-helpers.ts:467
 msgid "controls.chart.type.scatterplot"
 msgstr "Scatterplot"
 
-#: app/configurator/components/ui-helpers.ts:414
+#: app/configurator/components/ui-helpers.ts:475
 msgid "controls.chart.type.table"
 msgstr "Tabella"
 
-#: app/configurator/components/ui-helpers.ts:340
+#: app/configurator/components/ui-helpers.ts:385
 msgid "controls.color"
 msgstr "Colore"
 
@@ -248,33 +248,33 @@ msgstr "Ripristina la tavolozza dei colori"
 msgid "controls.colorpicker.open"
 msgstr "Apri il selettore di colore"
 
-#: app/configurator/components/ui-helpers.ts:350
+#: app/configurator/components/ui-helpers.ts:395
 msgid "controls.column.grouped"
 msgstr "raggruppate"
 
-#: app/configurator/components/ui-helpers.ts:346
+#: app/configurator/components/ui-helpers.ts:391
 msgid "controls.column.stacked"
 msgstr "impilate"
 
-#: app/configurator/components/ui-helpers.ts:342
+#: app/configurator/components/ui-helpers.ts:387
 msgid "controls.description"
 msgstr "Descrizione"
 
-#: app/configurator/components/field.tsx:517
+#: app/configurator/components/field.tsx:503
 msgid "controls.dimension.none"
 msgstr "Nessuno"
 
-#: app/charts/shared/chart-data-filters.tsx:124
-#: app/configurator/components/field.tsx:76
-#: app/configurator/components/field.tsx:146
+#: app/charts/shared/chart-data-filters.tsx:194
+#: app/configurator/components/field.tsx:77
+#: app/configurator/components/field.tsx:135
 msgid "controls.dimensionvalue.none"
 msgstr "Nessun filtro"
 
-#: app/configurator/components/filters.tsx:84
+#: app/configurator/components/filters.tsx:89
 msgid "controls.filter.select.all"
 msgstr "Seleziona tutti"
 
-#: app/configurator/components/filters.tsx:93
+#: app/configurator/components/filters.tsx:98
 msgid "controls.filter.select.none"
 msgstr "Deseleziona tutto"
 
@@ -290,43 +290,63 @@ msgstr "Seleziona un elemento di design o una dimensione dei dati per modificarn
 msgid "controls.hint.describing.chart"
 msgstr "Seleziona una delle annotazioni proposte per modificarla."
 
+#: app/configurator/components/ui-helpers.ts:435
+msgid "controls.imputation"
+msgstr ""
+
+#: app/configurator/components/chart-options-selector.tsx:474
+#: app/configurator/components/ui-helpers.ts:447
+msgid "controls.imputation.type.linear"
+msgstr ""
+
+#: app/configurator/components/chart-options-selector.tsx:467
+#: app/configurator/components/chart-options-selector.tsx:479
+#: app/configurator/components/ui-helpers.ts:439
+msgid "controls.imputation.type.none"
+msgstr ""
+
+#: app/configurator/components/chart-options-selector.tsx:469
+#: app/configurator/components/ui-helpers.ts:443
+msgid "controls.imputation.type.zeros"
+msgstr ""
+
 #: app/configurator/interactive-filters/interactive-filters-configurator.tsx:92
 msgid "controls.interactive.filters.dataFilter"
 msgstr "Filtri di dati"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:263
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:266
 msgid "controls.interactiveFilters.dataFilters.toggledataFilters"
 msgstr "Mostra i filtri di dati"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:63
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:64
 msgid "controls.interactiveFilters.legend.toggleInteractiveLegend"
 msgstr "Mostra la legenda filtrante"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:198
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:199
 msgid "controls.interactiveFilters.time.noTimeDimension"
 msgstr "Nessuna dimensione temporale disponibile!"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:172
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:173
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Mostra i filtri temporali"
 
-#: app/configurator/components/ui-helpers.ts:422
+#: app/configurator/components/ui-helpers.ts:483
 msgid "controls.language.english"
 msgstr "Inglese"
 
-#: app/configurator/components/ui-helpers.ts:430
+#: app/configurator/components/ui-helpers.ts:491
 msgid "controls.language.french"
 msgstr "Francese"
 
-#: app/configurator/components/ui-helpers.ts:426
+#: app/configurator/components/ui-helpers.ts:487
 msgid "controls.language.german"
 msgstr "Tedesco"
 
-#: app/configurator/components/ui-helpers.ts:434
+#: app/configurator/components/ui-helpers.ts:495
 msgid "controls.language.italian"
 msgstr "Italiano"
 
-#: app/configurator/components/ui-helpers.ts:332
+#: app/configurator/components/ui-helpers.ts:377
 msgid "controls.measure"
 msgstr "Misura"
 
@@ -350,7 +370,7 @@ msgstr "Opzioni del grafico"
 msgid "controls.section.columns"
 msgstr "Colonne"
 
-#: app/configurator/table/table-chart-options.tsx:266
+#: app/configurator/table/table-chart-options.tsx:234
 msgid "controls.section.columnstyle"
 msgstr "Stile della colonna"
 
@@ -362,12 +382,12 @@ msgstr "Filtri"
 msgid "controls.section.description"
 msgstr "Titolo e descrizione"
 
-#: app/configurator/components/chart-options-selector.tsx:219
-#: app/configurator/components/chart-options-selector.tsx:223
-#: app/configurator/table/table-chart-options.tsx:333
-#: app/configurator/table/table-chart-options.tsx:337
-#: app/configurator/table/table-chart-options.tsx:357
-#: app/configurator/table/table-chart-options.tsx:361
+#: app/configurator/components/chart-options-selector.tsx:259
+#: app/configurator/components/chart-options-selector.tsx:263
+#: app/configurator/table/table-chart-options.tsx:301
+#: app/configurator/table/table-chart-options.tsx:305
+#: app/configurator/table/table-chart-options.tsx:325
+#: app/configurator/table/table-chart-options.tsx:329
 msgid "controls.section.filter"
 msgstr "Filtro"
 
@@ -375,19 +395,27 @@ msgstr "Filtro"
 msgid "controls.section.groups"
 msgstr "Gruppi"
 
+#: app/configurator/components/chart-options-selector.tsx:508
+msgid "controls.section.imputation"
+msgstr ""
+
+#: app/configurator/components/chart-options-selector.tsx:513
+msgid "controls.section.imputation.explanation"
+msgstr ""
+
 #: app/configurator/interactive-filters/interactive-filters-configurator.tsx:63
 msgid "controls.section.interactive.filters"
 msgstr "Filtri interattivi"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:94
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:95
 msgid "controls.section.interactiveFilters.dataFilters"
 msgstr "Filtri di dati"
 
-#: app/configurator/components/chart-options-selector.tsx:355
+#: app/configurator/components/chart-options-selector.tsx:395
 msgid "controls.section.sorting"
 msgstr "Ordina"
 
-#: app/configurator/table/table-chart-options.tsx:501
+#: app/configurator/table/table-chart-options.tsx:469
 msgid "controls.section.tableSettings"
 msgstr "Impostazioni della tabella"
 
@@ -412,54 +440,54 @@ msgstr "Funzionalità in sperimentazione"
 msgid "controls.select.chart.type.experimental.description"
 msgstr "Guarda il prototipo della mappa con un numero limitato di dati (link ad una nuova pagina)."
 
-#: app/configurator/components/chart-options-selector.tsx:265
+#: app/configurator/components/chart-options-selector.tsx:305
 msgid "controls.select.column.layout"
 msgstr "Layout a colonne"
 
-#: app/configurator/table/table-chart-options.tsx:271
+#: app/configurator/table/table-chart-options.tsx:239
 msgid "controls.select.columnStyle"
 msgstr "Stile della colonna"
 
-#: app/configurator/table/table-chart-options.tsx:476
+#: app/configurator/table/table-chart-options.tsx:444
 msgid "controls.select.columnStyle.barColorBackground"
 msgstr "Colore dello sfondo"
 
-#: app/configurator/table/table-chart-options.tsx:468
+#: app/configurator/table/table-chart-options.tsx:436
 msgid "controls.select.columnStyle.barColorNegative"
 msgstr "Colore dei valori negativi"
 
-#: app/configurator/table/table-chart-options.tsx:460
+#: app/configurator/table/table-chart-options.tsx:428
 msgid "controls.select.columnStyle.barColorPositive"
 msgstr "Colore dei valori positivi"
 
-#: app/configurator/table/table-chart-options.tsx:484
+#: app/configurator/table/table-chart-options.tsx:452
 msgid "controls.select.columnStyle.barShowBackground"
 msgstr "Mostra il colore dello sfondo"
 
-#: app/configurator/table/table-chart-options.tsx:433
+#: app/configurator/table/table-chart-options.tsx:401
 msgid "controls.select.columnStyle.columnColor"
 msgstr "Colore della colonna"
 
-#: app/configurator/table/table-chart-options.tsx:425
+#: app/configurator/table/table-chart-options.tsx:393
 msgid "controls.select.columnStyle.textColor"
 msgstr "Colore del testo"
 
-#: app/configurator/table/table-chart-options.tsx:402
+#: app/configurator/table/table-chart-options.tsx:370
 msgid "controls.select.columnStyle.textStyle"
 msgstr "Stile del testo"
 
-#: app/configurator/components/chart-options-selector.tsx:135
-#: app/configurator/components/chart-options-selector.tsx:137
+#: app/configurator/components/chart-options-selector.tsx:169
+#: app/configurator/components/chart-options-selector.tsx:171
 msgid "controls.select.dimension"
 msgstr "Seleziona una dimensione"
 
-#: app/configurator/components/chart-options-selector.tsx:136
+#: app/configurator/components/chart-options-selector.tsx:170
 msgid "controls.select.measure"
 msgstr "Seleziona una misura"
 
-#: app/configurator/components/field.tsx:81
-#: app/configurator/components/field.tsx:151
-#: app/configurator/components/field.tsx:522
+#: app/configurator/components/field.tsx:82
+#: app/configurator/components/field.tsx:140
+#: app/configurator/components/field.tsx:508
 msgid "controls.select.optional"
 msgstr "facoltativo"
 
@@ -467,48 +495,48 @@ msgstr "facoltativo"
 msgid "controls.sorting.addDimension"
 msgstr "Aggiungi una dimensione"
 
-#: app/configurator/components/chart-options-selector.tsx:306
-#: app/configurator/components/chart-options-selector.tsx:312
+#: app/configurator/components/chart-options-selector.tsx:346
+#: app/configurator/components/chart-options-selector.tsx:352
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Nome"
 
-#: app/configurator/components/ui-helpers.ts:358
+#: app/configurator/components/ui-helpers.ts:403
 msgid "controls.sorting.byDimensionLabel.ascending"
 msgstr "A → Z"
 
-#: app/configurator/components/ui-helpers.ts:362
+#: app/configurator/components/ui-helpers.ts:407
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
-#: app/configurator/components/chart-options-selector.tsx:308
+#: app/configurator/components/chart-options-selector.tsx:348
 msgid "controls.sorting.byMeasure"
 msgstr "Misura"
 
-#: app/configurator/components/ui-helpers.ts:382
+#: app/configurator/components/ui-helpers.ts:427
 msgid "controls.sorting.byMeasure.ascending"
 msgstr "1 → 9"
 
-#: app/configurator/components/ui-helpers.ts:386
+#: app/configurator/components/ui-helpers.ts:431
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
-#: app/configurator/components/chart-options-selector.tsx:310
+#: app/configurator/components/chart-options-selector.tsx:350
 msgid "controls.sorting.byTotalSize"
 msgstr "Grandezza totale"
 
-#: app/configurator/components/ui-helpers.ts:366
+#: app/configurator/components/ui-helpers.ts:411
 msgid "controls.sorting.byTotalSize.ascending"
 msgstr "Il più grande per ultimo"
 
-#: app/configurator/components/ui-helpers.ts:378
+#: app/configurator/components/ui-helpers.ts:423
 msgid "controls.sorting.byTotalSize.largestBottom"
 msgstr "Il più grande sotto"
 
-#: app/configurator/components/ui-helpers.ts:370
+#: app/configurator/components/ui-helpers.ts:415
 msgid "controls.sorting.byTotalSize.largestFirst"
 msgstr "Il più grande per primo"
 
-#: app/configurator/components/ui-helpers.ts:374
+#: app/configurator/components/ui-helpers.ts:419
 msgid "controls.sorting.byTotalSize.largestTop"
 msgstr "Il più grande sopra"
 
@@ -520,22 +548,22 @@ msgstr "Rimuovi l'ordinamento"
 msgid "controls.sorting.selectDimension"
 msgstr "Seleziona una dimensione ..."
 
-#: app/configurator/components/ui-helpers.ts:354
+#: app/configurator/components/ui-helpers.ts:399
 #: app/configurator/table/table-chart-sorting-options.tsx:305
 msgid "controls.sorting.sortBy"
 msgstr "Ordina per"
 
-#: app/configurator/table/table-chart-options.tsx:227
+#: app/configurator/table/table-chart-options.tsx:211
 msgid "controls.table.column.group"
 msgstr "Raggruppa secondo questa colonna"
 
-#: app/configurator/table/table-chart-options.tsx:252
+#: app/configurator/table/table-chart-options.tsx:221
 msgid "controls.table.column.hide"
 msgstr "Nascondi la colonna"
 
 #: app/configurator/table/table-chart-options.tsx:238
-msgid "controls.table.column.hidefilter"
-msgstr "Nascondi e filtra questa colonna"
+#~ msgid "controls.table.column.hidefilter"
+#~ msgstr "Nascondi e filtra questa colonna"
 
 #: app/configurator/table/table-chart-configurator.tsx:101
 msgid "controls.table.settings"
@@ -545,11 +573,11 @@ msgstr "Opzioni"
 msgid "controls.table.sorting"
 msgstr "Ordinamento"
 
-#: app/configurator/table/table-chart-options.tsx:505
+#: app/configurator/table/table-chart-options.tsx:473
 msgid "controls.tableSettings.showSearch"
 msgstr "Mostra il campo di ricerca"
 
-#: app/configurator/components/ui-helpers.ts:341
+#: app/configurator/components/ui-helpers.ts:386
 msgid "controls.title"
 msgstr "Titolo"
 
@@ -597,13 +625,13 @@ msgstr "Il più rilevante"
 msgid "dataset.order.title"
 msgstr "Titolo"
 
-#: app/components/chart-preview.tsx:53
-#: app/components/chart-published.tsx:58
-#: app/configurator/components/dataset-preview.tsx:35
+#: app/components/chart-preview.tsx:56
+#: app/components/chart-published.tsx:59
+#: app/configurator/components/dataset-preview.tsx:36
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Attenzione, questo set di dati è una bozza.<0/><1>Non utilizzare questo grafico per un rapporto!</1>"
 
-#: app/components/chart-published.tsx:69
+#: app/components/chart-published.tsx:70
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Attenzione, questo set di dati è scaduto.<0/><1>Non utilizzare questo grafico per un rapporto!</1>"
 
@@ -625,15 +653,15 @@ msgstr "Ordina per"
 msgid "dataset.tag.draft"
 msgstr "Bozza"
 
-#: app/configurator/components/dataset-preview.tsx:85
+#: app/configurator/components/dataset-preview.tsx:86
 msgid "datatable.showing.first.rows"
 msgstr "Sono mostrate soltanto le prime 10 righe"
 
-#: app/components/footer.tsx:38
+#: app/components/footer.tsx:66
 msgid "footer.institution.name"
 msgstr "Ufficio federale dell'ambiente UFAM"
 
-#: app/components/footer.tsx:33
+#: app/components/footer.tsx:61
 msgid "footer.institution.url"
 msgstr "https://www.bafu.admin.ch/bafu/it/home.html"
 
@@ -697,11 +725,11 @@ msgstr "Seleziona un dataset"
 msgid "hint.select.dataset.to.preview"
 msgstr "Seleziona un dataset per vedere l'anteprima della sua struttura e del suo contenuto."
 
-#: app/charts/shared/chart-data-filters.tsx:63
+#: app/charts/shared/chart-data-filters.tsx:67
 msgid "interactive.data.filters.hide"
 msgstr "Nascondi i filtri"
 
-#: app/charts/shared/chart-data-filters.tsx:61
+#: app/charts/shared/chart-data-filters.tsx:65
 msgid "interactive.data.filters.show"
 msgstr "Mostra i filtri"
 

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -292,23 +292,23 @@ msgstr "Seleziona una delle annotazioni proposte per modificarla."
 
 #: app/configurator/components/ui-helpers.ts:435
 msgid "controls.imputation"
-msgstr ""
+msgstr "Tipo di imputazione"
 
 #: app/configurator/components/chart-options-selector.tsx:477
 #: app/configurator/components/ui-helpers.ts:447
 msgid "controls.imputation.type.linear"
-msgstr ""
+msgstr "Interpolazione lineare"
 
 #: app/configurator/components/chart-options-selector.tsx:470
 #: app/configurator/components/chart-options-selector.tsx:482
 #: app/configurator/components/ui-helpers.ts:439
 msgid "controls.imputation.type.none"
-msgstr ""
+msgstr "-"
 
 #: app/configurator/components/chart-options-selector.tsx:472
 #: app/configurator/components/ui-helpers.ts:443
 msgid "controls.imputation.type.zeros"
-msgstr ""
+msgstr "Zeri"
 
 #: app/configurator/interactive-filters/interactive-filters-configurator.tsx:92
 msgid "controls.interactive.filters.dataFilter"
@@ -397,11 +397,11 @@ msgstr "Gruppi"
 
 #: app/configurator/components/chart-options-selector.tsx:511
 msgid "controls.section.imputation"
-msgstr ""
+msgstr "Valori mancanti"
 
 #: app/configurator/components/chart-options-selector.tsx:516
 msgid "controls.section.imputation.explanation"
-msgstr ""
+msgstr "A causa della natura del tipo di grafico selezionato, sono stati introdotti alcuni valori mancanti. Decidere la logica di imputazione o passare a un altro tipo di grafico."
 
 #: app/configurator/interactive-filters/interactive-filters-configurator.tsx:63
 msgid "controls.section.interactive.filters"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -294,18 +294,18 @@ msgstr "Seleziona una delle annotazioni proposte per modificarla."
 msgid "controls.imputation"
 msgstr ""
 
-#: app/configurator/components/chart-options-selector.tsx:474
+#: app/configurator/components/chart-options-selector.tsx:477
 #: app/configurator/components/ui-helpers.ts:447
 msgid "controls.imputation.type.linear"
 msgstr ""
 
-#: app/configurator/components/chart-options-selector.tsx:467
-#: app/configurator/components/chart-options-selector.tsx:479
+#: app/configurator/components/chart-options-selector.tsx:470
+#: app/configurator/components/chart-options-selector.tsx:482
 #: app/configurator/components/ui-helpers.ts:439
 msgid "controls.imputation.type.none"
 msgstr ""
 
-#: app/configurator/components/chart-options-selector.tsx:469
+#: app/configurator/components/chart-options-selector.tsx:472
 #: app/configurator/components/ui-helpers.ts:443
 msgid "controls.imputation.type.zeros"
 msgstr ""
@@ -382,8 +382,8 @@ msgstr "Filtri"
 msgid "controls.section.description"
 msgstr "Titolo e descrizione"
 
-#: app/configurator/components/chart-options-selector.tsx:259
-#: app/configurator/components/chart-options-selector.tsx:263
+#: app/configurator/components/chart-options-selector.tsx:262
+#: app/configurator/components/chart-options-selector.tsx:266
 #: app/configurator/table/table-chart-options.tsx:301
 #: app/configurator/table/table-chart-options.tsx:305
 #: app/configurator/table/table-chart-options.tsx:325
@@ -395,11 +395,11 @@ msgstr "Filtro"
 msgid "controls.section.groups"
 msgstr "Gruppi"
 
-#: app/configurator/components/chart-options-selector.tsx:508
+#: app/configurator/components/chart-options-selector.tsx:511
 msgid "controls.section.imputation"
 msgstr ""
 
-#: app/configurator/components/chart-options-selector.tsx:513
+#: app/configurator/components/chart-options-selector.tsx:516
 msgid "controls.section.imputation.explanation"
 msgstr ""
 
@@ -411,7 +411,7 @@ msgstr "Filtri interattivi"
 msgid "controls.section.interactiveFilters.dataFilters"
 msgstr "Filtri di dati"
 
-#: app/configurator/components/chart-options-selector.tsx:395
+#: app/configurator/components/chart-options-selector.tsx:398
 msgid "controls.section.sorting"
 msgstr "Ordina"
 
@@ -440,7 +440,7 @@ msgstr "Funzionalità in sperimentazione"
 msgid "controls.select.chart.type.experimental.description"
 msgstr "Guarda il prototipo della mappa con un numero limitato di dati (link ad una nuova pagina)."
 
-#: app/configurator/components/chart-options-selector.tsx:305
+#: app/configurator/components/chart-options-selector.tsx:308
 msgid "controls.select.column.layout"
 msgstr "Layout a colonne"
 
@@ -476,12 +476,12 @@ msgstr "Colore del testo"
 msgid "controls.select.columnStyle.textStyle"
 msgstr "Stile del testo"
 
-#: app/configurator/components/chart-options-selector.tsx:169
 #: app/configurator/components/chart-options-selector.tsx:171
+#: app/configurator/components/chart-options-selector.tsx:173
 msgid "controls.select.dimension"
 msgstr "Seleziona una dimensione"
 
-#: app/configurator/components/chart-options-selector.tsx:170
+#: app/configurator/components/chart-options-selector.tsx:172
 msgid "controls.select.measure"
 msgstr "Seleziona una misura"
 
@@ -495,8 +495,8 @@ msgstr "facoltativo"
 msgid "controls.sorting.addDimension"
 msgstr "Aggiungi una dimensione"
 
-#: app/configurator/components/chart-options-selector.tsx:346
-#: app/configurator/components/chart-options-selector.tsx:352
+#: app/configurator/components/chart-options-selector.tsx:349
+#: app/configurator/components/chart-options-selector.tsx:355
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Nome"
 
@@ -508,7 +508,7 @@ msgstr "A → Z"
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
-#: app/configurator/components/chart-options-selector.tsx:348
+#: app/configurator/components/chart-options-selector.tsx:351
 msgid "controls.sorting.byMeasure"
 msgstr "Misura"
 
@@ -520,7 +520,7 @@ msgstr "1 → 9"
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
-#: app/configurator/components/chart-options-selector.tsx:350
+#: app/configurator/components/chart-options-selector.tsx:353
 msgid "controls.sorting.byTotalSize"
 msgstr "Grandezza totale"
 
@@ -581,6 +581,10 @@ msgstr "Mostra il campo di ricerca"
 msgid "controls.title"
 msgstr "Titolo"
 
+#: app/components/chart-published.tsx:80
+msgid "dataset.hasImputedValues"
+msgstr "In questo set di dati mancano alcuni dati. Questi sono stati interpolati per colmare le lacune.."
+
 #: app/configurator/components/dataset-selector.tsx:103
 msgid "dataset.includeDrafts"
 msgstr "Includi la bozza del set di dati"
@@ -626,12 +630,12 @@ msgid "dataset.order.title"
 msgstr "Titolo"
 
 #: app/components/chart-preview.tsx:56
-#: app/components/chart-published.tsx:59
+#: app/components/chart-published.tsx:58
 #: app/configurator/components/dataset-preview.tsx:36
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Attenzione, questo set di dati è una bozza.<0/><1>Non utilizzare questo grafico per un rapporto!</1>"
 
-#: app/components/chart-published.tsx:70
+#: app/components/chart-published.tsx:69
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Attenzione, questo set di dati è scaduto.<0/><1>Non utilizzare questo grafico per un rapporto!</1>"
 


### PR DESCRIPTION
This PR is based on the conversation in #148 and it:
- introduces a concept of imputation of missing data (currently only applicable to stacked area charts with different time ranges for individual series),
- allows imputations with zeros or linearly interpolated values (in this case, if a series has a missing value at the beginning or at the end, then it will still be filled using 0),
- adds a proper section (called "Missing values") in the chart configurator (right panel) when using an area chart,
- the above section is disabled when no missing values are detected and is activated otherwise (I found it distracting when the whole section was disappearing and re-appearing but let me know what do you think about this).

Still TODO if you think the approach is ok:
- [x] add translations (only for published charts as of now)
- [x] add some info on the published chart to let people know about the fact that missing values were filled (?)
- [x] add tests

I will also add some comments to the code itself, as I'm not sure if I placed the some things in correct places :)

Thanks!