### PR TITLE
feat: Redirect to latest cube iri when going to on browse/dataset/<unversionedIri>

### DIFF
--- a/app/pages/browse/[type]/[iri].tsx
+++ b/app/pages/browse/[type]/[iri].tsx
@@ -4,6 +4,10 @@ import { queryLatestPublishedCubeFromUnversionedIri } from "../../../rdf/query-c
 import { defaultLocale } from "../../../src";
 export default GenericBrowse;
 
+/**
+ * Heuristic to check if a dataset IRI is versioned.
+ * Versioned iris look like https://blabla/<number/
+ */
 const isDatasetIriVersioned = (iri: string) => {
   return iri.match(/\/\d+\/$/) !== null;
 };

--- a/app/pages/browse/[type]/[iri].tsx
+++ b/app/pages/browse/[type]/[iri].tsx
@@ -1,2 +1,45 @@
 import { GenericBrowse } from "../index";
+import { GetServerSideProps } from "next";
+import { queryLatestPublishedCubeFromUnversionedIri } from "../../../rdf/query-cube-metadata";
+import { defaultLocale } from "../../../src";
 export default GenericBrowse;
+
+const isDatasetIriVersioned = (iri: string) => {
+  return iri.match(/\/\d+\/$/) !== null;
+};
+
+const getServerSideProps: GetServerSideProps = async function (ctx) {
+  const { params } = ctx;
+  if (!params) {
+    return { props: {} };
+  }
+  if (
+    params?.type === "dataset" &&
+    params.iri &&
+    !Array.isArray(params.iri) &&
+    !isDatasetIriVersioned(params.iri)
+  ) {
+    const resp = await queryLatestPublishedCubeFromUnversionedIri(params.iri);
+    if (!resp) {
+      return {
+        redirect: {
+          permanent: false,
+          destination: "/",
+        },
+      };
+    }
+    return {
+      redirect: {
+        permanent: false,
+        destination: `/${
+          ctx.locale || defaultLocale
+        }/browse/dataset/${encodeURIComponent(resp.iri)}`,
+      },
+    };
+  }
+  return {
+    props: {},
+  };
+};
+
+export { getServerSideProps };

--- a/app/pages/browse/index.tsx
+++ b/app/pages/browse/index.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from "next/router";
 import React from "react";
 import { AppLayout } from "../../components/layout";
 import { SelectDatasetStep } from "../../configurator/components/select-dataset-step";
@@ -18,7 +17,6 @@ export type BrowseParams = {
 
 // Generic component for all browse subpages
 export const GenericBrowse = () => {
-  const router = useRouter();
   return (
     <AppLayout>
       <ConfiguratorStateProvider chartId="new" allowDefaultRedirect={false}>


### PR DESCRIPTION
Fixes https://github.com/visualize-admin/visualization-tool/issues/288

When we land on /en/browse/dataset/<unversionedIri>, we fetch the latest published cube to get the latest unversioned iri and redirect server side to /en/browse/dataset/<versionedIri>.
To detect unversionedIri, a heuristic is used, it should end with `/<number>/`.