### PR TITLE
fix: Weird shapes colors

### DIFF
--- a/app/charts/map/map.tsx
+++ b/app/charts/map/map.tsx
@@ -242,7 +242,7 @@ export const MapComponent = () => {
                   ? areaLayer.getColor(
                       areaLayer.getValue(d.properties.observation)
                     )
-                  : null
+                  : [33, 33, 33, 33]
               }
             />
             <GeoJsonLayer


### PR DESCRIPTION
Closes #281.

Previously, if no observation was mapped to a shape (or its measure value was equal to `null`), a `null` was used as a shape fill color. This led to weird bugs - changing this to a light gray color fixes the issue.