### PR TITLE
Fix newer cubes sorting by version in RDF query

### DIFF
--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -84,8 +84,8 @@ const getLatestCube = async (cube: Cube): Promise<Cube> => {
   if (newerCubes.length > 0) {
     newerCubes.sort((a, b) =>
       descending(
-        a.out(ns.schema.version)?.value,
-        b.out(ns.schema.version)?.value
+        +a.out(ns.schema.version)?.value!,
+        +b.out(ns.schema.version)?.value!
       )
     );
 


### PR DESCRIPTION
Fixes #348.

`a.out(ns.schema.version)?.value` had a string type, so cube 9 would be considered as more recent than cube 10. This PR fixes the issue in one of the homepage examples.