### PR TITLE
Publish actions spacing

### DIFF
--- a/app/components/publish-actions.tsx
+++ b/app/components/publish-actions.tsx
@@ -1,4 +1,12 @@
 import { t, Trans } from "@lingui/macro";
+import * as clipboard from "clipboard-polyfill/text";
+import Downshift, { DownshiftState, StateChangeOptions } from "downshift";
+import {
+  MouseEvent as ReactMouseEvent,
+  ReactNode,
+  useEffect,
+  useState,
+} from "react";
 import {
   Box,
   Button,
@@ -9,19 +17,10 @@ import {
   Link,
   Text,
 } from "theme-ui";
-import * as clipboard from "clipboard-polyfill/text";
-import Downshift, { DownshiftState, StateChangeOptions } from "downshift";
-import {
-  MouseEvent as ReactMouseEvent,
-  ReactNode,
-  useEffect,
-  useState,
-} from "react";
 import { Icon } from "../icons";
+import { useI18n } from "../lib/use-i18n";
 import { useLocale } from "../locales/use-locale";
 import { IconLink } from "./links";
-import { useI18n } from "../lib/use-i18n";
-import Stack from "./Stack";
 
 export const PublishActions = ({
   configKey,
@@ -33,10 +32,10 @@ export const PublishActions = ({
   const locale = useLocale();
 
   return (
-    <Stack direction={["column", "row"]} spacing={2} sx={sx}>
+    <Flex sx={{ flexWrap: "wrap", gap: 2, ...sx }}>
       <Share configKey={configKey} locale={locale} />
       <Embed configKey={configKey} locale={locale}></Embed>
-    </Stack>
+    </Flex>
   );
 };
 

--- a/app/pages/v/[chartId].tsx
+++ b/app/pages/v/[chartId].tsx
@@ -1,19 +1,18 @@
 import { Trans } from "@lingui/macro";
-import { Box, Button, Text } from "theme-ui";
 import { GetServerSideProps } from "next";
 import ErrorPage from "next/error";
 import Head from "next/head";
+import NextLink from "next/link";
 import { useRouter } from "next/router";
+import { Box, Button, Flex, Text } from "theme-ui";
 import { ChartPanel } from "../../components/chart-panel";
 import { ChartPublished } from "../../components/chart-published";
 import { Success } from "../../components/hint";
 import { ContentLayout } from "../../components/layout";
 import { PublishActions } from "../../components/publish-actions";
-import { getConfig } from "../../db/config";
 import { Config } from "../../configurator";
+import { getConfig } from "../../db/config";
 import { useLocale } from "../../locales/use-locale";
-import NextLink from "next/link";
-import Stack from "../../components/Stack";
 
 type PageProps =
   | {
@@ -111,7 +110,7 @@ const VisualizationPage = (props: PageProps) => {
               )}
             </Text>
 
-            <Stack direction={["column", "row"]} spacing={2}>
+            <Flex sx={{ flexWrap: "wrap", gap: 2 }}>
               <NextLink href="/create/new" passHref>
                 <Button as="a" variant="secondary">
                   <Trans id="button.new.visualization">
@@ -129,7 +128,7 @@ const VisualizationPage = (props: PageProps) => {
                   </Trans>
                 </Button>
               </NextLink>
-            </Stack>
+            </Flex>
           </Box>
         </Box>
       </ContentLayout>


### PR DESCRIPTION
Fixes #382.

I don't think we need a `direction=['column', 'row']` there, as "Share" and "Embed" buttons IMO should be next to each other if the space allows. Let me know what you think, I can also switch back to `Stack`, but it wasn't working as expected (open https://int.visualize.admin.ch/en/v/Fz1D2p8CtLlj and resize the window; the margin between items is removed at a point where they should be stacked, but they are not).