### PR TITLE
Improve translations on dataset selection step

### DIFF
--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -43,7 +43,7 @@ msgstr "Kategorien"
 
 #: app/configurator/components/dataset-preview.tsx:54
 msgid "browse.dataset.create-visualization"
-msgstr "Erstellen Sie die Visualisierung von Dataset"
+msgstr "Visualisierung erstellen"
 
 #: app/pages/v/[chartId].tsx:122
 msgid "button.copy.visualization"
@@ -595,7 +595,7 @@ msgstr "Titel hinzufügen"
 
 #: app/configurator/components/select-dataset-step.tsx:102
 msgid "dataset-preview.back-to-results"
-msgstr "Zurück zu den Ergebnissen"
+msgstr "Zurück zu den Datensätzen"
 
 #: app/components/chart-published.tsx:80
 msgid "dataset.hasImputedValues"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -43,7 +43,7 @@ msgstr "Categories"
 
 #: app/configurator/components/dataset-preview.tsx:54
 msgid "browse.dataset.create-visualization"
-msgstr "Create visualization from dataset"
+msgstr "Create visualization"
 
 #: app/pages/v/[chartId].tsx:122
 msgid "button.copy.visualization"
@@ -595,7 +595,7 @@ msgstr "Title"
 
 #: app/configurator/components/select-dataset-step.tsx:102
 msgid "dataset-preview.back-to-results"
-msgstr "Back to the list"
+msgstr "Back to the datasets"
 
 #: app/components/chart-published.tsx:80
 msgid "dataset.hasImputedValues"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -595,7 +595,7 @@ msgstr "Titre"
 
 #: app/configurator/components/select-dataset-step.tsx:102
 msgid "dataset-preview.back-to-results"
-msgstr "Revenir aux résultats"
+msgstr "Revenir aux jeux de données"
 
 #: app/components/chart-published.tsx:80
 msgid "dataset.hasImputedValues"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -43,7 +43,7 @@ msgstr "Categorie"
 
 #: app/configurator/components/dataset-preview.tsx:54
 msgid "browse.dataset.create-visualization"
-msgstr "Creare la visualizzazione dal set di dati"
+msgstr "Crea una visualizzazione"
 
 #: app/pages/v/[chartId].tsx:122
 msgid "button.copy.visualization"
@@ -595,7 +595,7 @@ msgstr "Titolo"
 
 #: app/configurator/components/select-dataset-step.tsx:102
 msgid "dataset-preview.back-to-results"
-msgstr "Torna ai risultati"
+msgstr "Torna ai set di dati"
 
 #: app/components/chart-published.tsx:80
 msgid "dataset.hasImputedValues"


### PR DESCRIPTION
The wording on the dataset page was inconsistent, not self-descriptive enough or just wrong (at least in German).

Changes:
- "back to list" (was "back to results" in some languages?) to "back to datasets" (more descriptive and consistent)
- "create visualization from dataset" to "create visualization" (was inconsistent between languages and wrong in German)