### PR TITLE
docs: Docs for form works

### DIFF
--- a/app/components/autocomplete.tsx
+++ b/app/components/autocomplete.tsx
@@ -16,6 +16,7 @@ const menuStyles = {
   top: "3rem",
   left: 0,
   right: 0,
+  zIndex: 100,
 };
 
 const AutocompleteList = React.forwardRef<HTMLDivElement>(

--- a/app/docs/form.docs.tsx
+++ b/app/docs/form.docs.tsx
@@ -11,6 +11,7 @@ import {
   Switch,
 } from "../components/form";
 import SearchAutocomplete from "../components/search-autocomplete";
+import { BrowseStateProvider } from "../configurator/components/dataset-browse";
 
 const SwitchExample = () => {
   const [checked, toggle] = useState(false);
@@ -163,7 +164,7 @@ ${(
 
   ${(
     <ReactSpecimen span={2}>
-      <>
+      <BrowseStateProvider>
         <SearchAutocomplete
           onSelectedItemChange={({ selectedItem }) => {
             if (selectedItem?.__typename !== "FreeSearchItem") {
@@ -175,7 +176,7 @@ ${(
             }
           }}
         />
-      </>
+      </BrowseStateProvider>
     </ReactSpecimen>
   )}
 


### PR DESCRIPTION
The search autocomplete needed to be wrapped into a context provided. Additionally I had to set a high z-index for it to be over other components (unfortunately, theme-ui does not surface CSS variables for z-index).