### PR TITLE
feat: Do not show standard error in possible filters

### DIFF
--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -19,6 +19,7 @@ import {
 import { getFieldComponentIris } from "../../charts";
 import { chartConfigOptionsUISpec } from "../../charts/chart-config-ui-options";
 import { Loading } from "../../components/hint";
+import { isStandardErrorDimension } from "../../domain/data";
 import {
   DataCubeMetadataWithComponentValuesQuery,
   PossibleFiltersDocument,
@@ -291,7 +292,10 @@ export const ChartConfigurator = ({
       [(x) => keysOrder[x.iri] ?? Infinity]
     );
     const addableDimensions = data?.dataCubeByIri.dimensions.filter(
-      (dim) => !mappedIris.has(dim.iri) && keysOrder[dim.iri] === undefined
+      (dim) =>
+        !mappedIris.has(dim.iri) &&
+        keysOrder[dim.iri] === undefined &&
+        !isStandardErrorDimension(dim)
     );
 
     const handleDragEnd: OnDragEndResponder = (result) => {

--- a/app/domain/data.ts
+++ b/app/domain/data.ts
@@ -208,6 +208,10 @@ export const isStandardErrorResolvedDimension = (dim: ResolvedDimension) => {
   return dim.data?.related.some((x) => x.type === "StandardError");
 };
 
+export const isStandardErrorDimension = (dim: DimensionMetaDataFragment) => {
+  return dim?.related?.some((r) => r.type === "StandardError");
+};
+
 export const shouldValuesBeLoadedForResolvedDimension = (
   dim: ResolvedDimension
 ) => {


### PR DESCRIPTION
Fix https://github.com/visualize-admin/visualization-tool/issues/383

Filters out standard error dimension from possible left filters.﻿
