### PR TITLE
Account for xsd:gYearMonth timeFormat when parsing a TemporalDimension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 - Search improvements (handles trailing space and casing)
 - Data download improvements (new UI with an ability to select XLSX file format)
 - Raw data preview from the chart level
+- Fixed parsing of xsd:gYearMonth timeFormat in TemporalDimension
+- Updated date formatting for the Month timeUnit to be more user-friendly
 
 ## [3.4.7] - 2022-02-18
 

--- a/app/configurator/components/ui-helpers.ts
+++ b/app/configurator/components/ui-helpers.ts
@@ -36,13 +36,13 @@ import {
   schemeTableau10,
   timeDay,
   timeHour,
+  TimeLocaleObject,
   timeMinute,
   timeMonth,
+  timeParse,
   timeSecond,
   timeWeek,
   timeYear,
-  TimeLocaleObject,
-  timeParse,
 } from "d3";
 import { memoize } from "lodash";
 import { useMemo } from "react";
@@ -179,7 +179,7 @@ const timeIntervals = new Map<TimeUnit, CountableTimeInterval>([
 
 const timeFormats = new Map<TimeUnit, string>([
   [TimeUnit.Year, "%Y"],
-  [TimeUnit.Month, "%d.%m.%Y"],
+  [TimeUnit.Month, "%b %Y"],
   [TimeUnit.Week, "%d.%m.%Y"],
   [TimeUnit.Day, "%d.%m.%Y"],
   [TimeUnit.Hour, "%d.%m.%Y %H:%M"],

--- a/app/rdf/parse.ts
+++ b/app/rdf/parse.ts
@@ -92,6 +92,7 @@ const timeUnits = new Map<string, TimeUnit>([
 
 const timeFormats = new Map<string, string>([
   [ns.xsd.gYear.value, "%Y"],
+  [ns.xsd.gYearMonth.value, "%Y-%m"],
   [ns.xsd.date.value, "%Y-%m-%d"],
   [ns.xsd.dateTime.value, "%Y-%m-%dT%H:%M:%S"],
 ]);


### PR DESCRIPTION
Closes #461.

Also, changes the formatting of Month timeUnit to a shortened month name + year.