### PR TITLE
fix: Not changing filters when initial filters length = 2

### DIFF
--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -170,6 +170,7 @@ export const useEnsurePossibleFilters = ({
         .query(PossibleFiltersDocument, {
           iri: state.dataSet,
           filters: unmappedFilters,
+          filterKey: Object.keys(unmappedFilters).join(", "),
         })
         .toPromise();
       if (error || !data) {

--- a/app/graphql/resolvers.spec.ts
+++ b/app/graphql/resolvers.spec.ts
@@ -1,0 +1,81 @@
+import { Query } from "./resolvers";
+import {
+  getCubeObservations as getCubeObservations_,
+  createSource as createSource_,
+} from "../rdf/queries";
+import { unversionObservation as unversionObservation_ } from "../rdf/query-dimension-values";
+import { GraphQLResolveInfo } from "graphql";
+
+const getCubeObservations = getCubeObservations_ as unknown as jest.Mock<
+  typeof getCubeObservations_
+>;
+const createSource = createSource_ as unknown as jest.Mock<
+  typeof createSource_
+>;
+
+const unversionObservation = unversionObservation_ as unknown as jest.Mock<
+  typeof unversionObservation_
+>;
+
+jest.mock("../rdf/query-dimension-values", () => ({
+  unversionObservation: jest.fn(),
+}));
+jest.mock("../rdf/queries", () => ({
+  getCubeObservations: jest.fn(),
+  createSource: jest.fn(),
+}));
+
+jest.mock("../rdf/query-cube-metadata", () => ({}));
+
+describe("possible filters", () => {
+  beforeEach(() => {
+    getCubeObservations.mockReset();
+  });
+  it("should try to find an observation given possible filters, relaxing fitlers from the bottom", async () => {
+    // @ts-ignore
+    getCubeObservations.mockImplementation(async ({ filters }) => {
+      if (Object.keys(filters).length == 2) {
+        return {
+          observations: [],
+          observationsRaw: {},
+          query: "",
+        };
+      } else {
+        return {
+          observationsRaw: {},
+          query: "",
+          observations: [
+            {
+              "https://fake-dimension-iri-1": 1,
+              "https://fake-dimension-iri-2": 3,
+            },
+          ],
+        };
+      }
+    });
+
+    unversionObservation.mockImplementation(({ observation }) => observation);
+
+    // @ts-ignore
+    createSource.mockImplementation(() => ({
+      cube: () => ({}),
+    }));
+    const res = await Query?.possibleFilters?.(
+      {},
+      {
+        iri: "https://fake-iri",
+        filters: {
+          "https://fake-dimension-iri-1": { type: "single", value: 1 },
+          "https://fake-dimension-iri-2": { type: "single", value: 2 },
+        },
+      },
+      undefined,
+      {} as GraphQLResolveInfo
+    );
+    expect(res).toEqual([
+      { iri: "https://fake-dimension-iri-1", type: "single", value: 1 },
+      { iri: "https://fake-dimension-iri-2", type: "single", value: 3 },
+    ]);
+    expect(getCubeObservations).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/graphql/resolvers.ts
+++ b/app/graphql/resolvers.ts
@@ -42,7 +42,7 @@ import { ResolvedDimension } from "./shared-types";
 import { ObservationFilter } from "./query-hooks";
 import { unversionObservation } from "../rdf/query-dimension-values";
 
-const Query: QueryResolvers = {
+export const Query: QueryResolvers = {
   possibleFilters: async (_, { iri, filters }) => {
     const source = createSource();
 
@@ -54,7 +54,7 @@ const Query: QueryResolvers = {
     const nbFilters = Object.keys(filters).length;
     for (let i = nbFilters; i > 0; i--) {
       const queryFilters = Object.fromEntries(
-        Object.entries(filters).slice(0, i + 1)
+        Object.entries(filters).slice(0, i)
       );
       const { observations: obs } = await getCubeObservations({
         cube,


### PR DESCRIPTION
Possible filters query would make a too big slice of the filters resulting
in possible filters trying twice with 2 filters if filters initial length
is 2. This would result in empty results and the filters not being changed
in the UI.

fix #400
