### PR TITLE
Back link improvements

### DIFF
--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -39,7 +39,7 @@ const DatasetSelector = ({ state }: { state: ConfiguratorState }) => {
           <div>{metaData.dataCubeByIri?.title}</div>
           <div>
             <NextLink href="/browse" passHref>
-              <Link sx={{ fontSize: 3 }}>
+              <Link variant="primary" sx={{ fontSize: 3 }}>
                 <Trans id="dataset-selector.choose-another-dataset">
                   Choose another dataset
                 </Trans>

--- a/app/configurator/components/dataset-metadata.tsx
+++ b/app/configurator/components/dataset-metadata.tsx
@@ -1,7 +1,7 @@
 import { Trans } from "@lingui/macro";
 import NextLink from "next/link";
 import React, { ReactNode } from "react";
-import { Box, Link } from "theme-ui";
+import { Box, BoxProps, Link } from "theme-ui";
 import { Loading } from "../../components/hint";
 import Stack from "../../components/Stack";
 import { useFormatDate } from "../../configurator/components/ui-helpers";
@@ -12,7 +12,11 @@ import {
 import { useLocale } from "../../locales/use-locale";
 import truthy from "../../utils/truthy";
 import Tag from "./Tag";
-export const DataSetMetadata = ({ dataSetIri }: { dataSetIri: string }) => {
+
+export const DataSetMetadata = ({
+  dataSetIri,
+  ...boxProps
+}: { dataSetIri: string } & BoxProps) => {
   const locale = useLocale();
   const formatDate = useFormatDate();
   const [{ data }] = useDataCubeMetadataQuery({
@@ -24,7 +28,7 @@ export const DataSetMetadata = ({ dataSetIri }: { dataSetIri: string }) => {
   }
 
   return (
-    <Box sx={{ m: 4 }}>
+    <Box {...boxProps} sx={{ mx: 4, ...boxProps.sx }}>
       {cube.publisher && (
         <>
           <DatasetMetadataTitle>

--- a/app/configurator/components/select-dataset-step.tsx
+++ b/app/configurator/components/select-dataset-step.tsx
@@ -84,19 +84,23 @@ export const SelectDatasetStepContent = () => {
         pt: 3,
       }}
     >
-      <PanelLeftWrapper raised={false} sx={{ mt: 50, bg: "transparent" }}>
+      <PanelLeftWrapper
+        raised={false}
+        sx={{ mt: "2.25rem", bg: "transparent" }}
+      >
         {dataset ? (
           <>
-            <Box mb={4} px={4}>
+            <Box px={4}>
               <NextLink passHref href={backLink}>
-                <Link variant="inline">
+                <Link variant="primary">
+                  ←{" "}
                   <Trans id="dataset-preview.back-to-results">
                     Back to the list
                   </Trans>
                 </Link>
               </NextLink>
             </Box>
-            <DataSetMetadata dataSetIri={dataset} />
+            <DataSetMetadata sx={{ mt: "3rem" }} dataSetIri={dataset} />
           </>
         ) : (
           <SearchFilters />


### PR DESCRIPTION
- Back to results link is separated from dataset metadata, a bit bigger, and with arrow
- Choose another dataset link is styled properly (primary color with underline on hover)
