### PR TITLE
Fix scatterplot crash

### DIFF
--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -120,7 +120,7 @@ const useScatterplotState = ({
     const orderedSegmentLabelsAndColors = segments.map((segment) => {
       const dvIri = segmentDimension.values.find(
         (s: $FixMe) => s.label === segment
-      ).value;
+      )?.value;
 
       return {
         label: segment,

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -32,7 +32,7 @@ export const ChartDataFilters = ({
 
   return (
     <>
-      {dataSet && (
+      {dataSet && componentIris.length > 0 && (
         <Flex sx={{ flexDirection: "column", my: 4 }}>
           <Flex
             sx={{

--- a/app/configurator/interactive-filters/interactive-filters-configurator.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-configurator.tsx
@@ -15,7 +15,7 @@ import {
 import { ConfiguratorStateDescribingChart } from "@/configurator/config-types";
 import { useConfiguratorState } from "@/configurator/configurator-state";
 
-export type InteractveFilterType = "legend" | "time" | "dataFilters";
+export type InteractiveFilterType = "legend" | "time" | "dataFilters";
 
 export const InteractiveFiltersConfigurator = ({
   state,
@@ -105,7 +105,7 @@ const InteractiveFilterTabField = ({
   icon,
   label,
 }: {
-  value: InteractveFilterType;
+  value: InteractiveFilterType;
   disabled?: boolean;
   icon: string;
   label: ReactNode;


### PR DESCRIPTION
- fix: Prevent scatterplot chart from crashing when data segment value does not have an IRI
- fix: Prevent margins due to empty interactive filters component
- refactor: Typo in type
