### PR TITLE
fix: Can navigate back after data selection and browsing state is kept

### DIFF
--- a/app/configurator/components/dataset-browse.tsx
+++ b/app/configurator/components/dataset-browse.tsx
@@ -3,7 +3,6 @@ import { Plural, t, Trans } from "@lingui/macro";
 import { mapValues, pick, pickBy, sortBy } from "lodash";
 import Link from "next/link";
 import { Router, useRouter } from "next/router";
-import qs from "qs";
 import React, {
   useCallback,
   useContext,
@@ -859,17 +858,20 @@ export const DatasetResult = ({
   const browseState = useBrowseContext();
   const { search, includeDrafts, order } = browseState;
   const filterParams = useMemo(() => {
-    return qs.stringify({
+    return {
       previous: JSON.stringify({
         ...getBrowseParamsFromQuery(router.query),
         search,
         includeDrafts,
         order,
       }),
-    });
+    };
   }, [router.query, search, includeDrafts, order]);
   const handleClick = useCallback(() => {
-    router.push(`/browse/dataset/${encodeURIComponent(iri)}?${filterParams}`);
+    router.push({
+      pathname: `/browse/dataset/${encodeURIComponent(iri)}`,
+      query: filterParams,
+    });
   }, [router, iri, filterParams]);
   return (
     <Card

--- a/app/configurator/components/dataset-browse.tsx
+++ b/app/configurator/components/dataset-browse.tsx
@@ -858,16 +858,14 @@ export const DatasetResult = ({
 
   const browseState = useBrowseContext();
   const { search, includeDrafts, order } = browseState;
+  const browseParams = useMemo(() => {
+    return getBrowseParamsFromQuery(router.query);
+  }, [router]);
   const filterParams = useMemo(() => {
     return {
-      previous: JSON.stringify({
-        ...getBrowseParamsFromQuery(router.query),
-        search,
-        includeDrafts,
-        order,
-      }),
+      previous: JSON.stringify(browseParams),
     };
-  }, [router.query, search, includeDrafts, order]);
+  }, [browseParams]);
   const handleClick = useCallback(() => {
     router.push(
       {

--- a/app/configurator/components/dataset-browse.tsx
+++ b/app/configurator/components/dataset-browse.tsx
@@ -148,7 +148,9 @@ export const useBrowseState = () => {
     (param: keyof BrowseParams, newValue: string | boolean) => {
       const state = getBrowseParamsFromQuery(router.query);
       const newState = { ...state, [param]: newValue } as BrowseParams;
-      router.replace(buildURLFromBrowseState(newState));
+      router.replace(buildURLFromBrowseState(newState), undefined, {
+        shallow: true,
+      });
     },
     [router]
   );
@@ -867,10 +869,14 @@ export const DatasetResult = ({
     };
   }, [router.query, search, includeDrafts, order]);
   const handleClick = useCallback(() => {
-    router.push({
-      pathname: `/browse/dataset/${encodeURIComponent(iri)}`,
-      query: filterParams,
-    });
+    router.push(
+      {
+        pathname: `/browse/dataset/${encodeURIComponent(iri)}`,
+        query: filterParams,
+      },
+      undefined,
+      { shallow: true }
+    );
   }, [router, iri, filterParams]);
   return (
     <Card

--- a/app/configurator/components/select-dataset-step.tsx
+++ b/app/configurator/components/select-dataset-step.tsx
@@ -1,7 +1,6 @@
 import { Trans } from "@lingui/macro";
 import NextLink from "next/link";
 import { Router, useRouter } from "next/router";
-import qs from "qs";
 import React, { useMemo } from "react";
 import { Box, Link, Text } from "theme-ui";
 import { useDebounce } from "use-debounce";
@@ -28,7 +27,9 @@ const softJSONParse = (v: string) => {
   }
 };
 
-const formatBackLink = (query: Router["query"]): string => {
+const formatBackLink = (
+  query: Router["query"]
+): React.ComponentProps<typeof NextLink>["href"] => {
   const backParameters = softJSONParse(query.previous as string);
   if (!backParameters) {
     return "/browse";
@@ -46,7 +47,10 @@ const formatBackLink = (query: Router["query"]): string => {
       : undefined;
 
   const pathname = ["/browse", typePart, subtypePart].filter(Boolean).join("/");
-  return `${pathname}?${qs.stringify(queryParams)}`;
+  return {
+    pathname,
+    query: queryParams,
+  };
 };
 
 export const SelectDatasetStepContent = () => {
@@ -100,7 +104,7 @@ export const SelectDatasetStepContent = () => {
         {dataset ? (
           <>
             <Box mb={4} px={4}>
-              <NextLink passHref href={`${backLink}`}>
+              <NextLink passHref href={backLink}>
                 <Link variant="inline">
                   <Trans id="dataset-preview.back-to-results">
                     Back to the list

--- a/app/configurator/components/select-dataset-step.tsx
+++ b/app/configurator/components/select-dataset-step.tsx
@@ -9,8 +9,8 @@ import { useDataCubesQuery } from "../../graphql/query-hooks";
 import { useConfiguratorState, useLocale } from "../../src";
 import {
   BrowseStateProvider,
+  buildURLFromBrowseState,
   DatasetResults,
-  getBrowseParamsFromQuery,
   SearchDatasetBox,
   SearchFilters,
   useBrowseContext,
@@ -34,23 +34,7 @@ const formatBackLink = (
   if (!backParameters) {
     return "/browse";
   }
-  const { type, iri, subtype, subiri, ...queryParams } =
-    getBrowseParamsFromQuery(backParameters);
-
-  const typePart =
-    type && iri
-      ? `${encodeURIComponent(type)}/${encodeURIComponent(iri)}`
-      : undefined;
-  const subtypePart =
-    subtype && subiri
-      ? `${encodeURIComponent(subtype)}/${encodeURIComponent(subiri)}`
-      : undefined;
-
-  const pathname = ["/browse", typePart, subtypePart].filter(Boolean).join("/");
-  return {
-    pathname,
-    query: queryParams,
-  };
+  return buildURLFromBrowseState(backParameters);
 };
 
 export const SelectDatasetStepContent = () => {

--- a/app/lib/use-nprogress.ts
+++ b/app/lib/use-nprogress.ts
@@ -1,5 +1,5 @@
-import NProgress from "nprogress";
 import { useRouter } from "next/router";
+import NProgress from "nprogress";
 import { useEffect } from "react";
 
 /**
@@ -13,7 +13,15 @@ export const useNProgress = () => {
 
   useEffect(() => {
     NProgress.configure({ showSpinner: false });
-    const startProgress = () => NProgress.start();
+    const startProgress = (
+      _routeName: string,
+      options?: { shallow: boolean }
+    ) => {
+      if (options?.shallow) {
+        return;
+      }
+      NProgress.start();
+    };
     const stopProgress = () => NProgress.done();
 
     routerEvents.on("routeChangeStart", startProgress);

--- a/app/pages/browse/index.tsx
+++ b/app/pages/browse/index.tsx
@@ -10,6 +10,10 @@ export type BrowseParams = {
   iri?: string;
   subiri?: string;
   topic?: string;
+  search?: string;
+  order?: string;
+  includeDrafts?: string;
+  dataset?: string;
 };
 
 // Generic component for all browse subpages

--- a/app/pages/browse/index.tsx
+++ b/app/pages/browse/index.tsx
@@ -12,7 +12,7 @@ export type BrowseParams = {
   topic?: string;
   search?: string;
   order?: string;
-  includeDrafts?: string;
+  includeDrafts?: boolean;
   dataset?: string;
 };
 


### PR DESCRIPTION
Search, order and includeDrafts are passed from browsing page to dataset result and are passed into the back link : now the user goes back to the exact state she left.

fix #238 