### PR TITLE
feat: Remove select dataset step from stepper

### DIFF
--- a/app/configurator/components/action-bar.tsx
+++ b/app/configurator/components/action-bar.tsx
@@ -1,5 +1,4 @@
 import { Trans } from "@lingui/macro";
-import NextLink from "next/link";
 import { ReactNode, useCallback } from "react";
 import { Button, Flex } from "theme-ui";
 import {
@@ -55,27 +54,12 @@ export const ActionBar = ({ dataSetIri }: { dataSetIri?: string }) => {
         alignItems: "center",
       }}
     >
-      {state.state === "SELECTING_DATASET" ? (
-        <>
-          <NextButton
-            label={nextLabel}
-            onClick={goNext}
-            disabled={nextDisabled}
-          />
-        </>
-      ) : state.state === "SELECTING_CHART_TYPE" ? (
-        <>
-          <NextLink href="/create/new" passHref>
-            <Button as="a" variant="inline" sx={{ mr: 4 }}>
-              {previousLabel}
-            </Button>
-          </NextLink>
-          <NextButton
-            label={nextLabel}
-            onClick={goNext}
-            disabled={nextDisabled}
-          />
-        </>
+      {state.state === "SELECTING_CHART_TYPE" ? (
+        <NextButton
+          label={nextLabel}
+          onClick={goNext}
+          disabled={nextDisabled}
+        />
       ) : (
         <>
           <Button

--- a/app/configurator/components/chart-type-selector.tsx
+++ b/app/configurator/components/chart-type-selector.tsx
@@ -8,10 +8,10 @@ import { useDataCubeMetadataWithComponentValuesQuery } from "../../graphql/query
 import { DataCubeMetadata } from "../../graphql/types";
 import { Icon } from "../../icons";
 import { useLocale } from "../../locales/use-locale";
+import { useTheme } from "../../themes";
 import { FieldProps, useChartTypeSelectorField } from "../config-form";
 import { SectionTitle } from "./chart-controls/section";
 import { getFieldLabel, getIconName } from "./ui-helpers";
-import { useTheme } from "../../themes";
 
 export const ChartTypeSelectionButton = ({
   label,
@@ -33,7 +33,6 @@ export const ChartTypeSelectionButton = ({
       sx={{
         width: "86px",
         height: "86px",
-        mt: 4,
         borderRadius: "default",
 
         backgroundColor: checked ? "primary" : "monochrome100",

--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -1,11 +1,18 @@
+import { Trans } from "@lingui/macro";
+import NextLink from "next/link";
 import React from "react";
-import { useConfiguratorState } from "..";
+import { Link } from "theme-ui";
+import { ConfiguratorState, useConfiguratorState } from "..";
 import { ChartPanel } from "../../components/chart-panel";
 import { ChartPreview } from "../../components/chart-preview";
+import Stack from "../../components/Stack";
+import { useDataCubeMetadataQuery } from "../../graphql/query-hooks";
+import { useLocale } from "../../src";
 import { ChartConfiguratorTable } from "../table/table-chart-configurator";
 import { ChartAnnotationsSelector } from "./chart-annotations-selector";
 import { ChartAnnotator } from "./chart-annotator";
 import { ChartConfigurator } from "./chart-configurator";
+import { SectionTitle } from "./chart-controls/section";
 import { ChartOptionsSelector } from "./chart-options-selector";
 import { ChartTypeSelector } from "./chart-type-selector";
 import {
@@ -18,6 +25,33 @@ import {
 import { SelectDatasetStep } from "./select-dataset-step";
 import { Stepper } from "./stepper";
 
+const DatasetSelector = ({ state }: { state: ConfiguratorState }) => {
+  const locale = useLocale();
+  const [{ data: metaData }] = useDataCubeMetadataQuery({
+    variables: { iri: state.dataSet || "", locale },
+    pause: !state.dataSet,
+  });
+  return (
+    <div>
+      <SectionTitle>Dataset</SectionTitle>
+      {metaData ? (
+        <Stack direction="column" mx={4} spacing={2}>
+          <div>{metaData.dataCubeByIri?.title}</div>
+          <div>
+            <NextLink href="/browse" passHref>
+              <Link sx={{ fontSize: 3 }}>
+                <Trans id="dataset-selector.choose-another-dataset">
+                  Choose another dataset
+                </Trans>
+              </Link>
+            </NextLink>
+          </div>
+        </Stack>
+      ) : null}
+    </div>
+  );
+};
+
 const SelectChartTypeStep = () => {
   const [state] = useConfiguratorState();
   if (state.state !== "SELECTING_CHART_TYPE") {
@@ -26,6 +60,7 @@ const SelectChartTypeStep = () => {
   return (
     <>
       <PanelLeftWrapper>
+        <DatasetSelector state={state} />
         <ChartTypeSelector state={state} />
       </PanelLeftWrapper>
       <PanelMiddleWrapper>

--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -60,8 +60,10 @@ const SelectChartTypeStep = () => {
   return (
     <>
       <PanelLeftWrapper>
-        <DatasetSelector state={state} />
-        <ChartTypeSelector state={state} />
+        <Stack spacing={2} direction="column">
+          <DatasetSelector state={state} />
+          <ChartTypeSelector state={state} />
+        </Stack>
       </PanelLeftWrapper>
       <PanelMiddleWrapper>
         <ChartPanel>

--- a/app/configurator/components/layout.tsx
+++ b/app/configurator/components/layout.tsx
@@ -19,7 +19,7 @@ export const PanelLeftWrapper = ({
       sx={{
         overflowX: "hidden",
         overflowY: "auto",
-        bgColor: "blue",
+        bg: "monochrome100",
         boxShadow: raised ? "rightSide" : undefined,
         borderRightColor: raised ? "monochrome500" : undefined,
         borderRightWidth: raised ? "1px" : undefined,

--- a/app/configurator/components/select-dataset-step.tsx
+++ b/app/configurator/components/select-dataset-step.tsx
@@ -84,7 +84,7 @@ export const SelectDatasetStepContent = () => {
         pt: 3,
       }}
     >
-      <PanelLeftWrapper raised={false} sx={{ mt: 50 }}>
+      <PanelLeftWrapper raised={false} sx={{ mt: 50, bg: "transparent" }}>
         {dataset ? (
           <>
             <Box mb={4} px={4}>

--- a/app/configurator/components/stepper.tsx
+++ b/app/configurator/components/stepper.tsx
@@ -1,5 +1,4 @@
 import { Trans } from "@lingui/macro";
-import NextLink from "next/link";
 import { Fragment, ReactNode, useCallback, useMemo } from "react";
 import { Box, Button, Flex, Text } from "theme-ui";
 import { useConfiguratorState } from "..";
@@ -8,18 +7,13 @@ import { useTheme } from "../../themes";
 import { ActionBar } from "./action-bar";
 
 export type StepStatus = "past" | "current" | "future";
-type StepState =
-  | "SELECTING_DATASET"
-  | "SELECTING_CHART_TYPE"
-  | "CONFIGURING_CHART"
-  | "DESCRIBING_CHART";
 
-const steps: Array<StepState> = [
-  "SELECTING_DATASET",
+const steps = [
   "SELECTING_CHART_TYPE",
   "CONFIGURING_CHART",
   "DESCRIBING_CHART",
-];
+] as const;
+type StepState = typeof steps[number];
 
 export const Stepper = ({ dataSetIri }: { dataSetIri?: string }) => {
   const [{ state }, dispatch] = useConfiguratorState();
@@ -148,30 +142,7 @@ export const Step = ({
     </>
   );
 
-  return stepState === "SELECTING_DATASET" ? (
-    <NextLink
-      href={
-        dataSet ? `/browse/dataset/${encodeURIComponent(dataSet)}` : `/browse`
-      }
-      passHref
-    >
-      <Button
-        as="a"
-        variant="reset"
-        sx={{
-          appearance: "none",
-          display: "flex",
-          flexDirection: "row",
-          justifyContent: "flex-start",
-          alignItems: "center",
-          cursor: status === "past" ? "pointer" : undefined,
-        }}
-        disabled={status !== "past"}
-      >
-        {content}
-      </Button>
-    </NextLink>
-  ) : (
+  return (
     <Button
       variant="reset"
       sx={{
@@ -198,13 +169,6 @@ export const StepLabel = ({
   highlight: boolean;
 }) => {
   switch (stepState) {
-    case "SELECTING_DATASET":
-      return (
-        <StepLabelText
-          label={<Trans id="step.dataset">Dataset</Trans>}
-          highlight={highlight}
-        />
-      );
     case "SELECTING_CHART_TYPE":
       return (
         <StepLabelText
@@ -227,6 +191,7 @@ export const StepLabel = ({
         />
       );
   }
+  return null;
 };
 
 const StepLabelText = ({

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -33,11 +33,11 @@ msgstr "[ Ohne Beschreibung ]"
 msgid "annotation.add.title"
 msgstr "[ Ohne Titel ]"
 
-#: app/configurator/components/dataset-browse.tsx:683
+#: app/configurator/components/dataset-browse.tsx:714
 msgid "browse-panel.organizations"
 msgstr "Organisationen"
 
-#: app/configurator/components/dataset-browse.tsx:640
+#: app/configurator/components/dataset-browse.tsx:671
 msgid "browse-panel.themes"
 msgstr "Kategorien"
 
@@ -45,7 +45,7 @@ msgstr "Kategorien"
 msgid "browse.dataset.create-visualization"
 msgstr "Visualisierung erstellen"
 
-#: app/configurator/components/select-dataset-step.tsx:128
+#: app/configurator/components/select-dataset-step.tsx:119
 msgid "browse.datasets.all-datasets"
 msgstr "Alle Datensätze"
 
@@ -78,15 +78,15 @@ msgstr "Kopiert!"
 msgid "button.new.visualization"
 msgstr "Neue Visualisierung erstellen"
 
-#: app/configurator/components/action-bar.tsx:46
+#: app/configurator/components/action-bar.tsx:45
 msgid "button.next"
 msgstr "Weiter"
 
-#: app/configurator/components/action-bar.tsx:41
+#: app/configurator/components/action-bar.tsx:40
 msgid "button.previous"
 msgstr "Zurück"
 
-#: app/configurator/components/action-bar.tsx:44
+#: app/configurator/components/action-bar.tsx:43
 msgid "button.publish"
 msgstr "Veröffentlichen"
 
@@ -288,7 +288,7 @@ msgstr "gestapelt"
 msgid "controls.description"
 msgstr "Beschreibung hinzufügen"
 
-#: app/configurator/components/field.tsx:503
+#: app/configurator/components/field.tsx:514
 msgid "controls.dimension.none"
 msgstr "Keine"
 
@@ -507,7 +507,7 @@ msgstr "Messwert auswählen"
 
 #: app/configurator/components/field.tsx:82
 #: app/configurator/components/field.tsx:140
-#: app/configurator/components/field.tsx:508
+#: app/configurator/components/field.tsx:519
 msgid "controls.select.optional"
 msgstr "optional"
 
@@ -597,15 +597,19 @@ msgstr "Suche anzeigen"
 msgid "controls.title"
 msgstr "Titel hinzufügen"
 
-#: app/configurator/components/select-dataset-step.tsx:102
+#: app/configurator/components/select-dataset-step.tsx:93
 msgid "dataset-preview.back-to-results"
 msgstr "Zurück zu den Datensätzen"
+
+#: app/configurator/components/configurator.tsx:43
+msgid "dataset-selector.choose-another-dataset"
+msgstr "Wählen Sie ein anderes Datensatz"
 
 #: app/components/chart-published.tsx:80
 msgid "dataset.hasImputedValues"
 msgstr "Einige Daten in diesem Datensatz fehlen und wurden interpoliert, um die Lücken zu füllen."
 
-#: app/configurator/components/dataset-browse.tsx:291
+#: app/configurator/components/dataset-browse.tsx:322
 msgid "dataset.includeDrafts"
 msgstr "Entwürfe einschließen"
 
@@ -629,15 +633,15 @@ msgstr "Quelle"
 msgid "dataset.metadata.version"
 msgstr "Version"
 
-#: app/configurator/components/dataset-browse.tsx:259
+#: app/configurator/components/dataset-browse.tsx:290
 msgid "dataset.order.newest"
 msgstr "Neueste"
 
-#: app/configurator/components/dataset-browse.tsx:251
+#: app/configurator/components/dataset-browse.tsx:282
 msgid "dataset.order.relevance"
 msgstr "Relevanz"
 
-#: app/configurator/components/dataset-browse.tsx:255
+#: app/configurator/components/dataset-browse.tsx:286
 msgid "dataset.order.title"
 msgstr "Titel"
 
@@ -651,19 +655,19 @@ msgstr "Achtung, dieser Datensatz ist im Entwurfs-Stadium.<0/><1>Diese Grafik ni
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Achtung, dieser Datensatz ist abgelaufen.<0/><1>Diese Grafik nicht für Berichte verwenden.</1>"
 
-#: app/configurator/components/dataset-browse.tsx:315
+#: app/configurator/components/dataset-browse.tsx:346
 msgid "dataset.results"
 msgstr "Ergebnisse"
 
-#: app/configurator/components/dataset-browse.tsx:263
+#: app/configurator/components/dataset-browse.tsx:294
 msgid "dataset.search.label"
 msgstr "Suchen"
 
-#: app/configurator/components/dataset-browse.tsx:335
+#: app/configurator/components/dataset-browse.tsx:366
 msgid "dataset.sortby"
 msgstr "Sortieren nach"
 
-#: app/configurator/components/dataset-browse.tsx:862
+#: app/configurator/components/dataset-browse.tsx:905
 msgid "dataset.tag.draft"
 msgstr "Luftzug"
 
@@ -808,19 +812,19 @@ msgstr "Hier ist eine Visualisierung, die ich mit visualize.admin.ch erstellt ha
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
-#: app/configurator/components/stepper.tsx:225
+#: app/configurator/components/stepper.tsx:189
 msgid "step.annotate"
 msgstr "Beschreiben"
 
 #: app/configurator/components/stepper.tsx:204
-msgid "step.dataset"
-msgstr "Datensatz"
+#~ msgid "step.dataset"
+#~ msgstr "Datensatz"
 
-#: app/configurator/components/stepper.tsx:211
+#: app/configurator/components/stepper.tsx:175
 msgid "step.visualization.type"
 msgstr "Diagrammtyp"
 
-#: app/configurator/components/stepper.tsx:218
+#: app/configurator/components/stepper.tsx:182
 msgid "step.visualize"
 msgstr "Visualisieren"
 

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -33,11 +33,11 @@ msgstr "[ No Description ]"
 msgid "annotation.add.title"
 msgstr "[ No Title ]"
 
-#: app/configurator/components/dataset-browse.tsx:683
+#: app/configurator/components/dataset-browse.tsx:714
 msgid "browse-panel.organizations"
 msgstr "Organizations"
 
-#: app/configurator/components/dataset-browse.tsx:640
+#: app/configurator/components/dataset-browse.tsx:671
 msgid "browse-panel.themes"
 msgstr "Categories"
 
@@ -45,7 +45,7 @@ msgstr "Categories"
 msgid "browse.dataset.create-visualization"
 msgstr "Create visualization"
 
-#: app/configurator/components/select-dataset-step.tsx:128
+#: app/configurator/components/select-dataset-step.tsx:119
 msgid "browse.datasets.all-datasets"
 msgstr "All Datasets"
 
@@ -78,15 +78,15 @@ msgstr "Copied!"
 msgid "button.new.visualization"
 msgstr "Create New Visualization"
 
-#: app/configurator/components/action-bar.tsx:46
+#: app/configurator/components/action-bar.tsx:45
 msgid "button.next"
 msgstr "Next"
 
-#: app/configurator/components/action-bar.tsx:41
+#: app/configurator/components/action-bar.tsx:40
 msgid "button.previous"
 msgstr "Previous"
 
-#: app/configurator/components/action-bar.tsx:44
+#: app/configurator/components/action-bar.tsx:43
 msgid "button.publish"
 msgstr "Publish"
 
@@ -288,7 +288,7 @@ msgstr "Stacked"
 msgid "controls.description"
 msgstr "Description"
 
-#: app/configurator/components/field.tsx:503
+#: app/configurator/components/field.tsx:514
 msgid "controls.dimension.none"
 msgstr "None"
 
@@ -507,7 +507,7 @@ msgstr "Select a measure"
 
 #: app/configurator/components/field.tsx:82
 #: app/configurator/components/field.tsx:140
-#: app/configurator/components/field.tsx:508
+#: app/configurator/components/field.tsx:519
 msgid "controls.select.optional"
 msgstr "optional"
 
@@ -597,15 +597,19 @@ msgstr "Show search field"
 msgid "controls.title"
 msgstr "Title"
 
-#: app/configurator/components/select-dataset-step.tsx:102
+#: app/configurator/components/select-dataset-step.tsx:93
 msgid "dataset-preview.back-to-results"
 msgstr "Back to the datasets"
+
+#: app/configurator/components/configurator.tsx:43
+msgid "dataset-selector.choose-another-dataset"
+msgstr "Choose another dataset"
 
 #: app/components/chart-published.tsx:80
 msgid "dataset.hasImputedValues"
 msgstr "Some data in this dataset is missing and has been interpolated to fill the gaps."
 
-#: app/configurator/components/dataset-browse.tsx:291
+#: app/configurator/components/dataset-browse.tsx:322
 msgid "dataset.includeDrafts"
 msgstr "Include draft datasets"
 
@@ -629,15 +633,15 @@ msgstr "Source"
 msgid "dataset.metadata.version"
 msgstr "Version"
 
-#: app/configurator/components/dataset-browse.tsx:259
+#: app/configurator/components/dataset-browse.tsx:290
 msgid "dataset.order.newest"
 msgstr "Newest"
 
-#: app/configurator/components/dataset-browse.tsx:251
+#: app/configurator/components/dataset-browse.tsx:282
 msgid "dataset.order.relevance"
 msgstr "Relevance"
 
-#: app/configurator/components/dataset-browse.tsx:255
+#: app/configurator/components/dataset-browse.tsx:286
 msgid "dataset.order.title"
 msgstr "Title"
 
@@ -651,19 +655,19 @@ msgstr "Careful, this dataset is only a draft.<0/><1>Don't use for reporting!</1
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Careful, the data for this chart has expired.<0/><1>Don't use for reporting!</1>"
 
-#: app/configurator/components/dataset-browse.tsx:315
+#: app/configurator/components/dataset-browse.tsx:346
 msgid "dataset.results"
 msgstr "{0, plural, zero {No results} one {# result} other {# results}}"
 
-#: app/configurator/components/dataset-browse.tsx:263
+#: app/configurator/components/dataset-browse.tsx:294
 msgid "dataset.search.label"
 msgstr "Search datasets"
 
-#: app/configurator/components/dataset-browse.tsx:335
+#: app/configurator/components/dataset-browse.tsx:366
 msgid "dataset.sortby"
 msgstr "Sort by"
 
-#: app/configurator/components/dataset-browse.tsx:862
+#: app/configurator/components/dataset-browse.tsx:905
 msgid "dataset.tag.draft"
 msgstr "Draft"
 
@@ -808,19 +812,19 @@ msgstr "Here is a visualization I created using visualize.admin.ch"
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
-#: app/configurator/components/stepper.tsx:225
+#: app/configurator/components/stepper.tsx:189
 msgid "step.annotate"
 msgstr "Annotate"
 
 #: app/configurator/components/stepper.tsx:204
-msgid "step.dataset"
-msgstr "Dataset"
+#~ msgid "step.dataset"
+#~ msgstr "Dataset"
 
-#: app/configurator/components/stepper.tsx:211
+#: app/configurator/components/stepper.tsx:175
 msgid "step.visualization.type"
 msgstr "Chart Type"
 
-#: app/configurator/components/stepper.tsx:218
+#: app/configurator/components/stepper.tsx:182
 msgid "step.visualize"
 msgstr "Visualize"
 

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -33,11 +33,11 @@ msgstr "[ Pas de description ]"
 msgid "annotation.add.title"
 msgstr "[ Pas de titre ]"
 
-#: app/configurator/components/dataset-browse.tsx:683
+#: app/configurator/components/dataset-browse.tsx:714
 msgid "browse-panel.organizations"
 msgstr "Organisations"
 
-#: app/configurator/components/dataset-browse.tsx:640
+#: app/configurator/components/dataset-browse.tsx:671
 msgid "browse-panel.themes"
 msgstr "Catégories"
 
@@ -45,7 +45,7 @@ msgstr "Catégories"
 msgid "browse.dataset.create-visualization"
 msgstr "Créer une visualisation"
 
-#: app/configurator/components/select-dataset-step.tsx:128
+#: app/configurator/components/select-dataset-step.tsx:119
 msgid "browse.datasets.all-datasets"
 msgstr "Tout les jeux de données"
 
@@ -78,15 +78,15 @@ msgstr "Copié!"
 msgid "button.new.visualization"
 msgstr "Créer une nouvelle visualisation"
 
-#: app/configurator/components/action-bar.tsx:46
+#: app/configurator/components/action-bar.tsx:45
 msgid "button.next"
 msgstr "Suivant"
 
-#: app/configurator/components/action-bar.tsx:41
+#: app/configurator/components/action-bar.tsx:40
 msgid "button.previous"
 msgstr "Précédent"
 
-#: app/configurator/components/action-bar.tsx:44
+#: app/configurator/components/action-bar.tsx:43
 msgid "button.publish"
 msgstr "Publier"
 
@@ -288,7 +288,7 @@ msgstr "empilées"
 msgid "controls.description"
 msgstr "Description"
 
-#: app/configurator/components/field.tsx:503
+#: app/configurator/components/field.tsx:514
 msgid "controls.dimension.none"
 msgstr "Aucune"
 
@@ -507,7 +507,7 @@ msgstr "Sélectionner une variable"
 
 #: app/configurator/components/field.tsx:82
 #: app/configurator/components/field.tsx:140
-#: app/configurator/components/field.tsx:508
+#: app/configurator/components/field.tsx:519
 msgid "controls.select.optional"
 msgstr "optionnel"
 
@@ -597,15 +597,19 @@ msgstr "Afficher le champ de recherche"
 msgid "controls.title"
 msgstr "Titre"
 
-#: app/configurator/components/select-dataset-step.tsx:102
+#: app/configurator/components/select-dataset-step.tsx:93
 msgid "dataset-preview.back-to-results"
 msgstr "Revenir aux jeux de données"
+
+#: app/configurator/components/configurator.tsx:43
+msgid "dataset-selector.choose-another-dataset"
+msgstr "Choisir un autre jeu de données"
 
 #: app/components/chart-published.tsx:80
 msgid "dataset.hasImputedValues"
 msgstr "Certaines données de cet ensemble de données sont manquantes et ont été interpolées pour combler les lacunes."
 
-#: app/configurator/components/dataset-browse.tsx:291
+#: app/configurator/components/dataset-browse.tsx:322
 msgid "dataset.includeDrafts"
 msgstr "Inclure les brouillons"
 
@@ -629,15 +633,15 @@ msgstr "Source"
 msgid "dataset.metadata.version"
 msgstr "Version"
 
-#: app/configurator/components/dataset-browse.tsx:259
+#: app/configurator/components/dataset-browse.tsx:290
 msgid "dataset.order.newest"
 msgstr ""
 
-#: app/configurator/components/dataset-browse.tsx:251
+#: app/configurator/components/dataset-browse.tsx:282
 msgid "dataset.order.relevance"
 msgstr ""
 
-#: app/configurator/components/dataset-browse.tsx:255
+#: app/configurator/components/dataset-browse.tsx:286
 msgid "dataset.order.title"
 msgstr ""
 
@@ -651,19 +655,19 @@ msgstr "Attention, ce jeu de données est à l'état d'ébauche.<0/><1>Ne l'util
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Attention, ce jeu de données est expiré.<0/><1>Ne l'utilisez pas pour une publication!</1>"
 
-#: app/configurator/components/dataset-browse.tsx:315
+#: app/configurator/components/dataset-browse.tsx:346
 msgid "dataset.results"
 msgstr ""
 
-#: app/configurator/components/dataset-browse.tsx:263
+#: app/configurator/components/dataset-browse.tsx:294
 msgid "dataset.search.label"
 msgstr "Chercher"
 
-#: app/configurator/components/dataset-browse.tsx:335
+#: app/configurator/components/dataset-browse.tsx:366
 msgid "dataset.sortby"
 msgstr "Trier par"
 
-#: app/configurator/components/dataset-browse.tsx:862
+#: app/configurator/components/dataset-browse.tsx:905
 msgid "dataset.tag.draft"
 msgstr "Brouillon"
 
@@ -808,19 +812,19 @@ msgstr "Voici une visualisation que j'ai créée sur visualize.admin.ch"
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
-#: app/configurator/components/stepper.tsx:225
+#: app/configurator/components/stepper.tsx:189
 msgid "step.annotate"
 msgstr "Annoter"
 
 #: app/configurator/components/stepper.tsx:204
-msgid "step.dataset"
-msgstr "Données"
+#~ msgid "step.dataset"
+#~ msgstr "Données"
 
-#: app/configurator/components/stepper.tsx:211
+#: app/configurator/components/stepper.tsx:175
 msgid "step.visualization.type"
 msgstr "Type de graphique"
 
-#: app/configurator/components/stepper.tsx:218
+#: app/configurator/components/stepper.tsx:182
 msgid "step.visualize"
 msgstr "Visualiser"
 

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -33,11 +33,11 @@ msgstr "[ Nessuna descrizione ]"
 msgid "annotation.add.title"
 msgstr "[ Nessun titolo ]"
 
-#: app/configurator/components/dataset-browse.tsx:683
+#: app/configurator/components/dataset-browse.tsx:714
 msgid "browse-panel.organizations"
 msgstr "Organizzazioni"
 
-#: app/configurator/components/dataset-browse.tsx:640
+#: app/configurator/components/dataset-browse.tsx:671
 msgid "browse-panel.themes"
 msgstr "Categorie"
 
@@ -45,7 +45,7 @@ msgstr "Categorie"
 msgid "browse.dataset.create-visualization"
 msgstr "Crea una visualizzazione"
 
-#: app/configurator/components/select-dataset-step.tsx:128
+#: app/configurator/components/select-dataset-step.tsx:119
 msgid "browse.datasets.all-datasets"
 msgstr "Tutti i set di dati"
 
@@ -78,15 +78,15 @@ msgstr "Copiato!"
 msgid "button.new.visualization"
 msgstr "Crea una nuova visualizzazione"
 
-#: app/configurator/components/action-bar.tsx:46
+#: app/configurator/components/action-bar.tsx:45
 msgid "button.next"
 msgstr "Successivo"
 
-#: app/configurator/components/action-bar.tsx:41
+#: app/configurator/components/action-bar.tsx:40
 msgid "button.previous"
 msgstr "Precedente"
 
-#: app/configurator/components/action-bar.tsx:44
+#: app/configurator/components/action-bar.tsx:43
 msgid "button.publish"
 msgstr "Pubblica"
 
@@ -288,7 +288,7 @@ msgstr "impilate"
 msgid "controls.description"
 msgstr "Descrizione"
 
-#: app/configurator/components/field.tsx:503
+#: app/configurator/components/field.tsx:514
 msgid "controls.dimension.none"
 msgstr "Nessuno"
 
@@ -507,7 +507,7 @@ msgstr "Seleziona una misura"
 
 #: app/configurator/components/field.tsx:82
 #: app/configurator/components/field.tsx:140
-#: app/configurator/components/field.tsx:508
+#: app/configurator/components/field.tsx:519
 msgid "controls.select.optional"
 msgstr "facoltativo"
 
@@ -597,15 +597,19 @@ msgstr "Mostra il campo di ricerca"
 msgid "controls.title"
 msgstr "Titolo"
 
-#: app/configurator/components/select-dataset-step.tsx:102
+#: app/configurator/components/select-dataset-step.tsx:93
 msgid "dataset-preview.back-to-results"
 msgstr "Torna ai set di dati"
+
+#: app/configurator/components/configurator.tsx:43
+msgid "dataset-selector.choose-another-dataset"
+msgstr "Scegli un altro set di dati"
 
 #: app/components/chart-published.tsx:80
 msgid "dataset.hasImputedValues"
 msgstr "In questo set di dati mancano alcuni dati. Questi sono stati interpolati per colmare le lacune.."
 
-#: app/configurator/components/dataset-browse.tsx:291
+#: app/configurator/components/dataset-browse.tsx:322
 msgid "dataset.includeDrafts"
 msgstr "Includere le bozze"
 
@@ -629,15 +633,15 @@ msgstr "Fonte"
 msgid "dataset.metadata.version"
 msgstr "versione"
 
-#: app/configurator/components/dataset-browse.tsx:259
+#: app/configurator/components/dataset-browse.tsx:290
 msgid "dataset.order.newest"
 msgstr ""
 
-#: app/configurator/components/dataset-browse.tsx:251
+#: app/configurator/components/dataset-browse.tsx:282
 msgid "dataset.order.relevance"
 msgstr ""
 
-#: app/configurator/components/dataset-browse.tsx:255
+#: app/configurator/components/dataset-browse.tsx:286
 msgid "dataset.order.title"
 msgstr ""
 
@@ -651,19 +655,19 @@ msgstr "Attenzione, questo set di dati è una bozza.<0/><1>Non utilizzare questo
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Attenzione, questo set di dati è scaduto.<0/><1>Non utilizzare questo grafico per un rapporto!</1>"
 
-#: app/configurator/components/dataset-browse.tsx:315
+#: app/configurator/components/dataset-browse.tsx:346
 msgid "dataset.results"
 msgstr ""
 
-#: app/configurator/components/dataset-browse.tsx:263
+#: app/configurator/components/dataset-browse.tsx:294
 msgid "dataset.search.label"
 msgstr ""
 
-#: app/configurator/components/dataset-browse.tsx:335
+#: app/configurator/components/dataset-browse.tsx:366
 msgid "dataset.sortby"
 msgstr ""
 
-#: app/configurator/components/dataset-browse.tsx:862
+#: app/configurator/components/dataset-browse.tsx:905
 msgid "dataset.tag.draft"
 msgstr ""
 
@@ -808,19 +812,19 @@ msgstr "Ecco una visualizzazione che ho creato usando visualize.admin.ch"
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
-#: app/configurator/components/stepper.tsx:225
+#: app/configurator/components/stepper.tsx:189
 msgid "step.annotate"
 msgstr "Annota"
 
 #: app/configurator/components/stepper.tsx:204
-msgid "step.dataset"
-msgstr "Dataset"
+#~ msgid "step.dataset"
+#~ msgstr "Dataset"
 
-#: app/configurator/components/stepper.tsx:211
+#: app/configurator/components/stepper.tsx:175
 msgid "step.visualization.type"
 msgstr "Tipo di grafico"
 
-#: app/configurator/components/stepper.tsx:218
+#: app/configurator/components/stepper.tsx:182
 msgid "step.visualize"
 msgstr "Visualizzare"
 


### PR DESCRIPTION
Since the browsing mode is now separated from the chart creation, we chose to remove the step 1 "Selecting dataset" of the creation stepper.

fix #244 

- [x] Provide a mean to go back to the dataset selection