### PR TITLE
Fix: ability to encode geo dimensions

### DIFF
--- a/app/charts/chart-config-ui-options.ts
+++ b/app/charts/chart-config-ui-options.ts
@@ -74,7 +74,13 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
       {
         field: "x",
         optional: false,
-        values: ["TemporalDimension", "NominalDimension", "OrdinalDimension"],
+        values: [
+          "TemporalDimension",
+          "NominalDimension",
+          "OrdinalDimension",
+          "GeoCoordinatesDimension",
+          "GeoShapesDimension",
+        ],
         filters: true,
         sorting: [
           { sortingType: "byMeasure", sortingOrder: ["asc", "desc"] },
@@ -84,7 +90,12 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
       {
         field: "segment",
         optional: true,
-        values: ["NominalDimension", "OrdinalDimension"],
+        values: [
+          "NominalDimension",
+          "OrdinalDimension",
+          "GeoCoordinatesDimension",
+          "GeoShapesDimension",
+        ],
         filters: true,
         sorting: [
           { sortingType: "byDimensionLabel", sortingOrder: ["asc", "desc"] },
@@ -104,7 +115,13 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
       {
         field: "y",
         optional: false,
-        values: ["TemporalDimension", "NominalDimension", "OrdinalDimension"],
+        values: [
+          "TemporalDimension",
+          "NominalDimension",
+          "OrdinalDimension",
+          "GeoCoordinatesDimension",
+          "GeoShapesDimension",
+        ],
         filters: true,
       },
       {
@@ -116,7 +133,12 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
       {
         field: "segment",
         optional: true,
-        values: ["NominalDimension", "OrdinalDimension"],
+        values: [
+          "NominalDimension",
+          "OrdinalDimension",
+          "GeoCoordinatesDimension",
+          "GeoShapesDimension",
+        ],
         filters: true,
         sorting: [
           { sortingType: "byDimensionLabel", sortingOrder: ["asc", "desc"] },
@@ -143,7 +165,12 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
       {
         field: "segment",
         optional: true,
-        values: ["NominalDimension", "OrdinalDimension"],
+        values: [
+          "NominalDimension",
+          "OrdinalDimension",
+          "GeoCoordinatesDimension",
+          "GeoShapesDimension",
+        ],
         filters: true,
         // sorting: [
         //   { sortingType: "byTotalSize", sortingOrder: ["asc", "desc"] },
@@ -168,7 +195,12 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
       {
         field: "segment",
         optional: true,
-        values: ["NominalDimension", "OrdinalDimension"],
+        values: [
+          "NominalDimension",
+          "OrdinalDimension",
+          "GeoCoordinatesDimension",
+          "GeoShapesDimension",
+        ],
         filters: true,
         sorting: [
           { sortingType: "byDimensionLabel", sortingOrder: ["asc", "desc"] },
@@ -195,7 +227,12 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
       {
         field: "segment",
         optional: true,
-        values: ["NominalDimension", "OrdinalDimension"],
+        values: [
+          "NominalDimension",
+          "OrdinalDimension",
+          "GeoCoordinatesDimension",
+          "GeoShapesDimension",
+        ],
         filters: true,
         options: [{ field: "color", values: ["palette"] }],
       },
@@ -214,7 +251,12 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
       {
         field: "segment",
         optional: false,
-        values: ["NominalDimension", "OrdinalDimension"],
+        values: [
+          "NominalDimension",
+          "OrdinalDimension",
+          "GeoCoordinatesDimension",
+          "GeoShapesDimension",
+        ],
         filters: true,
         sorting: [
           { sortingType: "byMeasure", sortingOrder: ["asc", "desc"] },

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -202,6 +202,17 @@ const EncodingOptionsPanel = ({
     (f) => (fields as any)[f].componentIri
   );
 
+  const options = useMemo(() => {
+    return getDimensionsByDimensionType({
+      dimensionTypes: encoding.values,
+      dimensions,
+      measures,
+    }).map((dimension) => ({
+      value: dimension.iri,
+      label: dimension.label,
+      disabled: otherFieldsIris.includes(dimension.iri),
+    }));
+  }, [dimensions, encoding.values, measures, otherFieldsIris]);
   return (
     <div
       key={`control-panel-${encoding.field}`}
@@ -220,15 +231,7 @@ const EncodingOptionsPanel = ({
             field={encoding.field}
             label={getFieldLabelHint[encoding.field]}
             optional={encoding.optional}
-            options={getDimensionsByDimensionType({
-              dimensionTypes: encoding.values,
-              dimensions,
-              measures,
-            }).map((dimension) => ({
-              value: dimension.iri,
-              label: dimension.label,
-              disabled: otherFieldsIris.includes(dimension.iri),
-            }))}
+            options={options}
             dataSetMetadata={metaData}
           />
           {encoding.options && (


### PR DESCRIPTION
We have to add geo dimensions to the encoding specs (that specify constraints
on which type of dimension can be mapped to which encoding) so that we
can map the bathing site dimension (that has been changed recently into
a geocoordinates dimension)﻿to a color.

- fix: Add GeoShape and GeoCoordinates dimensions to the UI encoding spec
