### PR TITLE
fix: Color segmentation filtering

### DIFF
--- a/app/charts/shared/use-chart-state.tsx
+++ b/app/charts/shared/use-chart-state.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext } from "react";
 import { ChartFields, InteractiveFiltersConfig } from "../../configurator";
 import { Observation } from "../../domain/data";
 import { DimensionMetaDataFragment } from "../../graphql/query-hooks";
+import { Has } from "../../lib/has";
 import { AreasState } from "../area/areas-state";
 import { GroupedBarsState } from "../bar/bars-grouped-state";
 import { BarsState } from "../bar/bars-state";
@@ -35,10 +36,6 @@ export type ChartState =
   | TableChartState
   | MapState
   | undefined;
-
-type Has<T extends unknown, R extends string> = T extends { [k in R]: any }
-  ? T
-  : never;
 
 export type ColorsChartState = Has<ChartState, "colors">;
 export const ChartContext = createContext<ChartState>(undefined);

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -226,18 +226,26 @@ export const ChartConfigurator = ({
 }) => {
   const locale = useLocale();
   const [, dispatch] = useConfiguratorState();
+
+  const unmappedFilters = React.useMemo(() => {
+    const mappedIris = new Set(
+      Object.values(state.chartConfig.fields).map((x) => x.componentIri)
+    );
+    return pickBy(state.chartConfig.filters, (v, iri) => !mappedIris.has(iri));
+  }, [state.chartConfig.filters, state.chartConfig.fields]);
+
   const variables = React.useMemo(
     () => ({
       iri: state.dataSet,
       locale,
-      filters: state.chartConfig.filters,
+      filters: unmappedFilters,
       // This is important for urql not to think that filters
       // are the same  while the order of the keys has changed.
       // If this is not present, we'll have outdated dimension
       // values after we change the filter order
-      filterKeys: Object.keys(state.chartConfig.filters).join(", "),
+      filterKeys: Object.keys(unmappedFilters).join(", "),
     }),
-    [state, locale]
+    [state.dataSet, locale, unmappedFilters]
   );
   const [{ data, fetching: dataFetching }, executeQuery] =
     useDataCubeMetadataWithComponentValuesQuery({

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -1,5 +1,5 @@
 import produce from "immer";
-import { mapValues } from "lodash";
+import { mapValues, pickBy } from "lodash";
 import setWith from "lodash/setWith";
 import { useRouter } from "next/router";
 import {
@@ -12,6 +12,8 @@ import {
 import { Client, useClient } from "urql";
 import { Reducer, useImmerReducer } from "use-immer";
 import {
+  ConfiguratorStateConfiguringChart,
+  ConfiguratorStateSelectingChartType,
   ImputationType,
   isAreaConfig,
   isColumnConfig,
@@ -567,6 +569,18 @@ export const canTransitionToPreviousStep = (
 ): boolean => {
   // All states are interchangeable in terms of validity
   return true;
+};
+
+export const getFiltersByMappingStatus = (
+  fields: ConfiguratorStateConfiguringChart["chartConfig"]["fields"],
+  filters: ConfiguratorStateConfiguringChart["chartConfig"]["filters"]
+) => {
+  const mappedIris = new Set(
+    Object.values(fields).map((fieldValue) => fieldValue.componentIri)
+  );
+  const unmapped = pickBy(filters, (value, iri) => !mappedIris.has(iri));
+  const mapped = pickBy(filters, (value, iri) => mappedIris.has(iri));
+  return { unmapped, mapped };
 };
 
 const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -13,7 +13,6 @@ import { Client, useClient } from "urql";
 import { Reducer, useImmerReducer } from "use-immer";
 import {
   ConfiguratorStateConfiguringChart,
-  ConfiguratorStateSelectingChartType,
   ImputationType,
   isAreaConfig,
   isColumnConfig,

--- a/app/configurator/table/table-chart-options.tsx
+++ b/app/configurator/table/table-chart-options.tsx
@@ -37,6 +37,7 @@ import {
 import { useConfiguratorState } from "../configurator-state";
 import { TableSortingOptions } from "./table-chart-sorting-options";
 import { updateIsGroup, updateIsHidden } from "./table-config-state";
+import { canDimensionBeMultiFiltered } from "../../domain/data";
 
 const useTableColumnGroupHiddenField = ({
   path,
@@ -294,8 +295,7 @@ export const TableColumnOptions = ({
           </ControlSectionContent>
         </ControlSection>
       )}
-      {component.__typename === "NominalDimension" ||
-      component.__typename === "OrdinalDimension" ? (
+      {canDimensionBeMultiFiltered(component) ? (
         <ControlSection>
           <SectionTitle disabled={!component} iconName="filter">
             <Trans id="controls.section.filter">Filter</Trans>

--- a/app/domain/data.ts
+++ b/app/domain/data.ts
@@ -4,6 +4,8 @@ import {
   DimensionMetaDataFragment,
   GeoCoordinatesDimension,
   GeoShapesDimension,
+  NominalDimension,
+  OrdinalDimension,
 } from "../graphql/query-hooks";
 
 export type RawObservationValue = Literal | NamedNode;
@@ -128,16 +130,28 @@ export const parseObservationValue = ({
  */
 export const getTimeDimensions = (dimensions: DimensionMetaDataFragment[]) =>
   dimensions.filter((d) => d.__typename === "TemporalDimension");
+
+export const isCategoricalDimension = (
+  d: DimensionMetaDataFragment
+): d is NominalDimension | OrdinalDimension => {
+  return isNominalDimension(d) || isOrdinalDimension(d);
+};
+
+export const canDimensionBeMultiFiltered = (d: DimensionMetaDataFragment) => {
+  return (
+    isNominalDimension(d) ||
+    isOrdinalDimension(d) ||
+    isGeoCoordinatesDimension(d) ||
+    isGeoShapesDimension(d)
+  );
+};
+
 /**
  * @fixme use metadata to filter categorical dimension!
  */
 export const getCategoricalDimensions = (
   dimensions: DimensionMetaDataFragment[]
-) =>
-  dimensions.filter(
-    (d) =>
-      d.__typename === "NominalDimension" || d.__typename === "OrdinalDimension"
-  );
+) => dimensions.filter(isCategoricalDimension);
 
 export const getGeoCoordinatesDimensions = (
   dimensions: DimensionMetaDataFragment[]
@@ -164,6 +178,18 @@ export const getDimensionsByDimensionType = ({
   [...measures, ...dimensions].filter((component) =>
     dimensionTypes.includes(component.__typename)
   );
+
+export const isNominalDimension = (
+  dimension?: DimensionMetaDataFragment
+): dimension is GeoCoordinatesDimension => {
+  return dimension?.__typename === "GeoCoordinatesDimension";
+};
+
+export const isOrdinalDimension = (
+  dimension?: DimensionMetaDataFragment
+): dimension is GeoCoordinatesDimension => {
+  return dimension?.__typename === "GeoCoordinatesDimension";
+};
 
 export const isGeoCoordinatesDimension = (
   dimension?: DimensionMetaDataFragment

--- a/app/lib/has.ts
+++ b/app/lib/has.ts
@@ -1,0 +1,5 @@
+export type Has<T extends unknown, R extends string> = T extends {
+  [k in R]: any;
+}
+  ? T
+  : never;

--- a/app/utils/dimension-hierarchy.ts
+++ b/app/utils/dimension-hierarchy.ts
@@ -167,6 +167,9 @@ type TreeSorters = Record<
 
 /** Recursively sorts tree children  */
 export const sortTree = (tree: HierarchyValue[], sorters?: TreeSorters) => {
+  if (!tree.length) {
+    return;
+  }
   const dimensionIri = tree[0].dimensionIri;
   const sorter = sorters?.[dimensionIri] || defaultSorter;
   if (dimensionIri && sorter) {


### PR DESCRIPTION
With the change of loading possible filters, a mistake was made since
the "right" filters (= filters that are on an IRI that is mapped)
should not be considered in the query that tries to find possible values for left filters.

- [x] Remove right filters from the possible filters query
- [x] Do not re-run possible filters query when changing right filters
- [x] Keep right filters when possible filters query result is set as filters 

Tested on multiple datasets:

- [x] Red list
- [x] Bathing water quality
- [x] Heavy metal

Also, a change was made so that GeoShapesDimension and GeoCoordinatesDimension can be filtered correctly in table view.

fix #355 