### PR TITLE
Sort the wideData in order to make time brush run correctly

### DIFF
--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -121,7 +121,7 @@ const useAreasState = ({
     [data, getX]
   );
 
-  const sortedDataGroupedByX = useMemo(
+  const dataGroupedByX = useMemo(
     () => group(data, getGroups),
     [data, getGroups]
   );
@@ -129,12 +129,12 @@ const useAreasState = ({
   const allDataWide = useMemo(
     () =>
       getWideData({
-        dataGroupedByX: sortedDataGroupedByX,
+        dataGroupedByX,
         xKey,
         getY,
         getSegment,
       }),
-    [sortedDataGroupedByX, xKey, getY, getSegment]
+    [dataGroupedByX, xKey, getY, getSegment]
   );
 
   // Data for chart

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -102,13 +102,13 @@ const useLinesState = ({
     [data, getX]
   );
 
-  const sortedDataGroupedByX = useMemo(
+  const dataGroupedByX = useMemo(
     () => group(sortedData, getGroups),
     [sortedData, getGroups]
   );
 
   const allDataWide = getWideData({
-    dataGroupedByX: sortedDataGroupedByX,
+    dataGroupedByX,
     xKey,
     getY,
     getSegment,

--- a/app/charts/shared/chart-helpers.spec.tsx
+++ b/app/charts/shared/chart-helpers.spec.tsx
@@ -1,9 +1,11 @@
-import { prepareQueryFilters } from "./chart-helpers";
-import line1Fixture from "../../test/__fixtures/prod/line-1.json";
-import { LineConfig } from "../../configurator";
-import { InteractiveFiltersState } from "./use-interactive-filters";
+import { InternMap } from "d3-array";
 import { merge } from "lodash";
+import { LineConfig } from "../../configurator";
 import { FIELD_VALUE_NONE } from "../../configurator/constants";
+import { Observation } from "../../domain/data";
+import line1Fixture from "../../test/__fixtures/prod/line-1.json";
+import { getWideData, prepareQueryFilters } from "./chart-helpers";
+import { InteractiveFiltersState } from "./use-interactive-filters";
 
 const makeCubeNsGetters = (cubeIri: string) => ({
   col: (col: string) => `${cubeIri}/dimension/${col}`,
@@ -102,5 +104,27 @@ describe("useQueryFilters", () => {
       })
     );
     expect(queryFilters[col("3")]).toBeUndefined();
+  });
+});
+
+describe("getWideData", () => {
+  const exampleMap: InternMap<string, Observation[]> = new Map();
+  exampleMap.set("2021-01-02", [{ segment: "abc", value: 1 }]);
+  exampleMap.set("2015-03-03", [{ segment: "abc", value: 10 }]);
+  exampleMap.set("2028-12-12", [{ segment: "abc", value: 12 }]);
+
+  it("should return sorted data", () => {
+    const wideData = getWideData({
+      dataGroupedByX: exampleMap,
+      xKey: "date",
+      getY: (d: Observation) => Number(d["value"]),
+      getSegment: (d: Observation) => String(d["segment"]),
+    });
+
+    expect(wideData.map((d) => d["date"])).toEqual([
+      "2015-03-03",
+      "2021-01-02",
+      "2028-12-12",
+    ]);
   });
 });

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -155,7 +155,10 @@ export const useOptionalNumericVariable = (
 export const useStringVariable = (
   key: string
 ): ((d: Observation) => string) => {
-  const getVariable = useCallback((d: Observation) => `${d[key]}`, [key]);
+  const getVariable = useCallback(
+    (d: Observation) => (d[key] !== null ? `${d[key]}` : ""),
+    [key]
+  );
 
   return getVariable;
 };
@@ -293,10 +296,10 @@ const getBaseWideData = ({
   ) => Array<{ [key: string]: number }>;
 }): Array<Observation> => {
   const wideData = [];
-  const dataGroupedByXEntries = [...dataGroupedByX.entries()];
+  const sortedDataGroupedByXEntries = [...dataGroupedByX.entries()].sort();
 
   for (let i = 0; i < dataGroupedByX.size; i++) {
-    const [date, values] = dataGroupedByXEntries[i];
+    const [date, values] = sortedDataGroupedByXEntries[i];
 
     const observation: Observation = Object.assign(
       {


### PR DESCRIPTION
The time brush displayed below the charts needs sorted data in order to run correctly – this PR fixes that by sorting the wideData.

Closes #220.