### PR TITLE
Standard error in map tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-Nothing yet.
+- Show standard error inside map tooltip
 
 ## [3.4.2] - 2022-02-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-- Show standard error inside map tooltip
+- Show unit and standard error inside map tooltip
+- Prevent geo coordinates display error when all shapes on a map are deselected
+- Show "-" inside a map tooltip when no value is present
 
 ## [3.4.2] - 2022-02-21
 
-* Hide all elements related to labels, not only text by @bprusinowski in https://github.com/visualize-admin/visualization-tool/pull/387
-* Do not set automatically empty filters by @ptbrowne in https://github.com/visualize-admin/visualization-tool/pull/384
-* Do not show standard error in possible filters by @ptbrowne in https://github.com/visualize-admin/visualization-tool/pull/395
-* Fix search and drafts count by @ptbrowne in https://github.com/visualize-admin/visualization-tool/pull/396
-* Map improvements by @bprusinowski in https://github.com/visualize-admin/visualization-tool/pull/397
+- Hide all elements related to labels, not only text by @bprusinowski in https://github.com/visualize-admin/visualization-tool/pull/387
+- Do not set automatically empty filters by @ptbrowne in https://github.com/visualize-admin/visualization-tool/pull/384
+- Do not show standard error in possible filters by @ptbrowne in https://github.com/visualize-admin/visualization-tool/pull/395
+- Fix search and drafts count by @ptbrowne in https://github.com/visualize-admin/visualization-tool/pull/396
+- Map improvements by @bprusinowski in https://github.com/visualize-admin/visualization-tool/pull/397
 
 ## [3.4.0] - 2022-02-18
 

--- a/app/charts/map/map-tooltip.tsx
+++ b/app/charts/map/map-tooltip.tsx
@@ -9,7 +9,10 @@ import {
   useState,
 } from "react";
 import { Box, Grid, Text } from "theme-ui";
-import { useFormatNumber } from "../../configurator/components/ui-helpers";
+import {
+  formatNumberWithUnit,
+  useFormatNumber,
+} from "../../configurator/components/ui-helpers";
 import { TooltipBox } from "../shared/interaction/tooltip-box";
 import { useChartState } from "../shared/use-chart-state";
 import { useInteraction } from "../shared/use-interaction";
@@ -123,7 +126,18 @@ export const MapTooltip = () => {
                         }}
                       >
                         <Text as="div" variant="meta">
-                          {formatNumber(areaLayerValue)}
+                          <Text as="div" variant="meta">
+                            {formatNumberWithUnit(
+                              areaLayerValue,
+                              formatNumber,
+                              areaLayer?.measureDimension?.unit
+                            )}
+                            {areaLayer.getFormattedError
+                              ? ` ± ${areaLayer?.getFormattedError?.(
+                                  interaction.d
+                                )}`
+                              : null}
+                          </Text>
                         </Text>
                       </Box>
                     </>
@@ -145,12 +159,17 @@ export const MapTooltip = () => {
                           background: symbolLayer.color,
                         }}
                       >
-                        <Text
-                          as="div"
-                          variant="meta"
-                          sx={{ color: "monochrome100" }}
-                        >
-                          {formatNumber(symbolLayerValue)}
+                        <Text as="div" variant="meta">
+                          {formatNumberWithUnit(
+                            symbolLayerValue,
+                            formatNumber,
+                            symbolLayer?.measureDimension?.unit
+                          )}
+                          {symbolLayer.getFormattedError
+                            ? ` ± ${symbolLayer?.getFormattedError?.(
+                                interaction.d
+                              )}`
+                            : null}
                         </Text>
                       </Box>
                     </>

--- a/app/components/debug-panel.tsx
+++ b/app/components/debug-panel.tsx
@@ -4,7 +4,10 @@ import { Box, Link, Text } from "theme-ui";
 import { useInteractiveFilters } from "../charts/shared/use-interactive-filters";
 import { useConfiguratorState } from "../configurator";
 import { SPARQL_EDITOR, SPARQL_ENDPOINT } from "../domain/env";
+import { useDataCubeMetadataWithComponentValuesQuery } from "../graphql/query-hooks";
 import { Icon } from "../icons";
