### PR TITLE
feat: Display counts per theme / organisations depending on search

### DIFF
--- a/app/configurator/components/select-dataset-step.tsx
+++ b/app/configurator/components/select-dataset-step.tsx
@@ -103,7 +103,7 @@ export const SelectDatasetStepContent = () => {
             <DataSetMetadata sx={{ mt: "3rem" }} dataSetIri={dataset} />
           </>
         ) : (
-          <SearchFilters />
+          <SearchFilters data={data} />
         )}
       </PanelLeftWrapper>
       <PanelMiddleWrapper


### PR DESCRIPTION
When a search has been entered, the nav panel counts will reflect
the numbers of *results* per theme/organization instead of the *overall
count of cubes per theme/organization.

fix https://github.com/visualize-admin/visualization-tool/issues/310