### PR TITLE
fix: Tags have max width + ellipsis and are displayed as a list in dataset metadata

### DIFF
--- a/app/configurator/components/dataset-metadata.tsx
+++ b/app/configurator/components/dataset-metadata.tsx
@@ -1,7 +1,7 @@
 import { Trans } from "@lingui/macro";
+import NextLink from "next/link";
 import React, { ReactNode } from "react";
 import { Box, Link } from "theme-ui";
-import NextLink from "next/link";
 import { Loading } from "../../components/hint";
 import Stack from "../../components/Stack";
 import { useFormatDate } from "../../configurator/components/ui-helpers";
@@ -10,8 +10,8 @@ import {
   useDataCubeMetadataQuery,
 } from "../../graphql/query-hooks";
 import { useLocale } from "../../locales/use-locale";
-import Tag from "./Tag";
 import truthy from "../../utils/truthy";
+import Tag from "./Tag";
 export const DataSetMetadata = ({ dataSetIri }: { dataSetIri: string }) => {
   const locale = useLocale();
   const formatDate = useFormatDate();
@@ -131,7 +131,7 @@ const DatasetTags = ({
   cube: NonNullable<DataCubeMetadataQuery["dataCubeByIri"]>;
 }) => {
   return (
-    <Stack spacing={1} direction="row">
+    <Stack spacing={1} direction="column">
       {[cube.creator, ...cube.themes].filter(truthy).map((t) => (
         <NextLink
           key={t.iri}
@@ -140,7 +140,18 @@ const DatasetTags = ({
           }/${encodeURIComponent(t.iri)}`}
           passHref
         >
-          <Tag as="a" type={t.__typename}>
+          <Tag
+            as="a"
+            type={t.__typename}
+            title={t.label || undefined}
+            sx={{
+              maxWidth: "100%",
+              display: "block",
+              whiteSpace: "nowrap",
+              textOverflow: "ellipsis",
+              overflow: "hidden",
+            }}
+          >
             {t.label}
           </Tag>
         </NextLink>


### PR DESCRIPTION
Long tags could be cut by line break and this was not pretty.

Now tags in the dataset metadata are shown as a list (line break between each element).

https://visualize-ad-fix-datase-jx9gw1.herokuapp.com/en/browse/dataset/https%3A%2F%2Fenergy.ld.admin.ch%2Fsfoe%2Fbfe_ogd10_energieforschungsstatistik_ch%2F2%2F?previous=%7B%7D

If the organization name is too long (does not happen right now for any organization), there is an ellipsis, and full title is shown on hover (via HTML title attribute)