### PR TITLE
fix: Allowing for empty key dimension time filter

### DIFF
--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -273,6 +273,7 @@ const DataFilterTemporalDimension = ({
       value={value}
       timeFormat={timeFormat}
       formatLocale={formatLocale}
+      isOptional={!isKeyDimension}
       onChange={onChange}
     />
   );

--- a/app/configurator/components/field.spec.tsx
+++ b/app/configurator/components/field.spec.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render } from "@testing-library/react";
+import { getD3TimeFormatLocale } from "../../locales/locales";
+import { TimeInput } from "./field";
+
+describe("TimeInput", () => {
+  const expectedValue = "2020-05-24";
+  const setup = ({ isOptional, id }: { isOptional: boolean; id: string }) => {
+    let currentValue = "";
+
+    const root = render(
+      <TimeInput
+        id={id}
+        label={id}
+        value={currentValue}
+        timeFormat="%Y-%m-%d"
+        formatLocale={getD3TimeFormatLocale("en")}
+        isOptional={isOptional}
+        onChange={(e) => (currentValue = e.currentTarget.value)}
+      />
+    );
+
+    return { node: root.getByLabelText(id), getValue: () => currentValue };
+  };
+
+  describe("key dimension", () => {
+    const { node, getValue } = setup({
+      isOptional: false,
+      id: "mandatory-input",
+    });
+
+    it("should set the date if passed in correct format", async () => {
+      fireEvent.change(node, {
+        target: { value: expectedValue },
+      });
+      expect(getValue()).toEqual(expectedValue);
+
+      fireEvent.change(node, {
+        target: { value: "2020-13-38" },
+      });
+      expect(getValue()).toEqual(expectedValue);
+    });
+
+    it("should revert to previous value if passed an empty string for mandatory input", () => {
+      fireEvent.change(node, {
+        target: { value: expectedValue },
+      });
+
+      fireEvent.change(node, {
+        target: { value: "" },
+      });
+      expect(getValue()).toEqual(expectedValue);
+    });
+  });
+
+  describe("optional dimension", () => {
+    const { node, getValue } = setup({
+      isOptional: true,
+      id: "optional-input",
+    });
+    it("shouldn't revert to previous correct value if passed an empty string for optional input", () => {
+      fireEvent.change(node, {
+        target: { value: expectedValue },
+      });
+
+      fireEvent.change(node, {
+        target: { value: "" },
+      });
+      expect(getValue()).toEqual("");
+    });
+  });
+});

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -193,6 +193,7 @@ export const DataFilterSelectTime = ({
       value={fieldProps.value}
       timeFormat={timeFormat}
       formatLocale={formatLocale}
+      isOptional={isOptional}
       onChange={fieldProps.onChange}
     />
   );
@@ -204,6 +205,7 @@ export const TimeInput = ({
   value,
   timeFormat,
   formatLocale,
+  isOptional,
   onChange,
 }: {
   id: string;
@@ -211,6 +213,7 @@ export const TimeInput = ({
   value: string | undefined;
   timeFormat: string;
   formatLocale: TimeLocaleObject;
+  isOptional: boolean | undefined;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
 }) => {
   const [inputValue, setInputValue] = useState(
@@ -225,16 +228,24 @@ export const TimeInput = ({
   const onInputChange = useCallback<(e: ChangeEvent<HTMLInputElement>) => void>(
     (e) => {
       setInputValue(e.currentTarget.value);
-      const parsed = parseDateValue(e.currentTarget.value);
-      if (
-        (parsed !== null &&
-          formatDateValue(parsed) === e.currentTarget.value) ||
-        e.currentTarget.value === ""
-      ) {
-        onChange(e);
+
+      if (e.currentTarget.value === "") {
+        if (isOptional) {
+          onChange(e);
+        } else {
+          setInputValue(value);
+        }
+      } else {
+        const parsed = parseDateValue(e.currentTarget.value);
+        const isValidDate =
+          parsed !== null && formatDateValue(parsed) === e.currentTarget.value;
+
+        if (isValidDate) {
+          onChange(e);
+        }
       }
     },
-    [formatDateValue, onChange, parseDateValue]
+    [formatDateValue, onChange, parseDateValue, value, isOptional]
   );
 
   return (


### PR DESCRIPTION
Closes #209.

This PR allows to have an empty optional time filter (non-key dimension) and forces it to have some value for key dimensions.