### PR TITLE
Try to fetch dimension values when no values are there initially

### DIFF
--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -18,7 +18,10 @@ import {
   parseObservationValue,
 } from "../domain/data";
 import { SPARQL_EDITOR, SPARQL_ENDPOINT } from "../domain/env";
+import { DataCubeSearchFilter, DataCubeTheme } from "../graphql/query-hooks";
 import { ResolvedDataCube, ResolvedDimension } from "../graphql/shared-types";
+import isAttrEqual from "../utils/is-attr-equal";
+import truthy from "../utils/truthy";
 import * as ns from "./namespace";
 import {
   getQueryLocales,
@@ -26,15 +29,10 @@ import {
   parseCube,
   parseCubeDimension,
 } from "./parse";
+import { loadDimensionValues } from "./query-dimension-values";
 import { loadResourceLabels } from "./query-labels";
-import { loadUnitLabels } from "./query-unit-labels";
 import { loadUnversionedResources } from "./query-sameas";
-import truthy from "../utils/truthy";
-import {
-  DataCubeSearchFilter,
-  DataCubeTheme,
-} from "../graphql/query-hooks";
-import isAttrEqual from "../utils/is-attr-equal";
+import { loadUnitLabels } from "./query-unit-labels";
 
 const DIMENSION_VALUE_UNDEFINED = ns.cube.Undefined.value;
 
@@ -314,6 +312,14 @@ const groupLabelsPerValue = ({
 const dimensionIsVersioned = (dimension: CubeDimension) =>
   dimension.out(ns.schema.version)?.value ? true : false;
 
+const filterCubeDimensionValuesByTermType = ({
+  values,
+  termType,
+}: {
+  values: (Literal | NamedNode)[] | undefined;
+  termType: "Literal" | "NamedNode";
+}) => values?.filter((d) => d.termType === termType) ?? [];
+
 const getCubeDimensionValuesWithLabels = async ({
   dimension,
   cube,
@@ -323,13 +329,14 @@ const getCubeDimensionValuesWithLabels = async ({
   cube: Cube;
   locale: string;
 }): Promise<DimensionValue[]> => {
-  const dimensionValueNamedNodes = (dimension.in?.filter(
-    (v) => v.termType === "NamedNode"
-  ) ?? []) as NamedNode[];
-
-  const dimensionValueLiterals = (dimension.in?.filter(
-    (v) => v.termType === "Literal"
-  ) ?? []) as Literal[];
+  let dimensionValueNamedNodes = filterCubeDimensionValuesByTermType({
+    values: dimension.in,
+    termType: "NamedNode",
+  }) as NamedNode[];
+  let dimensionValueLiterals = filterCubeDimensionValuesByTermType({
+    values: dimension.in,
+    termType: "Literal",
+  }) as Literal[];
 
   if (
     dimensionValueNamedNodes.length > 0 &&
@@ -349,9 +356,29 @@ const getCubeDimensionValuesWithLabels = async ({
     dimensionValueNamedNodes.length === 0 &&
     dimensionValueLiterals.length === 0
   ) {
-    console.warn(
-      `WARNING: dimension with NO values <${dimension.path?.value}>`
-    );
+    const resolvedDimensionValues = await loadDimensionValues({
+      datasetIri: cube.term,
+      dimensionIri: dimension.path,
+    });
+
+    if (resolvedDimensionValues.length) {
+      const unpackedDimensionValues = resolvedDimensionValues.map(
+        (d) => d.value
+      );
+
+      dimensionValueNamedNodes = filterCubeDimensionValuesByTermType({
+        values: unpackedDimensionValues,
+        termType: "NamedNode",
+      }) as NamedNode[];
+      dimensionValueLiterals = filterCubeDimensionValuesByTermType({
+        values: unpackedDimensionValues,
+        termType: "Literal",
+      }) as Literal[];
+    } else {
+      console.warn(
+        `WARNING: dimension with NO values <${dimension.path?.value}>`
+      );
+    }
   }
 
   /**

--- a/app/rdf/query-dimension-values.ts
+++ b/app/rdf/query-dimension-values.ts
@@ -16,22 +16,22 @@ export async function loadDimensionValues({
 }: {
   datasetIri: Term | undefined;
   dimensionIri: Term | undefined;
-}): Promise<DimensionValue[]> {
+}): Promise<Array<Literal | NamedNode>> {
   const query = SELECT.DISTINCT`?value`.WHERE`
     ${datasetIri} ${cube.observationSet} ?observationSet .
     ?observationSet ${cube.observation} ?observation .
     ?observation ${dimensionIri} ?value .
   `;
 
-  let result: DimensionValue[] = [];
+  let result: Array<DimensionValue> = [];
 
   try {
     result = (await query.execute(sparqlClient.query, {
       operation: "postUrlencoded",
-    })) as unknown as DimensionValue[];
+    })) as unknown as Array<DimensionValue>;
   } catch {
     console.warn(`Failed to fetch dimension values for ${datasetIri}.`);
   } finally {
-    return result;
+    return result.map((d) => d.value);
   }
 }

--- a/app/rdf/query-dimension-values.ts
+++ b/app/rdf/query-dimension-values.ts
@@ -1,0 +1,37 @@
+import { SELECT } from "@tpluscode/sparql-builder";
+import { Literal, NamedNode, Term } from "rdf-js";
+import { cube } from "./namespace";
+import { sparqlClient } from "./sparql-client";
+
+interface DimensionValue {
+  value: Literal | NamedNode<string>;
+}
+
+/**
+ * Load dimension values.
+ */
+export async function loadDimensionValues({
+  datasetIri,
+  dimensionIri,
+}: {
+  datasetIri: Term | undefined;
+  dimensionIri: Term | undefined;
+}): Promise<DimensionValue[]> {
+  const query = SELECT.DISTINCT`?value`.WHERE`
+    ${datasetIri} ${cube.observationSet} ?observationSet .
+    ?observationSet ${cube.observation} ?observation .
+    ?observation ${dimensionIri} ?value .
+  `;
+
+  let result: DimensionValue[] = [];
+
+  try {
+    result = (await query.execute(sparqlClient.query, {
+      operation: "postUrlencoded",
+    })) as unknown as DimensionValue[];
+  } catch {
+    console.warn(`Failed to fetch dimension values for ${datasetIri}.`);
+  } finally {
+    return result;
+  }
+}


### PR DESCRIPTION
Right now the logic brings back the previous functionality – tries to fetch all of the dimension values if no values are present initially. We still need to wait for autocomplete API from Zazuko and I'm not quite sure how this should look like in UI (and the code), so I didn't try to come up with new ideas, it probably would make sense to also consult this with Annina.

Let me know what do you think (and if this should be already merged to main – if not, I can merge this to maps PR to continue working on it if the code looks fine).