### PR TITLE
fix: Ending slash is optional for iris (versioned or unversioned)

### DIFF
--- a/app/pages/browse/[type]/[iri].tsx
+++ b/app/pages/browse/[type]/[iri].tsx
@@ -9,7 +9,7 @@ export default GenericBrowse;
  * Versioned iris look like https://blabla/<number/
  */
 const isDatasetIriVersioned = (iri: string) => {
-  return iri.match(/\/\d+\/$/) !== null;
+  return iri.match(/\/\d+\/?$/) !== null;
 };
 
 const getServerSideProps: GetServerSideProps = async function (ctx) {


### PR DESCRIPTION
Iris for dataset can contain an optional ending slash.

Since the regex would match only URLs with ending slash, we would consider some URLs as unversioned when in fact they are versioned, and then we would try to find the versioned dataset and it would fail. Now we correctly consider http://<iri>/1 as versioned (and also http://<iri>/1/).

fix #313 
