### PR TITLE
fix: Sort by relevance by default

### DIFF
--- a/app/configurator/components/dataset-browse.tsx
+++ b/app/configurator/components/dataset-browse.tsx
@@ -181,7 +181,7 @@ export const useBrowseState = () => {
   );
 
   const previousOrderRef = useRef<DataCubeResultOrder>(
-    DataCubeResultOrder.TitleAsc
+    DataCubeResultOrder.Score
   );
 
   return useMemo(


### PR DESCRIPTION
The score by default was "title", by mistake, which meant the results were
alphabetically ordered instead of being ordered by relevance.﻿
