### PR TITLE
fix: Expose client env via API endpoint

### DIFF
--- a/app/pages/_document.tsx
+++ b/app/pages/_document.tsx
@@ -5,15 +5,8 @@ import Document, {
   NextScript,
   DocumentContext,
 } from "next/document";
+import { GA_TRACKING_ID } from "../domain/env";
 import { parseLocaleString } from "../locales/locales";
-
-const clientEnv = {
-  GA_TRACKING_ID: process.env.GA_TRACKING_ID,
-  SPARQL_EDITOR: process.env.SPARQL_EDITOR,
-  SPARQL_ENDPOINT: process.env.SPARQL_ENDPOINT,
-  PUBLIC_URL: process.env.PUBLIC_URL,
-  GRAPHQL_ENDPOINT: process.env.GRAPHQL_ENDPOINT,
-};
 
 class MyDocument extends Document<{ locale: string }> {
   static async getInitialProps(ctx: DocumentContext) {
@@ -40,20 +33,16 @@ class MyDocument extends Document<{ locale: string }> {
         lang={this.props.locale}
       >
         <Head>
-          <script
-            dangerouslySetInnerHTML={{
-              __html: `window.__clientEnv__=${JSON.stringify(clientEnv)}`,
-            }}
-          />
-          {clientEnv.GA_TRACKING_ID && (
+          <script src="/api/client-env"></script>
+          {GA_TRACKING_ID && (
             <>
               <script
                 async
-                src={`https://www.googletagmanager.com/gtag/js?id=${clientEnv.GA_TRACKING_ID}`}
+                src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
               />
               <script
                 dangerouslySetInnerHTML={{
-                  __html: `window.dataLayer = window.dataLayer || [];function gtag() {window.dataLayer.push(arguments);};gtag("js", new Date());gtag("config", "${clientEnv.GA_TRACKING_ID}", {anonymize_ip:true});`,
+                  __html: `window.dataLayer = window.dataLayer || [];function gtag() {window.dataLayer.push(arguments);};gtag("js", new Date());gtag("config", "${GA_TRACKING_ID}", {anonymize_ip:true});`,
                 }}
               ></script>
             </>

--- a/app/pages/api/client-env.ts
+++ b/app/pages/api/client-env.ts
@@ -1,0 +1,42 @@
+import { NextApiRequest, NextApiResponse } from "next";
+
+/**
+ * Endpoint to get env variables client-side
+ */
+export default async function clientEnvApi(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const { method } = req;
+
+  switch (method) {
+    case "GET":
+      try {
+        const result = `window.__clientEnv__=${JSON.stringify({
+          GA_TRACKING_ID: process.env.GA_TRACKING_ID,
+          SPARQL_EDITOR: process.env.SPARQL_EDITOR,
+          SPARQL_ENDPOINT: process.env.SPARQL_ENDPOINT,
+          PUBLIC_URL: process.env.PUBLIC_URL,
+          GRAPHQL_ENDPOINT: process.env.GRAPHQL_ENDPOINT,
+        })}`;
+
+        if (result) {
+          res.setHeader(
+            "Content-Type",
+            "application/javascript; charset=UTF-8"
+          );
+          res.status(200).send(result);
+        } else {
+          res.status(404).send("Not found.");
+        }
+      } catch (e) {
+        console.error(e);
+        res.status(500).json("Something went wrong!");
+      }
+
+      break;
+    default:
+      res.setHeader("Allow", ["GET"]);
+      res.status(405).end(`Method ${method} Not Allowed`);
+  }
+}


### PR DESCRIPTION
Because the process.env.* variables for some reason are only set in next.js dev mode inside of _document.tsx, the only way to expose them reliably is through an API route.

To ensure it's loaded before other scripts, it's imported as a synchronous script that sets `window.__clientEnv__` in the document `<head>`.

Fixes #254