### PR TITLE
Hierarchical filters step 1

### DIFF
--- a/app/configurator/components/chart-controls/color-picker.tsx
+++ b/app/configurator/components/chart-controls/color-picker.tsx
@@ -134,11 +134,11 @@ export const ColorPickerMenu = (props: Props) => {
         sx={{
           "> button": {
             bg: "monochrome100",
-            borderRadius: "default",
+            borderRadius: 4,
+            overflow: "hidden",
             borderWidth: 1,
-            borderStyle: "solid",
-            borderColor: "monochrome500",
-            p: 1,
+            border: 0,
+            p: 0,
           },
           "> button:hover": {
             borderColor,
@@ -157,8 +157,8 @@ export const ColorPickerMenu = (props: Props) => {
             <Box
               sx={{
                 bg: props.selectedColor,
-                width: ["1rem", "1.5rem", "2rem"],
-                height: ["0.75rem", "1.125rem", "1.5rem"],
+                width: "1rem",
+                height: "1rem",
               }}
             ></Box>
           </Box>

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -20,6 +20,7 @@ import { IconName } from "../../icons";
 import {
   useChartOptionBooleanField,
   useChartOptionSelectField,
+  useMultiFilterCheckboxes,
   useSingleFilterSelect,
 } from "../config-form";
 import { FIELD_VALUE_NONE } from "../constants";
@@ -386,7 +387,7 @@ export const MultiFilterFieldCheckbox = ({
   disabled,
   allValues,
   checked,
-  onChange,
+  onChange: onChangeProp,
   checkAction,
   colorConfigPath,
 }: {
@@ -400,36 +401,13 @@ export const MultiFilterFieldCheckbox = ({
   checkAction: "ADD" | "SET";
   colorConfigPath?: string;
 }) => {
-  const [state, dispatch] = useConfiguratorState();
-
-  const onFieldChange = useCallback<(e: ChangeEvent<HTMLInputElement>) => void>(
-    (e) => {
-      if (e.currentTarget.checked) {
-        dispatch({
-          type:
-            checkAction === "ADD"
-              ? "CHART_CONFIG_FILTER_ADD_MULTI"
-              : "CHART_CONFIG_FILTER_SET_MULTI",
-          value: {
-            dimensionIri,
-            value,
-            allValues,
-          },
-        });
-      } else {
-        dispatch({
-          type: "CHART_CONFIG_FILTER_REMOVE_MULTI",
-          value: {
-            dimensionIri,
-            value,
-            allValues,
-          },
-        });
-      }
-      // Call onChange prop
-      onChange?.();
-    },
-    [dispatch, dimensionIri, allValues, value, onChange, checkAction]
+  const [state] = useConfiguratorState();
+  const { onChange: onFieldChange } = useMultiFilterCheckboxes(
+    dimensionIri,
+    value,
+    allValues,
+    checkAction,
+    onChangeProp
   );
 
   if (state.state !== "CONFIGURING_CHART") {
@@ -453,6 +431,7 @@ export const MultiFilterFieldCheckbox = ({
     />
   );
 };
+
 export const SingleFilterField = ({
   dimensionIri,
   label,

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -21,7 +21,6 @@ import {
   useChartOptionBooleanField,
   useChartOptionSelectField,
   useMultiFilterCheckboxes,
-  useMultiFilterContext,
   useSingleFilterSelect,
 } from "../config-form";
 import { FIELD_VALUE_NONE } from "../constants";
@@ -302,7 +301,6 @@ const useMultiFilterColorPicker = (
   colorConfigPath?: string
 ) => {
   const [configuratorState, dispatch] = useConfiguratorState();
-  const { isFilterActive, selectionState } = useMultiFilterContext();
   const { activeField } = configuratorState;
   const onChange = useCallback(
     (color: string) => {
@@ -361,22 +359,9 @@ const useMultiFilterColorPicker = (
       color,
       palette,
       onChange,
-      checked:
-        selectionState === "ALL_SELECTED"
-          ? true
-          : selectionState === "SOME_SELECTED"
-          ? !!isFilterActive.has(value)
-          : undefined && checkedState,
+      checked: checkedState,
     }),
-    [
-      color,
-      palette,
-      onChange,
-      selectionState,
-      isFilterActive,
-      value,
-      checkedState,
-    ]
+    [color, palette, onChange, checkedState]
   );
 };
 

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -368,7 +368,15 @@ const useMultiFilterColorPicker = (
           ? !!isFilterActive.has(value)
           : undefined && checkedState,
     }),
-    [color, palette, onChange, checkedState, isFilterActive, value]
+    [
+      color,
+      palette,
+      onChange,
+      selectionState,
+      isFilterActive,
+      value,
+      checkedState,
+    ]
   );
 };
 

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -293,6 +293,17 @@ export const MetaInputField = ({
   return <Input label={label} {...field} disabled={disabled} />;
 };
 
+const isMultiFilterFieldChecked = (
+  chartConfig: ChartConfig,
+  dimensionIri: string,
+  value: string
+) => {
+  const filter = chartConfig.filters[dimensionIri];
+  const fieldChecked =
+    filter?.type === "multi" ? filter.values?.[value] ?? false : false;
+  return fieldChecked;
+};
+
 export const MultiFilterFieldColorPicker = ({
   colorConfigPath,
   value,
@@ -329,9 +340,11 @@ export const MultiFilterFieldColorPicker = ({
     return null;
   }
 
-  const filter = state.chartConfig.filters[dimensionIri];
-  const fieldChecked =
-    filter?.type === "multi" ? filter.values?.[value] ?? false : false;
+  const fieldChecked = isMultiFilterFieldChecked(
+    state.chartConfig,
+    dimensionIri,
+    value
+  );
 
   return color && (checked ?? fieldChecked) ? (
     <ColorPickerMenu
@@ -408,9 +421,11 @@ export const MultiFilterField = ({
     return null;
   }
 
-  const filter = state.chartConfig.filters[dimensionIri];
-  const fieldChecked =
-    filter?.type === "multi" ? filter.values?.[value] ?? false : false;
+  const fieldChecked = isMultiFilterFieldChecked(
+    state.chartConfig,
+    dimensionIri,
+    value
+  );
 
   return (
     <Flex

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -4,7 +4,6 @@ import get from "lodash/get";
 import { ChangeEvent, ReactNode, useCallback, useMemo, useState } from "react";
 import { Flex } from "theme-ui";
 import {
-  ChartConfig,
   Option,
   useActiveFieldField,
   useChartFieldField,
@@ -18,9 +17,11 @@ import { DimensionMetaDataFragment, TimeUnit } from "../../graphql/query-hooks";
 import { DataCubeMetadata } from "../../graphql/types";
 import { IconName } from "../../icons";
 import {
+  isMultiFilterFieldChecked,
   useChartOptionBooleanField,
   useChartOptionSelectField,
   useMultiFilterCheckboxes,
+  useMultiFilterContext,
   useSingleFilterSelect,
 } from "../config-form";
 import { FIELD_VALUE_NONE } from "../constants";
@@ -295,31 +296,15 @@ export const MetaInputField = ({
   return <Input label={label} {...field} disabled={disabled} />;
 };
 
-const isMultiFilterFieldChecked = (
-  chartConfig: ChartConfig,
+const useMultiFilterColorPicker = (
+  value: string,
   dimensionIri: string,
-  value: string
+  colorConfigPath?: string
 ) => {
-  const filter = chartConfig.filters[dimensionIri];
-  const fieldChecked =
-    filter?.type === "multi" ? filter.values?.[value] ?? false : false;
-  return fieldChecked;
-};
-
-export const MultiFilterFieldColorPicker = ({
-  colorConfigPath,
-  value,
-  dimensionIri,
-  checked,
-}: {
-  colorConfigPath?: string;
-  value: string;
-  dimensionIri: string;
-  checked?: boolean;
-}) => {
   const [configuratorState, dispatch] = useConfiguratorState();
+  const { isFilterActive, selectionState } = useMultiFilterContext();
   const { activeField } = configuratorState;
-  const updateColor = useCallback(
+  const onChange = useCallback(
     (color: string) => {
       if (activeField) {
         dispatch({
@@ -362,7 +347,7 @@ export const MultiFilterFieldColorPicker = ({
     );
   }, [chartConfig, colorConfigPath, activeField]);
 
-  const fieldChecked =
+  const checkedState =
     configuratorState.state === "CONFIGURING_CHART"
       ? isMultiFilterFieldChecked(
           configuratorState.chartConfig,
@@ -371,11 +356,43 @@ export const MultiFilterFieldColorPicker = ({
         )
       : null;
 
-  return color && (checked ?? fieldChecked) ? (
+  return useMemo(
+    () => ({
+      color,
+      palette,
+      onChange,
+      checked:
+        selectionState === "ALL_SELECTED"
+          ? true
+          : selectionState === "SOME_SELECTED"
+          ? !!isFilterActive.has(value)
+          : undefined && checkedState,
+    }),
+    [color, palette, onChange, checkedState, isFilterActive, value]
+  );
+};
+
+export const MultiFilterFieldColorPicker = ({
+  colorConfigPath,
+  value,
+  dimensionIri,
+}: {
+  colorConfigPath?: string;
+  value: string;
+  dimensionIri: string;
+  checked?: boolean;
+}) => {
+  const { color, checked, palette, onChange } = useMultiFilterColorPicker(
+    value,
+    dimensionIri,
+    colorConfigPath
+  );
+
+  return color && checked ? (
     <ColorPickerMenu
       colors={palette}
       selectedColor={color}
-      onChange={updateColor}
+      onChange={onChange}
     />
   ) : null;
 };
@@ -385,40 +402,24 @@ export const MultiFilterFieldCheckbox = ({
   label,
   value,
   disabled,
-  allValues,
-  checked,
   onChange: onChangeProp,
-  checkAction,
-  colorConfigPath,
 }: {
   dimensionIri: string;
   label: string;
   value: string;
-  allValues: string[];
   disabled?: boolean;
-  checked?: boolean;
   onChange?: () => void;
-  checkAction: "ADD" | "SET";
-  colorConfigPath?: string;
 }) => {
   const [state] = useConfiguratorState();
-  const { onChange: onFieldChange } = useMultiFilterCheckboxes(
+  const { onChange: onFieldChange, checked } = useMultiFilterCheckboxes(
     dimensionIri,
     value,
-    allValues,
-    checkAction,
     onChangeProp
   );
 
   if (state.state !== "CONFIGURING_CHART") {
     return null;
   }
-
-  const fieldChecked = isMultiFilterFieldChecked(
-    state.chartConfig,
-    dimensionIri,
-    value
-  );
 
   return (
     <Checkbox
@@ -427,7 +428,7 @@ export const MultiFilterFieldCheckbox = ({
       label={label}
       disabled={disabled}
       onChange={onFieldChange}
-      checked={checked ?? fieldChecked}
+      checked={checked}
     />
   );
 };

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -2,8 +2,9 @@ import { t } from "@lingui/macro";
 import { TimeLocaleObject } from "d3";
 import get from "lodash/get";
 import { ChangeEvent, ReactNode, useCallback, useMemo, useState } from "react";
-import { Box, Flex } from "theme-ui";
+import { Flex } from "theme-ui";
 import {
+  ChartConfig,
   Option,
   useActiveFieldField,
   useChartFieldField,
@@ -307,24 +308,23 @@ const isMultiFilterFieldChecked = (
 export const MultiFilterFieldColorPicker = ({
   colorConfigPath,
   value,
-  color,
   dimensionIri,
   checked,
 }: {
   colorConfigPath?: string;
   value: string;
-  color?: string;
   dimensionIri: string;
   checked?: boolean;
 }) => {
-  const [state, dispatch] = useConfiguratorState();
+  const [configuratorState, dispatch] = useConfiguratorState();
+  const { activeField } = configuratorState;
   const updateColor = useCallback(
     (color: string) => {
-      if (state.activeField) {
+      if (activeField) {
         dispatch({
           type: "CHART_COLOR_CHANGED",
           value: {
-            field: state.activeField,
+            field: activeField,
             colorConfigPath,
             color,
             value,
@@ -333,36 +333,53 @@ export const MultiFilterFieldColorPicker = ({
       }
     },
 
-    [colorConfigPath, dispatch, state.activeField, value]
+    [colorConfigPath, dispatch, activeField, value]
   );
 
-  if (state.state !== "CONFIGURING_CHART") {
-    return null;
-  }
+  const path = colorConfigPath ? `${colorConfigPath}.` : "";
+  const chartConfig =
+    configuratorState.state === "CONFIGURING_CHART"
+      ? configuratorState.chartConfig
+      : null;
 
-  const fieldChecked = isMultiFilterFieldChecked(
-    state.chartConfig,
-    dimensionIri,
-    value
-  );
+  const color = chartConfig
+    ? get(
+        chartConfig,
+        `fields["${activeField}"].${path}colorMapping["${value}"]`
+      )
+    : null;
+
+  const palette = useMemo(() => {
+    if (!chartConfig) {
+      return [];
+    }
+    return getPalette(
+      get(
+        chartConfig,
+        `fields["${activeField}"].${colorConfigPath ?? ""}.palette`
+      )
+    );
+  }, [chartConfig, colorConfigPath, activeField]);
+
+  const fieldChecked =
+    configuratorState.state === "CONFIGURING_CHART"
+      ? isMultiFilterFieldChecked(
+          configuratorState.chartConfig,
+          dimensionIri,
+          value
+        )
+      : null;
 
   return color && (checked ?? fieldChecked) ? (
     <ColorPickerMenu
-      colors={getPalette(
-        get(
-          state,
-          `chartConfig.fields["${state.activeField}"].${
-            colorConfigPath ?? ""
-          }.palette`
-        )
-      )}
+      colors={palette}
       selectedColor={color}
-      onChange={(c) => updateColor(c)}
+      onChange={updateColor}
     />
   ) : null;
 };
 
-export const MultiFilterField = ({
+export const MultiFilterFieldCheckbox = ({
   dimensionIri,
   label,
   value,
@@ -371,7 +388,6 @@ export const MultiFilterField = ({
   checked,
   onChange,
   checkAction,
-  color,
   colorConfigPath,
 }: {
   dimensionIri: string;
@@ -382,7 +398,6 @@ export const MultiFilterField = ({
   checked?: boolean;
   onChange?: () => void;
   checkAction: "ADD" | "SET";
-  color?: string;
   colorConfigPath?: string;
 }) => {
   const [state, dispatch] = useConfiguratorState();
@@ -428,32 +443,14 @@ export const MultiFilterField = ({
   );
 
   return (
-    <Flex
-      sx={{
-        justifyContent: "space-between",
-        alignItems: "center",
-        mb: 2,
-        height: "2rem",
-      }}
-    >
-      <Box sx={{ maxWidth: "82%" }}>
-        <Checkbox
-          name={dimensionIri}
-          value={value}
-          label={label}
-          disabled={disabled}
-          onChange={onFieldChange}
-          checked={checked ?? fieldChecked}
-        />
-      </Box>
-      <MultiFilterFieldColorPicker
-        dimensionIri={dimensionIri}
-        value={value}
-        color={color}
-        checked={checked}
-        colorConfigPath={colorConfigPath}
-      />
-    </Flex>
+    <Checkbox
+      name={dimensionIri}
+      value={value}
+      label={label}
+      disabled={disabled}
+      onChange={onFieldChange}
+      checked={checked ?? fieldChecked}
+    />
   );
 };
 export const SingleFilterField = ({

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -293,6 +293,62 @@ export const MetaInputField = ({
   return <Input label={label} {...field} disabled={disabled} />;
 };
 
+export const MultiFilterFieldColorPicker = ({
+  colorConfigPath,
+  value,
+  color,
+  dimensionIri,
+  checked,
+}: {
+  colorConfigPath?: string;
+  value: string;
+  color?: string;
+  dimensionIri: string;
+  checked?: boolean;
+}) => {
+  const [state, dispatch] = useConfiguratorState();
+  const updateColor = useCallback(
+    (color: string) => {
+      if (state.activeField) {
+        dispatch({
+          type: "CHART_COLOR_CHANGED",
+          value: {
+            field: state.activeField,
+            colorConfigPath,
+            color,
+            value,
+          },
+        });
+      }
+    },
+
+    [colorConfigPath, dispatch, state.activeField, value]
+  );
+
+  if (state.state !== "CONFIGURING_CHART") {
+    return null;
+  }
+
+  const filter = state.chartConfig.filters[dimensionIri];
+  const fieldChecked =
+    filter?.type === "multi" ? filter.values?.[value] ?? false : false;
+
+  return color && (checked ?? fieldChecked) ? (
+    <ColorPickerMenu
+      colors={getPalette(
+        get(
+          state,
+          `chartConfig.fields["${state.activeField}"].${
+            colorConfigPath ?? ""
+          }.palette`
+        )
+      )}
+      selectedColor={color}
+      onChange={(c) => updateColor(c)}
+    />
+  ) : null;
+};
+
 export const MultiFilterField = ({
   dimensionIri,
   label,
@@ -348,23 +404,6 @@ export const MultiFilterField = ({
     [dispatch, dimensionIri, allValues, value, onChange, checkAction]
   );
 
-  const updateColor = useCallback(
-    (color: string) => {
-      if (state.activeField) {
-        dispatch({
-          type: "CHART_COLOR_CHANGED",
-          value: {
-            field: state.activeField,
-            colorConfigPath,
-            color,
-            value,
-          },
-        });
-      }
-    },
-    [colorConfigPath, dispatch, state.activeField, value]
-  );
-
   if (state.state !== "CONFIGURING_CHART") {
     return null;
   }
@@ -392,20 +431,13 @@ export const MultiFilterField = ({
           checked={checked ?? fieldChecked}
         />
       </Box>
-      {color && (checked ?? fieldChecked) && (
-        <ColorPickerMenu
-          colors={getPalette(
-            get(
-              state,
-              `chartConfig.fields["${state.activeField}"].${
-                colorConfigPath ?? ""
-              }.palette`
-            )
-          )}
-          selectedColor={color}
-          onChange={(c) => updateColor(c)}
-        />
-      )}
+      <MultiFilterFieldColorPicker
+        dimensionIri={dimensionIri}
+        value={value}
+        color={color}
+        checked={checked}
+        colorConfigPath={colorConfigPath}
+      />
     </Flex>
   );
 };

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -1,7 +1,11 @@
 import { Trans } from "@lingui/macro";
 import { useCallback, useMemo } from "react";
 import { Box, Button, Flex } from "theme-ui";
-import { getFilterValue, useConfiguratorState } from "..";
+import {
+  getFilterValue,
+  useConfiguratorState,
+  useDimensionSelection,
+} from "..";
 import { Loading } from "../../components/hint";
 import {
   useDimensionValuesQuery,
@@ -21,28 +25,6 @@ import {
 } from "./ui-helpers";
 
 type SelectionState = "SOME_SELECTED" | "NONE_SELECTED" | "ALL_SELECTED";
-
-const useDimensionSelection = (dimensionIri: string) => {
-  const [state, dispatch] = useConfiguratorState();
-
-  const selectAll = useCallback(() => {
-    dispatch({
-      type: "CHART_CONFIG_FILTER_RESET_MULTI",
-      value: {
-        dimensionIri,
-      },
-    });
-  }, [dispatch, dimensionIri]);
-
-  const selectNone = useCallback(() => {
-    dispatch({
-      type: "CHART_CONFIG_FILTER_SET_NONE_MULTI",
-      value: { dimensionIri },
-    });
-  }, [dispatch, dimensionIri]);
-
-  return useMemo(() => ({ selectAll, selectNone }), [selectAll, selectNone]);
-};
 
 const SelectionControls = ({
   dimensionIri,

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -28,14 +28,15 @@ import {
 
 const SelectionControls = ({ dimensionIri }: { dimensionIri: string }) => {
   const { selectAll, selectNone } = useDimensionSelection(dimensionIri);
-  const { selectionState } = useMultiFilterContext();
+  const { activeKeys, allValues } = useMultiFilterContext();
+
   return (
     <Box color="monochrome500">
       <Button
         onClick={selectAll}
         variant="inline"
         sx={{ mr: 2, mb: 4 }}
-        disabled={selectionState === "ALL_SELECTED"}
+        disabled={activeKeys.size === allValues.length}
       >
         <Trans id="controls.filter.select.all">Select all</Trans>
       </Button>
@@ -44,7 +45,7 @@ const SelectionControls = ({ dimensionIri }: { dimensionIri: string }) => {
         onClick={selectNone}
         variant="inline"
         sx={{ ml: 2, mb: 4 }}
-        disabled={selectionState === "NONE_SELECTED"}
+        disabled={activeKeys.size === 0}
       >
         <Trans id="controls.filter.select.none">Select none</Trans>
       </Button>

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -1,7 +1,6 @@
 import { Trans } from "@lingui/macro";
-import get from "lodash/get";
 import { useCallback, useMemo } from "react";
-import { Box, Button } from "theme-ui";
+import { Box, Button, Flex } from "theme-ui";
 import { getFilterValue, useConfiguratorState } from "..";
 import { Loading } from "../../components/hint";
 import {
@@ -10,7 +9,11 @@ import {
 } from "../../graphql/query-hooks";
 import { useLocale } from "../../locales/use-locale";
 import { EditorIntervalBrush } from "../interactive-filters/editor-time-interval-brush";
-import { MultiFilterField, SingleFilterField } from "./field";
+import {
+  MultiFilterFieldCheckbox,
+  MultiFilterFieldColorPicker,
+  SingleFilterField,
+} from "./field";
 import {
   getTimeInterval,
   useTimeFormatLocale,
@@ -118,6 +121,17 @@ export const DimensionValuesMultiFilter = ({
     ? "NONE_SELECTED"
     : "SOME_SELECTED";
 
+  const isFieldChecked = useCallback(
+    (dv: $FixMe) => {
+      return selectionState === "ALL_SELECTED"
+        ? true
+        : selectionState === "SOME_SELECTED"
+        ? !!isFilterActive.has(dv.value)
+        : undefined;
+    },
+    [selectionState, isFilterActive]
+  );
+
   if (data?.dataCubeByIri?.dimensionByIri) {
     return (
       <>
@@ -128,31 +142,36 @@ export const DimensionValuesMultiFilter = ({
 
         {sortedDimensionValues.map((dv) => {
           if (state.state === "CONFIGURING_CHART") {
-            const path = colorConfigPath ? `${colorConfigPath}.` : "";
-
-            const color = get(
-              state,
-              `chartConfig.fields["${state.activeField}"].${path}colorMapping["${dv.value}"]`
-            );
-
             return (
-              <MultiFilterField
-                key={dv.value}
-                dimensionIri={dimensionIri}
-                label={dv.label}
-                value={dv.value}
-                allValues={dimension?.values.map((d) => d.value) ?? []}
-                checked={
-                  selectionState === "ALL_SELECTED"
-                    ? true
-                    : selectionState === "SOME_SELECTED"
-                    ? !!isFilterActive.has(dv.value)
-                    : undefined
-                }
-                checkAction={selectionState === "NONE_SELECTED" ? "SET" : "ADD"}
-                color={color}
-                colorConfigPath={colorConfigPath}
-              />
+              <Flex
+                sx={{
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  mb: 2,
+                  height: "2rem",
+                }}
+              >
+                <Box sx={{ maxWidth: "82%" }}>
+                  <MultiFilterFieldCheckbox
+                    key={dv.value}
+                    dimensionIri={dimensionIri}
+                    label={dv.label}
+                    value={dv.value}
+                    allValues={dimension?.values.map((d) => d.value) ?? []}
+                    checked={isFieldChecked(dv)}
+                    checkAction={
+                      selectionState === "NONE_SELECTED" ? "SET" : "ADD"
+                    }
+                    colorConfigPath={colorConfigPath}
+                  />
+                </Box>
+                <MultiFilterFieldColorPicker
+                  dimensionIri={dimensionIri}
+                  value={dv.value}
+                  checked={isFieldChecked(dv)}
+                  colorConfigPath={colorConfigPath}
+                />
+              </Flex>
             );
           } else {
             return null;

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -4,6 +4,7 @@ import {
   InputHTMLAttributes,
   SyntheticEvent,
   useCallback,
+  useMemo,
 } from "react";
 import { SelectProps } from "theme-ui";
 import { getFieldComponentIri } from "../charts";
@@ -112,6 +113,28 @@ export const useChartOptionSelectField = <ValueType extends {} = string>({
     // checked,
     onChange,
   };
+};
+
+export const useDimensionSelection = (dimensionIri: string) => {
+  const [state, dispatch] = useConfiguratorState();
+
+  const selectAll = useCallback(() => {
+    dispatch({
+      type: "CHART_CONFIG_FILTER_RESET_MULTI",
+      value: {
+        dimensionIri,
+      },
+    });
+  }, [dispatch, dimensionIri]);
+
+  const selectNone = useCallback(() => {
+    dispatch({
+      type: "CHART_CONFIG_FILTER_SET_NONE_MULTI",
+      value: { dimensionIri },
+    });
+  }, [dispatch, dimensionIri]);
+
+  return useMemo(() => ({ selectAll, selectNone }), [selectAll, selectNone]);
 };
 
 export const useChartOptionRadioField = ({
@@ -339,6 +362,47 @@ export const useSingleFilterField = ({
     checked,
     onChange,
   };
+};
+
+export const useMultiFilterCheckboxes = (
+  dimensionIri: string,
+  value: string,
+  allValues: string[],
+  checkAction: string,
+  onChangeProp?: () => void
+) => {
+  const [, dispatch] = useConfiguratorState();
+
+  const onChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      if (e.currentTarget.checked) {
+        dispatch({
+          type:
+            checkAction === "ADD"
+              ? "CHART_CONFIG_FILTER_ADD_MULTI"
+              : "CHART_CONFIG_FILTER_SET_MULTI",
+          value: {
+            dimensionIri,
+            value,
+            allValues,
+          },
+        });
+      } else {
+        dispatch({
+          type: "CHART_CONFIG_FILTER_REMOVE_MULTI",
+          value: {
+            dimensionIri,
+            value,
+            allValues,
+          },
+        });
+      }
+      onChangeProp?.();
+    },
+    [dispatch, dimensionIri, allValues, value, onChangeProp, checkAction]
+  );
+
+  return { onChange };
 };
 
 export const useMetaField = ({

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -150,8 +150,8 @@ export const useChartOptionRadioField = ({
 }): FieldProps => {
   const [state, dispatch] = useConfiguratorState();
 
-  const onChange = useCallback<(e: ChangeEvent<HTMLInputElement>) => void>(
-    (e) => {
+  const onChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
       dispatch({
         type: "CHART_OPTION_CHANGED",
         value: {
@@ -386,7 +386,6 @@ export type MultiFilterSelectionState =
 
 const MultiFilterContext = React.createContext({
   isFilterActive: new Set() as Set<string>,
-  checkAction: "SET" as CheckActionType, // TODO fix, use imported type
   allValues: [] as string[],
   selectionState: "NONE_SELECTED" as MultiFilterSelectionState,
 });
@@ -460,20 +459,16 @@ export const useMultiFilterCheckboxes = (
   onChangeProp?: () => void
 ) => {
   const [state, dispatch] = useConfiguratorState();
-  const { checkAction, allValues, isFilterActive, selectionState } =
-    useMultiFilterContext();
+  const { allValues, isFilterActive, selectionState } = useMultiFilterContext();
 
   const onChange = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       if (e.currentTarget.checked) {
         dispatch({
-          type:
-            checkAction === "ADD"
-              ? "CHART_CONFIG_FILTER_ADD_MULTI"
-              : "CHART_CONFIG_FILTER_SET_MULTI",
+          type: "CHART_CONFIG_FILTER_ADD_MULTI",
           value: {
             dimensionIri,
-            value,
+            values: [value],
             allValues,
           },
         });
@@ -482,14 +477,14 @@ export const useMultiFilterCheckboxes = (
           type: "CHART_CONFIG_FILTER_REMOVE_MULTI",
           value: {
             dimensionIri,
-            value,
+            values: [value],
             allValues,
           },
         });
       }
       onChangeProp?.();
     },
-    [dispatch, dimensionIri, allValues, value, onChangeProp, checkAction]
+    [dispatch, dimensionIri, allValues, value, onChangeProp]
   );
 
   const checkedState =

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -470,9 +470,8 @@ export const useMultiFilterCheckboxes = (
   );
 
   const isChecked =
-    state.state === "CONFIGURING_CHART"
-      ? isMultiFilterFieldChecked(state.chartConfig, dimensionIri, value)
-      : false;
+    state.state === "CONFIGURING_CHART" &&
+    isMultiFilterFieldChecked(state.chartConfig, dimensionIri, value);
 
   return {
     onChange,


### PR DESCRIPTION
This PR prepares the future work on hierarchical filters. It does not add any new functionality (yay!?).

Since in the future we want to be able to display hierarchical multi checkboxes, and we will possibly separate the color pickers from the data filters, this PR ensures that the UI components can be more freely re-arranged. 

- Checkboxes and color pickers are now separate components
- They know what to dispatch and do not rely on their parents to pass the correct properties
- Since we need to have a shared state (containing what is checked, the selection state and several other values), I used a context to share the information
- I used hooks that contain the budget logic to separate the presentation from the logic. This could be useful in the future when we want to have the color picker directly on the chart. This followed the model that was already used for some fields in config-form.tsx
