### PR TITLE
fix: Show dimension values even when column datatype is rdf:langString

### DIFF
--- a/app/rdf/query-dimension-values.ts
+++ b/app/rdf/query-dimension-values.ts
@@ -45,15 +45,20 @@ const formatFilterIntoSparqlFilter = (
   index: number
 ) => {
   const suffix = versioned ? "_unversioned" : "";
+  const dimensionVar = `?dimension${suffix}${index}`;
+  // We do not keep the language information inside the filter so for now
+  // we only filter on the value
+  const leftSide =
+    dimension?.datatype?.value === ns.rdf.langString.value
+      ? `str(${dimensionVar})`
+      : dimensionVar;
   if (filter.type === "single") {
-    return `FILTER ( (?dimension${suffix}${index} = ${formatFilterValue(
+    return `FILTER ( (${leftSide} = ${formatFilterValue(
       filter.value,
       dimension
     )}) )`;
   } else if (filter.type === "multi") {
-    return `FILTER ( (?dimension${suffix}${index} in (${Object.keys(
-      filter.values
-    )
+    return `FILTER ( (${leftSide} in (${Object.keys(filter.values)
       .map((x) => formatFilterValue(x, dimension))
       .join(",")}) ) )`;
   } else {


### PR DESCRIPTION
Some datasets have been created with rdf:langString in some columns. This means that strings are tagged with their language. Since we do not keep the language information inside the filter, we have to filter only based on the string representation of the value.