### PR TITLE
Improve filter value selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added rivers and lakes through vector layer [#309](https://github.com/visualize-admin/visualization-tool/pull/309)
 - Improved chart editing navigation [#337](https://github.com/visualize-admin/visualization-tool/pull/337)
 - Improved chart publish action buttons [#337](https://github.com/visualize-admin/visualization-tool/pull/337)
+- Improve cascading filters selection to ensure data is shown after filter selection [#343](https://github.com/visualize-admin/visualization-tool/pull/343)
 
 ### Bugs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added rivers and lakes through vector layer [#309](https://github.com/visualize-admin/visualization-tool/pull/309)
 - Improved chart editing navigation [#337](https://github.com/visualize-admin/visualization-tool/pull/337)
 - Improved chart publish action buttons [#337](https://github.com/visualize-admin/visualization-tool/pull/337)
-- Improve cascading filters selection to ensure data is shown after filter selection [#343](https://github.com/visualize-admin/visualization-tool/pull/343)
+- Improved cascading filters selection to ensure data is shown after filter selection [#343](https://github.com/visualize-admin/visualization-tool/pull/343)
+- Improved initial filter selection to ensure data is shown on the selecting chart type step [#327](https://github.com/visualize-admin/visualization-tool/pull/327)
 
 ### Bugs
 

--- a/app/components/debug-panel.tsx
+++ b/app/components/debug-panel.tsx
@@ -67,7 +67,15 @@ DESCRIBE <${configuratorState.dataSet ?? ""}>`
         )}
       </Box>
       <Box as="h3" variant="text.lead" sx={{ px: 5, color: "monochrome700" }}>
-        Configurator State
+        Configurator State{" "}
+        <Link
+          variant="inline"
+          onClick={() => {
+            console.log(configuratorState);
+          }}
+        >
+          (dump to console)
+        </Link>
       </Box>
       <Box sx={{ p: 5 }}>
         <Inspector expandLevel={3} data={configuratorState} />

--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -189,7 +189,7 @@ export const Select = ({
   }, [options, locale, sortOptions]);
 
   return (
-    <Box sx={{ color: "monochrome700", pb: 2 }}>
+    <Box sx={{ color: "monochrome700" }}>
       {label && (
         <Label htmlFor={id} disabled={disabled} smaller>
           {label}

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -277,11 +277,12 @@ export const ChartConfigurator = ({
         >["dimensions"]
       >[number]
     ) => {
+      const filterValue = dimension.values.find((v) => v !== FIELD_VALUE_NONE);
       dispatch({
         type: "CHART_CONFIG_FILTER_SET_SINGLE",
         value: {
           dimensionIri: dimension.iri,
-          value: dimension.values[0],
+          value: filterValue,
         },
       });
     };
@@ -323,7 +324,10 @@ export const ChartConfigurator = ({
           <SectionTitle titleId="controls-data">
             <Trans id="controls.section.data.filters">Filters</Trans>{" "}
             {fetching ? (
-              <Spinner size={12} sx={{ display: "inline-block", ml: 1 }} />
+              <Spinner
+                size={12}
+                sx={{ color: "hint", display: "inline-block", ml: 1 }}
+              />
             ) : null}
           </SectionTitle>
 

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -342,6 +342,7 @@ export const ChartConfigurator = ({
                   >
                     {filterDimensions.map((dimension, i) => (
                       <Draggable
+                        isDragDisabled={fetching}
                         draggableId={dimension.iri}
                         index={i}
                         key={dimension.iri}
@@ -362,9 +363,11 @@ export const ChartConfigurator = ({
                                   opacity: 0.25,
                                   color: "secondaryActive",
                                 },
-                                ".buttons:hover": {
-                                  opacity: 1,
-                                },
+                                ".buttons:hover": fetching
+                                  ? {}
+                                  : {
+                                      opacity: 1,
+                                    },
                               }}
                             >
                               <DataFilterSelectGeneric

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -277,12 +277,12 @@ export const ChartConfigurator = ({
         >["dimensions"]
       >[number]
     ) => {
-      const filterValue = dimension.values.find((v) => v !== FIELD_VALUE_NONE);
+      const filterValue = dimension.values[0];
       dispatch({
         type: "CHART_CONFIG_FILTER_SET_SINGLE",
         value: {
           dimensionIri: dimension.iri,
-          value: filterValue,
+          value: filterValue.value,
         },
       });
     };

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -29,7 +29,7 @@ import {
 import { DataCubeMetadata } from "../../graphql/types";
 import { Icon } from "../../icons";
 import { useLocale } from "../../locales/use-locale";
-import { setFilters, moveFilterField } from "../configurator-state";
+import { moveFilterField } from "../configurator-state";
 import { FIELD_VALUE_NONE } from "../constants";
 import {
   ControlSection,
@@ -180,10 +180,6 @@ export const ChartConfigurator = ({
   const client = useClient();
 
   useEffect(() => {
-    if (!metaData) {
-      return;
-    }
-
     const run = async () => {
       const {
         data,
@@ -204,25 +200,20 @@ export const ChartConfigurator = ({
           x.iri,
           { type: x.type, value: x.value },
         ])
-      );
-      const chartConfig = setFilters(
-        state.chartConfig,
-        filters as ChartConfig["filters"]
-      );
+      ) as ChartConfig["filters"];
 
-      if (!isEqual(chartConfig.filters, state.chartConfig.filters)) {
+      if (!isEqual(filters, state.chartConfig.filters)) {
         dispatch({
-          type: "CHART_CONFIG_REPLACED",
+          type: "CHART_CONFIG_FILTERS_UPDATE",
           value: {
-            chartConfig,
-            dataSetMetadata: metaData,
+            filters,
           },
         });
       }
     };
 
     run();
-  }, [client, dispatch, metaData, state.chartConfig, state.dataSet]);
+  }, [client, dispatch, state.chartConfig, state.dataSet]);
 
   if (data?.dataCubeByIri) {
     const mappedIris = getFieldComponentIris(state.chartConfig.fields);

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -75,7 +75,7 @@ const DataFilterSelectGeneric = ({
     </Box>
   );
   return (
-    <Box sx={{ pl: 2, mb: 2, flexGrow: 1 }}>
+    <Box sx={{ pl: 2, flexGrow: 1 }}>
       {dimension.__typename === "TemporalDimension" &&
       dimension.timeUnit !== "Day" ? (
         <DataFilterSelectTime
@@ -314,7 +314,11 @@ export const ChartConfigurator = ({
             <DragDropContext onDragEnd={handleDragEnd}>
               <Droppable droppableId="filters">
                 {(provided) => (
-                  <div {...provided.droppableProps} ref={provided.innerRef}>
+                  <Box
+                    {...provided.droppableProps}
+                    sx={{ "& > * + *": { mt: 3 }, mb: 4 }}
+                    ref={provided.innerRef}
+                  >
                     {filterDimensions.map((dimension, i) => (
                       <Draggable
                         draggableId={dimension.iri}
@@ -359,7 +363,7 @@ export const ChartConfigurator = ({
                                   justifyContent: "flex-end",
                                   flexGrow: 0,
                                   flexShrink: 0,
-                                  pb: 3,
+                                  pb: 1,
                                 }}
                               >
                                 <MoveDragButtons
@@ -389,7 +393,7 @@ export const ChartConfigurator = ({
                       </Draggable>
                     ))}
                     {provided.placeholder}
-                  </div>
+                  </Box>
                 )}
               </Droppable>
             </DragDropContext>

--- a/app/configurator/components/chart-controls/section.tsx
+++ b/app/configurator/components/chart-controls/section.tsx
@@ -42,19 +42,21 @@ export const ControlSectionContent = ({
   role,
   ariaLabelledBy,
   children,
+  sx,
 }: {
   side: "left" | "right";
   as?: ElementType;
   role?: string;
   ariaLabelledBy?: string;
   children: ReactNode;
+  sx?: BoxProps["sx"];
 }) => {
   return (
     <Box
       as={as}
       role={role}
       aria-labelledby={ariaLabelledBy}
-      sx={{ px: side === "left" ? 2 : 4, pb: 4 }}
+      sx={{ px: side === "left" ? 2 : 4, pb: 4, ...sx }}
     >
       {children}
     </Box>

--- a/app/configurator/components/chart-type-selector.tsx
+++ b/app/configurator/components/chart-type-selector.tsx
@@ -1,6 +1,6 @@
 import { Trans } from "@lingui/macro";
 import React, { SyntheticEvent } from "react";
-import { Box, Button, Grid, Text } from "theme-ui";
+import { Box, Button, Grid, Spinner, Text } from "theme-ui";
 import { ConfiguratorStateSelectingChartType } from "..";
 import { enabledChartTypes, getPossibleChartType } from "../../charts";
 import { Hint, Loading } from "../../components/hint";
@@ -12,6 +12,7 @@ import { useTheme } from "../../themes";
 import { FieldProps, useChartTypeSelectorField } from "../config-form";
 import { SectionTitle } from "./chart-controls/section";
 import { getFieldLabel, getIconName } from "./ui-helpers";
+import { useEnsurePossibleFilters } from "./chart-configurator";
 
 export const ChartTypeSelectionButton = ({
   label,
@@ -110,10 +111,13 @@ export const ChartTypeSelector = ({
 }: {
   state: ConfiguratorStateSelectingChartType;
 }) => {
-  const theme = useTheme();
   const locale = useLocale();
   const [{ data }] = useDataCubeMetadataWithComponentValuesQuery({
     variables: { iri: state.dataSet, locale },
+  });
+
+  const { fetching: possibleFiltersFetching } = useEnsurePossibleFilters({
+    state,
   });
 
   if (data?.dataCubeByIri) {
@@ -127,6 +131,9 @@ export const ChartTypeSelector = ({
         </legend>
         <SectionTitle>
           <Trans id="controls.select.chart.type">Chart Type</Trans>
+          {possibleFiltersFetching ? (
+            <Spinner size={12} sx={{ display: "inline-block", ml: 1 }} />
+          ) : null}
         </SectionTitle>
 
         {!possibleChartTypes ? (

--- a/app/configurator/components/chart-type-selector.tsx
+++ b/app/configurator/components/chart-type-selector.tsx
@@ -131,7 +131,10 @@ export const ChartTypeSelector = ({
         <SectionTitle>
           <Trans id="controls.select.chart.type">Chart Type</Trans>
           {possibleFiltersFetching ? (
-            <Spinner size={12} sx={{ display: "inline-block", ml: 1 }} />
+            <Spinner
+              size={12}
+              sx={{ color: "hint", display: "inline-block", ml: 1 }}
+            />
           ) : null}
         </SectionTitle>
 

--- a/app/configurator/components/chart-type-selector.tsx
+++ b/app/configurator/components/chart-type-selector.tsx
@@ -8,7 +8,6 @@ import { useDataCubeMetadataWithComponentValuesQuery } from "../../graphql/query
 import { DataCubeMetadata } from "../../graphql/types";
 import { Icon } from "../../icons";
 import { useLocale } from "../../locales/use-locale";
-import { useTheme } from "../../themes";
 import { FieldProps, useChartTypeSelectorField } from "../config-form";
 import { SectionTitle } from "./chart-controls/section";
 import { getFieldLabel, getIconName } from "./ui-helpers";

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -150,7 +150,7 @@ export const DataFilterSelect = ({
       options={allOptions}
       controls={controls}
       {...fieldProps}
-    ></Select>
+    />
   );
 };
 

--- a/app/configurator/components/select-dataset-step.tsx
+++ b/app/configurator/components/select-dataset-step.tsx
@@ -28,7 +28,7 @@ const softJSONParse = (v: string) => {
   }
 };
 
-const formatBackLink = (
+export const formatBackLink = (
   query: Router["query"]
 ): React.ComponentProps<typeof NextLink>["href"] => {
   const backParameters = softJSONParse(query.previous as string);

--- a/app/configurator/components/stepper.tsx
+++ b/app/configurator/components/stepper.tsx
@@ -1,5 +1,6 @@
 import { Trans } from "@lingui/macro";
-import React, { ReactNode, useCallback, useEffect } from "react";
+import { useRouter } from "next/router";
+import React, { ReactNode, useCallback, useEffect, useMemo } from "react";
 import { Button, ButtonProps, Flex, Text } from "theme-ui";
 import {
   useConfiguratorState,
@@ -11,6 +12,7 @@ import { useDataCubeMetadataWithComponentValuesQuery } from "../../graphql/query
 import SvgIcChevronLeft from "../../icons/components/IcChevronLeft";
 import SvgIcChevronRight from "../../icons/components/IcChevronRight";
 import { useLocale } from "../../src";
+import { formatBackLink } from "./select-dataset-step";
 
 export type StepStatus = "past" | "current" | "future";
 
@@ -152,11 +154,20 @@ export const Stepper = ({ dataSetIri }: { dataSetIri?: string }) => {
     }
   }, [data, dispatch]);
 
+  const router = useRouter();
+  const backLink = useMemo(() => {
+    return formatBackLink(router.query);
+  }, [router.query]);
+
   const goPrevious = useCallback(() => {
-    dispatch({
-      type: "STEP_PREVIOUS",
-    });
-  }, [dispatch]);
+    if (state.state === "SELECTING_CHART_TYPE") {
+      router.push(backLink);
+    } else {
+      dispatch({
+        type: "STEP_PREVIOUS",
+      });
+    }
+  }, [backLink, dispatch, router, state.state]);
 
   return (
     <StepperDumb

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -939,7 +939,10 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       return draft;
 
     case "CHART_CONFIG_FILTERS_UPDATE":
-      if (draft.state === "CONFIGURING_CHART") {
+      if (
+        draft.state === "CONFIGURING_CHART" ||
+        draft.state === "SELECTING_CHART_TYPE"
+      ) {
         const { filters } = action.value;
         draft.chartConfig.filters = filters;
       }

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -135,6 +135,10 @@ export type ConfiguratorStateAction =
       value: { dimensionIri: string; value: string };
     }
   | {
+      type: "CHART_CONFIG_FILTERS_UPDATE";
+      value: { filters: Filters };
+    }
+  | {
       type: "CHART_CONFIG_FILTER_ADD_MULTI";
       value: { dimensionIri: string; values: string[]; allValues: string[] };
     }
@@ -204,12 +208,6 @@ export const getFilterValue = (
     ? state.chartConfig.filters[dimensionIri]
     : undefined;
 };
-
-export const setFilters = produce(
-  (chartConfig: ChartConfig, newFilters: ChartConfig["filters"]) => {
-    chartConfig.filters = newFilters;
-  }
-);
 
 export const ensureFilterValuesCorrect = produce(
   (
@@ -937,6 +935,13 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
           from,
           to,
         };
+      }
+      return draft;
+
+    case "CHART_CONFIG_FILTERS_UPDATE":
+      if (draft.state === "CONFIGURING_CHART") {
+        const { filters } = action.value;
+        draft.chartConfig.filters = filters;
       }
       return draft;
 

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -205,6 +205,12 @@ export const getFilterValue = (
     : undefined;
 };
 
+export const setFilters = produce(
+  (chartConfig: ChartConfig, newFilters: ChartConfig["filters"]) => {
+    chartConfig.filters = newFilters;
+  }
+);
+
 export const ensureFilterValuesCorrect = produce(
   (
     chartConfig: ChartConfig,

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -212,6 +212,14 @@ query DataCubeObservations(
   }
 }
 
+query PossibleFilters($iri: String!, $filters: Filters!) {
+  possibleFilters(iri: $iri, filters: $filters) {
+    iri
+    type
+    value
+  }
+}
+
 query Themes($locale: String!) {
   themes(locale: $locale) {
     iri

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -16,6 +16,7 @@ export type Scalars = {
   Filters: any;
   GeoShapes: any;
   Observation: any;
+  ObservationValue: any;
   RawObservation: any;
 };
 
@@ -182,6 +183,14 @@ export type NominalDimensionValuesArgs = {
 };
 
 
+export type ObservationFilter = {
+  __typename: 'ObservationFilter';
+  type: Scalars['String'];
+  value?: Maybe<Scalars['ObservationValue']>;
+  iri: Scalars['String'];
+};
+
+
 export type ObservationsQuery = {
   __typename: 'ObservationsQuery';
   /** Observations with their values parsed to native JS types */
@@ -212,6 +221,7 @@ export type OrdinalDimensionValuesArgs = {
 export type Query = {
   __typename: 'Query';
   dataCubeByIri?: Maybe<DataCube>;
+  possibleFilters: Array<ObservationFilter>;
   dataCubes: Array<DataCubeResult>;
   themes: Array<DataCubeTheme>;
   subthemes: Array<DataCubeTheme>;
@@ -225,6 +235,12 @@ export type QueryDataCubeByIriArgs = {
   iri: Scalars['String'];
   latest?: Maybe<Scalars['Boolean']>;
   filters?: Maybe<Scalars['Filters']>;
+};
+
+
+export type QueryPossibleFiltersArgs = {
+  iri: Scalars['String'];
+  filters: Scalars['Filters'];
 };
 
 
@@ -488,6 +504,14 @@ export type DataCubeObservationsQuery = { __typename: 'Query', dataCubeByIri?: M
       & DimensionMetaData_Measure_Fragment
     )>, observations: { __typename: 'ObservationsQuery', data: Array<any>, sparqlEditorUrl?: Maybe<string> } }> };
 
+export type PossibleFiltersQueryVariables = Exact<{
+  iri: Scalars['String'];
+  filters: Scalars['Filters'];
+}>;
+
+
+export type PossibleFiltersQuery = { __typename: 'Query', possibleFilters: Array<{ __typename: 'ObservationFilter', iri: string, type: string, value?: Maybe<any> }> };
+
 export type ThemesQueryVariables = Exact<{
   locale: Scalars['String'];
 }>;
@@ -734,6 +758,19 @@ export const DataCubeObservationsDocument = gql`
 
 export function useDataCubeObservationsQuery(options: Omit<Urql.UseQueryArgs<DataCubeObservationsQueryVariables>, 'query'> = {}) {
   return Urql.useQuery<DataCubeObservationsQuery>({ query: DataCubeObservationsDocument, ...options });
+};
+export const PossibleFiltersDocument = gql`
+    query PossibleFilters($iri: String!, $filters: Filters!) {
+  possibleFilters(iri: $iri, filters: $filters) {
+    iri
+    type
+    value
+  }
+}
+    `;
+
+export function usePossibleFiltersQuery(options: Omit<Urql.UseQueryArgs<PossibleFiltersQueryVariables>, 'query'> = {}) {
+  return Urql.useQuery<PossibleFiltersQuery>({ query: PossibleFiltersDocument, ...options });
 };
 export const ThemesDocument = gql`
     query Themes($locale: String!) {

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -13,10 +13,10 @@ export type Scalars = {
   Int: number;
   Float: number;
   DimensionValue: any;
+  FilterValue: any;
   Filters: any;
   GeoShapes: any;
   Observation: any;
-  ObservationValue: any;
   RawObservation: any;
 };
 
@@ -111,6 +111,7 @@ export type DimensionValuesArgs = {
 
 
 
+
 export type GeoCoordinates = {
   __typename: 'GeoCoordinates';
   iri: Scalars['String'];
@@ -186,10 +187,9 @@ export type NominalDimensionValuesArgs = {
 export type ObservationFilter = {
   __typename: 'ObservationFilter';
   type: Scalars['String'];
-  value?: Maybe<Scalars['ObservationValue']>;
+  value?: Maybe<Scalars['FilterValue']>;
   iri: Scalars['String'];
 };
-
 
 export type ObservationsQuery = {
   __typename: 'ObservationsQuery';

--- a/app/graphql/resolver-types.ts
+++ b/app/graphql/resolver-types.ts
@@ -1,6 +1,7 @@
 import { DimensionValue } from '../domain/data';
 import { Filters } from '../configurator';
 import { Observation } from '../domain/data';
+import { ObservationValue } from '../domain/data';
 import { RawObservation } from '../domain/data';
 import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
 import { ResolvedDataCube, ResolvedObservationsQuery, ResolvedMeasure, ResolvedDimension } from './shared-types';
@@ -21,6 +22,7 @@ export type Scalars = {
   Filters: Filters;
   GeoShapes: any;
   Observation: Observation;
+  ObservationValue: ObservationValue;
   RawObservation: RawObservation;
 };
 
@@ -187,6 +189,14 @@ export type NominalDimensionValuesArgs = {
 };
 
 
+export type ObservationFilter = {
+  __typename?: 'ObservationFilter';
+  type: Scalars['String'];
+  value?: Maybe<Scalars['ObservationValue']>;
+  iri: Scalars['String'];
+};
+
+
 export type ObservationsQuery = {
   __typename?: 'ObservationsQuery';
   /** Observations with their values parsed to native JS types */
@@ -217,6 +227,7 @@ export type OrdinalDimensionValuesArgs = {
 export type Query = {
   __typename?: 'Query';
   dataCubeByIri?: Maybe<DataCube>;
+  possibleFilters: Array<ObservationFilter>;
   dataCubes: Array<DataCubeResult>;
   themes: Array<DataCubeTheme>;
   subthemes: Array<DataCubeTheme>;
@@ -230,6 +241,12 @@ export type QueryDataCubeByIriArgs = {
   iri: Scalars['String'];
   latest?: Maybe<Scalars['Boolean']>;
   filters?: Maybe<Scalars['Filters']>;
+};
+
+
+export type QueryPossibleFiltersArgs = {
+  iri: Scalars['String'];
+  filters: Scalars['Filters'];
 };
 
 
@@ -380,6 +397,8 @@ export type ResolversTypes = ResolversObject<{
   Measure: ResolverTypeWrapper<ResolvedMeasure>;
   NominalDimension: ResolverTypeWrapper<ResolvedDimension>;
   Observation: ResolverTypeWrapper<Scalars['Observation']>;
+  ObservationFilter: ResolverTypeWrapper<ObservationFilter>;
+  ObservationValue: ResolverTypeWrapper<Scalars['ObservationValue']>;
   ObservationsQuery: ResolverTypeWrapper<ResolvedObservationsQuery>;
   OrdinalDimension: ResolverTypeWrapper<ResolvedDimension>;
   Query: ResolverTypeWrapper<{}>;
@@ -410,6 +429,8 @@ export type ResolversParentTypes = ResolversObject<{
   Measure: ResolvedMeasure;
   NominalDimension: ResolvedDimension;
   Observation: Scalars['Observation'];
+  ObservationFilter: ObservationFilter;
+  ObservationValue: Scalars['ObservationValue'];
   ObservationsQuery: ResolvedObservationsQuery;
   OrdinalDimension: ResolvedDimension;
   Query: {};
@@ -540,6 +561,17 @@ export interface ObservationScalarConfig extends GraphQLScalarTypeConfig<Resolve
   name: 'Observation';
 }
 
+export type ObservationFilterResolvers<ContextType = any, ParentType extends ResolversParentTypes['ObservationFilter'] = ResolversParentTypes['ObservationFilter']> = ResolversObject<{
+  type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  value?: Resolver<Maybe<ResolversTypes['ObservationValue']>, ParentType, ContextType>;
+  iri?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export interface ObservationValueScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['ObservationValue'], any> {
+  name: 'ObservationValue';
+}
+
 export type ObservationsQueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['ObservationsQuery'] = ResolversParentTypes['ObservationsQuery']> = ResolversObject<{
   data?: Resolver<Array<ResolversTypes['Observation']>, ParentType, ContextType>;
   rawData?: Resolver<Array<ResolversTypes['RawObservation']>, ParentType, ContextType>;
@@ -560,6 +592,7 @@ export type OrdinalDimensionResolvers<ContextType = any, ParentType extends Reso
 
 export type QueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
   dataCubeByIri?: Resolver<Maybe<ResolversTypes['DataCube']>, ParentType, ContextType, RequireFields<QueryDataCubeByIriArgs, 'iri' | 'latest'>>;
+  possibleFilters?: Resolver<Array<ResolversTypes['ObservationFilter']>, ParentType, ContextType, RequireFields<QueryPossibleFiltersArgs, 'iri' | 'filters'>>;
   dataCubes?: Resolver<Array<ResolversTypes['DataCubeResult']>, ParentType, ContextType, RequireFields<QueryDataCubesArgs, never>>;
   themes?: Resolver<Array<ResolversTypes['DataCubeTheme']>, ParentType, ContextType, RequireFields<QueryThemesArgs, 'locale'>>;
   subthemes?: Resolver<Array<ResolversTypes['DataCubeTheme']>, ParentType, ContextType, RequireFields<QuerySubthemesArgs, 'locale' | 'parentIri'>>;
@@ -599,6 +632,8 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   Measure?: MeasureResolvers<ContextType>;
   NominalDimension?: NominalDimensionResolvers<ContextType>;
   Observation?: GraphQLScalarType;
+  ObservationFilter?: ObservationFilterResolvers<ContextType>;
+  ObservationValue?: GraphQLScalarType;
   ObservationsQuery?: ObservationsQueryResolvers<ContextType>;
   OrdinalDimension?: OrdinalDimensionResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;

--- a/app/graphql/resolver-types.ts
+++ b/app/graphql/resolver-types.ts
@@ -1,7 +1,6 @@
 import { DimensionValue } from '../domain/data';
 import { Filters } from '../configurator';
 import { Observation } from '../domain/data';
-import { ObservationValue } from '../domain/data';
 import { RawObservation } from '../domain/data';
 import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
 import { ResolvedDataCube, ResolvedObservationsQuery, ResolvedMeasure, ResolvedDimension } from './shared-types';
@@ -19,10 +18,10 @@ export type Scalars = {
   Int: number;
   Float: number;
   DimensionValue: DimensionValue;
+  FilterValue: any;
   Filters: Filters;
   GeoShapes: any;
   Observation: Observation;
-  ObservationValue: ObservationValue;
   RawObservation: RawObservation;
 };
 
@@ -117,6 +116,7 @@ export type DimensionValuesArgs = {
 
 
 
+
 export type GeoCoordinates = {
   __typename?: 'GeoCoordinates';
   iri: Scalars['String'];
@@ -192,10 +192,9 @@ export type NominalDimensionValuesArgs = {
 export type ObservationFilter = {
   __typename?: 'ObservationFilter';
   type: Scalars['String'];
-  value?: Maybe<Scalars['ObservationValue']>;
+  value?: Maybe<Scalars['FilterValue']>;
   iri: Scalars['String'];
 };
-
 
 export type ObservationsQuery = {
   __typename?: 'ObservationsQuery';
@@ -389,6 +388,7 @@ export type ResolversTypes = ResolversObject<{
   Dimension: ResolverTypeWrapper<ResolvedDimension>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
   DimensionValue: ResolverTypeWrapper<Scalars['DimensionValue']>;
+  FilterValue: ResolverTypeWrapper<Scalars['FilterValue']>;
   Filters: ResolverTypeWrapper<Scalars['Filters']>;
   GeoCoordinates: ResolverTypeWrapper<GeoCoordinates>;
   GeoCoordinatesDimension: ResolverTypeWrapper<ResolvedDimension>;
@@ -398,7 +398,6 @@ export type ResolversTypes = ResolversObject<{
   NominalDimension: ResolverTypeWrapper<ResolvedDimension>;
   Observation: ResolverTypeWrapper<Scalars['Observation']>;
   ObservationFilter: ResolverTypeWrapper<ObservationFilter>;
-  ObservationValue: ResolverTypeWrapper<Scalars['ObservationValue']>;
   ObservationsQuery: ResolverTypeWrapper<ResolvedObservationsQuery>;
   OrdinalDimension: ResolverTypeWrapper<ResolvedDimension>;
   Query: ResolverTypeWrapper<{}>;
@@ -421,6 +420,7 @@ export type ResolversParentTypes = ResolversObject<{
   Dimension: ResolvedDimension;
   Boolean: Scalars['Boolean'];
   DimensionValue: Scalars['DimensionValue'];
+  FilterValue: Scalars['FilterValue'];
   Filters: Scalars['Filters'];
   GeoCoordinates: GeoCoordinates;
   GeoCoordinatesDimension: ResolvedDimension;
@@ -430,7 +430,6 @@ export type ResolversParentTypes = ResolversObject<{
   NominalDimension: ResolvedDimension;
   Observation: Scalars['Observation'];
   ObservationFilter: ObservationFilter;
-  ObservationValue: Scalars['ObservationValue'];
   ObservationsQuery: ResolvedObservationsQuery;
   OrdinalDimension: ResolvedDimension;
   Query: {};
@@ -499,6 +498,10 @@ export interface DimensionValueScalarConfig extends GraphQLScalarTypeConfig<Reso
   name: 'DimensionValue';
 }
 
+export interface FilterValueScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['FilterValue'], any> {
+  name: 'FilterValue';
+}
+
 export interface FiltersScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['Filters'], any> {
   name: 'Filters';
 }
@@ -563,14 +566,10 @@ export interface ObservationScalarConfig extends GraphQLScalarTypeConfig<Resolve
 
 export type ObservationFilterResolvers<ContextType = any, ParentType extends ResolversParentTypes['ObservationFilter'] = ResolversParentTypes['ObservationFilter']> = ResolversObject<{
   type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  value?: Resolver<Maybe<ResolversTypes['ObservationValue']>, ParentType, ContextType>;
+  value?: Resolver<Maybe<ResolversTypes['FilterValue']>, ParentType, ContextType>;
   iri?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
-
-export interface ObservationValueScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['ObservationValue'], any> {
-  name: 'ObservationValue';
-}
 
 export type ObservationsQueryResolvers<ContextType = any, ParentType extends ResolversParentTypes['ObservationsQuery'] = ResolversParentTypes['ObservationsQuery']> = ResolversObject<{
   data?: Resolver<Array<ResolversTypes['Observation']>, ParentType, ContextType>;
@@ -624,6 +623,7 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   DatasetCount?: DatasetCountResolvers<ContextType>;
   Dimension?: DimensionResolvers<ContextType>;
   DimensionValue?: GraphQLScalarType;
+  FilterValue?: GraphQLScalarType;
   Filters?: GraphQLScalarType;
   GeoCoordinates?: GeoCoordinatesResolvers<ContextType>;
   GeoCoordinatesDimension?: GeoCoordinatesDimensionResolvers<ContextType>;
@@ -633,7 +633,6 @@ export type Resolvers<ContextType = any> = ResolversObject<{
   NominalDimension?: NominalDimensionResolvers<ContextType>;
   Observation?: GraphQLScalarType;
   ObservationFilter?: ObservationFilterResolvers<ContextType>;
-  ObservationValue?: GraphQLScalarType;
   ObservationsQuery?: ObservationsQueryResolvers<ContextType>;
   OrdinalDimension?: OrdinalDimensionResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -1,5 +1,6 @@
 scalar Observation
 scalar DimensionValue
+scalar ObservationValue
 scalar RawObservation
 scalar Filters
 scalar GeoShapes
@@ -68,6 +69,12 @@ type GeoCoordinatesDimension implements Dimension {
   isKeyDimension: Boolean!
   values(filters: Filters): [DimensionValue!]!
   geoCoordinates: [GeoCoordinates!]
+}
+
+type ObservationFilter {
+  type: String!
+  value: ObservationValue
+  iri: String!
 }
 
 type GeoShapesDimension implements Dimension {
@@ -170,6 +177,7 @@ type Query {
     latest: Boolean = true
     filters: Filters
   ): DataCube
+  possibleFilters(iri: String!, filters: Filters!): [ObservationFilter!]!
   dataCubes(
     locale: String
     query: String

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -1,6 +1,6 @@
 scalar Observation
 scalar DimensionValue
-scalar ObservationValue
+scalar FilterValue
 scalar RawObservation
 scalar Filters
 scalar GeoShapes
@@ -73,7 +73,7 @@ type GeoCoordinatesDimension implements Dimension {
 
 type ObservationFilter {
   type: String!
-  value: ObservationValue
+  value: FilterValue
   iri: String!
 }
 

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -403,7 +403,7 @@ export const getCubeObservations = async ({
   filters?: Filters;
   /** Limit on the number of observations returned */
   limit?: number;
-  /** Returns URIs instead of labels for NamedNodes  */
+  /** Returns IRIs instead of labels for NamedNodes  */
   raw?: boolean;
 }): Promise<{
   query: string;

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -39,7 +39,7 @@ const DIMENSION_VALUE_UNDEFINED = ns.cube.Undefined.value;
 /** Adds a suffix to an iri to mark its label */
 const labelDimensionIri = (iri: string) => `${iri}/__label__`;
 
-const createSource = () =>
+export const createSource = () =>
   new Source({
     endpointUrl: SPARQL_ENDPOINT,
     queryOperation: "postUrlencoded",
@@ -395,11 +395,16 @@ export const getCubeObservations = async ({
   locale,
   filters,
   limit,
+  raw,
 }: {
   cube: Cube;
   locale: string;
+  /** Observations filters that should be considered */
   filters?: Filters;
+  /** Limit on the number of observations returned */
   limit?: number;
+  /** Returns URIs instead of labels for NamedNodes  */
+  raw?: boolean;
 }): Promise<{
   query: string;
   observations: Observation[];
@@ -438,6 +443,9 @@ export const getCubeObservations = async ({
   lookupSource.ptr.addOut(ns.cubeView.graph, rdf.defaultGraph());
 
   for (const dimension of namedDimensions) {
+    if (raw) {
+      continue;
+    }
     const labelDimension = cubeView.createDimension({
       source: lookupSource,
       path: ns.schema.name,
@@ -477,8 +485,7 @@ export const getCubeObservations = async ({
   }
 
   const observationsRaw = await observationsView.observations();
-
-  const observations = observationsRaw.map((obs) => {
+  const observations = observationsRaw.map((obs, i) => {
     return Object.fromEntries(
       cubeDimensions.map((d) => {
         const label = obs[labelDimensionIri(d.data.iri)]?.value;
@@ -489,9 +496,10 @@ export const getCubeObservations = async ({
             ? null
             : obs[d.data.iri]?.value;
 
+        const rawValue = parseObservationValue({ value: obs[d.data.iri] });
         return [
           d.data.iri,
-          label ?? value ?? null,
+          raw ? rawValue : label ?? value ?? null,
           // v !== undefined ? parseObservationValue({ value: v }) : null,
         ];
       })

--- a/app/rdf/query-dimension-values.ts
+++ b/app/rdf/query-dimension-values.ts
@@ -69,7 +69,6 @@ export async function unversionObservation({
     cube.dimensions,
     (x) => x.path?.value
   ) as Record<string, CubeDimension>;
-  console.log(dimensionsByPath);
   const versionedDimensions = Object.keys(observation).filter((x) =>
     dimensionIsVersioned(dimensionsByPath[x])
   );
@@ -79,8 +78,6 @@ export async function unversionObservation({
     }
     ?versioned ${ns.schema.sameAs} ?unversioned.
   `;
-
-  console.log(query.build());
 
   const result = (await query.execute(sparqlClient.query, {
     operation: "postUrlencoded",


### PR DESCRIPTION
Previously when changing a filter in a cascading facets. we would take the first value of each dimension value that was present and this could lead to dead-end, and was slow since each filter could be changed after the filter just before it has been changed. Now the approach is different: when a filter is changed/moved, we try to find an observation with the filter, and if we do not find an observation, we relax the filters 1 by 1 starting from the bottom until we have an observations. This ensures that data is shown after filter have been loaded, and it also tries to keep as much as possible what the user has chosen (= change the bottomost filters first).

fix #327
fix #328 