### PR TITLE
feat: Improve tooltip placement

### DIFF
--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -348,16 +348,11 @@ const useAreasState = ({
       ...sortedTooltipValues.map(cumulativeSum),
     ];
 
-    const yAnchor = yScale(
-      Math.max(
-        cumulativeRulerItemValues[cumulativeRulerItemValues.length - 1],
-        0
-      )
-    );
+    const yAnchor = 0;
 
-    const xPlacement = xAnchor < chartWidth * 0.5 ? "right" : "left";
+    const xPlacement = "center";
 
-    const yPlacement = yAnchor < chartHeight * 0.33 ? "middle" : "top";
+    const yPlacement = "top";
 
     return {
       xAnchor,

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -350,11 +350,13 @@ const useGroupedColumnsState = (
     const yPlacement = "top";
 
     const getXPlacement = () => {
-      return xRef < chartWidth * 0.33
-        ? "right"
-        : xRef > chartWidth * 0.66
-        ? "left"
-        : "center";
+      if (xRef + xOffset * 2 > 0.75 * chartWidth) {
+        return "left";
+      } else if (xRef < 0.25 * chartWidth) {
+        return "right";
+      } else {
+        return "center";
+      }
     };
     const xPlacement = getXPlacement();
 

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -347,33 +347,23 @@ const useGroupedColumnsState = (
       sortOrder: "asc",
     });
 
-    const yPlacement = yAnchor < chartHeight * 0.33 ? "middle" : "top";
+    const yPlacement = "top";
 
     const getXPlacement = () => {
-      if (yPlacement === "top") {
-        return xRef < chartWidth * 0.33
-          ? "right"
-          : xRef > chartWidth * 0.66
-          ? "left"
-          : "center";
-      } else {
-        // yPlacement === "middle"
-        return xRef < chartWidth * 0.5 ? "right" : "left";
-      }
+      return xRef < chartWidth * 0.33
+        ? "right"
+        : xRef > chartWidth * 0.66
+        ? "left"
+        : "center";
     };
     const xPlacement = getXPlacement();
 
     const getXAnchor = () => {
-      if (yPlacement === "top") {
-        return xPlacement === "right"
-          ? xRef
-          : xPlacement === "center"
-          ? xRef + xOffset
-          : xRef + xOffset * 2;
-      } else {
-        // yPlacement === "middle"
-        return xPlacement === "right" ? xRef + xOffset * 2 : xRef;
-      }
+      return xPlacement === "right"
+        ? xRef
+        : xPlacement === "center"
+        ? xRef + xOffset
+        : xRef + xOffset * 2;
     };
     const xAnchor = getXAnchor();
 

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -392,31 +392,25 @@ const useColumnsStackedState = ({
         )
       );
       const yAnchor = yRef;
-      const yPlacement = yAnchor < chartHeight * 0.33 ? "middle" : "top";
+      const yPlacement = "top";
 
       const getXPlacement = () => {
-        if (yPlacement === "top") {
-          return xRef < chartWidth * 0.33
-            ? "right"
-            : xRef > chartWidth * 0.66
-            ? "left"
-            : "center";
+        if (xRef + xOffset * 2 > 0.75 * chartWidth) {
+          return "left";
+        } else if (xRef < 0.25 * chartWidth) {
+          return "right";
         } else {
-          return xRef < chartWidth * 0.5 ? "right" : "left";
+          return "center";
         }
       };
       const xPlacement = getXPlacement();
 
       const getXAnchor = () => {
-        if (yPlacement === "top") {
-          return xPlacement === "right"
-            ? xRef
-            : xPlacement === "center"
-            ? xRef + xOffset
-            : xRef + xOffset * 2;
-        } else {
-          return xPlacement === "right" ? xRef + xOffset * 2 : xRef;
-        }
+        return xPlacement === "right"
+          ? xRef
+          : xPlacement === "center"
+          ? xRef + xOffset
+          : xRef + xOffset * 2;
       };
       const xAnchor = getXAnchor();
 

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -231,33 +231,25 @@ const useColumnsState = (
     const yRef = yScale(Math.max(getY(datum) ?? NaN, 0));
     const yAnchor = yRef;
 
-    const yPlacement = yAnchor < chartHeight * 0.33 ? "middle" : "top";
+    const yPlacement = "top";
 
     const getXPlacement = () => {
-      if (yPlacement === "top") {
-        return xRef < chartWidth * 0.33
-          ? "right"
-          : xRef > chartWidth * 0.66
-          ? "left"
-          : "center";
+      if (xRef + xOffset * 2 > 0.75 * chartWidth) {
+        return "left";
+      } else if (xRef < 0.25 * chartWidth) {
+        return "right";
       } else {
-        // yPlacement === "middle"
-        return xRef < chartWidth * 0.5 ? "right" : "left";
+        return "center";
       }
     };
     const xPlacement = getXPlacement();
 
     const getXAnchor = () => {
-      if (yPlacement === "top") {
-        return xPlacement === "right"
-          ? xRef
-          : xPlacement === "center"
-          ? xRef + xOffset
-          : xRef + xOffset * 2;
-      } else {
-        // yPlacement === "middle"
-        return xPlacement === "right" ? xRef + xOffset * 2 : xRef;
-      }
+      return xPlacement === "right"
+        ? xRef
+        : xPlacement === "center"
+        ? xRef + xOffset
+        : xRef + xOffset * 2;
     };
     const xAnchor = getXAnchor();
 

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -258,9 +258,9 @@ const useLinesState = ({
       sortOrder: "asc",
     });
 
-    const xPlacement = xAnchor < chartWidth * 0.5 ? "right" : "left";
+    const xPlacement = "center";
 
-    const yPlacement = "middle";
+    const yPlacement = "top";
 
     return {
       xAnchor,

--- a/app/charts/shared/interaction/tooltip.tsx
+++ b/app/charts/shared/interaction/tooltip.tsx
@@ -53,14 +53,8 @@ const TooltipInner = ({
   const { margins } = bounds;
   const { xAnchor, yAnchor, placement, xValue, tooltipContent, datum, values } =
     getAnnotationInfo(d);
-
   return (
-    <TooltipBox
-      x={xAnchor}
-      y={mouse && values && values.length > 1 ? mouse.y : yAnchor}
-      placement={placement}
-      margins={margins}
-    >
+    <TooltipBox x={xAnchor} y={yAnchor} placement={placement} margins={margins}>
       {tooltipContent ? (
         tooltipContent
       ) : type === "multiple" && values ? (


### PR DESCRIPTION
- Only allow top placement, this way we do not hide chart data (future work could include having the same behavior that the tooltip stays at the same place vertically). Checked with Annina
- Improve x placement by considering right edge of columns
- Tooltip is now absolutely positionned and portalled so that it can escape the chart container, this removes problems with tooltip being cut

Fix #315 