### PR TITLE
Do not set automatically empty filters

### DIFF
--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -1,6 +1,6 @@
 import { t, Trans } from "@lingui/macro";
 import { Menu, MenuButton, MenuItem, MenuList } from "@reach/menu-button";
-import { isEqual, sortBy } from "lodash";
+import { isEmpty, isEqual, sortBy } from "lodash";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   DragDropContext,
@@ -189,7 +189,7 @@ export const useEnsurePossibleFilters = ({
         mappedFilters
       );
 
-      if (!isEqual(filters, state.chartConfig.filters)) {
+      if (!isEqual(filters, state.chartConfig.filters) && !isEmpty(filters)) {
         dispatch({
           type: "CHART_CONFIG_FILTERS_UPDATE",
           value: {


### PR DESCRIPTION
This removes a patological case where filters are completely removed. In most cases we do not want filters to be completely removed automatically, it's better if "no data" is shown.
In the case where filters can be changed to show data they will be changed (starting from the bottom).

fix #385 