### PR TITLE
feat: Change icons for segments

### DIFF
--- a/app/configurator/components/ui-helpers.ts
+++ b/app/configurator/components/ui-helpers.ts
@@ -391,7 +391,7 @@ export const getIconName = (name: string): IconName => {
     case "y":
       return "yAxis";
     case "segment":
-      return "segments";
+      return "color";
     case "table":
       return "table";
     case "filter":

--- a/app/configurator/map/map-chart-options.tsx
+++ b/app/configurator/map/map-chart-options.tsx
@@ -229,7 +229,7 @@ export const AreaLayerSettings = memo(
           </ControlSectionContent>
         </ControlSection>
         <ControlSection>
-          <SectionTitle iconName="segments">
+          <SectionTitle iconName="color">
             {t({ id: "controls.color", message: "Color" })}
           </SectionTitle>
           <ControlSectionContent side="right">
@@ -434,7 +434,7 @@ export const SymbolLayerSettings = memo(
           </ControlSectionContent>
         </ControlSection>
         <ControlSection>
-          <SectionTitle iconName="segments">
+          <SectionTitle iconName="color">
             {t({ id: "controls.color", message: "Color" })}
           </SectionTitle>
           <ControlSectionContent side="right">

--- a/app/icons/components/IcColor.tsx
+++ b/app/icons/components/IcColor.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+
+function SvgIcColor(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      width="1em"
+      height="1em"
+      {...props}
+    >
+      <g transform="translate(3, 1)" fill="currentColor" fillRule="nonzero">
+        <polygon
+          transform="translate(11.75, 8.25) rotate(-45) translate(-11.75, -8.25)"
+          points="7.87 0.47 15.64 0.47 15.64 16.02 7.87 16.02"
+        />
+        <path d="M1.68,7.33 L0.76,8.25 C-0.25,9.26 -0.25,10.90 0.76,11.91 L2.59,13.74 L0.76,15.58 C-0.25,16.59 -0.25,18.23 0.76,19.24 C1.77,20.25 3.41,20.25 4.42,19.24 L6.26,17.41 L8.09,19.24 C9.10,20.25 10.74,20.25 11.75,19.24 L12.67,18.32 L1.68,7.33 Z" />
+      </g>
+    </svg>
+  );
+}
+
+export default SvgIcColor;

--- a/app/icons/components/index.tsx
+++ b/app/icons/components/index.tsx
@@ -29,6 +29,7 @@ import { default as ChevronUp } from "./IcChevronUp";
 import { default as Circle } from "./IcCircle";
 import { default as Clear } from "./IcClear";
 import { default as Close } from "./IcClose";
+import { default as Color } from "./IcColor";
 import { default as Column } from "./IcColumn";
 import { default as Copy } from "./IcCopy";
 import { default as Cursor } from "./IcCursor";
@@ -38,8 +39,8 @@ import { default as DatasetSuccess } from "./IcDatasetSuccess";
 import { default as Description } from "./IcDescription";
 import { default as Desktop } from "./IcDesktop";
 import { default as Download } from "./IcDownload";
-import { default as DragHandle } from "./IcDragHandle";
 import { default as Drag } from "./IcDrag";
+import { default as DragHandle } from "./IcDragHandle";
 import { default as Dragndrop } from "./IcDragndrop";
 import { default as Edit } from "./IcEdit";
 import { default as Embed } from "./IcEmbed";
@@ -58,8 +59,8 @@ import { default as Image } from "./IcImage";
 import { default as Info } from "./IcInfo";
 import { default as Laptop } from "./IcLaptop";
 import { default as LeftAligned } from "./IcLeftAligned";
-import { default as LinkExternal } from "./IcLinkExternal";
 import { default as Link } from "./IcLink";
+import { default as LinkExternal } from "./IcLinkExternal";
 import { default as List } from "./IcList";
 import { default as Loading } from "./IcLoading";
 import { default as Mail } from "./IcMail";
@@ -123,7 +124,7 @@ import { default as Word } from "./IcWord";
 import { default as XAxis } from "./IcXAxis";
 import { default as YAxis } from "./IcYAxis";
 import { default as ZoomIn } from "./IcZoomIn";
-  
+
 export const Icons = {
   add: Add,
   annotationArea: AnnotationArea,
@@ -156,6 +157,7 @@ export const Icons = {
   circle: Circle,
   clear: Clear,
   close: Close,
+  color: Color,
   column: Column,
   copy: Copy,
   cursor: Cursor,
@@ -253,4 +255,3 @@ export const Icons = {
 };
 
 export type IconName = keyof typeof Icons;
-  


### PR DESCRIPTION
Closes #405.

I think it makes sense to change the icon there, as segments in all cases are represented by colors and we already have a "Color" label instead of "Segment".