+import { useLocale } from "../src";
+import Stack from "./Stack";
 
 const DebugInteractiveFilters = () => {
   const [interactiveFiltersState] = useInteractiveFilters();
@@ -20,6 +23,27 @@ const DebugInteractiveFilters = () => {
   );
 };
 
+const CubeMetadata = ({ datasetIri }: { datasetIri: string }) => {
+  const locale = useLocale();
+  const [{ data: metadata }] = useDataCubeMetadataWithComponentValuesQuery({
+    variables: {
+      iri: datasetIri,
+      locale: locale,
+    },
+  });
+  return metadata ? (
+    <Stack direction="row" spacing={2}>
+      <Icon name="column" display="inline" size={16} />
+      <Text variant="paragraph2">Dimensions</Text>
+      <Inspector
+        data={Object.fromEntries(
+          metadata?.dataCubeByIri?.dimensions.map((d) => [d.label, d]) || []
+        )}
+      />
+    </Stack>
+  ) : null;
+};
+
 const DebugConfigurator = () => {
   const [configuratorState] = useConfiguratorState();
   return (
@@ -27,7 +51,7 @@ const DebugConfigurator = () => {
       <Box as="h3" variant="text.lead" sx={{ px: 5, color: "monochrome700" }}>
         Cube Tools
       </Box>
-      <Box sx={{ p: 5 }}>
+      <Stack spacing={2} sx={{ p: 5 }}>
         {configuratorState.dataSet ? (
           <Link
             variant="primary"
@@ -57,7 +81,7 @@ DESCRIBE <${configuratorState.dataSet ?? ""}>`
             )}&requestMethod=POST`}
             target="_blank"
             rel="noopener noreferrer"
-            sx={{ display: "flex", alignItems: "center", mt: 3 }}
+            sx={{ display: "flex", alignItems: "center" }}
           >
             <Icon name="linkExternal" size={16} />
             <Text sx={{ ml: 2, fontSize: 3 }} variant="body">
@@ -65,7 +89,10 @@ DESCRIBE <${configuratorState.dataSet ?? ""}>`
             </Text>
           </Link>
         )}
-      </Box>
+        {configuratorState.dataSet ? (
+          <CubeMetadata datasetIri={configuratorState.dataSet} />
+        ) : null}
+      </Stack>
       <Box as="h3" variant="text.lead" sx={{ px: 5, color: "monochrome700" }}>
         Configurator State{" "}
         <Link

--- a/app/configurator/components/ui-helpers.ts
+++ b/app/configurator/components/ui-helpers.ts
@@ -304,13 +304,16 @@ export const formatNumberWithUnit = (
   formatter: (n: number) => string,
   unit?: string | null
 ) => {
-  if (nb === null) {
-    return "";
+  if (nb === null || nb === undefined) {
+    return "-";
   }
   return `${formatter(nb)}${unit ? ` ${unit}` : ""}`;
 };
 
-export const useErrorMeasure = (chartState: ChartProps, valueIri: string) => {
+export const useErrorMeasure = (
+  chartState: Pick<ChartProps, "measures" | "dimensions">,
+  valueIri: string
+) => {
   const { measures, dimensions } = chartState;
   return useMemo(() => {
     return [...measures, ...dimensions].find((m) => {

--- a/app/domain/data.ts
+++ b/app/domain/data.ts
@@ -212,6 +212,15 @@ export const isStandardErrorDimension = (dim: DimensionMetaDataFragment) => {
   return dim?.related?.some((r) => r.type === "StandardError");
 };
 
+export const findRelatedErrorDimension = (
+  dimIri: string,
+  dimensions: DimensionMetaDataFragment[]
+) => {
+  return dimensions.find((x) =>
+    x.related?.some((r) => r.iri === dimIri && r.type === "StandardError")
+  );
+};
+
 export const shouldValuesBeLoadedForResolvedDimension = (
   dim: ResolvedDimension
 ) => {


### PR DESCRIPTION
As for column chart, the map tooltip now show the standard error along
with its unit if the measure dimension has an associated SE dimension.

- Tested with COVID dataset for "-" edgecase
- Tested with Waldfläche dataset for SE in tooltip
