### PR TITLE
fix: Make CssBaseline work

### DIFF
--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -73,9 +73,9 @@ export default function App({ Component, pageProps }: AppProps) {
         <I18nProvider i18n={i18n}>
           <GraphqlProvider>
             <ThemeProvider theme={federalTheme.theme}>
+              <CssBaseline />
               <ContentMDXProvider>
                 <AsyncLocalizationProvider locale={locale}>
-                  <CssBaseline />
                   <Component {...pageProps} />
                 </AsyncLocalizationProvider>
               </ContentMDXProvider>


### PR DESCRIPTION
Move CssBaseline in the hope that the CssBaseline overrides rules will work in production.