### PR TITLE
Page titles

### DIFF
--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -1,4 +1,5 @@
 import { Trans } from "@lingui/macro";
+import Head from "next/head";
 import * as React from "react";
 import { Box, Flex, Text } from "theme-ui";
 import { ChartDataFilters } from "../charts/shared/chart-data-filters";
@@ -65,6 +66,14 @@ export const ChartPreview = ({ dataSetIri }: { dataSetIri: string }) => {
                   state.meta.title[locale]
                 )}
               </Text>
+              <Head>
+                <title key="title">
+                  {state.meta.title[locale] === ""
+                    ? metaData?.dataCubeByIri?.title
+                    : state.meta.title[locale]}{" "}
+                  - visualize.admin.ch
+                </title>
+              </Head>
               <Text
                 variant="paragraph1"
                 sx={{

--- a/app/configurator/components/dataset-preview.tsx
+++ b/app/configurator/components/dataset-preview.tsx
@@ -8,6 +8,7 @@ import { useLocale } from "../../locales/use-locale";
 import { DataCubePublicationStatus } from "../../graphql/resolver-types";
 import DebugPanel from "../../components/debug-panel";
 import LinkButton from "./link-button";
+import Head from "next/head";
 
 export interface Preview {
   iri: string;
@@ -44,6 +45,11 @@ export const DataSetPreview = ({ dataSetIri }: { dataSetIri: string }) => {
         <Flex
           sx={{ alignItems: "center", justifyContent: "space-between", mb: 6 }}
         >
+          <Head>
+            <title key="title">
+              {dataCubeByIri.title} - visualize.admin.ch
+            </title>
+          </Head>
           <Text as="div" variant="heading1">
             {dataCubeByIri.title}
           </Text>

--- a/app/configurator/components/select-dataset-step.tsx
+++ b/app/configurator/components/select-dataset-step.tsx
@@ -1,4 +1,5 @@
-import { Trans } from "@lingui/macro";
+import { t, Trans } from "@lingui/macro";
+import Head from "next/head";
 import NextLink from "next/link";
 import { Router, useRouter } from "next/router";
 import React, { useMemo } from "react";
@@ -171,9 +172,26 @@ export const SelectDatasetStepContent = () => {
   );
 };
 
+const PageTitle = () => {
+  const { search, filters } = useBrowseContext();
+  return (
+    <Head>
+      <title key="title">
+        {search
+          ? `"${search}"`
+          : filters?.length > 0 && filters[0].__typename !== "DataCubeAbout"
+          ? filters[0].label
+          : t({ id: "browse.datasets.all-datasets" })}{" "}
+        - visualize.admin.ch
+      </title>
+    </Head>
+  );
+};
+
 export const SelectDatasetStep = () => {
   return (
     <BrowseStateProvider>
+      <PageTitle />
       <SelectDatasetStepContent />
     </BrowseStateProvider>
   );

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -63,7 +63,7 @@ msgstr "Create visualization"
 
 #: app/configurator/components/select-dataset-step.tsx:133
 msgid "browse.datasets.all-datasets"
-msgstr "All Datasets"
+msgstr "All datasets"
 
 #: app/configurator/components/select-dataset-step.tsx:145
 msgid "browse.datasets.description"

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -77,7 +77,7 @@ export default function App({ Component, pageProps }: AppProps) {
   return (
     <>
       <Head>
-        <title>visualize.admin.ch</title>
+        <title key="title">visualize.admin.ch</title>
         <meta property="og:type" content="website" />
         <meta property="og:title" content={"visualize.admin.ch"} />
         <meta property="og:url" content={`${PUBLIC_URL}${asPath}`} />


### PR DESCRIPTION
- feat: Add page titles in browsing pages
- feat: Add browsing title in dataset preview page
- feat: Add page title when creating chart

fix #330

Examples


- All datasets - visualize.admin.ch (while browsing all datasets, no search has been entered)
- "penguins" - visualize.admin.ch (while browsing datasets, search has been entered)
- Territory and environment - visualize.admin.ch (user has chosen a specific filter)
- Palmer penguins - visualize.admin.ch (user is previewing a dataset)
- Palmer penguins - visualize.admin.ch (user is creating a chart and has not chosen a title yet)
- My chart about penguins - visualize.admin.ch (user has put a title to its chart)


