### PR TITLE
Remove experimental map from chart type selector

### DIFF
--- a/app/configurator/components/chart-type-selector.tsx
+++ b/app/configurator/components/chart-type-selector.tsx
@@ -159,88 +159,9 @@ export const ChartTypeSelector = ({
             ))}
           </Grid>
         )}
-        {/* Experimental features */}
-        <Box sx={{ mt: 4, color: "warning" }}>
-          <SectionTitle color={theme.colors.warning}>
-            <Trans id="controls.select.chart.type.experimental">
-              Experimental Features
-            </Trans>
-          </SectionTitle>
-          <Box sx={{ mx: 4, fontSize: 3 }}>
-            <Trans id="controls.select.chart.type.experimental.description">
-              Preview the upcoming map feature with a limited subset of datasets
-              (link to a new page).
-            </Trans>
-          </Box>
-        </Box>
-        <Grid
-          sx={{
-            gridTemplateColumns: ["1fr 1fr", "1fr 1fr", "1fr 1fr 1fr"],
-            mx: 4,
-          }}
-        >
-          <TemporaryLinkToMapPrototype label={"map"} value={"map"} />
-        </Grid>
       </Box>
     );
   } else {
     return <Loading />;
   }
-};
-
-const TemporaryLinkToMapPrototype = ({
-  value,
-  label,
-}: {
-  value: string;
-  label: string;
-}) => {
-  return (
-    <Link href="/experimental/map">
-      <a style={{ textDecoration: "none" }}>
-        <Button
-          variant="reset"
-          tabIndex={0}
-          value={value}
-          sx={{
-            width: "86px",
-            height: "86px",
-            mt: 4,
-            borderRadius: "default",
-
-            backgroundColor: "monochrome100",
-            color: "warning",
-
-            display: "flex",
-            flexDirection: "column",
-            justifyContent: "center",
-            alignItems: "center",
-
-            cursor: "pointer",
-            pointerEvents: "initial",
-
-            // border: "1px solid",
-            // borderColor: "warningLight",
-
-            transition: "all .2s",
-
-            ":hover": {
-              backgroundColor: "warningLight",
-            },
-          }}
-        >
-          <Icon size={48} name={getIconName(label)} />
-          <Text
-            variant="paragraph2"
-            sx={{
-              color: "warning",
-              fontSize: [2, 2, 2],
-            }}
-          >
-            {getFieldLabel(label)}
-          </Text>
-        </Button>
-      </a>
-    </Link>
-  );
 };

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -453,12 +453,12 @@ msgid "controls.select.chart.type"
 msgstr "Diagrammtyp"
 
 #: app/configurator/components/chart-type-selector.tsx:165
-msgid "controls.select.chart.type.experimental"
-msgstr "Experimentelle Features"
+#~ msgid "controls.select.chart.type.experimental"
+#~ msgstr "Experimentelle Features"
 
 #: app/configurator/components/chart-type-selector.tsx:170
-msgid "controls.select.chart.type.experimental.description"
-msgstr "Vorschau von zukünftigen Features mit limitierten Daten auf einer separaten Seite."
+#~ msgid "controls.select.chart.type.experimental.description"
+#~ msgstr "Vorschau von zukünftigen Features mit limitierten Daten auf einer separaten Seite."
 
 #: app/configurator/components/chart-options-selector.tsx:308
 msgid "controls.select.column.layout"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -453,12 +453,12 @@ msgid "controls.select.chart.type"
 msgstr "Chart Type"
 
 #: app/configurator/components/chart-type-selector.tsx:165
-msgid "controls.select.chart.type.experimental"
-msgstr "Experimental Features"
+#~ msgid "controls.select.chart.type.experimental"
+#~ msgstr "Experimental Features"
 
 #: app/configurator/components/chart-type-selector.tsx:170
-msgid "controls.select.chart.type.experimental.description"
-msgstr "Preview upcoming features with a limited subset of data on a separate page."
+#~ msgid "controls.select.chart.type.experimental.description"
+#~ msgstr "Preview upcoming features with a limited subset of data on a separate page."
 
 #: app/configurator/components/chart-options-selector.tsx:308
 msgid "controls.select.column.layout"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -453,12 +453,12 @@ msgid "controls.select.chart.type"
 msgstr "Type de graphique"
 
 #: app/configurator/components/chart-type-selector.tsx:165
-msgid "controls.select.chart.type.experimental"
-msgstr "Fonctionnalités expérimentales"
+#~ msgid "controls.select.chart.type.experimental"
+#~ msgstr "Fonctionnalités expérimentales"
 
 #: app/configurator/components/chart-type-selector.tsx:170
-msgid "controls.select.chart.type.experimental.description"
-msgstr "Voir le prototype de la carte avec un nombre limité de jeu de données (lien vers une nouvelle page)."
+#~ msgid "controls.select.chart.type.experimental.description"
+#~ msgstr "Voir le prototype de la carte avec un nombre limité de jeu de données (lien vers une nouvelle page)."
 
 #: app/configurator/components/chart-options-selector.tsx:308
 msgid "controls.select.column.layout"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -453,12 +453,12 @@ msgid "controls.select.chart.type"
 msgstr "Tipo di grafico"
 
 #: app/configurator/components/chart-type-selector.tsx:165
-msgid "controls.select.chart.type.experimental"
-msgstr "Funzionalità in sperimentazione"
+#~ msgid "controls.select.chart.type.experimental"
+#~ msgstr "Funzionalità in sperimentazione"
 
 #: app/configurator/components/chart-type-selector.tsx:170
-msgid "controls.select.chart.type.experimental.description"
-msgstr "Guarda il prototipo della mappa con un numero limitato di dati (link ad una nuova pagina)."
+#~ msgid "controls.select.chart.type.experimental.description"
+#~ msgstr "Guarda il prototipo della mappa con un numero limitato di dati (link ad una nuova pagina)."
 
 #: app/configurator/components/chart-options-selector.tsx:308
 msgid "controls.select.column.layout"


### PR DESCRIPTION
Removes the experimental section from the chart type selector.

The feature itself is still available at /experimental/map