### PR TITLE
Sort imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,10 +1,22 @@
 {
   "extends": "next",
-  "plugins": ["unused-imports"],
+  "plugins": ["unused-imports", "import"],
   "rules": {
     "react/display-name": "off",
     "unused-imports/no-unused-imports-ts": "error",
-    "@next/next/no-html-link-for-pages": ["error", "app/pages/"]
+    "@next/next/no-html-link-for-pages": ["error", "app/pages/"],
+    "import/order": [2, {
+      "alphabetize": { "order": "asc" },
+      "newlines-between": "always",
+      "groups": ["builtin", "external", "internal", "parent", "sibling", "index", "object", "type"],
+      "pathGroups": [
+        {
+          "pattern": "@/**",
+          "group": "internal"
+        }
+      ],
+      "pathGroupsExcludedImportTypes": ["builtin"]
+    }]
   },
   "overrides": [
     {

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -20,17 +20,8 @@ import {
 } from "d3";
 import { sortBy } from "lodash";
 import { ReactNode, useMemo } from "react";
-import { AreaFields } from "@/configurator";
-import {
-  getPalette,
-  useFormatNumber,
-  useTimeFormatUnit,
-} from "@/configurator/components/ui-helpers";
-import { Observation } from "@/domain/data";
-import { sortByIndex } from "@/lib/array";
-import { estimateTextWidth } from "@/lib/estimate-text-width";
-import { useLocale } from "@/locales/use-locale";
-import { makeOrdinalDimensionSorter } from "@/utils/sorting-values";
+
+import { LEFT_MARGIN_OFFSET } from "@/charts/area/constants";
 import { BRUSH_BOTTOM_SPACE } from "@/charts/shared/brush";
 import {
   getLabelWithUnit,
@@ -47,7 +38,17 @@ import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useInteractiveFilters } from "@/charts/shared/use-interactive-filters";
 import { Bounds, Observer, useWidth } from "@/charts/shared/use-width";
-import { LEFT_MARGIN_OFFSET } from "@/charts/area/constants";
+import { AreaFields } from "@/configurator";
+import {
+  getPalette,
+  useFormatNumber,
+  useTimeFormatUnit,
+} from "@/configurator/components/ui-helpers";
+import { Observation } from "@/domain/data";
+import { sortByIndex } from "@/lib/array";
+import { estimateTextWidth } from "@/lib/estimate-text-width";
+import { useLocale } from "@/locales/use-locale";
+import { makeOrdinalDimensionSorter } from "@/utils/sorting-values";
 
 export interface AreasState {
   chartType: "area";

--- a/app/charts/area/areas.tsx
+++ b/app/charts/area/areas.tsx
@@ -1,8 +1,9 @@
 import { area } from "d3";
 import { memo } from "react";
-import { useTheme } from "@/themes";
-import { useChartState } from "@/charts/shared/use-chart-state";
+
 import { AreasState } from "@/charts/area/areas-state";
+import { useChartState } from "@/charts/shared/use-chart-state";
+import { useTheme } from "@/themes";
 
 export const Areas = () => {
   const { bounds, getX, xScale, yScale, colors, series, segments } =

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -1,5 +1,21 @@
-import React, { memo } from "react";
 import { Box } from "@mui/material";
+import React, { memo } from "react";
+
+import { Areas } from "@/charts/area/areas";
+import { AreaChart } from "@/charts/area/areas-state";
+import { A11yTable } from "@/charts/shared/a11y-table";
+import { AxisHeightLinear } from "@/charts/shared/axis-height-linear";
+import { AxisTime, AxisTimeDomain } from "@/charts/shared/axis-width-time";
+import { BrushTime } from "@/charts/shared/brush";
+import { QueryFilters } from "@/charts/shared/chart-helpers";
+import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
+import { Ruler } from "@/charts/shared/interaction/ruler";
+import { Tooltip } from "@/charts/shared/interaction/tooltip";
+import {
+  InteractiveLegendColor,
+  LegendColor,
+} from "@/charts/shared/legend-color";
+import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import {
   Loading,
   LoadingDataError,
@@ -18,18 +34,6 @@ import {
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
-import { A11yTable } from "@/charts/shared/a11y-table";
-import { AxisHeightLinear } from "@/charts/shared/axis-height-linear";
-import { AxisTime, AxisTimeDomain } from "@/charts/shared/axis-width-time";
-import { BrushTime } from "@/charts/shared/brush";
-import { QueryFilters } from "@/charts/shared/chart-helpers";
-import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
-import { Ruler } from "@/charts/shared/interaction/ruler";
-import { Tooltip } from "@/charts/shared/interaction/tooltip";
-import { InteractiveLegendColor, LegendColor } from "@/charts/shared/legend-color";
-import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
-import { Areas } from "@/charts/area/areas";
-import { AreaChart } from "@/charts/area/areas-state";
 
 export const ChartAreasVisualization = ({
   dataSetIri,

--- a/app/charts/bar/bars-grouped-state.tsx
+++ b/app/charts/bar/bars-grouped-state.tsx
@@ -14,11 +14,12 @@ import {
   sum,
 } from "d3";
 import React, { ReactNode, useMemo } from "react";
-import { BarFields, SortingOrder, SortingType } from "@/configurator";
-import { getPalette, mkNumber } from "@/configurator/components/ui-helpers";
-import { Observation } from "@/domain/data";
-import { sortByIndex } from "@/lib/array";
-import { useLocale } from "@/locales/use-locale";
+
+import {
+  BAR_HEIGHT,
+  BAR_SPACE_ON_TOP,
+  BOTTOM_MARGIN_OFFSET,
+} from "@/charts/bar/constants";
 import {
   useNumericVariable,
   useSegment,
@@ -28,11 +29,11 @@ import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { InteractiveFiltersProvider } from "@/charts/shared/use-interactive-filters";
 import { Bounds, Observer, useWidth } from "@/charts/shared/use-width";
-import {
-  BAR_HEIGHT,
-  BAR_SPACE_ON_TOP,
-  BOTTOM_MARGIN_OFFSET,
-} from "@/charts/bar/constants";
+import { BarFields, SortingOrder, SortingType } from "@/configurator";
+import { getPalette, mkNumber } from "@/configurator/components/ui-helpers";
+import { Observation } from "@/domain/data";
+import { sortByIndex } from "@/lib/array";
+import { useLocale } from "@/locales/use-locale";
 
 export interface GroupedBarsState {
   chartType: string;

--- a/app/charts/bar/bars-grouped.tsx
+++ b/app/charts/bar/bars-grouped.tsx
@@ -1,8 +1,8 @@
+import { GroupedBarsState } from "@/charts/bar/bars-grouped-state";
+import { Bar } from "@/charts/bar/bars-simple";
 import { BAR_AXIS_OFFSET, BAR_SPACE_ON_TOP } from "@/charts/bar/constants";
 import { useChartState } from "@/charts/shared/use-chart-state";
 import { useChartTheme } from "@/charts/shared/use-chart-theme";
-import { GroupedBarsState } from "@/charts/bar/bars-grouped-state";
-import { Bar } from "@/charts/bar/bars-simple";
 import { useInteractiveFilters } from "@/charts/shared/use-interactive-filters";
 
 export const BarsGrouped = () => {
@@ -72,14 +72,8 @@ export const BarsGrouped = () => {
 };
 
 export const BarsGroupedLabels = () => {
-  const {
-    bounds,
-    yScaleIn,
-    getX,
-    yScale,
-    getSegment,
-    grouped,
-  } = useChartState() as GroupedBarsState;
+  const { bounds, yScaleIn, getX, yScale, getSegment, grouped } =
+    useChartState() as GroupedBarsState;
   const { margins } = bounds;
   const { axisLabelColor, labelFontSize, fontFamily } = useChartTheme();
 

--- a/app/charts/bar/bars-simple.tsx
+++ b/app/charts/bar/bars-simple.tsx
@@ -1,25 +1,21 @@
-import { useTheme } from "@/themes";
-import { BAR_AXIS_OFFSET, BAR_HEIGHT, BAR_SPACE_ON_TOP } from "@/charts/bar/constants";
-import { useChartState } from "@/charts/shared/use-chart-state";
-import { useChartTheme } from "@/charts/shared/use-chart-theme";
-import { BarsState } from "@/charts/bar/bars-state";
 import { memo } from "react";
 
+import { BarsState } from "@/charts/bar/bars-state";
+import {
+  BAR_AXIS_OFFSET,
+  BAR_HEIGHT,
+  BAR_SPACE_ON_TOP,
+} from "@/charts/bar/constants";
+import { useChartState } from "@/charts/shared/use-chart-state";
+import { useChartTheme } from "@/charts/shared/use-chart-theme";
+import { useTheme } from "@/themes";
+
 export const Bars = () => {
-  const {
-    sortedData,
-    bounds,
-    getX,
-    xScale,
-    getY,
-    yScale,
-  } = useChartState() as BarsState;
+  const { sortedData, bounds, getX, xScale, getY, yScale } =
+    useChartState() as BarsState;
   const theme = useTheme();
-  const {
-    axisLabelFontSize,
-    axisLabelFontWeight,
-    axisLabelColor,
-  } = useChartTheme();
+  const { axisLabelFontSize, axisLabelFontWeight, axisLabelColor } =
+    useChartTheme();
   const { margins } = bounds;
 
   return (
@@ -44,7 +40,9 @@ export const Bars = () => {
               y={BAR_SPACE_ON_TOP - BAR_AXIS_OFFSET}
               height={BAR_HEIGHT}
               color={
-                getX(d) <= 0 ? theme.palette.secondary.main : theme.palette.primary.main
+                getX(d) <= 0
+                  ? theme.palette.secondary.main
+                  : theme.palette.primary.main
               }
             />
           </g>
@@ -55,13 +53,8 @@ export const Bars = () => {
 };
 
 export const BarLabels = () => {
-  const {
-    sortedData,
-    bounds,
-    getX,
-    getY,
-    yScale,
-  } = useChartState() as BarsState;
+  const { sortedData, bounds, getX, getY, yScale } =
+    useChartState() as BarsState;
   const { labelColor, labelFontSize, fontFamily } = useChartTheme();
   const { margins } = bounds;
 

--- a/app/charts/bar/bars-state.tsx
+++ b/app/charts/bar/bars-state.tsx
@@ -11,9 +11,13 @@ import {
   scaleOrdinal,
 } from "d3";
 import { ReactNode, useMemo } from "react";
-import { BarFields, SortingOrder, SortingType } from "@/configurator";
-import { getPalette, mkNumber } from "@/configurator/components/ui-helpers";
-import { Observation } from "@/domain/data";
+
+import {
+  BAR_HEIGHT,
+  BAR_SPACE_ON_TOP,
+  BOTTOM_MARGIN_OFFSET,
+  LEFT_MARGIN_OFFSET,
+} from "@/charts/bar/constants";
 import {
   useNumericVariable,
   useSegment,
@@ -22,12 +26,9 @@ import {
 import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { Bounds, Observer, useWidth } from "@/charts/shared/use-width";
-import {
-  BAR_HEIGHT,
-  BAR_SPACE_ON_TOP,
-  BOTTOM_MARGIN_OFFSET,
-  LEFT_MARGIN_OFFSET,
-} from "@/charts/bar/constants";
+import { BarFields, SortingOrder, SortingType } from "@/configurator";
+import { getPalette, mkNumber } from "@/configurator/components/ui-helpers";
+import { Observation } from "@/domain/data";
 
 export interface BarsState {
   chartType: "bar";

--- a/app/charts/bar/chart-bar.tsx
+++ b/app/charts/bar/chart-bar.tsx
@@ -1,5 +1,23 @@
-import React, { memo } from "react";
 import { Box } from "@mui/material";
+import React, { memo } from "react";
+
+import { BarsGrouped } from "@/charts/bar/bars-grouped";
+import { GroupedBarsChart } from "@/charts/bar/bars-grouped-state";
+import { Bars } from "@/charts/bar/bars-simple";
+import { BarChart } from "@/charts/bar/bars-state";
+import { A11yTable } from "@/charts/shared/a11y-table";
+import { AxisWidthLinear } from "@/charts/shared/axis-width-linear";
+import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
+import {
+  InteractiveLegendColor,
+  LegendColor,
+} from "@/charts/shared/legend-color";
+import {
+  Loading,
+  LoadingDataError,
+  LoadingOverlay,
+  NoDataHint,
+} from "@/components/hint";
 import {
   Filters,
   BarConfig,
@@ -7,27 +25,13 @@ import {
   InteractiveFiltersConfig,
   FilterValueSingle,
 } from "@/configurator";
-import { Observation } from "@/domain/data";
 import { isNumber } from "@/configurator/components/ui-helpers";
+import { Observation } from "@/domain/data";
 import {
   DimensionMetaDataFragment,
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
-import { A11yTable } from "@/charts/shared/a11y-table";
-import { AxisWidthLinear } from "@/charts/shared/axis-width-linear";
-import { BarsGrouped } from "@/charts/bar/bars-grouped";
-import { GroupedBarsChart } from "@/charts/bar/bars-grouped-state";
-import { Bars } from "@/charts/bar/bars-simple";
-import { BarChart } from "@/charts/bar/bars-state";
-import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
-import { InteractiveLegendColor, LegendColor } from "@/charts/shared/legend-color";
-import {
-  Loading,
-  LoadingDataError,
-  LoadingOverlay,
-  NoDataHint,
-} from "@/components/hint";
 
 export const ChartBarsVisualization = ({
   dataSetIri,

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -1,5 +1,29 @@
-import React, { memo } from "react";
 import { Box } from "@mui/material";
+import React, { memo } from "react";
+
+import {
+  ColumnsGrouped,
+  ErrorWhiskers as ErrorWhiskersGrouped,
+} from "@/charts/column/columns-grouped";
+import { GroupedColumnChart } from "@/charts/column/columns-grouped-state";
+import { Columns, ErrorWhiskers } from "@/charts/column/columns-simple";
+import { ColumnsStacked } from "@/charts/column/columns-stacked";
+import { StackedColumnsChart } from "@/charts/column/columns-stacked-state";
+import { ColumnChart } from "@/charts/column/columns-state";
+import { InteractionColumns } from "@/charts/column/overlay-columns";
+import { A11yTable } from "@/charts/shared/a11y-table";
+import { AxisHeightLinear } from "@/charts/shared/axis-height-linear";
+import {
+  AxisWidthBand,
+  AxisWidthBandDomain,
+} from "@/charts/shared/axis-width-band";
+import { BrushTime } from "@/charts/shared/brush";
+import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
+import { Tooltip } from "@/charts/shared/interaction/tooltip";
+import {
+  InteractiveLegendColor,
+  LegendColor,
+} from "@/charts/shared/legend-color";
 import {
   Loading,
   LoadingDataError,
@@ -20,23 +44,6 @@ import {
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
-import { A11yTable } from "@/charts/shared/a11y-table";
-import { AxisHeightLinear } from "@/charts/shared/axis-height-linear";
-import { AxisWidthBand, AxisWidthBandDomain } from "@/charts/shared/axis-width-band";
-import { BrushTime } from "@/charts/shared/brush";
-import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
-import { Tooltip } from "@/charts/shared/interaction/tooltip";
-import { InteractiveLegendColor, LegendColor } from "@/charts/shared/legend-color";
-import {
-  ColumnsGrouped,
-  ErrorWhiskers as ErrorWhiskersGrouped,
-} from "@/charts/column/columns-grouped";
-import { GroupedColumnChart } from "@/charts/column/columns-grouped-state";
-import { Columns, ErrorWhiskers } from "@/charts/column/columns-simple";
-import { ColumnsStacked } from "@/charts/column/columns-stacked";
-import { StackedColumnsChart } from "@/charts/column/columns-stacked-state";
-import { ColumnChart } from "@/charts/column/columns-state";
-import { InteractionColumns } from "@/charts/column/overlay-columns";
 
 export const ChartColumnsVisualization = ({
   dataSetIri,

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -18,18 +18,14 @@ import {
 } from "d3";
 import { get, sortBy } from "lodash";
 import React, { ReactNode, useMemo } from "react";
-import { ColumnFields, SortingOrder, SortingType } from "@/configurator";
+
 import {
-  getPalette,
-  mkNumber,
-  useErrorMeasure,
-  useErrorRange,
-  useFormatNumber,
-} from "@/configurator/components/ui-helpers";
-import { Observation } from "@/domain/data";
-import { sortByIndex } from "@/lib/array";
-import { useLocale } from "@/locales/use-locale";
-import { makeOrdinalDimensionSorter } from "@/utils/sorting-values";
+  BOTTOM_MARGIN_OFFSET,
+  LEFT_MARGIN_OFFSET,
+  PADDING_INNER,
+  PADDING_OUTER,
+  PADDING_WITHIN,
+} from "@/charts/column/constants";
 import {
   getLabelWithUnit,
   useOptionalNumericVariable,
@@ -44,13 +40,18 @@ import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useInteractiveFilters } from "@/charts/shared/use-interactive-filters";
 import { Bounds, Observer, useWidth } from "@/charts/shared/use-width";
+import { ColumnFields, SortingOrder, SortingType } from "@/configurator";
 import {
-  BOTTOM_MARGIN_OFFSET,
-  LEFT_MARGIN_OFFSET,
-  PADDING_INNER,
-  PADDING_OUTER,
-  PADDING_WITHIN,
-} from "@/charts/column/constants";
+  getPalette,
+  mkNumber,
+  useErrorMeasure,
+  useErrorRange,
+  useFormatNumber,
+} from "@/configurator/components/ui-helpers";
+import { Observation } from "@/domain/data";
+import { sortByIndex } from "@/lib/array";
+import { useLocale } from "@/locales/use-locale";
+import { makeOrdinalDimensionSorter } from "@/utils/sorting-values";
 
 export interface GroupedColumnsState {
   chartType: "column";

--- a/app/charts/column/columns-grouped.tsx
+++ b/app/charts/column/columns-grouped.tsx
@@ -1,7 +1,7 @@
-import { useChartState } from "@/charts/shared/use-chart-state";
-import { VerticalWhisker } from "@/charts/whiskers";
 import { GroupedColumnsState } from "@/charts/column/columns-grouped-state";
 import { Column } from "@/charts/column/rendering-utils";
+import { useChartState } from "@/charts/shared/use-chart-state";
+import { VerticalWhisker } from "@/charts/whiskers";
 
 export const ErrorWhiskers = () => {
   const {

--- a/app/charts/column/columns-simple.tsx
+++ b/app/charts/column/columns-simple.tsx
@@ -1,8 +1,8 @@
-import { useTheme } from "@/themes";
-import { useChartState } from "@/charts/shared/use-chart-state";
-import { VerticalWhisker } from "@/charts/whiskers";
 import { ColumnsState } from "@/charts/column/columns-state";
 import { Column } from "@/charts/column/rendering-utils";
+import { useChartState } from "@/charts/shared/use-chart-state";
+import { VerticalWhisker } from "@/charts/whiskers";
+import { useTheme } from "@/themes";
 
 export const ErrorWhiskers = () => {
   const state = useChartState() as ColumnsState;

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -23,16 +23,13 @@ import {
 } from "d3";
 import { keyBy, sortBy } from "lodash";
 import React, { ReactNode, useCallback, useMemo } from "react";
-import { ColumnFields, SortingOrder, SortingType } from "@/configurator";
+
 import {
-  getPalette,
-  useFormatNumber,
-} from "@/configurator/components/ui-helpers";
-import { Observation } from "@/domain/data";
-import { DimensionMetaDataFragment } from "@/graphql/query-hooks";
-import { sortByIndex } from "@/lib/array";
-import { useLocale } from "@/locales/use-locale";
-import { makeOrdinalDimensionSorter } from "@/utils/sorting-values";
+  BOTTOM_MARGIN_OFFSET,
+  LEFT_MARGIN_OFFSET,
+  PADDING_INNER,
+  PADDING_OUTER,
+} from "@/charts/column/constants";
 import {
   getLabelWithUnit,
   getWideData,
@@ -48,12 +45,16 @@ import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useInteractiveFilters } from "@/charts/shared/use-interactive-filters";
 import { Bounds, Observer, useWidth } from "@/charts/shared/use-width";
+import { ColumnFields, SortingOrder, SortingType } from "@/configurator";
 import {
-  BOTTOM_MARGIN_OFFSET,
-  LEFT_MARGIN_OFFSET,
-  PADDING_INNER,
-  PADDING_OUTER,
-} from "@/charts/column/constants";
+  getPalette,
+  useFormatNumber,
+} from "@/configurator/components/ui-helpers";
+import { Observation } from "@/domain/data";
+import { DimensionMetaDataFragment } from "@/graphql/query-hooks";
+import { sortByIndex } from "@/lib/array";
+import { useLocale } from "@/locales/use-locale";
+import { makeOrdinalDimensionSorter } from "@/utils/sorting-values";
 
 export interface StackedColumnsState {
   chartType: "column";

--- a/app/charts/column/columns-stacked.tsx
+++ b/app/charts/column/columns-stacked.tsx
@@ -1,6 +1,6 @@
-import { useChartState } from "@/charts/shared/use-chart-state";
 import { StackedColumnsState } from "@/charts/column/columns-stacked-state";
 import { Column } from "@/charts/column/rendering-utils";
+import { useChartState } from "@/charts/shared/use-chart-state";
 
 export const ColumnsStacked = () => {
   const { bounds, getX, xScale, yScale, colors, series } =

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -15,20 +15,13 @@ import {
 } from "d3";
 import { get, sortBy } from "lodash";
 import { ReactNode, useMemo } from "react";
-import { ColumnFields, SortingOrder, SortingType } from "@/configurator";
+
 import {
-  formatNumberWithUnit,
-  getPalette,
-  mkNumber,
-  useErrorMeasure,
-  useErrorRange,
-  useErrorVariable,
-  useFormatNumber,
-  useTimeFormatUnit,
-} from "@/configurator/components/ui-helpers";
-import { Observation } from "@/domain/data";
-import { TimeUnit } from "@/graphql/query-hooks";
-import { makeOrdinalDimensionSorter } from "@/utils/sorting-values";
+  BOTTOM_MARGIN_OFFSET,
+  LEFT_MARGIN_OFFSET,
+  PADDING_INNER,
+  PADDING_OUTER,
+} from "@/charts/column/constants";
 import {
   getLabelWithUnit,
   useOptionalNumericVariable,
@@ -43,12 +36,20 @@ import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useInteractiveFilters } from "@/charts/shared/use-interactive-filters";
 import { Bounds, Observer, useWidth } from "@/charts/shared/use-width";
+import { ColumnFields, SortingOrder, SortingType } from "@/configurator";
 import {
-  BOTTOM_MARGIN_OFFSET,
-  LEFT_MARGIN_OFFSET,
-  PADDING_INNER,
-  PADDING_OUTER,
-} from "@/charts/column/constants";
+  formatNumberWithUnit,
+  getPalette,
+  mkNumber,
+  useErrorMeasure,
+  useErrorRange,
+  useErrorVariable,
+  useFormatNumber,
+  useTimeFormatUnit,
+} from "@/configurator/components/ui-helpers";
+import { Observation } from "@/domain/data";
+import { TimeUnit } from "@/graphql/query-hooks";
+import { makeOrdinalDimensionSorter } from "@/utils/sorting-values";
 
 export interface ColumnsState {
   chartType: "column";

--- a/app/charts/column/overlay-columns.tsx
+++ b/app/charts/column/overlay-columns.tsx
@@ -1,17 +1,13 @@
-import { Observation } from "@/domain/data";
+import { ColumnsState } from "@/charts/column/columns-state";
 import { useChartState } from "@/charts/shared/use-chart-state";
 import { useInteraction } from "@/charts/shared/use-interaction";
-import { ColumnsState } from "@/charts/column/columns-state";
+import { Observation } from "@/domain/data";
 
 export const InteractionColumns = () => {
   const [, dispatch] = useInteraction();
 
-  const {
-    preparedData,
-    bounds,
-    getX,
-    xScaleInteraction,
-  } = useChartState() as ColumnsState;
+  const { preparedData, bounds, getX, xScaleInteraction } =
+    useChartState() as ColumnsState;
   const { margins, chartHeight } = bounds;
 
   const showTooltip = (d: Observation) => {

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -1,5 +1,6 @@
 import produce from "immer";
 import { get, groupBy } from "lodash";
+
 import {
   ChartConfig,
   ChartConfigsAdjusters,

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -1,5 +1,21 @@
-import React, { memo } from "react";
 import { Box } from "@mui/material";
+import React, { memo } from "react";
+
+import { Lines } from "@/charts/line/lines";
+import { LineChart } from "@/charts/line/lines-state";
+import { A11yTable } from "@/charts/shared/a11y-table";
+import { AxisHeightLinear } from "@/charts/shared/axis-height-linear";
+import { AxisTime, AxisTimeDomain } from "@/charts/shared/axis-width-time";
+import { BrushTime } from "@/charts/shared/brush";
+import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
+import { HoverDotMultiple } from "@/charts/shared/interaction/hover-dots-multiple";
+import { Ruler } from "@/charts/shared/interaction/ruler";
+import { Tooltip } from "@/charts/shared/interaction/tooltip";
+import {
+  InteractiveLegendColor,
+  LegendColor,
+} from "@/charts/shared/legend-color";
+import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import {
   Loading,
   LoadingDataError,
@@ -20,18 +36,6 @@ import {
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
-import { A11yTable } from "@/charts/shared/a11y-table";
-import { AxisHeightLinear } from "@/charts/shared/axis-height-linear";
-import { AxisTime, AxisTimeDomain } from "@/charts/shared/axis-width-time";
-import { BrushTime } from "@/charts/shared/brush";
-import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
-import { HoverDotMultiple } from "@/charts/shared/interaction/hover-dots-multiple";
-import { Ruler } from "@/charts/shared/interaction/ruler";
-import { Tooltip } from "@/charts/shared/interaction/tooltip";
-import { InteractiveLegendColor, LegendColor } from "@/charts/shared/legend-color";
-import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
-import { Lines } from "@/charts/line/lines";
-import { LineChart } from "@/charts/line/lines-state";
 
 export const ChartLinesVisualization = ({
   dataSetIri,

--- a/app/charts/line/hover-line-values.tsx
+++ b/app/charts/line/hover-line-values.tsx
@@ -1,17 +1,10 @@
+import { LinesState } from "@/charts/line/lines-state";
 import { useChartState } from "@/charts/shared/use-chart-state";
 import { useInteraction } from "@/charts/shared/use-interaction";
-import { LinesState } from "@/charts/line/lines-state";
 
 export const HoverLineValues = () => {
-  const {
-    getX,
-    xScale,
-    getY,
-    yScale,
-    grouped,
-    colors,
-    bounds,
-  } = useChartState() as LinesState;
+  const { getX, xScale, getY, yScale, grouped, colors, bounds } =
+    useChartState() as LinesState;
   const [state] = useInteraction();
 
   // const { x, visible, segment } = state.tooltip;

--- a/app/charts/line/hover-line.tsx
+++ b/app/charts/line/hover-line.tsx
@@ -1,10 +1,10 @@
-import { useChartState } from "@/charts/shared/use-chart-state";
 import { line } from "d3";
-import { Observation } from "@/domain/data";
-import { LinesState } from "@/charts/line/lines-state";
-
-import { useInteraction } from "@/charts/shared/use-interaction";
 import { memo } from "react";
+
+import { LinesState } from "@/charts/line/lines-state";
+import { useChartState } from "@/charts/shared/use-chart-state";
+import { useInteraction } from "@/charts/shared/use-interaction";
+import { Observation } from "@/domain/data";
 
 export const HoverLine = () => {
   const { getX, xScale, getY, yScale, grouped, colors, bounds } =

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -13,17 +13,8 @@ import {
 } from "d3";
 import { sortBy } from "lodash";
 import { ReactNode, useMemo } from "react";
-import { LineFields } from "@/configurator";
-import {
-  getPalette,
-  useFormatNumber,
-  useTimeFormatUnit,
-} from "@/configurator/components/ui-helpers";
-import { Observation } from "@/domain/data";
-import { sortByIndex } from "@/lib/array";
-import { estimateTextWidth } from "@/lib/estimate-text-width";
-import { useTheme } from "@/themes";
-import { makeOrdinalDimensionSorter } from "@/utils/sorting-values";
+
+import { LEFT_MARGIN_OFFSET } from "@/charts/line/constants";
 import { BRUSH_BOTTOM_SPACE } from "@/charts/shared/brush";
 import {
   getLabelWithUnit,
@@ -39,7 +30,17 @@ import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useInteractiveFilters } from "@/charts/shared/use-interactive-filters";
 import { Bounds, Observer, useWidth } from "@/charts/shared/use-width";
-import { LEFT_MARGIN_OFFSET } from "@/charts/line/constants";
+import { LineFields } from "@/configurator";
+import {
+  getPalette,
+  useFormatNumber,
+  useTimeFormatUnit,
+} from "@/configurator/components/ui-helpers";
+import { Observation } from "@/domain/data";
+import { sortByIndex } from "@/lib/array";
+import { estimateTextWidth } from "@/lib/estimate-text-width";
+import { useTheme } from "@/themes";
+import { makeOrdinalDimensionSorter } from "@/utils/sorting-values";
 
 export interface LinesState {
   chartType: "line";

--- a/app/charts/line/lines.tsx
+++ b/app/charts/line/lines.tsx
@@ -1,9 +1,10 @@
 import { line } from "d3";
 import { Fragment, memo } from "react";
+
+import { LinesState } from "@/charts/line/lines-state";
+import { useChartState } from "@/charts/shared/use-chart-state";
 import { Observation } from "@/domain/data";
 import { useTheme } from "@/themes";
-import { useChartState } from "@/charts/shared/use-chart-state";
-import { LinesState } from "@/charts/line/lines-state";
 
 export const Lines = () => {
   const { getX, xScale, getY, yScale, grouped, colors, bounds } =

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -1,10 +1,17 @@
+import { Box } from "@mui/material";
 import { geoCentroid } from "d3";
 import React, { memo, useMemo } from "react";
-import { Box } from "@mui/material";
 import {
   feature as topojsonFeature,
   mesh as topojsonMesh,
 } from "topojson-client";
+
+import { MapComponent } from "@/charts/map/map";
+import { MapLegend } from "@/charts/map/map-legend";
+import { MapChart } from "@/charts/map/map-state";
+import { MapTooltip } from "@/charts/map/map-tooltip";
+import { QueryFilters } from "@/charts/shared/chart-helpers";
+import { ChartContainer } from "@/charts/shared/containers";
 import {
   Loading,
   LoadingDataError,
@@ -30,12 +37,6 @@ import {
   useGeoShapesByDimensionIriQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
-import { QueryFilters } from "@/charts/shared/chart-helpers";
-import { ChartContainer } from "@/charts/shared/containers";
-import { MapComponent } from "@/charts/map/map";
-import { MapLegend } from "@/charts/map/map-legend";
-import { MapChart } from "@/charts/map/map-state";
-import { MapTooltip } from "@/charts/map/map-tooltip";
 
 export const ChartMapVisualization = ({
   dataSetIri,

--- a/app/charts/map/get-base-layer-style.ts
+++ b/app/charts/map/get-base-layer-style.ts
@@ -1,6 +1,7 @@
 import { keyBy } from "lodash";
 import merge from "lodash/merge";
 import { MapOptions, StyleSpecification } from "maplibre-gl";
+
 import { BASE_VECTOR_TILE_URL } from "../../domain/env";
 import { Locale } from "../../locales/locales";
 

--- a/app/charts/map/helpers.ts
+++ b/app/charts/map/helpers.ts
@@ -1,4 +1,5 @@
 import { extent, geoBounds } from "d3";
+
 import { AreaLayer, SymbolLayer } from "../../domain/data";
 
 export type BBox = [[number, number], [number, number]];

--- a/app/charts/map/layer.tsx
+++ b/app/charts/map/layer.tsx
@@ -8,11 +8,13 @@
  * - Use for .. of on Object.entries instead of for in for Typescript
  */
 
-import isEqual from "lodash/isEqual";
 import assert from "assert";
-import { LayerProps, useMap } from "react-map-gl";
-import { useRef, useState, useMemo, useEffect } from "react";
+
+import isEqual from "lodash/isEqual";
 import { Map } from "maplibre-gl";
+import { useRef, useState, useMemo, useEffect } from "react";
+import { LayerProps, useMap } from "react-map-gl";
+
 import useChange from "@/utils/use-change";
 
 const MIN_ZOOM = 0;

--- a/app/charts/map/map-attribution.tsx
+++ b/app/charts/map/map-attribution.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
 import { Box } from "@mui/material";
+import React, { useState } from "react";
+
 import { Icon } from "@/icons";
 
 const ATTRIBUTION = "© Data: MapTiler, OpenStreetMap contributors, Swisstopo";

--- a/app/charts/map/map-legend.tsx
+++ b/app/charts/map/map-legend.tsx
@@ -1,4 +1,4 @@
-import Flex from "@/components/flex";
+import { Box, Typography } from "@mui/material";
 import {
   axisBottom,
   NumberValue,
@@ -13,7 +13,13 @@ import {
 } from "d3";
 import * as React from "react";
 import { useEffect, useMemo, useRef } from "react";
-import { Box, Typography } from "@mui/material";
+
+import { MapState } from "@/charts/map/map-state";
+import { useChartState } from "@/charts/shared/use-chart-state";
+import { useChartTheme } from "@/charts/shared/use-chart-theme";
+import { useInteraction } from "@/charts/shared/use-interaction";
+import { useWidth } from "@/charts/shared/use-width";
+import Flex from "@/components/flex";
 import { ColorRamp } from "@/configurator/components/chart-controls/color-ramp";
 import {
   getColorInterpolator,
@@ -21,11 +27,6 @@ import {
   useFormatNumber,
 } from "@/configurator/components/ui-helpers";
 import { Observation } from "@/domain/data";
-import { useChartState } from "@/charts/shared/use-chart-state";
-import { useChartTheme } from "@/charts/shared/use-chart-theme";
-import { useInteraction } from "@/charts/shared/use-interaction";
-import { useWidth } from "@/charts/shared/use-width";
-import { MapState } from "@/charts/map/map-state";
 
 const MAX_WIDTH = 204;
 const HEIGHT = 80;

--- a/app/charts/map/map-state.tsx
+++ b/app/charts/map/map-state.tsx
@@ -16,6 +16,15 @@ import {
 } from "d3";
 import { ReactNode, useCallback, useMemo } from "react";
 import { ckmeans } from "simple-statistics";
+
+import { MapTooltipProvider } from "@/charts/map/map-tooltip";
+import {
+  useOptionalNumericVariable,
+  useStringVariable,
+} from "@/charts/shared/chart-helpers";
+import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
+import { InteractionProvider } from "@/charts/shared/use-interaction";
+import { Bounds, Observer, useWidth } from "@/charts/shared/use-width";
 import {
   formatNumberWithUnit,
   getColorInterpolator,
@@ -39,14 +48,6 @@ import {
   ObservationValue,
 } from "@/domain/data";
 import { DimensionMetaDataFragment } from "@/graphql/query-hooks";
-import {
-  useOptionalNumericVariable,
-  useStringVariable,
-} from "@/charts/shared/chart-helpers";
-import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
-import { InteractionProvider } from "@/charts/shared/use-interaction";
-import { Bounds, Observer, useWidth } from "@/charts/shared/use-width";
-import { MapTooltipProvider } from "@/charts/map/map-tooltip";
 
 export interface MapState {
   chartType: "map";

--- a/app/charts/map/map-tooltip.tsx
+++ b/app/charts/map/map-tooltip.tsx
@@ -1,3 +1,4 @@
+import { Box, Typography } from "@mui/material";
 import { hcl } from "d3";
 import * as React from "react";
 import {
@@ -8,15 +9,15 @@ import {
   useMemo,
   useState,
 } from "react";
-import { Box, Typography } from "@mui/material";
+
+import { MapState } from "@/charts/map/map-state";
+import { TooltipBox } from "@/charts/shared/interaction/tooltip-box";
+import { useChartState } from "@/charts/shared/use-chart-state";
+import { useInteraction } from "@/charts/shared/use-interaction";
 import {
   formatNumberWithUnit,
   useFormatNumber,
 } from "@/configurator/components/ui-helpers";
-import { TooltipBox } from "@/charts/shared/interaction/tooltip-box";
-import { useChartState } from "@/charts/shared/use-chart-state";
-import { useInteraction } from "@/charts/shared/use-interaction";
-import { MapState } from "@/charts/map/map-state";
 
 type HoverObjectType = "area" | "symbol";
 

--- a/app/charts/map/map.tsx
+++ b/app/charts/map/map.tsx
@@ -1,7 +1,10 @@
 import { WebMercatorViewport } from "@deck.gl/core";
 import { GeoJsonLayer, ScatterplotLayer } from "@deck.gl/layers";
-
 import { MapboxLayer } from "@deck.gl/mapbox";
+import { Box, Button } from "@mui/material";
+import { geoArea } from "d3";
+import { orderBy } from "lodash";
+import maplibregl, { LngLatLike, StyleSpecification } from "maplibre-gl";
 import React, {
   useMemo,
   useEffect,
@@ -9,14 +12,8 @@ import React, {
   useState,
   useCallback,
 } from "react";
-import maplibregl, { LngLatLike, StyleSpecification } from "maplibre-gl";
+import ReactMap, { MapRef, ViewState } from "react-map-gl";
 
-import { Box, Button } from "@mui/material";
-import { GeoFeature, GeoPoint } from "@/domain/data";
-import { useLocale } from "@/src";
-import { convertHexToRgbArray } from "@/charts/shared/colors";
-import { useChartState } from "@/charts/shared/use-chart-state";
-import { useInteraction } from "@/charts/shared/use-interaction";
 import {
   emptyStyle,
   getBaseLayerStyle,
@@ -24,12 +21,15 @@ import {
 import { BBox, getBBox } from "@/charts/map/helpers";
 import { MapState } from "@/charts/map/map-state";
 import { useMapTooltip } from "@/charts/map/map-tooltip";
+import { convertHexToRgbArray } from "@/charts/shared/colors";
+import { useChartState } from "@/charts/shared/use-chart-state";
+import { useInteraction } from "@/charts/shared/use-interaction";
+import { GeoFeature, GeoPoint } from "@/domain/data";
+import { Icon, IconName } from "@/icons";
+import { useLocale } from "@/src";
+
 import "maplibre-gl/dist/maplibre-gl.css";
 import Layer from "./layer";
-import ReactMap, { MapRef, ViewState } from "react-map-gl";
-import { Icon, IconName } from "@/icons";
-import { orderBy } from "lodash";
-import { geoArea } from "d3";
 
 function getFirstLabelLayerId(style: StyleSpecification) {
   const layers = style.layers;

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -1,5 +1,15 @@
 import { Box } from "@mui/material";
 import React, { memo } from "react";
+
+import { Pie } from "@/charts/pie/pie";
+import { PieChart } from "@/charts/pie/pie-state";
+import { A11yTable } from "@/charts/shared/a11y-table";
+import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
+import { Tooltip } from "@/charts/shared/interaction/tooltip";
+import {
+  InteractiveLegendColor,
+  LegendColor,
+} from "@/charts/shared/legend-color";
 import {
   Loading,
   LoadingDataError,
@@ -20,12 +30,6 @@ import {
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
-import { A11yTable } from "@/charts/shared/a11y-table";
-import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
-import { Tooltip } from "@/charts/shared/interaction/tooltip";
-import { InteractiveLegendColor, LegendColor } from "@/charts/shared/legend-color";
-import { Pie } from "@/charts/pie/pie";
-import { PieChart } from "@/charts/pie/pie-state";
 
 export const ChartPieVisualization = ({
   dataSetIri,

--- a/app/charts/pie/pie-state.tsx
+++ b/app/charts/pie/pie-state.tsx
@@ -9,12 +9,7 @@ import {
   scaleOrdinal,
 } from "d3";
 import React, { ReactNode, useMemo } from "react";
-import { PieFields, SortingOrder, SortingType } from "@/configurator";
-import {
-  getPalette,
-  useFormatNumber,
-} from "@/configurator/components/ui-helpers";
-import { Observation } from "@/domain/data";
+
 import {
   useOptionalNumericVariable,
   usePreparedData,
@@ -25,6 +20,12 @@ import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useInteractiveFilters } from "@/charts/shared/use-interactive-filters";
 import { Bounds, Observer, useWidth } from "@/charts/shared/use-width";
+import { PieFields, SortingOrder, SortingType } from "@/configurator";
+import {
+  getPalette,
+  useFormatNumber,
+} from "@/configurator/components/ui-helpers";
+import { Observation } from "@/domain/data";
 
 const sortData = ({
   data,

--- a/app/charts/pie/pie.tsx
+++ b/app/charts/pie/pie.tsx
@@ -1,18 +1,13 @@
 import { arc, PieArcDatum } from "d3";
 
-import { Observation } from "@/domain/data";
+import { PieState } from "@/charts/pie/pie-state";
 import { useChartState } from "@/charts/shared/use-chart-state";
 import { useInteraction } from "@/charts/shared/use-interaction";
-import { PieState } from "@/charts/pie/pie-state";
+import { Observation } from "@/domain/data";
 
 export const Pie = () => {
-  const {
-    data,
-    getPieData,
-    getX,
-    colors,
-    bounds,
-  } = useChartState() as PieState;
+  const { data, getPieData, getX, colors, bounds } =
+    useChartState() as PieState;
   const { width, height, chartWidth, chartHeight } = bounds;
 
   const arcs = getPieData(data);
@@ -64,7 +59,7 @@ const Arc = ({
       value: {
         interaction: {
           visible: true,
-          d: (d as unknown) as Observation, // FIXME
+          d: d as unknown as Observation, // FIXME
         },
       },
     });

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -1,5 +1,24 @@
-import React, { memo } from "react";
 import { Box } from "@mui/material";
+import React, { memo } from "react";
+
+import { Scatterplot } from "@/charts/scatterplot/scatterplot-simple";
+import { ScatterplotChart } from "@/charts/scatterplot/scatterplot-state";
+import { A11yTable } from "@/charts/shared/a11y-table";
+import {
+  AxisHeightLinear,
+  AxisHeightLinearDomain,
+} from "@/charts/shared/axis-height-linear";
+import {
+  AxisWidthLinear,
+  AxisWidthLinearDomain,
+} from "@/charts/shared/axis-width-linear";
+import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
+import { Tooltip } from "@/charts/shared/interaction/tooltip";
+import {
+  InteractiveLegendColor,
+  LegendColor,
+} from "@/charts/shared/legend-color";
+import { InteractionVoronoi } from "@/charts/shared/overlay-voronoi";
 import {
   Loading,
   LoadingDataError,
@@ -20,21 +39,6 @@ import {
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
-import { A11yTable } from "@/charts/shared/a11y-table";
-import {
-  AxisHeightLinear,
-  AxisHeightLinearDomain,
-} from "@/charts/shared/axis-height-linear";
-import {
-  AxisWidthLinear,
-  AxisWidthLinearDomain,
-} from "@/charts/shared/axis-width-linear";
-import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
-import { Tooltip } from "@/charts/shared/interaction/tooltip";
-import { InteractiveLegendColor, LegendColor } from "@/charts/shared/legend-color";
-import { InteractionVoronoi } from "@/charts/shared/overlay-voronoi";
-import { Scatterplot } from "@/charts/scatterplot/scatterplot-simple";
-import { ScatterplotChart } from "@/charts/scatterplot/scatterplot-state";
 
 export const ChartScatterplotVisualization = ({
   dataSetIri,

--- a/app/charts/scatterplot/scatterplot-simple.tsx
+++ b/app/charts/scatterplot/scatterplot-simple.tsx
@@ -1,7 +1,8 @@
 import { memo } from "react";
-import { useTheme } from "@/themes";
-import { useChartState } from "@/charts/shared/use-chart-state";
+
 import { ScatterplotState } from "@/charts/scatterplot/scatterplot-state";
+import { useChartState } from "@/charts/shared/use-chart-state";
+import { useTheme } from "@/themes";
 
 export const Scatterplot = () => {
   const {
@@ -27,7 +28,9 @@ export const Scatterplot = () => {
             key={index}
             cx={xScale(getX(d) ?? NaN)}
             cy={yScale(getY(d) ?? NaN)}
-            color={hasSegment ? colors(getSegment(d)) : theme.palette.primary.main}
+            color={
+              hasSegment ? colors(getSegment(d)) : theme.palette.primary.main
+            }
           />
         );
       })}

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -8,14 +8,8 @@ import {
   scaleOrdinal,
 } from "d3";
 import React, { ReactNode } from "react";
-import { ScatterPlotFields } from "@/configurator";
-import {
-  getPalette,
-  mkNumber,
-  useFormatNumber,
-} from "@/configurator/components/ui-helpers";
-import { Observation } from "@/domain/data";
-import { estimateTextWidth } from "@/lib/estimate-text-width";
+
+import { LEFT_MARGIN_OFFSET } from "@/charts/scatterplot/constants";
 import {
   getLabelWithUnit,
   useOptionalNumericVariable,
@@ -28,7 +22,14 @@ import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useInteractiveFilters } from "@/charts/shared/use-interactive-filters";
 import { Bounds, Observer, useWidth } from "@/charts/shared/use-width";
-import { LEFT_MARGIN_OFFSET } from "@/charts/scatterplot/constants";
+import { ScatterPlotFields } from "@/configurator";
+import {
+  getPalette,
+  mkNumber,
+  useFormatNumber,
+} from "@/configurator/components/ui-helpers";
+import { Observation } from "@/domain/data";
+import { estimateTextWidth } from "@/lib/estimate-text-width";
 
 export interface ScatterplotState {
   chartType: string;

--- a/app/charts/shared/a11y-table.tsx
+++ b/app/charts/shared/a11y-table.tsx
@@ -1,5 +1,6 @@
 import { Box } from "@mui/material";
 import { memo, useMemo } from "react";
+
 import VisuallyHidden from "@/components/visually-hidden";
 import { ChartFields } from "@/configurator";
 import { Observation } from "@/domain/data";

--- a/app/charts/shared/axis-height-band.tsx
+++ b/app/charts/shared/axis-height-band.tsx
@@ -1,7 +1,7 @@
 import { axisLeft } from "d3";
 import { select, Selection } from "d3";
-
 import { useEffect, useRef } from "react";
+
 import { BarsState } from "@/charts/bar/bars-state";
 import { useChartState } from "@/charts/shared/use-chart-state";
 import { useChartTheme } from "@/charts/shared/use-chart-theme";

--- a/app/charts/shared/axis-height-linear.tsx
+++ b/app/charts/shared/axis-height-linear.tsx
@@ -1,12 +1,12 @@
 import { axisLeft } from "d3";
 import { select, Selection } from "d3";
-
 import { useEffect, useRef } from "react";
-import { useChartState } from "@/charts/shared/use-chart-state";
-import { useChartTheme } from "@/charts/shared/use-chart-theme";
+
+import { AreasState } from "@/charts/area/areas-state";
 import { ColumnsState } from "@/charts/column/columns-state";
 import { LinesState } from "@/charts/line/lines-state";
-import { AreasState } from "@/charts/area/areas-state";
+import { useChartState } from "@/charts/shared/use-chart-state";
+import { useChartTheme } from "@/charts/shared/use-chart-theme";
 import { useFormatNumber } from "@/configurator/components/ui-helpers";
 
 export const TICK_MIN_HEIGHT = 50;

--- a/app/charts/shared/axis-width-band.tsx
+++ b/app/charts/shared/axis-width-band.tsx
@@ -1,11 +1,11 @@
 import { axisBottom } from "d3";
 import { select, Selection } from "d3";
-
 import { useEffect, useRef } from "react";
-import { useTimeFormatUnit } from "@/configurator/components/ui-helpers";
+
 import { ColumnsState } from "@/charts/column/columns-state";
 import { useChartState } from "@/charts/shared/use-chart-state";
 import { useChartTheme } from "@/charts/shared/use-chart-theme";
+import { useTimeFormatUnit } from "@/configurator/components/ui-helpers";
 
 export const AxisWidthBand = () => {
   const ref = useRef<SVGGElement>(null);

--- a/app/charts/shared/axis-width-linear.tsx
+++ b/app/charts/shared/axis-width-linear.tsx
@@ -1,13 +1,13 @@
 import { axisBottom } from "d3";
 import { select, Selection } from "d3";
-
 import { useEffect, useRef } from "react";
+
+import { BarsState } from "@/charts/bar/bars-state";
+import { ScatterplotState } from "@/charts/scatterplot/scatterplot-state";
 import { useChartState } from "@/charts/shared/use-chart-state";
 import { useChartTheme } from "@/charts/shared/use-chart-theme";
-import { ScatterplotState } from "@/charts/scatterplot/scatterplot-state";
-import { estimateTextWidth } from "@/lib/estimate-text-width";
 import { useFormatNumber } from "@/configurator/components/ui-helpers";
-import { BarsState } from "@/charts/bar/bars-state";
+import { estimateTextWidth } from "@/lib/estimate-text-width";
 
 export const AxisWidthLinear = () => {
   const formatNumber = useFormatNumber();
@@ -15,13 +15,8 @@ export const AxisWidthLinear = () => {
     | ScatterplotState
     | BarsState;
   const { chartWidth, chartHeight, margins } = bounds;
-  const {
-    domainColor,
-    labelColor,
-    labelFontSize,
-    gridColor,
-    fontFamily,
-  } = useChartTheme();
+  const { domainColor, labelColor, labelFontSize, gridColor, fontFamily } =
+    useChartTheme();
   const xAxisRef = useRef<SVGGElement>(null);
 
   const mkAxis = (g: Selection<SVGGElement, unknown, null, undefined>) => {

--- a/app/charts/shared/axis-width-time.tsx
+++ b/app/charts/shared/axis-width-time.tsx
@@ -1,12 +1,12 @@
 import { axisBottom } from "d3";
 import { select, Selection } from "d3";
-
 import { useEffect, useRef } from "react";
-import { useFormatShortDateAuto } from "@/configurator/components/ui-helpers";
+
 import { AreasState } from "@/charts/area/areas-state";
 import { LinesState } from "@/charts/line/lines-state";
 import { useChartState } from "@/charts/shared/use-chart-state";
 import { useChartTheme } from "@/charts/shared/use-chart-theme";
+import { useFormatShortDateAuto } from "@/configurator/components/ui-helpers";
 
 // Approximate the longest date format we're using for
 // Roughly equivalent to estimateTextWidth("99.99.9999", 12);
@@ -18,13 +18,8 @@ export const AxisTime = () => {
 
   const { xScale, yScale, bounds } = useChartState() as LinesState | AreasState;
 
-  const {
-    labelColor,
-    gridColor,
-    domainColor,
-    labelFontSize,
-    fontFamily,
-  } = useChartTheme();
+  const { labelColor, gridColor, domainColor, labelFontSize, fontFamily } =
+    useChartTheme();
 
   const hasNegativeValues = yScale.domain()[0] < 0;
 

--- a/app/charts/shared/brush.tsx
+++ b/app/charts/shared/brush.tsx
@@ -1,14 +1,15 @@
 import { bisector, brushX, select, Selection, Transition } from "d3";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useFormatFullDateAuto } from "@/configurator/components/ui-helpers";
-import { Observation } from "@/domain/data";
-import { estimateTextWidth } from "@/lib/estimate-text-width";
+
 import { AreasState } from "@/charts/area/areas-state";
 import { ColumnsState } from "@/charts/column/columns-state";
 import { LinesState } from "@/charts/line/lines-state";
 import { useChartState } from "@/charts/shared/use-chart-state";
 import { useChartTheme } from "@/charts/shared/use-chart-theme";
 import { useInteractiveFilters } from "@/charts/shared/use-interactive-filters";
+import { useFormatFullDateAuto } from "@/configurator/components/ui-helpers";
+import { Observation } from "@/domain/data";
+import { estimateTextWidth } from "@/lib/estimate-text-width";
 
 // Space used in chart states as bottom margin
 export const BRUSH_BOTTOM_SPACE = 100;

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -1,8 +1,10 @@
-import Flex from "@/components/flex";
 import { t, Trans } from "@lingui/macro";
-import * as React from "react";
 import { Box, Button, SelectChangeEvent } from "@mui/material";
+import * as React from "react";
+
+import { useInteractiveFilters } from "@/charts/shared/use-interactive-filters";
 import { ChartFiltersList } from "@/components/chart-filters-list";
+import Flex from "@/components/flex";
 import { Select } from "@/components/form";
 import { Loading } from "@/components/hint";
 import { ChartConfig, InteractiveFiltersDataConfig } from "@/configurator";
@@ -16,7 +18,6 @@ import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import { TimeUnit, useDimensionValuesQuery } from "@/graphql/query-hooks";
 import { Icon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
-import { useInteractiveFilters } from "@/charts/shared/use-interactive-filters";
 
 export const ChartDataFilters = ({
   dataSet,

--- a/app/charts/shared/chart-helpers.spec.tsx
+++ b/app/charts/shared/chart-helpers.spec.tsx
@@ -1,14 +1,15 @@
 import { InternMap } from "d3";
 import { merge } from "lodash";
-import { LineConfig } from "@/configurator";
-import { FIELD_VALUE_NONE } from "@/configurator/constants";
-import { Observation } from "@/domain/data";
-import line1Fixture from "@/test/__fixtures/prod/line-1.json";
+
 import {
   getWideData,
   prepareQueryFilters,
 } from "@/charts/shared/chart-helpers";
 import { InteractiveFiltersState } from "@/charts/shared/use-interactive-filters";
+import { LineConfig } from "@/configurator";
+import { FIELD_VALUE_NONE } from "@/configurator/constants";
+import { Observation } from "@/domain/data";
+import line1Fixture from "@/test/__fixtures/prod/line-1.json";
 
 const makeCubeNsGetters = (cubeIri: string) => ({
   col: (col: string) => `${cubeIri}/dimension/${col}`,

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -1,18 +1,7 @@
 import { group, InternMap, sum } from "d3";
 import { omitBy, overEvery } from "lodash";
 import { useCallback, useMemo } from "react";
-import {
-  ChartConfig,
-  Filters,
-  FilterValueSingle,
-  ImputationType,
-  isAreaConfig,
-} from "@/configurator/config-types";
-import { parseDate } from "@/configurator/components/ui-helpers";
-import { FIELD_VALUE_NONE } from "@/configurator/constants";
-import { Observation } from "@/domain/data";
-import { DimensionMetaDataFragment } from "@/graphql/query-hooks";
-import truthy from "@/utils/truthy";
+
 import {
   imputeTemporalLinearSeries,
   interpolateZerosValue,
@@ -21,6 +10,18 @@ import {
   InteractiveFiltersState,
   useInteractiveFilters,
 } from "@/charts/shared/use-interactive-filters";
+import { parseDate } from "@/configurator/components/ui-helpers";
+import {
+  ChartConfig,
+  Filters,
+  FilterValueSingle,
+  ImputationType,
+  isAreaConfig,
+} from "@/configurator/config-types";
+import { FIELD_VALUE_NONE } from "@/configurator/constants";
+import { Observation } from "@/domain/data";
+import { DimensionMetaDataFragment } from "@/graphql/query-hooks";
+import truthy from "@/utils/truthy";
 
 export type QueryFilters = Filters | FilterValueSingle;
 

--- a/app/charts/shared/containers.tsx
+++ b/app/charts/shared/containers.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from "react";
+
 import { useChartState } from "@/charts/shared/use-chart-state";
 
 export const ChartContainer = ({ children }: { children: ReactNode }) => {

--- a/app/charts/shared/imputation.tsx
+++ b/app/charts/shared/imputation.tsx
@@ -1,4 +1,5 @@
 import { interpolate } from "d3";
+
 import { ChartConfig, isAreaConfig } from "@/configurator/config-types";
 
 export const interpolateZerosValue = () => {

--- a/app/charts/shared/interaction/hover-dot.tsx
+++ b/app/charts/shared/interaction/hover-dot.tsx
@@ -1,7 +1,8 @@
 import { Box } from "@mui/material";
-import { useInteraction } from "@/charts/shared/use-interaction";
-import { useChartState } from "@/charts/shared/use-chart-state";
+
 import { LinesState } from "@/charts/line/lines-state";
+import { useChartState } from "@/charts/shared/use-chart-state";
+import { useInteraction } from "@/charts/shared/use-interaction";
 import { Observation } from "@/domain/data";
 
 export const HoverDot = () => {

--- a/app/charts/shared/interaction/hover-dots-multiple.tsx
+++ b/app/charts/shared/interaction/hover-dots-multiple.tsx
@@ -1,9 +1,10 @@
-import { Fragment } from "react";
 import { Box } from "@mui/material";
-import { Observation } from "@/domain/data";
+import { Fragment } from "react";
+
 import { LinesState } from "@/charts/line/lines-state";
 import { useChartState } from "@/charts/shared/use-chart-state";
 import { useInteraction } from "@/charts/shared/use-interaction";
+import { Observation } from "@/domain/data";
 
 export const HoverDotMultiple = () => {
   const [state] = useInteraction();

--- a/app/charts/shared/interaction/ruler.tsx
+++ b/app/charts/shared/interaction/ruler.tsx
@@ -1,11 +1,15 @@
-import * as React from "react";
 import { Box } from "@mui/material";
-import { Observation } from "@/domain/data";
+import * as React from "react";
+
 import { LinesState } from "@/charts/line/lines-state";
-import { Margins } from "@/charts/shared/use-width";
+import {
+  TooltipValue,
+  TooltipPlacement,
+} from "@/charts/shared/interaction/tooltip";
 import { useChartState } from "@/charts/shared/use-chart-state";
 import { useInteraction } from "@/charts/shared/use-interaction";
-import { TooltipValue, TooltipPlacement } from "@/charts/shared/interaction/tooltip";
+import { Margins } from "@/charts/shared/use-width";
+import { Observation } from "@/domain/data";
 
 export const Ruler = () => {
   const [state] = useInteraction();

--- a/app/charts/shared/interaction/tooltip-box.tsx
+++ b/app/charts/shared/interaction/tooltip-box.tsx
@@ -1,3 +1,5 @@
+import { Box } from "@mui/material";
+import { throttle } from "lodash";
 import React, {
   ReactNode,
   useCallback,
@@ -5,8 +7,8 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import { Box } from "@mui/material";
-import { Margins } from "@/charts/shared/use-width";
+import ReactDOM from "react-dom";
+
 import {
   TRIANGLE_SIZE,
   TOOLTIP_OFFSET,
@@ -14,9 +16,8 @@ import {
   Xplacement,
   Yplacement,
 } from "@/charts/shared/interaction/tooltip";
+import { Margins } from "@/charts/shared/use-width";
 import { useTheme } from "@/themes";
-import ReactDOM from "react-dom";
-import { throttle } from "lodash";
 
 export interface TooltipBoxProps {
   x: number | undefined;

--- a/app/charts/shared/interaction/tooltip-content.tsx
+++ b/app/charts/shared/interaction/tooltip-content.tsx
@@ -1,6 +1,7 @@
 import { Box, Typography } from "@mui/material";
-import { LegendItem } from "@/charts/shared/legend-color";
+
 import { TooltipValue } from "@/charts/shared/interaction/tooltip";
+import { LegendItem } from "@/charts/shared/legend-color";
 
 // Generic
 export const TooltipSingle = ({
@@ -17,7 +18,11 @@ export const TooltipSingle = ({
   return (
     <Box>
       {xValue && (
-        <Typography component="div" variant="caption" sx={{ fontWeight: "bold" }}>
+        <Typography
+          component="div"
+          variant="caption"
+          sx={{ fontWeight: "bold" }}
+        >
           {xValue}
         </Typography>
       )}
@@ -46,7 +51,11 @@ export const TooltipMultiple = ({
   return (
     <Box>
       {xValue && (
-        <Typography component="div" variant="caption" sx={{ fontWeight: "bold" }}>
+        <Typography
+          component="div"
+          variant="caption"
+          sx={{ fontWeight: "bold" }}
+        >
           {xValue}
         </Typography>
       )}
@@ -75,7 +84,11 @@ export const TooltipScatterplot = ({
   return (
     <Box>
       {firstLine && (
-        <Typography component="div" variant="caption" sx={{ fontWeight: "bold" }}>
+        <Typography
+          component="div"
+          variant="caption"
+          sx={{ fontWeight: "bold" }}
+        >
           {firstLine}
         </Typography>
       )}

--- a/app/charts/shared/interaction/tooltip.tsx
+++ b/app/charts/shared/interaction/tooltip.tsx
@@ -1,10 +1,14 @@
 import { ReactNode } from "react";
-import { Observation } from "@/domain/data";
+
 import { LinesState } from "@/charts/line/lines-state";
+import { TooltipBox } from "@/charts/shared/interaction/tooltip-box";
+import {
+  TooltipMultiple,
+  TooltipSingle,
+} from "@/charts/shared/interaction/tooltip-content";
 import { useChartState } from "@/charts/shared/use-chart-state";
 import { useInteraction } from "@/charts/shared/use-interaction";
-import { TooltipBox } from "@/charts/shared/interaction/tooltip-box";
-import { TooltipMultiple, TooltipSingle } from "@/charts/shared/interaction/tooltip-content";
+import { Observation } from "@/domain/data";
 
 export const TRIANGLE_SIZE = 8;
 export const TOOLTIP_OFFSET = 4;

--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -1,6 +1,5 @@
-import Flex from "@/components/flex";
 import React, { memo } from "react";
-import { Checkbox } from "@/components/form";
+
 import { AreasState } from "@/charts/area/areas-state";
 import { GroupedBarsState } from "@/charts/bar/bars-grouped-state";
 import { BarsState } from "@/charts/bar/bars-state";
@@ -10,8 +9,13 @@ import { ColumnsState } from "@/charts/column/columns-state";
 import { LinesState } from "@/charts/line/lines-state";
 import { PieState } from "@/charts/pie/pie-state";
 import { ScatterplotState } from "@/charts/scatterplot/scatterplot-state";
-import { ColorsChartState, useChartState } from "@/charts/shared/use-chart-state";
+import {
+  ColorsChartState,
+  useChartState,
+} from "@/charts/shared/use-chart-state";
 import { useInteractiveFilters } from "@/charts/shared/use-interactive-filters";
+import Flex from "@/components/flex";
+import { Checkbox } from "@/components/form";
 
 type LegendSymbol = "square" | "line" | "circle";
 

--- a/app/charts/shared/overlay-horizontal.tsx
+++ b/app/charts/shared/overlay-horizontal.tsx
@@ -1,11 +1,12 @@
 import { bisector } from "d3";
 import { pointer } from "d3";
 import { memo, useRef, MouseEvent } from "react";
-import { Observation } from "@/domain/data";
+
 import { AreasState } from "@/charts/area/areas-state";
 import { LinesState } from "@/charts/line/lines-state";
 import { useChartState } from "@/charts/shared/use-chart-state";
 import { useInteraction } from "@/charts/shared/use-interaction";
+import { Observation } from "@/domain/data";
 
 export const InteractionHorizontal = memo(function InteractionHorizontal({
   debug,

--- a/app/charts/shared/overlay-voronoi.tsx
+++ b/app/charts/shared/overlay-voronoi.tsx
@@ -1,6 +1,7 @@
 import { Delaunay } from "d3";
 import { pointer } from "d3";
 import { memo, useRef, MouseEvent as ReactMouseEvent } from "react";
+
 import { AreasState } from "@/charts/area/areas-state";
 import { LinesState } from "@/charts/line/lines-state";
 import { ScatterplotState } from "@/charts/scatterplot/scatterplot-state";

--- a/app/charts/shared/padding.tsx
+++ b/app/charts/shared/padding.tsx
@@ -1,9 +1,10 @@
 import { max } from "d3";
 import { useMemo } from "react";
-import { estimateTextWidth } from "@/lib/estimate-text-width";
+
 import { getTickNumber } from "@/charts/shared/axis-height-linear";
 import { BRUSH_BOTTOM_SPACE } from "@/charts/shared/brush";
 import { ChartProps } from "@/charts/shared/use-chart-state";
+import { estimateTextWidth } from "@/lib/estimate-text-width";
 
 const computeChartPadding = (
   yScale: d3.ScaleLinear<number, number>,

--- a/app/charts/shared/use-chart-state.tsx
+++ b/app/charts/shared/use-chart-state.tsx
@@ -1,8 +1,5 @@
 import { createContext, useContext } from "react";
-import { ChartFields, InteractiveFiltersConfig } from "@/configurator";
-import { Observation } from "@/domain/data";
-import { DimensionMetaDataFragment } from "@/graphql/query-hooks";
-import { Has } from "@/lib/has";
+
 import { AreasState } from "@/charts/area/areas-state";
 import { GroupedBarsState } from "@/charts/bar/bars-grouped-state";
 import { BarsState } from "@/charts/bar/bars-state";
@@ -14,6 +11,10 @@ import { MapState } from "@/charts/map/map-state";
 import { PieState } from "@/charts/pie/pie-state";
 import { ScatterplotState } from "@/charts/scatterplot/scatterplot-state";
 import { TableChartState } from "@/charts/table/table-state";
+import { ChartFields, InteractiveFiltersConfig } from "@/configurator";
+import { Observation } from "@/domain/data";
+import { DimensionMetaDataFragment } from "@/graphql/query-hooks";
+import { Has } from "@/lib/has";
 
 export interface ChartProps {
   data: Observation[];

--- a/app/charts/shared/use-interaction.tsx
+++ b/app/charts/shared/use-interaction.tsx
@@ -6,6 +6,7 @@ import {
   useContext,
   useReducer,
 } from "react";
+
 import { Observation } from "@/domain/data";
 
 export interface InteractionElement {

--- a/app/charts/shared/use-interactive-filters.tsx
+++ b/app/charts/shared/use-interactive-filters.tsx
@@ -1,5 +1,6 @@
-import { useImmerReducer } from "use-immer";
 import { createContext, Dispatch, ReactNode, useContext } from "react";
+import { useImmerReducer } from "use-immer";
+
 import { FilterValueSingle } from "@/configurator";
 
 export type InteractiveFiltersState = {

--- a/app/charts/shared/use-sync-interactive-filters.spec.tsx
+++ b/app/charts/shared/use-sync-interactive-filters.spec.tsx
@@ -1,13 +1,14 @@
-import useSyncInteractiveFilters from "@/charts/shared/use-sync-interactive-filters";
-import fixture from "@/test/__fixtures/dev/4YL1p4QTFQS4.json";
+import { fireEvent, render } from "@testing-library/react";
+import { merge } from "lodash";
+import { useState } from "react";
+
 import {
   InteractiveFiltersProvider,
   useInteractiveFilters,
 } from "@/charts/shared/use-interactive-filters";
-import { fireEvent, render } from "@testing-library/react";
+import useSyncInteractiveFilters from "@/charts/shared/use-sync-interactive-filters";
 import { ChartConfig } from "@/configurator";
-import { useState } from "react";
-import { merge } from "lodash";
+import fixture from "@/test/__fixtures/dev/4YL1p4QTFQS4.json";
 
 const chartConfig = {
   ...fixture.data.chartConfig,

--- a/app/charts/shared/use-sync-interactive-filters.tsx
+++ b/app/charts/shared/use-sync-interactive-filters.tsx
@@ -1,13 +1,14 @@
 import { useEffect, useMemo } from "react";
+
+import { useInteractiveFilters } from "@/charts/shared/use-interactive-filters";
+import { parseDate } from "@/configurator/components/ui-helpers";
 import {
   ChartConfig,
   FilterValueSingle,
   isSegmentInConfig,
 } from "@/configurator/config-types";
-import { parseDate } from "@/configurator/components/ui-helpers";
 import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import useFilterChanges from "@/configurator/use-filter-changes";
-import { useInteractiveFilters } from "@/charts/shared/use-interactive-filters";
 
 /**
  * Makes sure interactive filters are in sync with chart config.

--- a/app/charts/shared/use-width.tsx
+++ b/app/charts/shared/use-width.tsx
@@ -1,4 +1,5 @@
 import { createContext, ReactNode, useContext } from "react";
+
 import { useResizeObserver } from "@/lib/use-resize-observer";
 
 export interface Margins {

--- a/app/charts/table/cell-desktop.tsx
+++ b/app/charts/table/cell-desktop.tsx
@@ -1,16 +1,18 @@
-import Flex from "@/components/flex";;
+
 import { Box } from "@mui/material";
 import { hcl, ScaleLinear } from "d3";
 import * as React from "react";
 import { Cell } from "react-table";
+
+import { BAR_CELL_PADDING } from "@/charts/table/constants";
+import { ColumnMeta } from "@/charts/table/table-state";
+import { Tag } from "@/charts/table/tag";
+import Flex from "@/components/flex";
 import {
   useFormatFullDateAuto,
   useFormatNumber,
 } from "@/configurator/components/ui-helpers";
 import { Observation } from "@/domain/data";
-import { BAR_CELL_PADDING } from "@/charts/table/constants";
-import { ColumnMeta } from "@/charts/table/table-state";
-import { Tag } from "@/charts/table/tag";
 
 export const CellDesktop = ({
   cell,
@@ -116,7 +118,9 @@ export const CellDesktop = ({
                 width: widthScale.range()[1],
                 height: 18,
                 position: "relative",
-                backgroundColor: barShowBackground ? barColorBackground : "grey.100",
+                backgroundColor: barShowBackground
+                  ? barColorBackground
+                  : "grey.100",
               }}
             >
               <Box
@@ -126,7 +130,8 @@ export const CellDesktop = ({
                   left: getBarLeftOffset(cell.value, widthScale),
                   width: getBarWidth(cell.value, widthScale),
                   height: 18,
-                  backgroundColor: cell.value > 0 ? barColorPositive : barColorNegative,
+                  backgroundColor:
+                    cell.value > 0 ? barColorPositive : barColorNegative,
                 }}
               />
               <Box

--- a/app/charts/table/cell-mobile.tsx
+++ b/app/charts/table/cell-mobile.tsx
@@ -1,15 +1,16 @@
-import Flex from "@/components/flex";
 import { Box, Typography } from "@mui/material";
 import { hcl } from "d3";
 import * as React from "react";
 import { Cell, Row } from "react-table";
+
+import { useChartState } from "@/charts/shared/use-chart-state";
+import { getBarLeftOffset, getBarWidth } from "@/charts/table/cell-desktop";
+import { ColumnMeta, TableChartState } from "@/charts/table/table-state";
+import { Tag } from "@/charts/table/tag";
+import Flex from "@/components/flex";
 import { useFormatNumber } from "@/configurator/components/ui-helpers";
 import { Observation } from "@/domain/data";
 import { Icon } from "@/icons";
-import { useChartState } from "@/charts/shared/use-chart-state";
-import { Tag } from "@/charts/table/tag";
-import { ColumnMeta, TableChartState } from "@/charts/table/table-state";
-import { getBarLeftOffset, getBarWidth } from "@/charts/table/cell-desktop";
 
 export const RowMobile = ({
   row,

--- a/app/charts/table/chart-table.tsx
+++ b/app/charts/table/chart-table.tsx
@@ -1,5 +1,8 @@
-import React, { memo } from "react";
 import { Box } from "@mui/material";
+import React, { memo } from "react";
+
+import { Table } from "@/charts/table/table";
+import { TableChart } from "@/charts/table/table-state";
 import {
   Loading,
   LoadingDataError,
@@ -14,8 +17,6 @@ import {
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
-import { Table } from "@/charts/table/table";
-import { TableChart } from "@/charts/table/table-state";
 
 export const ChartTableVisualization = ({
   dataSetIri,

--- a/app/charts/table/group-header.tsx
+++ b/app/charts/table/group-header.tsx
@@ -1,13 +1,15 @@
-import Flex from "@/components/flex";;
 import { Box } from "@mui/material";
+import { hcl } from "d3";
 import * as React from "react";
 import { Row } from "react-table";
+
+import { useChartState } from "@/charts/shared/use-chart-state";
+import { TableChartState } from "@/charts/table/table-state";
+import { Tag } from "@/charts/table/tag";
+import Flex from "@/components/flex";
 import { Observation } from "@/domain/data";
 import { Icon } from "@/icons";
-import { useChartState } from "@/charts/shared/use-chart-state";
-import { Tag } from "@/charts/table/tag";
-import { TableChartState } from "@/charts/table/table-state";
-import { hcl } from "d3";
+
 
 export const GroupHeader = ({
   row,

--- a/app/charts/table/table-content.tsx
+++ b/app/charts/table/table-content.tsx
@@ -1,8 +1,10 @@
 import { Box, TableSortLabel } from "@mui/material";
 import * as React from "react";
 import { HeaderGroup } from "react-table";
+
 import Flex from "../../components/flex";
 import { Observation } from "../../domain/data";
+
 import { SORTING_ARROW_WIDTH } from "./constants";
 import { ColumnMeta } from "./table-state";
 

--- a/app/charts/table/table-state.tsx
+++ b/app/charts/table/table-state.tsx
@@ -10,6 +10,14 @@ import {
 } from "d3";
 import { ReactNode, useMemo } from "react";
 import { Column } from "react-table";
+
+import {
+  getLabelWithUnit,
+  getSlugifiedIri,
+} from "@/charts/shared/chart-helpers";
+import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
+import { Bounds, Observer, useWidth } from "@/charts/shared/use-width";
+import { BAR_CELL_PADDING, TABLE_HEIGHT } from "@/charts/table/constants";
 import {
   ColumnStyleCategory,
   ColumnStyleHeatmap,
@@ -26,10 +34,6 @@ import { Observation } from "@/domain/data";
 import { DimensionMetaDataFragment } from "@/graphql/query-hooks";
 import { estimateTextWidth } from "@/lib/estimate-text-width";
 import { useTheme } from "@/themes";
-import { getLabelWithUnit, getSlugifiedIri } from "@/charts/shared/chart-helpers";
-import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
-import { Bounds, Observer, useWidth } from "@/charts/shared/use-width";
-import { BAR_CELL_PADDING, TABLE_HEIGHT } from "@/charts/table/constants";
 
 export interface ColumnMeta {
   iri: string;
@@ -255,7 +259,8 @@ const useTableState = ({
 
               return {
                 label: dvLabel,
-                color: colorMapping![colorMappingIri] || theme.palette.primary.main,
+                color:
+                  colorMapping![colorMappingIri] || theme.palette.primary.main,
               };
             }
           );

--- a/app/charts/table/table.tsx
+++ b/app/charts/table/table.tsx
@@ -1,5 +1,5 @@
-import Flex from "@/components/flex";
 import { Trans } from "@lingui/macro";
+import { Box, Typography } from "@mui/material";
 import FlexSearch from "flexsearch";
 import { forwardRef, useCallback, useMemo, useState } from "react";
 import {
@@ -10,17 +10,21 @@ import {
   useTable,
 } from "react-table";
 import { FixedSizeList, VariableSizeList } from "react-window";
-import { Box, Typography } from "@mui/material";
-import { Input, Switch } from "@/components/form";
-import { Observation } from "@/domain/data";
+
 import { useChartState } from "@/charts/shared/use-chart-state";
 import { CellDesktop } from "@/charts/table/cell-desktop";
 import { DDContent } from "@/charts/table/cell-mobile";
 import { TABLE_HEIGHT } from "@/charts/table/constants";
 import { GroupHeader } from "@/charts/table/group-header";
-import { TableContent, TableContentProvider } from "@/charts/table/table-content";
+import {
+  TableContent,
+  TableContentProvider,
+} from "@/charts/table/table-content";
 import { scrollbarWidth } from "@/charts/table/table-helpers";
 import { TableChartState } from "@/charts/table/table-state";
+import Flex from "@/components/flex";
+import { Input, Switch } from "@/components/form";
+import { Observation } from "@/domain/data";
 
 const MOBILE_VIEW_THRESHOLD = 384;
 

--- a/app/components/autocomplete.tsx
+++ b/app/components/autocomplete.tsx
@@ -1,14 +1,15 @@
-import * as React from "react";
+import { Trans } from "@lingui/macro";
+import { Box, BoxProps, Input } from "@mui/material";
 import {
   useCombobox,
   UseComboboxState,
   UseComboboxStateChangeOptions,
   UseComboboxStateChange,
 } from "downshift";
+import * as React from "react";
 import { useState } from "react";
-import { Box, BoxProps, Input } from "@mui/material";
+
 import Flex, { FlexProps } from "@/components/flex";
-import { Trans } from "@lingui/macro";
 
 const menuStyles = {
   listStyleType: "none",

--- a/app/components/browsing-autocomplete.tsx
+++ b/app/components/browsing-autocomplete.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from "next/router";
 import React, { useCallback } from "react";
+
 import SearchAutocomplete, {
   SearchAutocompleteItem,
 } from "@/components/search-autocomplete";

--- a/app/components/chart-error-boundary.tsx
+++ b/app/components/chart-error-boundary.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from "react";
 import { ErrorBoundary } from "react-error-boundary";
+
 import { ChartUnexpectedError } from "@/components/hint";
 
 export const ChartErrorBoundary = ({

--- a/app/components/chart-filters-list.tsx
+++ b/app/components/chart-filters-list.tsx
@@ -1,5 +1,6 @@
-import { Fragment } from "react";
 import { Box, Typography } from "@mui/material";
+import { Fragment } from "react";
+
 import { useQueryFilters } from "@/charts/shared/chart-helpers";
 import { ChartConfig } from "@/configurator";
 import { useTimeFormatUnit } from "@/configurator/components/ui-helpers";
@@ -57,7 +58,11 @@ export const ChartFiltersList = ({
     return (
       <>
         {namedFilters.length > 0 && (
-          <Typography component="div" variant="body2" sx={{ color: "grey.800" }}>
+          <Typography
+            component="div"
+            variant="body2"
+            sx={{ color: "grey.800" }}
+          >
             {namedFilters.map(({ dimension, value }, i) => (
               <Fragment key={dimension.iri}>
                 <Box component="span">

--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -1,3 +1,7 @@
+import { Trans } from "@lingui/macro";
+import { Box, Button, Stack, Typography } from "@mui/material";
+import { useEffect, useState } from "react";
+
 import { useChartTablePreview } from "@/components/chart-table-preview";
 import { DataDownloadMenu, RunSparqlQuery } from "@/components/data-download";
 import { ChartConfig } from "@/configurator";
@@ -7,9 +11,7 @@ import {
 } from "@/graphql/query-hooks";
 import { getChartIcon, Icon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
-import { Trans } from "@lingui/macro";
-import { Box, Button, Stack, Typography } from "@mui/material";
-import { useEffect, useState } from "react";
+
 import { useQueryFilters } from "../charts/shared/chart-helpers";
 
 export const ChartFootnotes = ({

--- a/app/components/chart-panel.tsx
+++ b/app/components/chart-panel.tsx
@@ -1,7 +1,7 @@
-import Flex from "@/components/flex";
 import { BoxProps } from "@mui/material";
-
 import { ReactNode } from "react";
+
+import Flex from "@/components/flex";
 
 export const ChartPanel = ({
   children,

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -1,3 +1,8 @@
+import { Trans } from "@lingui/macro";
+import { Box, Typography } from "@mui/material";
+import Head from "next/head";
+import * as React from "react";
+
 import { ChartDataFilters } from "@/charts/shared/chart-data-filters";
 import { useQueryFilters } from "@/charts/shared/chart-helpers";
 import { InteractiveFiltersProvider } from "@/charts/shared/use-interactive-filters";
@@ -18,10 +23,6 @@ import { DataSetTable } from "@/configurator/components/datatable";
 import { useDataCubeMetadataQuery } from "@/graphql/query-hooks";
 import { DataCubePublicationStatus } from "@/graphql/resolver-types";
 import { useLocale } from "@/locales/use-locale";
-import { Trans } from "@lingui/macro";
-import { Box, Typography } from "@mui/material";
-import Head from "next/head";
-import * as React from "react";
 
 export const ChartPreview = ({ dataSetIri }: { dataSetIri: string }) => {
   return (

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -1,3 +1,8 @@
+import { Trans } from "@lingui/macro";
+import { Box, Typography } from "@mui/material";
+import * as React from "react";
+import { useEffect } from "react";
+
 import { ChartDataFilters } from "@/charts/shared/chart-data-filters";
 import { isUsingImputation } from "@/charts/shared/imputation";
 import {
@@ -20,10 +25,6 @@ import { parseDate } from "@/configurator/components/ui-helpers";
 import { useDataCubeMetadataQuery } from "@/graphql/query-hooks";
 import { DataCubePublicationStatus } from "@/graphql/resolver-types";
 import { useLocale } from "@/locales/use-locale";
-import { Trans } from "@lingui/macro";
-import { Box, Typography } from "@mui/material";
-import * as React from "react";
-import { useEffect } from "react";
 
 export const ChartPublished = ({
   dataSet,

--- a/app/components/common-chart.tsx
+++ b/app/components/common-chart.tsx
@@ -5,9 +5,9 @@ import { ChartLinesVisualization } from "@/charts/line/chart-lines";
 import { ChartMapVisualization } from "@/charts/map/chart-map";
 import { ChartPieVisualization } from "@/charts/pie/chart-pie";
 import { ChartScatterplotVisualization } from "@/charts/scatterplot/chart-scatterplot";
+import { useQueryFilters } from "@/charts/shared/chart-helpers";
 import { ChartTableVisualization } from "@/charts/table/chart-table";
 import { ChartConfig } from "@/configurator";
-import { useQueryFilters } from "@/charts/shared/chart-helpers";
 
 const GenericChart = ({
   dataSet,

--- a/app/components/content-mdx-provider.tsx
+++ b/app/components/content-mdx-provider.tsx
@@ -1,8 +1,9 @@
 import { MDXProvider } from "@mdx-js/react";
-import { ContentLayout, StaticContentLayout } from "@/components/layout";
-import { Intro, Tutorial, Examples, Contribute } from "@/homepage";
 import { Box } from "@mui/material";
 import { ReactNode } from "react";
+
+import { ContentLayout, StaticContentLayout } from "@/components/layout";
+import { Intro, Tutorial, Examples, Contribute } from "@/homepage";
 
 const Wrapper = ({
   contentId,

--- a/app/components/data-download.tsx
+++ b/app/components/data-download.tsx
@@ -1,5 +1,3 @@
-import { QueryFilters } from "@/charts/shared/chart-helpers";
-import { useLocale } from "@/src";
 import { Trans } from "@lingui/macro";
 import {
   Button,
@@ -10,12 +8,12 @@ import {
 } from "@mui/material";
 import { saveAs } from "file-saver";
 import { keyBy } from "lodash";
+import HoverMenu from "material-ui-popup-state/HoverMenu";
 import {
   bindHover,
   bindMenu,
   usePopupState,
 } from "material-ui-popup-state/hooks";
-import HoverMenu from "material-ui-popup-state/HoverMenu";
 import React, {
   createContext,
   Dispatch,
@@ -27,6 +25,10 @@ import React, {
   useState,
 } from "react";
 import { OperationResult, useClient } from "urql";
+
+import { QueryFilters } from "@/charts/shared/chart-helpers";
+import { useLocale } from "@/src";
+
 import { Observation } from "../domain/data";
 import {
   DataCubeObservationsDocument,
@@ -34,6 +36,7 @@ import {
   DimensionMetaDataFragment,
 } from "../graphql/query-hooks";
 import { Icon } from "../icons";
+
 import Flex from "./flex";
 
 type DataDownloadState = {

--- a/app/components/debug-panel.tsx
+++ b/app/components/debug-panel.tsx
@@ -1,13 +1,14 @@
+import { Box, Button, Typography } from "@mui/material";
+import { Stack } from "@mui/material";
 import React from "react";
 import { Inspector } from "react-inspector";
-import { Box, Button, Typography } from "@mui/material";
+
 import { useInteractiveFilters } from "@/charts/shared/use-interactive-filters";
 import { useConfiguratorState } from "@/configurator";
 import { SPARQL_EDITOR, SPARQL_ENDPOINT } from "@/domain/env";
 import { useDataCubeMetadataWithComponentValuesQuery } from "@/graphql/query-hooks";
 import { Icon } from "@/icons";
 import { useLocale } from "@/src";
-import { Stack } from '@mui/material'
 
 const DebugInteractiveFilters = () => {
   const [interactiveFiltersState] = useInteractiveFilters();

--- a/app/components/error-pages-components.tsx
+++ b/app/components/error-pages-components.tsx
@@ -1,9 +1,10 @@
-import Flex from "@/components/flex";
+import { Link, Typography } from "@mui/material";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
 import * as React from "react";
 import { ReactNode } from "react";
-import { Link, Typography } from "@mui/material";
+
+import Flex from "@/components/flex";
 import { Locale } from "@/locales/locales";
 
 export const ErrorPageHint = ({ children }: { children: ReactNode }) => (

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -1,11 +1,12 @@
-import Flex, { FlexProps } from "@/components/flex";
 import { t, Trans } from "@lingui/macro";
 import { Box, Link, Typography } from "@mui/material";
 import NextLink from "next/link";
 import { forwardRef, ReactNode } from "react";
+
+import Flex, { FlexProps } from "@/components/flex";
 import contentRoutes from "@/content-routes.json";
-import { useLocale } from "@/locales/use-locale";
 import { BUILD_COMMIT, BUILD_GITHUB_REPO, BUILD_VERSION } from "@/domain/env";
+import { useLocale } from "@/locales/use-locale";
 
 const Version = () => {
   let commitLink = null;

--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -1,7 +1,5 @@
 import { Trans } from "@lingui/macro";
-import { useId } from "@reach/auto-id";
-import { ChangeEvent, ReactNode, useCallback, useMemo } from "react";
-
+import { DatePicker, DatePickerProps } from "@mui/lab";
 import {
   Box,
   BoxProps,
@@ -16,14 +14,16 @@ import {
   Typography,
   TextField,
 } from "@mui/material";
+import { useId } from "@reach/auto-id";
+import { timeFormat } from "d3-time-format";
+import { ChangeEvent, ReactNode, useCallback, useMemo } from "react";
+
 import Flex from "@/components/flex";
 import VisuallyHidden from "@/components/visually-hidden";
 import { FieldProps, Option } from "@/configurator";
 import { useBrowseContext } from "@/configurator/components/dataset-browse";
 import { Icon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
-import { DatePicker, DatePickerProps } from "@mui/lab";
-import { timeFormat } from "d3-time-format";
 
 export const Label = ({
   label,

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -1,8 +1,5 @@
-import Flex from "@/components/flex";
 import { Trans } from "@lingui/macro";
-
 import { Box, Typography } from "@mui/material";
-import { LanguageMenu } from "@/components/language-menu";
 import NextLink from "next/link";
 import React, {
   Dispatch,
@@ -11,6 +8,9 @@ import React, {
   useMemo,
   useState,
 } from "react";
+
+import Flex from "@/components/flex";
+import { LanguageMenu } from "@/components/language-menu";
 
 const DEFAULT_HEADER_PROGRESS = 100;
 

--- a/app/components/hint.tsx
+++ b/app/components/hint.tsx
@@ -1,7 +1,5 @@
-import Flex from "@/components/flex";
 import { keyframes } from "@emotion/react";
 import { Trans } from "@lingui/macro";
-import { ReactNode } from "react";
 import {
   Alert,
   AlertProps,
@@ -11,6 +9,9 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
+import { ReactNode } from "react";
+
+import Flex from "@/components/flex";
 import { Icon, IconName } from "@/icons";
 
 export const Error = ({ children }: { children: ReactNode }) => (

--- a/app/components/language-menu.tsx
+++ b/app/components/language-menu.tsx
@@ -1,8 +1,9 @@
-import Flex from "@/components/flex";
+import { Box } from "@mui/material";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
 import { ReactNode } from "react";
-import { Box } from "@mui/material";
+
+import Flex from "@/components/flex";
 import contentRoutes from "@/content-routes.json";
 import localeConfig from "@/locales/locales.json";
 import { useLocale } from "@/locales/use-locale";

--- a/app/components/layout.tsx
+++ b/app/components/layout.tsx
@@ -1,7 +1,8 @@
 import { ReactNode } from "react";
+
+import Flex from "@/components/flex";
 import { Footer } from "@/components/footer";
 import { Header, HeaderProgressProvider } from "@/components/header";
-import Flex from "@/components/flex";
 
 export const AppLayout = ({ children }: { children?: ReactNode }) => (
   <Flex sx={{ minHeight: "100vh", flexDirection: "column" }}>

--- a/app/components/links.tsx
+++ b/app/components/links.tsx
@@ -1,4 +1,5 @@
 import { Link as UILink } from "@mui/material";
+
 import { Icon, IconName } from "@/icons";
 
 export const IconLink = ({

--- a/app/components/publish-actions.tsx
+++ b/app/components/publish-actions.tsx
@@ -1,13 +1,4 @@
-import Flex from "@/components/flex";
 import { t, Trans } from "@lingui/macro";
-import * as clipboard from "clipboard-polyfill/text";
-import Downshift, { DownshiftState, StateChangeOptions } from "downshift";
-import {
-  MouseEvent as ReactMouseEvent,
-  ReactNode,
-  useEffect,
-  useState,
-} from "react";
 import {
   Box,
   BoxProps,
@@ -17,11 +8,21 @@ import {
   Link,
   Typography,
 } from "@mui/material";
+import { Stack } from "@mui/material";
+import * as clipboard from "clipboard-polyfill/text";
+import Downshift, { DownshiftState, StateChangeOptions } from "downshift";
+import {
+  MouseEvent as ReactMouseEvent,
+  ReactNode,
+  useEffect,
+  useState,
+} from "react";
+
+import Flex from "@/components/flex";
+import { IconLink } from "@/components/links";
 import { Icon } from "@/icons";
 import { useI18n } from "@/lib/use-i18n";
 import { useLocale } from "@/locales/use-locale";
-import { IconLink } from "@/components/links";
-import { Stack } from '@mui/material'
 
 export const PublishActions = ({
   configKey,

--- a/app/components/search-autocomplete.tsx
+++ b/app/components/search-autocomplete.tsx
@@ -1,18 +1,19 @@
+import { t } from "@lingui/macro";
+import { Box } from "@mui/material";
 import React, { useMemo } from "react";
+
+import Autocomplete, { AutocompleteProps } from "@/components/autocomplete";
 import {
   BrowseFilter,
   DataCubeAbout,
   useBrowseContext,
 } from "@/configurator/components/dataset-browse";
+import useDatasetCount from "@/configurator/components/use-dataset-count";
 import { useOrganizationsQuery, useThemesQuery } from "@/graphql/query-hooks";
 import SvgIcCategories from "@/icons/components/IcCategories";
 import SvgIcOrganisations from "@/icons/components/IcOrganisations";
-import { useLocale } from "@/src";
-import Autocomplete, { AutocompleteProps } from "@/components/autocomplete";
-import { Box } from "@mui/material";
-import useDatasetCount from "@/configurator/components/use-dataset-count";
-import { t } from "@lingui/macro";
 import SvgIcText from "@/icons/components/IcText";
+import { useLocale } from "@/src";
 
 const getItemIcon = (item: SearchAutocompleteItem) => {
   if (item.__typename === "DataCubeTheme") {

--- a/app/configurator/chart-module-types.ts
+++ b/app/configurator/chart-module-types.ts
@@ -1,6 +1,8 @@
 import { ComponentType } from "react";
+
 import { DataCubeMetadata } from "../graphql/types";
 import { IconName } from "../icons";
+
 import { ChartConfig, SortingOrder } from "./config-types";
 
 type ChartComponentProps = {

--- a/app/configurator/components/Accordion.tsx
+++ b/app/configurator/components/Accordion.tsx
@@ -1,6 +1,7 @@
-import Flex, { FlexProps } from "@/components/flex";
-import React, { useContext, useEffect, useMemo, useState } from "react";
 import { Box, BoxProps } from "@mui/material";
+import React, { useContext, useEffect, useMemo, useState } from "react";
+
+import Flex, { FlexProps } from "@/components/flex";
 import SvgIcChevronLeft from "@/icons/components/IcChevronLeft";
 
 const AccordionArrow = ({

--- a/app/configurator/components/Tag.tsx
+++ b/app/configurator/components/Tag.tsx
@@ -1,9 +1,7 @@
-import React, { ReactNode } from "react";
 import { Typography, TypographyProps, styled, BoxProps } from "@mui/material";
-import {
-  DataCubeOrganization,
-  DataCubeTheme,
-} from "@/graphql/resolver-types";
+import React, { ReactNode } from "react";
+
+import { DataCubeOrganization, DataCubeTheme } from "@/graphql/resolver-types";
 
 type TagType =
   | "draft"

--- a/app/configurator/components/chart-annotations-selector.tsx
+++ b/app/configurator/components/chart-annotations-selector.tsx
@@ -1,9 +1,7 @@
-import { useEffect, useRef } from "react";
 import { Box } from "@mui/material";
+import { useEffect, useRef } from "react";
+
 import { ConfiguratorStateDescribingChart } from "@/configurator";
-import { locales } from "@/locales/locales";
-import { useLocale } from "@/locales/use-locale";
-import { InteractiveFiltersOptions } from "@/configurator/interactive-filters/interactive-filters-config-options";
 import {
   ControlSection,
   ControlSectionContent,
@@ -15,6 +13,9 @@ import {
   getFieldLabel,
   getIconName,
 } from "@/configurator/components/ui-helpers";
+import { InteractiveFiltersOptions } from "@/configurator/interactive-filters/interactive-filters-config-options";
+import { locales } from "@/locales/locales";
+import { useLocale } from "@/locales/use-locale";
 
 export const ChartAnnotationsSelector = ({
   state,

--- a/app/configurator/components/chart-annotator.tsx
+++ b/app/configurator/components/chart-annotator.tsx
@@ -1,7 +1,6 @@
 import { Trans } from "@lingui/macro";
 import * as React from "react";
-import { ConfiguratorStateDescribingChart } from "@/configurator/config-types";
-import { InteractiveFiltersConfigurator } from "@/configurator/interactive-filters/interactive-filters-configurator";
+
 import {
   ControlSection,
   ControlSectionContent,
@@ -9,6 +8,8 @@ import {
 } from "@/configurator/components/chart-controls/section";
 import { AnnotatorTabField } from "@/configurator/components/field";
 import { getFieldLabel } from "@/configurator/components/ui-helpers";
+import { ConfiguratorStateDescribingChart } from "@/configurator/config-types";
+import { InteractiveFiltersConfigurator } from "@/configurator/interactive-filters/interactive-filters-configurator";
 
 export const ChartAnnotator = ({
   state,

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -1,3 +1,22 @@
+import { t, Trans } from "@lingui/macro";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  IconButton,
+  Menu,
+  MenuItem,
+} from "@mui/material";
+import { isEmpty, isEqual, sortBy } from "lodash";
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import {
+  DragDropContext,
+  Draggable,
+  Droppable,
+  OnDragEndResponder,
+} from "react-beautiful-dnd";
+import { CombinedError, useClient } from "urql";
+
 import { getFieldComponentIris } from "@/charts";
 import { chartConfigOptionsUISpec } from "@/charts/chart-config-ui-options";
 import {
@@ -37,24 +56,6 @@ import {
 import { DataCubeMetadata } from "@/graphql/types";
 import { Icon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
-import { t, Trans } from "@lingui/macro";
-import {
-  Box,
-  Button,
-  CircularProgress,
-  IconButton,
-  Menu,
-  MenuItem,
-} from "@mui/material";
-import { isEmpty, isEqual, sortBy } from "lodash";
-import React, { useCallback, useEffect, useRef, useState } from "react";
-import {
-  DragDropContext,
-  Draggable,
-  Droppable,
-  OnDragEndResponder,
-} from "react-beautiful-dnd";
-import { CombinedError, useClient } from "urql";
 
 const DataFilterSelectGeneric = ({
   dimension,

--- a/app/configurator/components/chart-controls/color-palette.tsx
+++ b/app/configurator/components/chart-controls/color-palette.tsx
@@ -1,19 +1,23 @@
-import Flex from "@/components/flex";
 import { Trans } from "@lingui/macro";
+import { Box, Button, Typography } from "@mui/material";
 import { useSelect } from "downshift";
 import get from "lodash/get";
 import { useCallback } from "react";
-import { Box, Button, Typography } from "@mui/material";
-import { ConfiguratorStateConfiguringChart, useConfiguratorState } from "@/configurator";
+
+import Flex from "@/components/flex";
 import { Label } from "@/components/form";
-import { DimensionMetaDataFragment } from "@/graphql/query-hooks";
-import { Icon } from "@/icons";
+import {
+  ConfiguratorStateConfiguringChart,
+  useConfiguratorState,
+} from "@/configurator";
 import {
   categoricalPalettes,
   divergingSteppedPalettes,
   getPalette,
   mapColorsToComponentValuesIris,
 } from "@/configurator/components/ui-helpers";
+import { DimensionMetaDataFragment } from "@/graphql/query-hooks";
+import { Icon } from "@/icons";
 
 type Props = {
   field: string;

--- a/app/configurator/components/chart-controls/color-picker.tsx
+++ b/app/configurator/components/chart-controls/color-picker.tsx
@@ -1,10 +1,11 @@
 import { Trans } from "@lingui/macro";
-import { color as d3Color } from "d3";
-import { styled } from "@mui/styles";
-import React, { MouseEventHandler, useCallback, useRef, useState } from "react";
 import { Box, Button, Input, Popover } from "@mui/material";
-import useDisclosure from "@/configurator/components/use-disclosure";
+import { styled } from "@mui/styles";
+import { color as d3Color } from "d3";
+import React, { MouseEventHandler, useCallback, useRef, useState } from "react";
+
 import VisuallyHidden from "@/components/visually-hidden";
+import useDisclosure from "@/configurator/components/use-disclosure";
 
 const Swatch = ({
   color,

--- a/app/configurator/components/chart-controls/color-ramp.tsx
+++ b/app/configurator/components/chart-controls/color-ramp.tsx
@@ -1,16 +1,17 @@
 import { Trans } from "@lingui/macro";
+import { Box, Button, Typography } from "@mui/material";
 import { useSelect } from "downshift";
 import { get } from "lodash";
 import { useCallback, useEffect, useMemo, useRef } from "react";
-import { Box, Button, Typography } from "@mui/material";
+
+import { Label } from "@/components/form";
 import {
   DivergingPaletteType,
   SequentialPaletteType,
   useConfiguratorState,
 } from "@/configurator";
-import { Label } from "@/components/form";
-import { Icon } from "@/icons";
 import { sequentialPalettes } from "@/configurator/components/ui-helpers";
+import { Icon } from "@/icons";
 
 // Adapted from https://observablehq.com/@mbostock/color-ramp
 

--- a/app/configurator/components/chart-controls/control-tab.tsx
+++ b/app/configurator/components/chart-controls/control-tab.tsx
@@ -1,14 +1,15 @@
-import Flex from "@/components/flex";
 import { Trans } from "@lingui/macro";
-import { ReactNode } from "react";
 import { Box, Button, Typography } from "@mui/material";
+import { ReactNode } from "react";
+
+import Flex from "@/components/flex";
 import { FieldProps } from "@/configurator";
-import { DimensionMetaDataFragment } from "@/graphql/query-hooks";
-import { Icon, IconName } from "@/icons";
 import {
   getFieldLabel,
   getIconName,
 } from "@/configurator/components/ui-helpers";
+import { DimensionMetaDataFragment } from "@/graphql/query-hooks";
+import { Icon, IconName } from "@/icons";
 
 export const ControlTab = ({
   component,

--- a/app/configurator/components/chart-controls/drag-and-drop-tab.tsx
+++ b/app/configurator/components/chart-controls/drag-and-drop-tab.tsx
@@ -1,15 +1,20 @@
 import { Trans } from "@lingui/macro";
+import { Box } from "@mui/material";
 import { ReactNode } from "react";
 import { Draggable, Droppable } from "react-beautiful-dnd";
-import { Box } from "@mui/material";
+
+import { DraggableTab } from "@/configurator/components/chart-controls/control-tab";
+import {
+  ControlSection,
+  ControlSectionContent,
+  SectionTitle,
+} from "@/configurator/components/chart-controls/section";
+import { getIconName } from "@/configurator/components/ui-helpers";
+import { useActiveFieldField } from "@/configurator/config-form";
+import { TableColumn } from "@/configurator/config-types";
 import { DimensionMetaDataFragment } from "@/graphql/query-hooks";
 import { DataCubeMetadata } from "@/graphql/types";
 import { Icon } from "@/icons";
-import { useActiveFieldField } from "@/configurator/config-form";
-import { TableColumn } from "@/configurator/config-types";
-import { getIconName } from "@/configurator/components/ui-helpers";
-import { DraggableTab } from "@/configurator/components/chart-controls/control-tab";
-import { ControlSection, ControlSectionContent, SectionTitle } from "@/configurator/components/chart-controls/section";
 
 type Props = {
   id: string;

--- a/app/configurator/components/chart-controls/section.tsx
+++ b/app/configurator/components/chart-controls/section.tsx
@@ -5,8 +5,8 @@ import {
   Typography,
   TypographyProps,
 } from "@mui/material";
-
 import { ElementType, forwardRef, ReactNode } from "react";
+
 import { Icon, IconName } from "@/icons";
 import { useTheme } from "@/themes";
 

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -1,3 +1,9 @@
+import { t, Trans } from "@lingui/macro";
+import { Box } from "@mui/material";
+import { keyBy } from "lodash";
+import get from "lodash/get";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+
 import { getFieldComponentIri } from "@/charts";
 import {
   chartConfigOptionsUISpec,
@@ -52,11 +58,6 @@ import {
 } from "@/graphql/query-hooks";
 import { DataCubeMetadata } from "@/graphql/types";
 import { useLocale } from "@/locales/use-locale";
-import { t, Trans } from "@lingui/macro";
-import { Box } from "@mui/material";
-import { keyBy } from "lodash";
-import get from "lodash/get";
-import { useCallback, useEffect, useMemo, useRef } from "react";
 
 export const ChartOptionsSelector = ({
   state,

--- a/app/configurator/components/chart-type-selector.tsx
+++ b/app/configurator/components/chart-type-selector.tsx
@@ -1,3 +1,7 @@
+import { Trans } from "@lingui/macro";
+import { Box, ButtonBase, CircularProgress, Typography } from "@mui/material";
+import React, { SyntheticEvent } from "react";
+
 import { enabledChartTypes, getPossibleChartType } from "@/charts";
 import { Hint, Loading } from "@/components/hint";
 import { useEnsurePossibleFilters } from "@/configurator/components/chart-configurator";
@@ -18,9 +22,7 @@ import { useDataCubeMetadataWithComponentValuesQuery } from "@/graphql/query-hoo
 import { DataCubeMetadata } from "@/graphql/types";
 import { Icon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
-import { Trans } from "@lingui/macro";
-import { Box, ButtonBase, CircularProgress, Typography } from "@mui/material";
-import React, { SyntheticEvent } from "react";
+
 import {
   ConfiguratorStateConfiguringChart,
   ConfiguratorStateDescribingChart,

--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+
 import { ChartPanel } from "@/components/chart-panel";
 import { ChartPreview } from "@/components/chart-preview";
 import { useConfiguratorState } from "@/configurator";
@@ -16,7 +18,6 @@ import {
 import { SelectDatasetStep } from "@/configurator/components/select-dataset-step";
 import { Stepper } from "@/configurator/components/stepper";
 import { ChartConfiguratorTable } from "@/configurator/table/table-chart-configurator";
-import React from "react";
 
 const ConfigureChartStep = () => {
   const [state] = useConfiguratorState();

--- a/app/configurator/components/dataset-browse.spec.tsx
+++ b/app/configurator/components/dataset-browse.spec.tsx
@@ -1,6 +1,6 @@
-import { DataCubeOrganization, DataCubeTheme } from "@/graphql/query-hooks";
 import { BrowseParams } from "@/browser/dataset-browser";
 import { getFiltersFromParams } from "@/configurator/components/dataset-browse";
+import { DataCubeOrganization, DataCubeTheme } from "@/graphql/query-hooks";
 
 const ctx = {
   themes: [

--- a/app/configurator/components/dataset-browse.tsx
+++ b/app/configurator/components/dataset-browse.tsx
@@ -1,5 +1,15 @@
 import { Maybe } from "@graphql-tools/utils/types";
 import { Plural, t, Trans } from "@lingui/macro";
+import {
+  Box,
+  Button,
+  ButtonBase,
+  Link as MUILink,
+  LinkProps as MUILinkProps,
+  Typography,
+} from "@mui/material";
+import { Stack } from "@mui/material";
+import { Reorder } from "framer-motion";
 import { mapValues, orderBy, pick, pickBy, sortBy } from "lodash";
 import Link from "next/link";
 import { Router, useRouter } from "next/router";
@@ -11,18 +21,21 @@ import React, {
   useRef,
   useState,
 } from "react";
-import {
-  Box,
-  Button,
-  ButtonBase,
-  Link as MUILink,
-  LinkProps as MUILinkProps,
-  Typography,
-} from "@mui/material";
+import { UseQueryState } from "urql";
+
+import { BrowseParams } from "@/browser/dataset-browser";
 import Flex, { FlexProps } from "@/components/flex";
 import { Checkbox, MiniSelect, SearchField } from "@/components/form";
 import { LoadingDataError, Loading } from "@/components/hint";
-import { Stack } from "@mui/material";
+import Tag from "@/configurator/components/Tag";
+import {
+  smoothPresenceProps,
+  MotionBox,
+  MotionCard,
+  accordionPresenceProps,
+} from "@/configurator/components/presence";
+import { useFormatDate } from "@/configurator/components/ui-helpers";
+import useDatasetCount from "@/configurator/components/use-dataset-count";
 import {
   DataCubeOrganization,
   DataCubeResultOrder,
@@ -39,21 +52,10 @@ import SvgIcCategories from "@/icons/components/IcCategories";
 import SvgIcClose from "@/icons/components/IcClose";
 import SvgIcOrganisations from "@/icons/components/IcOrganisations";
 import { useLocale } from "@/locales/use-locale";
-import { BrowseParams } from "@/browser/dataset-browser";
 import isAttrEqual from "@/utils/is-attr-equal";
 import truthy from "@/utils/truthy";
-import Tag from "@/configurator/components/Tag";
-import { useFormatDate } from "@/configurator/components/ui-helpers";
-import useDatasetCount from "@/configurator/components/use-dataset-count";
-import {
-  smoothPresenceProps,
-  MotionBox,
-  MotionCard,
-  accordionPresenceProps,
-} from "@/configurator/components/presence";
-import { UseQueryState } from "urql";
+
 import useDisclosure from "./use-disclosure";
-import { Reorder } from "framer-motion";
 
 export type DataCubeAbout = {
   __typename: "DataCubeAbout";

--- a/app/configurator/components/dataset-metadata.tsx
+++ b/app/configurator/components/dataset-metadata.tsx
@@ -1,8 +1,15 @@
 import { Trans } from "@lingui/macro";
+import { Box, BoxProps, Link, Typography } from "@mui/material";
+import { Stack } from "@mui/material";
+import { Link as MUILink } from "@mui/material";
 import NextLink from "next/link";
 import React, { ReactNode } from "react";
-import { Box, BoxProps, Link, Typography } from "@mui/material";
-import { Stack } from '@mui/material'
+
+import Tag from "@/configurator/components/Tag";
+import {
+  MotionBox,
+  smoothPresenceProps,
+} from "@/configurator/components/presence";
 import { useFormatDate } from "@/configurator/components/ui-helpers";
 import {
   DataCubeMetadataQuery,
@@ -10,9 +17,6 @@ import {
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 import truthy from "@/utils/truthy";
-import Tag from "@/configurator/components/Tag";
-import { MotionBox, smoothPresenceProps } from "@/configurator/components/presence";
-import { Link as MUILink } from "@mui/material";
 
 export const DataSetMetadata = ({
   dataSetIri,

--- a/app/configurator/components/dataset-preview.tsx
+++ b/app/configurator/components/dataset-preview.tsx
@@ -1,3 +1,9 @@
+import { Trans } from "@lingui/macro";
+import { Box, Button, Paper, Typography } from "@mui/material";
+import Head from "next/head";
+import Link from "next/link";
+import * as React from "react";
+
 import { DataDownloadMenu } from "@/components/data-download";
 import DebugPanel from "@/components/debug-panel";
 import Flex from "@/components/flex";
@@ -6,11 +12,6 @@ import { DataSetPreviewTable } from "@/configurator/components/datatable";
 import { useDataCubePreviewQuery } from "@/graphql/query-hooks";
 import { DataCubePublicationStatus } from "@/graphql/resolver-types";
 import { useLocale } from "@/locales/use-locale";
-import { Trans } from "@lingui/macro";
-import { Box, Button, Paper, Typography } from "@mui/material";
-import Head from "next/head";
-import Link from "next/link";
-import * as React from "react";
 
 export interface Preview {
   iri: string;

--- a/app/configurator/components/datatable.tsx
+++ b/app/configurator/components/datatable.tsx
@@ -1,3 +1,15 @@
+import {
+  Box,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TableSortLabel,
+} from "@mui/material";
+import { ascending, descending } from "d3";
+import { useMemo, useState } from "react";
+
 import { useQueryFilters } from "@/charts/shared/chart-helpers";
 import { Loading } from "@/components/hint";
 import {
@@ -12,17 +24,6 @@ import {
   useDataCubePreviewObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
-import {
-  Box,
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableRow,
-  TableSortLabel,
-} from "@mui/material";
-import { ascending, descending } from "d3";
-import { useMemo, useState } from "react";
 
 type Header = DimensionMetaDataFragment;
 

--- a/app/configurator/components/empty-right-panel.tsx
+++ b/app/configurator/components/empty-right-panel.tsx
@@ -1,6 +1,7 @@
 import { Trans } from "@lingui/macro";
 import { Typography } from "@mui/material";
 import { ReactNode } from "react";
+
 import {
   ConfiguratorStateConfiguringChart,
   ConfiguratorStateDescribingChart,

--- a/app/configurator/components/field.spec.tsx
+++ b/app/configurator/components/field.spec.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render } from "@testing-library/react";
-import { getD3TimeFormatLocale } from "@/locales/locales";
+
 import { TimeInput } from "@/configurator/components/field";
+import { getD3TimeFormatLocale } from "@/locales/locales";
 
 describe("TimeInput", () => {
   const expectedValue = "2020-05-24";

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -1,17 +1,9 @@
-import Flex from "@/components/flex";
 import { t } from "@lingui/macro";
 import { extent, timeFormat, TimeLocaleObject, timeParse } from "d3";
 import get from "lodash/get";
 import { ChangeEvent, ReactNode, useCallback, useMemo, useState } from "react";
-import {
-  Option,
-  useActiveFieldField,
-  useChartFieldField,
-  useChartOptionRadioField,
-  useMetaField,
-  useSingleFilterField,
-} from "@/configurator/config-form";
-import { useConfiguratorState } from "@/configurator/configurator-state";
+
+import Flex from "@/components/flex";
 import {
   Checkbox,
   DayPickerField,
@@ -20,19 +12,6 @@ import {
   Radio,
   Select,
 } from "@/components/form";
-import { DimensionMetaDataFragment, TimeUnit } from "@/graphql/query-hooks";
-import { DataCubeMetadata } from "@/graphql/types";
-import { IconName } from "@/icons";
-import truthy from "@/utils/truthy";
-import {
-  isMultiFilterFieldChecked,
-  useChartOptionBooleanField,
-  useChartOptionSelectField,
-  useMultiFilterCheckboxes,
-  useMultiFilterContext,
-  useSingleFilterSelect,
-} from "@/configurator/config-form";
-import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import { ColorPickerMenu } from "@/configurator/components/chart-controls/color-picker";
 import {
   AnnotatorTab,
@@ -45,6 +24,28 @@ import {
   getTimeIntervalWithProps,
   useTimeFormatLocale,
 } from "@/configurator/components/ui-helpers";
+import {
+  Option,
+  useActiveFieldField,
+  useChartFieldField,
+  useChartOptionRadioField,
+  useMetaField,
+  useSingleFilterField,
+} from "@/configurator/config-form";
+import {
+  isMultiFilterFieldChecked,
+  useChartOptionBooleanField,
+  useChartOptionSelectField,
+  useMultiFilterCheckboxes,
+  useMultiFilterContext,
+  useSingleFilterSelect,
+} from "@/configurator/config-form";
+import { useConfiguratorState } from "@/configurator/configurator-state";
+import { FIELD_VALUE_NONE } from "@/configurator/constants";
+import { DimensionMetaDataFragment, TimeUnit } from "@/graphql/query-hooks";
+import { DataCubeMetadata } from "@/graphql/types";
+import { IconName } from "@/icons";
+import truthy from "@/utils/truthy";
 
 export const ControlTabField = ({
   component,

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -1,7 +1,10 @@
-import Flex from "@/components/flex";
 import { Trans } from "@lingui/macro";
-import React, { useCallback, useMemo } from "react";
 import { Box, Button, Typography } from "@mui/material";
+import { Stack } from "@mui/material";
+import React, { useCallback, useMemo } from "react";
+
+import Flex from "@/components/flex";
+import { Loading } from "@/components/hint";
 import {
   getFilterValue,
   MultiFilterContextProvider,
@@ -9,19 +12,6 @@ import {
   useDimensionSelection,
   useMultiFilterContext,
 } from "@/configurator";
-import { Loading } from "@/components/hint";
-import { Stack } from "@mui/material";
-import {
-  useDimensionValuesQuery,
-  useTemporalDimensionValuesQuery,
-} from "@/graphql/query-hooks";
-import { useLocale } from "@/locales/use-locale";
-import {
-  HierarchyValue,
-  useHierarchicalDimensionValuesQuery,
-} from "@/utils/dimension-hierarchy";
-import { valueComparator } from "@/utils/sorting-values";
-import { EditorIntervalBrush } from "@/configurator/interactive-filters/editor-time-interval-brush";
 import {
   Accordion,
   AccordionContent,
@@ -37,6 +27,18 @@ import {
   useTimeFormatLocale,
   useTimeFormatUnit,
 } from "@/configurator/components/ui-helpers";
+import { EditorIntervalBrush } from "@/configurator/interactive-filters/editor-time-interval-brush";
+import {
+  useDimensionValuesQuery,
+  useTemporalDimensionValuesQuery,
+} from "@/graphql/query-hooks";
+import { useLocale } from "@/locales/use-locale";
+import {
+  HierarchyValue,
+  useHierarchicalDimensionValuesQuery,
+} from "@/utils/dimension-hierarchy";
+import { valueComparator } from "@/utils/sorting-values";
+
 import { ControlSectionSkeleton } from "./chart-controls/section";
 
 const SelectionControls = ({ dimensionIri }: { dimensionIri: string }) => {

--- a/app/configurator/components/layout.tsx
+++ b/app/configurator/components/layout.tsx
@@ -1,5 +1,5 @@
-import React from "react";
 import { Box, BoxProps } from "@mui/material";
+import React from "react";
 
 const commonPanelStyles = {};
 

--- a/app/configurator/components/move-drag-buttons.tsx
+++ b/app/configurator/components/move-drag-buttons.tsx
@@ -1,4 +1,5 @@
 import { Box, BoxProps, ButtonProps, styled } from "@mui/material";
+
 import { Icon } from "@/icons";
 
 const ArrowButton = styled("button", { label: "ArrowButton" })({

--- a/app/configurator/components/select-dataset-step.tsx
+++ b/app/configurator/components/select-dataset-step.tsx
@@ -1,13 +1,13 @@
 import { t, Trans } from "@lingui/macro";
+import { Box, Button, Typography } from "@mui/material";
+import { AnimatePresence } from "framer-motion";
 import Head from "next/head";
 import NextLink from "next/link";
 import { Router, useRouter } from "next/router";
 import React, { useMemo } from "react";
-import { Box, Button, Typography } from "@mui/material";
 import { useDebounce } from "use-debounce";
-import { AnimatePresence } from "framer-motion";
-import { useDataCubesQuery } from "@/graphql/query-hooks";
-import { useConfiguratorState, useLocale } from "@/src";
+
+import { Footer } from "@/components/footer";
 import {
   BrowseStateProvider,
   buildURLFromBrowseState,
@@ -28,8 +28,9 @@ import {
   MotionBox,
   navPresenceProps,
 } from "@/configurator/components/presence";
+import { useDataCubesQuery } from "@/graphql/query-hooks";
 import { Icon } from "@/icons";
-import { Footer } from "@/components/footer";
+import { useConfiguratorState, useLocale } from "@/src";
 
 const softJSONParse = (v: string) => {
   try {

--- a/app/configurator/components/stepper.tsx
+++ b/app/configurator/components/stepper.tsx
@@ -1,3 +1,7 @@
+import { Trans } from "@lingui/macro";
+import { Button, Typography } from "@mui/material";
+import React, { ReactNode, useCallback, useEffect } from "react";
+
 import Flex from "@/components/flex";
 import { useHeaderProgress } from "@/components/header";
 import {
@@ -9,9 +13,6 @@ import { useDataCubeMetadataWithComponentValuesQuery } from "@/graphql/query-hoo
 import SvgIcChevronLeft from "@/icons/components/IcChevronLeft";
 import SvgIcChevronRight from "@/icons/components/IcChevronRight";
 import { useLocale } from "@/src";
-import { Trans } from "@lingui/macro";
-import { Button, Typography } from "@mui/material";
-import React, { ReactNode, useCallback, useEffect } from "react";
 
 export type StepStatus = "past" | "current" | "future";
 

--- a/app/configurator/components/ui-helpers.spec.ts
+++ b/app/configurator/components/ui-helpers.spec.ts
@@ -1,5 +1,7 @@
 import { renderHook } from "@testing-library/react-hooks";
+
 import { TimeUnit } from "../../graphql/query-hooks";
+
 import {
   getTimeIntervalFormattedSelectOptions,
   getTimeIntervalWithProps,

--- a/app/configurator/components/ui-helpers.ts
+++ b/app/configurator/components/ui-helpers.ts
@@ -46,6 +46,7 @@ import {
 } from "d3";
 import { memoize } from "lodash";
 import { useMemo } from "react";
+
 import { ChartProps } from "../../charts/shared/use-chart-state";
 import { Observation } from "../../domain/data";
 import { DimensionMetaDataFragment, TimeUnit } from "../../graphql/query-hooks";

--- a/app/configurator/components/use-dataset-count.tsx
+++ b/app/configurator/components/use-dataset-count.tsx
@@ -1,7 +1,8 @@
 import { useMemo } from "react";
+
+import { BrowseFilter } from "@/configurator/components/dataset-browse";
 import { useDatasetCountQuery } from "@/graphql/query-hooks";
 import isAttrEqual from "@/utils/is-attr-equal";
-import { BrowseFilter } from "@/configurator/components/dataset-browse";
 
 const countListToIndexedCount = (l: { count: number; iri: string }[]) =>
   Object.fromEntries(l.map((o) => [o.iri, o.count]));

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -1,13 +1,3 @@
-import { getFieldComponentIri } from "@/charts";
-import { ChartConfig, ChartType } from "@/configurator/config-types";
-import {
-  getChartOptionBooleanField,
-  getFilterValue,
-  useConfiguratorState,
-} from "@/configurator/configurator-state";
-import { FIELD_VALUE_NONE } from "@/configurator/constants";
-import { DimensionValuesQuery } from "@/graphql/query-hooks";
-import { DataCubeMetadata } from "@/graphql/types";
 import { SelectChangeEvent, SelectProps } from "@mui/material";
 import { some } from "lodash";
 import get from "lodash/get";
@@ -19,6 +9,17 @@ import React, {
   useContext,
   useMemo,
 } from "react";
+
+import { getFieldComponentIri } from "@/charts";
+import { ChartConfig, ChartType } from "@/configurator/config-types";
+import {
+  getChartOptionBooleanField,
+  getFilterValue,
+  useConfiguratorState,
+} from "@/configurator/configurator-state";
+import { FIELD_VALUE_NONE } from "@/configurator/constants";
+import { DimensionValuesQuery } from "@/graphql/query-hooks";
+import { DataCubeMetadata } from "@/graphql/types";
 
 // interface FieldProps {
 //   name: HTMLInputElement["name"]

--- a/app/configurator/config-types.ts
+++ b/app/configurator/config-types.ts
@@ -1,8 +1,9 @@
 /* eslint-disable no-redeclare */
-import { DataCubeMetadata } from "@/graphql/types";
 import { fold } from "fp-ts/lib/Either";
 import { pipe } from "fp-ts/lib/pipeable";
 import * as t from "io-ts";
+
+import { DataCubeMetadata } from "@/graphql/types";
 
 const ComponentType = t.union([
   t.literal("Attribute"),

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -1,3 +1,7 @@
+import { Client } from "@urql/core";
+import { createDraft, current } from "immer";
+import { get } from "lodash";
+
 import * as api from "@/api";
 import { getChartConfigAdjustedToChartType } from "@/charts";
 import { ChartConfig } from "@/configurator";
@@ -17,9 +21,7 @@ import bathingWaterMetadata from "@/test/__fixtures/api/DataCubeMetadataWithComp
 import covid19Metadata from "@/test/__fixtures/api/DataCubeMetadataWithComponentValues-covid19.json";
 import covid19ChartConfig from "@/test/__fixtures/dev/chartConfig-column-covid19.json";
 import { data as fakeVizFixture } from "@/test/__fixtures/prod/line-1.json";
-import { Client } from "@urql/core";
-import { createDraft, current } from "immer";
-import { get } from "lodash";
+
 import { ChartType, ColumnConfig } from "./config-types";
 
 const mockedApi = api as jest.Mocked<typeof api>;

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -1,3 +1,17 @@
+import { current, produce } from "immer";
+import { get, mapValues, pickBy } from "lodash";
+import setWith from "lodash/setWith";
+import { useRouter } from "next/router";
+import {
+  createContext,
+  Dispatch,
+  ReactNode,
+  useContext,
+  useEffect,
+} from "react";
+import { Client, useClient } from "urql";
+import { Reducer, useImmerReducer } from "use-immer";
+
 import { fetchChartConfig, saveChartConfig } from "@/api";
 import {
   getChartConfigAdjustedToChartType,
@@ -7,6 +21,7 @@ import {
   getInitialConfig,
   getPossibleChartType,
 } from "@/charts";
+import { mapColorsToComponentValuesIris } from "@/configurator/components/ui-helpers";
 import {
   ConfiguratorStateConfiguringChart,
   ImputationType,
@@ -15,7 +30,6 @@ import {
   isMapConfig,
   isSegmentInConfig,
 } from "@/configurator/config-types";
-import { mapColorsToComponentValuesIris } from "@/configurator/components/ui-helpers";
 import {
   ChartConfig,
   ChartType,
@@ -38,19 +52,6 @@ import { DataCubeMetadata } from "@/graphql/types";
 import { createChartId } from "@/lib/create-chart-id";
 import { unreachableError } from "@/lib/unreachable";
 import { useLocale } from "@/locales/use-locale";
-import { current, produce } from "immer";
-import { get, mapValues, pickBy } from "lodash";
-import setWith from "lodash/setWith";
-import { useRouter } from "next/router";
-import {
-  createContext,
-  Dispatch,
-  ReactNode,
-  useContext,
-  useEffect,
-} from "react";
-import { Client, useClient } from "urql";
-import { Reducer, useImmerReducer } from "use-immer";
 
 export type ConfiguratorStateAction =
   | { type: "INITIALIZED"; value: ConfiguratorState }

--- a/app/configurator/interactive-filters/editor-time-brush.tsx
+++ b/app/configurator/interactive-filters/editor-time-brush.tsx
@@ -1,3 +1,8 @@
+import { Trans } from "@lingui/macro";
+import { Box, Typography } from "@mui/material";
+import { bisector, brushX, scaleTime, select, Selection } from "d3";
+import React, { useCallback, useEffect, useRef } from "react";
+
 import Flex from "@/components/flex";
 import { Label } from "@/components/form";
 import {
@@ -9,10 +14,6 @@ import { useConfiguratorState } from "@/configurator/configurator-state";
 import { updateInteractiveTimeFilter } from "@/configurator/interactive-filters/interactive-filters-config-state";
 import { useResizeObserver } from "@/lib/use-resize-observer";
 import { useTheme } from "@/themes";
-import { Trans } from "@lingui/macro";
-import { Box, Typography } from "@mui/material";
-import { bisector, brushX, scaleTime, select, Selection } from "d3";
-import React, { useCallback, useEffect, useRef } from "react";
 const HANDLE_HEIGHT = 20;
 const BRUSH_HEIGHT = 3;
 const MARGINS = {

--- a/app/configurator/interactive-filters/editor-time-interval-brush.tsx
+++ b/app/configurator/interactive-filters/editor-time-interval-brush.tsx
@@ -1,5 +1,6 @@
-import Flex from "@/components/flex";;
+
 import { Trans } from "@lingui/macro";
+import { Box, Typography } from "@mui/material";
 import {
   brushX,
   CountableTimeInterval,
@@ -8,11 +9,12 @@ import {
   Selection,
 } from "d3";
 import React, { useCallback, useEffect, useRef } from "react";
-import { Box, Typography } from "@mui/material";
+
+import Flex from "@/components/flex";
 import { Label } from "@/components/form";
+import { useFormatFullDateAuto } from "@/configurator/components/ui-helpers";
 import { useResizeObserver } from "@/lib/use-resize-observer";
 import { useTheme } from "@/themes";
-import { useFormatFullDateAuto } from "@/configurator/components/ui-helpers";
 
 const HANDLE_HEIGHT = 20;
 const BRUSH_HEIGHT = 3;

--- a/app/configurator/interactive-filters/interactive-filters-config-actions.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-config-actions.tsx
@@ -1,14 +1,15 @@
 import get from "lodash/get";
 import { ChangeEvent, useCallback } from "react";
-import { DimensionMetaDataFragment } from "@/graphql/query-hooks";
+
 import { ConfiguratorStateDescribingChart } from "@/configurator/config-types";
 import { useConfiguratorState } from "@/configurator/configurator-state";
-import { InteractiveFilterType } from "@/configurator/interactive-filters/interactive-filters-configurator";
 import {
   toggleInteractiveDataFilter,
   toggleInteractiveFilter,
   toggleInteractiveTimeFilter,
 } from "@/configurator/interactive-filters/interactive-filters-config-state";
+import { InteractiveFilterType } from "@/configurator/interactive-filters/interactive-filters-configurator";
+import { DimensionMetaDataFragment } from "@/graphql/query-hooks";
 
 export const useInteractiveFiltersToggle = ({
   path,

--- a/app/configurator/interactive-filters/interactive-filters-config-options.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-config-options.tsx
@@ -1,22 +1,20 @@
 import { t, Trans } from "@lingui/macro";
+import { Box } from "@mui/material";
 import { extent } from "d3";
 import React, { ChangeEvent, useCallback, useEffect, useRef } from "react";
-import { Box } from "@mui/material";
+
 import { getFieldComponentIri, getFieldComponentIris } from "@/charts";
 import { Checkbox } from "@/components/form";
 import { Loading } from "@/components/hint";
-import {
-  DimensionMetaDataFragment,
-  TimeUnit,
-  useDataCubeMetadataWithComponentValuesQuery,
-} from "@/graphql/query-hooks";
-import { useLocale } from "@/locales/use-locale";
 import {
   ControlSection,
   ControlSectionContent,
   SectionTitle,
 } from "@/configurator/components/chart-controls/section";
-import { parseDate, useFormatFullDateAuto } from "@/configurator/components/ui-helpers";
+import {
+  parseDate,
+  useFormatFullDateAuto,
+} from "@/configurator/components/ui-helpers";
 import { ConfiguratorStateDescribingChart } from "@/configurator/config-types";
 import { useConfiguratorState } from "@/configurator/configurator-state";
 import { EditorBrush } from "@/configurator/interactive-filters/editor-time-brush";
@@ -27,6 +25,12 @@ import {
 } from "@/configurator/interactive-filters/interactive-filters-config-actions";
 import { toggleInteractiveFilterDataDimension } from "@/configurator/interactive-filters/interactive-filters-config-state";
 import { InteractiveFilterType } from "@/configurator/interactive-filters/interactive-filters-configurator";
+import {
+  DimensionMetaDataFragment,
+  TimeUnit,
+  useDataCubeMetadataWithComponentValuesQuery,
+} from "@/graphql/query-hooks";
+import { useLocale } from "@/locales/use-locale";
 
 export const InteractiveFiltersOptions = ({
   state,

--- a/app/configurator/interactive-filters/interactive-filters-config-state.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-config-state.tsx
@@ -1,7 +1,8 @@
 import produce from "immer";
-import { DimensionMetaDataFragment } from "@/graphql/query-hooks";
+
 import { InteractiveFiltersConfig } from "@/configurator/config-types";
 import { InteractiveFilterType } from "@/configurator/interactive-filters/interactive-filters-configurator";
+import { DimensionMetaDataFragment } from "@/graphql/query-hooks";
 
 export const toggleInteractiveFilter = produce(
   (

--- a/app/configurator/interactive-filters/interactive-filters-configurator.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-configurator.tsx
@@ -1,11 +1,10 @@
 import { Trans } from "@lingui/macro";
 import get from "lodash/get";
 import { ReactNode, useCallback } from "react";
+
 import { getFieldComponentIri } from "@/charts";
 import { chartConfigOptionsUISpec } from "@/charts/chart-config-ui-options";
 import { Loading } from "@/components/hint";
-import { useDataCubeMetadataWithComponentValuesQuery } from "@/graphql/query-hooks";
-import { useLocale } from "@/locales/use-locale";
 import { OnOffControlTab } from "@/configurator/components/chart-controls/control-tab";
 import {
   ControlSection,
@@ -14,6 +13,8 @@ import {
 } from "@/configurator/components/chart-controls/section";
 import { ConfiguratorStateDescribingChart } from "@/configurator/config-types";
 import { useConfiguratorState } from "@/configurator/configurator-state";
+import { useDataCubeMetadataWithComponentValuesQuery } from "@/graphql/query-hooks";
+import { useLocale } from "@/locales/use-locale";
 
 export type InteractiveFilterType = "legend" | "time" | "dataFilters";
 

--- a/app/configurator/map/map-chart-options.tsx
+++ b/app/configurator/map/map-chart-options.tsx
@@ -1,17 +1,11 @@
-import Flex from "@/components/flex";;
+
 import { t, Trans } from "@lingui/macro";
-import React, { memo, useMemo } from "react";
 import { Box } from "@mui/material";
-import { ConfiguratorStateConfiguringChart, MapConfig } from "@/configurator";
+import React, { memo, useMemo } from "react";
+
+import Flex from "@/components/flex";
 import { FieldSetLegend } from "@/components/form";
-import {
-  GeoFeature,
-  getGeoDimensions,
-  getGeoShapesDimensions,
-} from "@/domain/data";
-import { useGeoShapesByDimensionIriQuery } from "@/graphql/query-hooks";
-import { DataCubeMetadata } from "@/graphql/types";
-import { useLocale } from "@/src";
+import { ConfiguratorStateConfiguringChart, MapConfig } from "@/configurator";
 import { ColorRampField } from "@/configurator/components/chart-controls/color-ramp";
 import {
   ControlSection,
@@ -25,6 +19,14 @@ import {
   ColorPickerField,
 } from "@/configurator/components/field";
 import { DimensionValuesMultiFilter } from "@/configurator/components/filters";
+import {
+  GeoFeature,
+  getGeoDimensions,
+  getGeoShapesDimensions,
+} from "@/domain/data";
+import { useGeoShapesByDimensionIriQuery } from "@/graphql/query-hooks";
+import { DataCubeMetadata } from "@/graphql/types";
+import { useLocale } from "@/src";
 
 export const MapColumnOptions = ({
   state,

--- a/app/configurator/table/table-chart-configurator.tsx
+++ b/app/configurator/table/table-chart-configurator.tsx
@@ -5,10 +5,9 @@ import {
   OnDragEndResponder,
   OnDragStartResponder,
 } from "react-beautiful-dnd";
-import { ConfiguratorStateConfiguringChart } from "@/configurator";
+
 import { Loading } from "@/components/hint";
-import { useDataCubeMetadataWithComponentValuesQuery } from "@/graphql/query-hooks";
-import { useLocale } from "@/locales/use-locale";
+import { ConfiguratorStateConfiguringChart } from "@/configurator";
 import { TabDropZone } from "@/configurator/components/chart-controls/drag-and-drop-tab";
 import {
   ControlSection,
@@ -20,6 +19,8 @@ import { useOrderedTableColumns } from "@/configurator/components/ui-helpers";
 import { TableFields } from "@/configurator/config-types";
 import { useConfiguratorState } from "@/configurator/configurator-state";
 import { moveFields } from "@/configurator/table/table-config-state";
+import { useDataCubeMetadataWithComponentValuesQuery } from "@/graphql/query-hooks";
+import { useLocale } from "@/locales/use-locale";
 
 export const ChartConfiguratorTable = ({
   state,

--- a/app/configurator/table/table-chart-options.tsx
+++ b/app/configurator/table/table-chart-options.tsx
@@ -1,11 +1,9 @@
 import { t, Trans } from "@lingui/macro";
+import { Stack } from "@mui/material";
 import get from "lodash/get";
 import React, { ChangeEvent, useCallback, useEffect, useRef } from "react";
+
 import { Checkbox } from "@/components/form";
-import { Stack } from '@mui/material'
-import { canDimensionBeMultiFiltered } from "@/domain/data";
-import { DimensionMetaDataFragment } from "@/graphql/query-hooks";
-import { DataCubeMetadata } from "@/graphql/types";
 import { ColorPalette } from "@/configurator/components/chart-controls/color-palette";
 import {
   ControlSection,
@@ -38,7 +36,13 @@ import {
 } from "@/configurator/config-types";
 import { useConfiguratorState } from "@/configurator/configurator-state";
 import { TableSortingOptions } from "@/configurator/table/table-chart-sorting-options";
-import { updateIsGroup, updateIsHidden } from "@/configurator/table/table-config-state";
+import {
+  updateIsGroup,
+  updateIsHidden,
+} from "@/configurator/table/table-config-state";
+import { canDimensionBeMultiFiltered } from "@/domain/data";
+import { DimensionMetaDataFragment } from "@/graphql/query-hooks";
+import { DataCubeMetadata } from "@/graphql/types";
 
 const useTableColumnGroupHiddenField = ({
   path,

--- a/app/configurator/table/table-chart-sorting-options.tsx
+++ b/app/configurator/table/table-chart-sorting-options.tsx
@@ -1,5 +1,5 @@
-import Flex from "@/components/flex";
 import { t, Trans } from "@lingui/macro";
+import { Box, Button, SelectChangeEvent, Typography } from "@mui/material";
 import React, { useCallback } from "react";
 import {
   DragDropContext,
@@ -7,11 +7,10 @@ import {
   Droppable,
   OnDragEndResponder,
 } from "react-beautiful-dnd";
-import { Box, Button, SelectChangeEvent, Typography } from "@mui/material";
-import VisuallyHidden from "@/components/visually-hidden";
+
+import Flex from "@/components/flex";
 import { Radio, Select } from "@/components/form";
-import { DataCubeMetadata } from "@/graphql/types";
-import { Icon } from "@/icons";
+import VisuallyHidden from "@/components/visually-hidden";
 import {
   ControlSection,
   SectionTitle,
@@ -33,6 +32,8 @@ import {
   moveSortingOptions,
   removeSortingOption,
 } from "@/configurator/table/table-config-state";
+import { DataCubeMetadata } from "@/graphql/types";
+import { Icon } from "@/icons";
 
 const TableSortingOptionItem = ({
   componentIri,

--- a/app/configurator/table/table-config-state.ts
+++ b/app/configurator/table/table-config-state.ts
@@ -1,5 +1,6 @@
 import produce from "immer";
 import { DraggableLocation } from "react-beautiful-dnd";
+
 import { getOrderedTableColumns } from "../components/ui-helpers";
 import { SortingOrder, TableConfig, TableSortingOption } from "../config-types";
 

--- a/app/configurator/use-filter-changes.spec.tsx
+++ b/app/configurator/use-filter-changes.spec.tsx
@@ -1,5 +1,6 @@
 import { renderHook } from "@testing-library/react-hooks";
 import { merge } from "lodash";
+
 import { ChartConfig } from "@/configurator/config-types";
 import useFilterChanges from "@/configurator/use-filter-changes";
 

--- a/app/configurator/use-filter-changes.ts
+++ b/app/configurator/use-filter-changes.ts
@@ -1,6 +1,8 @@
 import { isEqual } from "lodash";
-import { ChartConfig, FilterValue } from ".";
+
 import useChanges from "../utils/use-changes";
+
+import { ChartConfig, FilterValue } from ".";
 
 const isEqualFilter = (fa?: FilterValue, fb?: FilterValue) => {
   if (fa?.type === "single" && fb?.type === "single") {

--- a/app/db/config.ts
+++ b/app/db/config.ts
@@ -1,5 +1,6 @@
-import { pool } from "./pg-pool";
 import { createChartId } from "../lib/create-chart-id";
+
+import { pool } from "./pg-pool";
 
 /**
  * Store data in the DB.

--- a/app/db/pg-pool.ts
+++ b/app/db/pg-pool.ts
@@ -1,4 +1,5 @@
 import { Pool } from "pg";
+
 import { DATABASE_URL } from "../domain/env";
 
 export const pool = new Pool({

--- a/app/docs/annotations.docs.tsx
+++ b/app/docs/annotations.docs.tsx
@@ -1,13 +1,16 @@
-import Flex from "@/components/flex";
+import { Box } from "@mui/material";
 import { markdown, ReactSpecimen } from "catalog";
 import { ReactNode } from "react";
-import { Box } from "@mui/material";
+
+import { ColumnChart } from "@/charts/column/columns-state";
+import { RulerContent } from "@/charts/shared/interaction/ruler";
 import { TooltipBox } from "@/charts/shared/interaction/tooltip-box";
 import {
   TooltipMultiple,
   TooltipSingle,
 } from "@/charts/shared/interaction/tooltip-content";
-import { ColumnChart } from "@/charts/column/columns-state";
+import { InteractiveFiltersProvider } from "@/charts/shared/use-interactive-filters";
+import Flex from "@/components/flex";
 import {
   fields,
   margins,
@@ -15,8 +18,6 @@ import {
   dimensions,
   observations,
 } from "@/docs/fixtures";
-import { RulerContent } from "@/charts/shared/interaction/ruler";
-import { InteractiveFiltersProvider } from "@/charts/shared/use-interactive-filters";
 
 export default () => markdown`
 

--- a/app/docs/button.docs.tsx
+++ b/app/docs/button.docs.tsx
@@ -1,8 +1,9 @@
 import { Button } from "@mui/material";
 import { markdown, ReactSpecimen } from "catalog";
+
 import { Icon } from "@/icons";
-import SvgIcChevronRight from "@/icons/components/IcChevronRight";
 import SvgIcChevronLeft from "@/icons/components/IcChevronLeft";
+import SvgIcChevronRight from "@/icons/components/IcChevronRight";
 
 export default () => markdown`
 > Buttons are used to trigger an event after a user interaction.

--- a/app/docs/chart-config.tsx
+++ b/app/docs/chart-config.tsx
@@ -1,6 +1,6 @@
 import { ImageSpecimen, markdown, TableSpecimen } from "catalog";
 
-const Doc =  () => markdown`
+const Doc = () => markdown`
 
 ## Content
 1. [Chart Configuration Interface](#1-chart-configuration-interface)

--- a/app/docs/color-ramp.docs.tsx
+++ b/app/docs/color-ramp.docs.tsx
@@ -1,6 +1,7 @@
+import { Box } from "@mui/material";
 import { markdown } from "catalog";
 import { interpolateBrBG, interpolateOranges } from "d3";
-import { Box } from "@mui/material";
+
 import { ColorRamp } from "@/configurator/components/chart-controls/color-ramp";
 
 export default () =>

--- a/app/docs/columns.docs.tsx
+++ b/app/docs/columns.docs.tsx
@@ -1,5 +1,6 @@
 import { markdown, ReactSpecimen } from "catalog";
 import * as React from "react";
+
 import { Columns, ErrorWhiskers } from "@/charts/column/columns-simple";
 import { ColumnChart } from "@/charts/column/columns-state";
 import { AxisHeightLinear } from "@/charts/shared/axis-height-linear";

--- a/app/docs/components.tsx
+++ b/app/docs/components.tsx
@@ -1,6 +1,6 @@
 import { markdown } from "catalog";
 
-const Doc =  () => markdown`
+const Doc = () => markdown`
 > The components used in the User Interface are built upon [rebass](https://rebassjs.org/), a library of React primitive UI components.
 
 > All styles are defined in a \`theme\` file [that can be customized to a specific brand](/theming).
@@ -18,4 +18,4 @@ import { Button } from "@mui/material"
 ~~~
 `;
 
-export default Doc
+export default Doc;

--- a/app/docs/controls.docs.tsx
+++ b/app/docs/controls.docs.tsx
@@ -1,6 +1,7 @@
+import { Box } from "@mui/material";
 import { markdown, ReactSpecimen } from "catalog";
 import { useState } from "react";
-import { Box } from "@mui/material";
+
 import { Checkbox, Input, Radio, Select } from "@/components/form";
 import {
   ColorPicker,

--- a/app/docs/data-table.docs.tsx
+++ b/app/docs/data-table.docs.tsx
@@ -1,15 +1,16 @@
 import { markdown, ReactSpecimen } from "catalog";
 import * as React from "react";
+
 import { ChartContainer } from "@/charts/shared/containers";
 import { Table } from "@/charts/table/table";
 import { TableChart } from "@/charts/table/table-state";
-import { DimensionMetaDataFragment } from "@/graphql/query-hooks";
 import {
   tableConfig,
   tableDimensions,
   tableMeasures,
   tableObservations,
 } from "@/docs/fixtures";
+import { DimensionMetaDataFragment } from "@/graphql/query-hooks";
 
 export const Docs = () => markdown`
 

--- a/app/docs/dataset-browse.docs.tsx
+++ b/app/docs/dataset-browse.docs.tsx
@@ -1,10 +1,11 @@
 /* eslint-disable import/no-anonymous-default-export */
 import { Box } from "@mui/material";
 import { markdown, ReactSpecimen } from "catalog";
+
 import { ConfiguratorStateProvider } from "@/configurator";
 import { DatasetResult } from "@/configurator/components/dataset-browse";
-import { DataCubePublicationStatus } from "@/graphql/query-hooks";
 import { states } from "@/docs/fixtures";
+import { DataCubePublicationStatus } from "@/graphql/query-hooks";
 
 export default () => markdown`
 

--- a/app/docs/footer.docs.tsx
+++ b/app/docs/footer.docs.tsx
@@ -1,4 +1,5 @@
 import { markdown, ReactSpecimen } from "catalog";
+
 import { Footer } from "@/components/footer";
 
 export default () => markdown`

--- a/app/docs/form.docs.tsx
+++ b/app/docs/form.docs.tsx
@@ -3,6 +3,7 @@ import { DatePicker, PickersDay } from "@mui/lab";
 import { TextField } from "@mui/material";
 import { markdown, ReactSpecimen } from "catalog";
 import React, { useState } from "react";
+
 import {
   Radio,
   Checkbox,

--- a/app/docs/header.docs.tsx
+++ b/app/docs/header.docs.tsx
@@ -1,4 +1,5 @@
 import { markdown, ReactSpecimen } from "catalog";
+
 import { Logo } from "@/components/header";
 
 export default () => markdown`

--- a/app/docs/hint.docs.tsx
+++ b/app/docs/hint.docs.tsx
@@ -1,3 +1,6 @@
+import { Stack } from "@mui/material";
+import { markdown, ReactSpecimen } from "catalog";
+
 import {
   Loading,
   Error,
@@ -7,8 +10,6 @@ import {
   LoadingGeoDimensionsError,
   LoadingDataError,
 } from "@/components/hint";
-import { markdown, ReactSpecimen } from "catalog";
-import { Stack } from '@mui/material'
 
 export default () => markdown`
 

--- a/app/docs/homepage.docs.tsx
+++ b/app/docs/homepage.docs.tsx
@@ -1,5 +1,6 @@
 import { Box } from "@mui/material";
 import { markdown, ReactSpecimen } from "catalog";
+
 import { Contribute, Examples, Intro, Tutorial } from "@/homepage";
 
 export default () => markdown`

--- a/app/docs/icons.docs.tsx
+++ b/app/docs/icons.docs.tsx
@@ -1,4 +1,5 @@
 import { markdown, TableSpecimen } from "catalog";
+
 import { Icon, Icons, IconName } from "@/icons";
 
 export default () => markdown`

--- a/app/docs/lines.docs.tsx
+++ b/app/docs/lines.docs.tsx
@@ -1,5 +1,6 @@
 import { markdown, ReactSpecimen } from "catalog";
 import * as React from "react";
+
 import { Lines } from "@/charts/line/lines";
 import { LineChart } from "@/charts/line/lines-state";
 import { AxisHeightLinear } from "@/charts/shared/axis-height-linear";

--- a/app/docs/mockups.tsx
+++ b/app/docs/mockups.tsx
@@ -43,8 +43,7 @@ const chartBuilderMockups = [
   },
   {
     group: "Customize Chart",
-    src:
-      "static/docs/design/mockups/1.4.3_l_chart-maker_step-3.3_filter-interactive.png",
+    src: "static/docs/design/mockups/1.4.3_l_chart-maker_step-3.3_filter-interactive.png",
   },
   {
     group: "Annotate Chart",
@@ -79,7 +78,7 @@ const chartBuilderMockups = [
   return all;
 }, {} as Record<string, { group: string; src: string }[]>);
 
-const Doc =  () =>
+const Doc = () =>
   markdown`
 > The design mockups illustrate an exemplary user flow through the _Visualization Tool_.
 
@@ -184,4 +183,4 @@ description: "[Open full-size image](./${mockup.src})"
   .join("\n")}
   `;
 
-export default Doc
+export default Doc;

--- a/app/docs/publish-actions.docs.tsx
+++ b/app/docs/publish-actions.docs.tsx
@@ -1,4 +1,5 @@
 import { markdown, ReactSpecimen } from "catalog";
+
 import { PublishActions } from "@/components/publish-actions";
 
 export default () => markdown`

--- a/app/docs/scatterplot.docs.tsx
+++ b/app/docs/scatterplot.docs.tsx
@@ -1,5 +1,6 @@
 import { markdown, ReactSpecimen } from "catalog";
 import * as React from "react";
+
 import { Scatterplot } from "@/charts/scatterplot/scatterplot-simple";
 import { ScatterplotChart } from "@/charts/scatterplot/scatterplot-state";
 import {
@@ -12,9 +13,7 @@ import {
 } from "@/charts/shared/axis-width-linear";
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
-import {
-  InteractiveLegendColor,
-} from "@/charts/shared/legend-color";
+import { InteractiveLegendColor } from "@/charts/shared/legend-color";
 import { InteractionVoronoi } from "@/charts/shared/overlay-voronoi";
 import { InteractiveFiltersProvider } from "@/charts/shared/use-interactive-filters";
 import { DimensionMetaDataFragment } from "@/graphql/query-hooks";
@@ -53,9 +52,7 @@ ${(
           </ChartSvg>
           <Tooltip type="single" />
         </ChartContainer>
-        {scatterplotFields.segment && (
-          <InteractiveLegendColor />
-        )}
+        {scatterplotFields.segment && <InteractiveLegendColor />}
       </ScatterplotChart>
     </InteractiveFiltersProvider>
   </ReactSpecimen>

--- a/app/docs/steps.docs.tsx
+++ b/app/docs/steps.docs.tsx
@@ -1,3 +1,5 @@
+import { markdown, ReactSpecimen } from "catalog";
+
 import { HeaderBorder, HeaderProgressProvider } from "@/components/header";
 import {
   ConfiguratorStateConfiguringChart,
@@ -5,7 +7,6 @@ import {
 } from "@/configurator";
 import { StepperDumb } from "@/configurator/components/stepper";
 import { DataCubeMetadataWithComponentValuesQuery } from "@/graphql/query-hooks";
-import { markdown, ReactSpecimen } from "catalog";
 
 const mockData = {
   __typename: "Query",

--- a/app/docs/table.docs.tsx
+++ b/app/docs/table.docs.tsx
@@ -1,5 +1,6 @@
 import { Paper } from "@mui/material";
 import { markdown, ReactSpecimen } from "catalog";
+
 import { PreviewTable } from "@/configurator/components/datatable";
 import observations from "@/test/__fixtures/api/bathingsite-observations.json";
 

--- a/app/docs/tags.docs.tsx
+++ b/app/docs/tags.docs.tsx
@@ -1,5 +1,6 @@
+import { Stack } from "@mui/material";
 import { markdown, ReactSpecimen } from "catalog";
-import { Stack } from '@mui/material'
+
 import Tag from "@/configurator/components/Tag";
 
 export default () => {

--- a/app/docs/text.docs.tsx
+++ b/app/docs/text.docs.tsx
@@ -1,5 +1,6 @@
-import { markdown, TableSpecimen } from "catalog";
 import { Typography } from "@mui/material";
+import { markdown, TableSpecimen } from "catalog";
+
 import { useTheme } from "@/themes/index";
 const pixelSize = 16;
 

--- a/app/domain/data.ts
+++ b/app/domain/data.ts
@@ -1,4 +1,5 @@
 import { Literal, NamedNode } from "rdf-js";
+
 import { DimensionType } from "../charts/chart-config-ui-options";
 import {
   DimensionMetaDataFragment,

--- a/app/embed-templates/embed-aem-ext.tsx
+++ b/app/embed-templates/embed-aem-ext.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+
 import { PUBLIC_URL } from "@/domain/env";
 
 type Props = {

--- a/app/graphql/context.tsx
+++ b/app/graphql/context.tsx
@@ -1,9 +1,10 @@
 import { ReactNode, useCallback } from "react";
 import { createClient, defaultExchanges, Provider } from "urql";
+
 import { GRAPHQL_ENDPOINT } from "@/domain/env";
-import { useLocale } from "@/src";
 // @ts-ignore - dynamic package import based on NODE_ENV
 import { devtoolsExchange } from "@/graphql/devtools";
+import { useLocale } from "@/src";
 
 const client = createClient({
   url: GRAPHQL_ENDPOINT,

--- a/app/graphql/resolvers.spec.ts
+++ b/app/graphql/resolvers.spec.ts
@@ -1,10 +1,13 @@
-import { Query } from "./resolvers";
+import { GraphQLResolveInfo } from "graphql";
+
 import {
   getCubeObservations as getCubeObservations_,
   createSource as createSource_,
 } from "../rdf/queries";
 import { unversionObservation as unversionObservation_ } from "../rdf/query-dimension-values";
-import { GraphQLResolveInfo } from "graphql";
+
+import { Query } from "./resolvers";
+
 
 const getCubeObservations = getCubeObservations_ as unknown as jest.Mock<
   typeof getCubeObservations_

--- a/app/graphql/resolvers.ts
+++ b/app/graphql/resolvers.ts
@@ -1,8 +1,10 @@
 import { ascending, descending } from "d3";
 import DataLoader from "dataloader";
 import { GraphQLJSONObject } from "graphql-type-json";
+import { keyBy } from "lodash";
 import { topology } from "topojson-server";
 import { parse as parseWKT } from "wellknown";
+
 import { Filters } from "../configurator";
 import {
   DimensionValue,
@@ -10,8 +12,6 @@ import {
   GeoProperties,
   GeoShapes,
 } from "../domain/data";
-
-import { keyBy } from "lodash";
 import { defaultLocale, parseLocaleString } from "../locales/locales";
 import { Loaders } from "../pages/api/graphql";
 import {
@@ -33,7 +33,13 @@ import {
 } from "../rdf/query-cube-metadata";
 import { unversionObservation } from "../rdf/query-dimension-values";
 import { RawGeoShape } from "../rdf/query-geo-shapes";
+import cachedWithTTL from "../utils/cached-with-ttl";
+import {
+  makeCubeIndex as makeCubeIndexRaw,
+  searchCubes,
+} from "../utils/search";
 import truthy from "../utils/truthy";
+
 import { ObservationFilter } from "./query-hooks";
 import {
   DataCubeResolvers,
@@ -42,11 +48,6 @@ import {
   Resolvers,
 } from "./resolver-types";
 import { ResolvedDataCube, ResolvedDimension } from "./shared-types";
-import cachedWithTTL from "../utils/cached-with-ttl";
-import {
-  makeCubeIndex as makeCubeIndexRaw,
-  searchCubes,
-} from "../utils/search";
 
 const CUBES_CACHE_TTL = 60 * 1000;
 

--- a/app/graphql/shared-types.ts
+++ b/app/graphql/shared-types.ts
@@ -1,6 +1,8 @@
 import { Cube, CubeDimension } from "rdf-cube-view-query";
 import { Literal, NamedNode } from "rdf-js";
+
 import { Observation } from "../domain/data";
+
 import { RelatedDimension } from "./query-hooks";
 import {
   DataCubeOrganization,

--- a/app/homepage/contribute.tsx
+++ b/app/homepage/contribute.tsx
@@ -1,6 +1,7 @@
-import Flex from "@/components/flex";
 import { Box, Button, Link, Typography } from "@mui/material";
 import * as React from "react";
+
+import Flex from "@/components/flex";
 
 export const Contribute = ({
   headline,

--- a/app/homepage/examples.tsx
+++ b/app/homepage/examples.tsx
@@ -1,7 +1,8 @@
-import Flex from "@/components/flex";
-import { ReactNode } from "react";
 import { Box, Typography } from "@mui/material";
+import { ReactNode } from "react";
+
 import { ChartPublished } from "@/components/chart-published";
+import Flex from "@/components/flex";
 import { HomepageSection } from "@/homepage/generic";
 
 export const Examples = ({

--- a/app/homepage/intro.tsx
+++ b/app/homepage/intro.tsx
@@ -1,6 +1,7 @@
+import { Box, Button, Typography } from "@mui/material";
 import NextLink from "next/link";
 import React, { ReactNode } from "react";
-import { Box, Button, Typography } from "@mui/material";
+
 import { HintRed } from "@/components/hint";
 
 export const Intro = ({

--- a/app/homepage/tutorial.tsx
+++ b/app/homepage/tutorial.tsx
@@ -1,11 +1,12 @@
-import Flex from "@/components/flex";
 import { Box, Typography } from "@mui/material";
 import { ReactNode } from "react";
-import { Icon } from "@/icons";
+
+import Flex from "@/components/flex";
 import { HomepageSection } from "@/homepage/generic";
 import { Step1 } from "@/homepage/step1";
 import { Step2 } from "@/homepage/step2";
 import { Step3 } from "@/homepage/step3";
+import { Icon } from "@/icons";
 
 export const Tutorial = ({
   headline,
@@ -19,9 +20,7 @@ export const Tutorial = ({
   step3: string;
 }) => {
   return (
-    <Box
-      sx={{ maxWidth: 1024, m: "0 auto", color: "grey.800", px: 4, pb: 7 }}
-    >
+    <Box sx={{ maxWidth: 1024, m: "0 auto", color: "grey.800", px: 4, pb: 7 }}>
       <HomepageSection>{headline}</HomepageSection>
       <Flex
         sx={{

--- a/app/icons/components/IcChevronLeft.tsx
+++ b/app/icons/components/IcChevronLeft.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
 import { Box, BoxProps } from "@mui/material";
+import * as React from "react";
 
 function SvgIcChevronLeft(
   props: React.SVGProps<SVGSVGElement> & { sx?: BoxProps["sx"] }

--- a/app/icons/components/Icons/24dp/index.tsx
+++ b/app/icons/components/Icons/24dp/index.tsx
@@ -1,8 +1,7 @@
 import { default as ChartMap } from "@/icons/components/Icons/24dp/IcChartMap";
-  
+
 export const Icons = {
   chartMap: ChartMap,
 };
 
 export type IconName = keyof typeof Icons;
-  

--- a/app/icons/index.tsx
+++ b/app/icons/index.tsx
@@ -1,4 +1,5 @@
 import { ComponentProps } from "react";
+
 import { ChartType } from "@/configurator";
 import { IconName, Icons } from "@/icons/components";
 

--- a/app/lib/use-resize-observer.ts
+++ b/app/lib/use-resize-observer.ts
@@ -1,5 +1,5 @@
-import { useEffect, useState, useRef } from "react";
 import { ResizeObserver } from "@juggle/resize-observer";
+import { useEffect, useState, useRef } from "react";
 
 export const useResizeObserver = <T extends Element>() => {
   const roRef = useRef<ResizeObserver>();

--- a/app/locales/locales.ts
+++ b/app/locales/locales.ts
@@ -1,5 +1,6 @@
 // If translations get too big, we should load them dynamically. But for now it's fine.
 // Use the same number format in each language
+import { i18n } from "@lingui/core";
 import { formatLocale, FormatLocaleDefinition, FormatLocaleObject } from "d3";
 import numberFormatCh from "d3-format/locale/de-CH.json";
 import {
@@ -11,17 +12,17 @@ import timeFormatDe from "d3-time-format/locale/de-CH.json";
 import timeFormatEn from "d3-time-format/locale/en-GB.json";
 import timeFormatFr from "d3-time-format/locale/fr-FR.json";
 import timeFormatIt from "d3-time-format/locale/it-IT.json";
-import { messages as catalogDe } from "./de/messages";
-import { messages as catalogEn } from "./en/messages";
-import { messages as catalogFr } from "./fr/messages";
-import { messages as catalogIt } from "./it/messages";
-import { i18n } from "@lingui/core";
 import {
   de as pluralsDe,
   fr as pluralsFr,
   it as pluralsIt,
   en as pluralsEn,
 } from "make-plural/plurals";
+
+import { messages as catalogDe } from "./de/messages";
+import { messages as catalogEn } from "./en/messages";
+import { messages as catalogFr } from "./fr/messages";
+import { messages as catalogIt } from "./it/messages";
 
 // Keep up-to-date with actual locales!
 export const defaultLocale = "de";

--- a/app/locales/use-locale.ts
+++ b/app/locales/use-locale.ts
@@ -1,5 +1,6 @@
-import { defaultLocale, Locale } from "./locales";
 import { createContext, useContext } from "react";
+
+import { defaultLocale, Locale } from "./locales";
 
 const LocaleContext = createContext<Locale>(defaultLocale);
 

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -1,10 +1,12 @@
-const { IgnorePlugin } = require("webpack");
-const pkg = require("../package.json");
-const withMDX = require("@next/mdx")();
+
 const withBundleAnalyzer = require("@next/bundle-analyzer")({
   enabled: process.env.ANALYZE === "true",
 });
+const withMDX = require("@next/mdx")();
 const withPreconstruct = require("@preconstruct/next");
+const { IgnorePlugin } = require("webpack");
+
+const pkg = require("../package.json");
 
 const { locales, defaultLocale } = require("./locales/locales.json");
 

--- a/app/pages/404.tsx
+++ b/app/pages/404.tsx
@@ -1,4 +1,5 @@
 import { Box, Typography } from "@mui/material";
+
 import {
   Actions,
   ErrorPageHint,

--- a/app/pages/500.tsx
+++ b/app/pages/500.tsx
@@ -1,4 +1,5 @@
 import { Box, Typography } from "@mui/material";
+
 import {
   Actions,
   ErrorPageHint,

--- a/app/pages/[slug].tsx
+++ b/app/pages/[slug].tsx
@@ -1,4 +1,5 @@
 import { GetStaticPaths, GetStaticProps } from "next";
+
 import { staticPages } from "@/static-pages";
 
 /**

--- a/app/pages/__test/[chartId].tsx
+++ b/app/pages/__test/[chartId].tsx
@@ -1,4 +1,5 @@
 import { NextPage, GetStaticProps, GetStaticPaths } from "next";
+
 import { ChartPublished } from "@/components/chart-published";
 import { Config } from "@/configurator";
 import { loadFixtureConfigIds, loadFixtureConfig } from "@/test/utils";

--- a/app/pages/__test/index.tsx
+++ b/app/pages/__test/index.tsx
@@ -1,5 +1,6 @@
 import { GetStaticProps, NextPage } from "next";
 import Link from "next/link";
+
 import { loadFixtureConfigIds } from "@/test/utils";
 
 type PageProps = {

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -1,12 +1,12 @@
 import { I18nProvider } from "@lingui/react";
-
 // Used for color-picker component. Must include here because of next.js constraints about global CSS imports
 import "core-js/features/array/flat-map";
+import { CssBaseline, ThemeProvider } from "@mui/material";
 import { AppProps } from "next/app";
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { useEffect } from "react";
-import { CssBaseline, ThemeProvider } from "@mui/material";
+
 import { ContentMDXProvider } from "@/components/content-mdx-provider";
 import { PUBLIC_URL } from "@/domain/env";
 import { GraphqlProvider } from "@/graphql/context";

--- a/app/pages/_charts.tsx
+++ b/app/pages/_charts.tsx
@@ -1,9 +1,10 @@
+import { Box, Link } from "@mui/material";
 import { NextPage } from "next";
 import NextLink from "next/link";
-import { Box, Link } from "@mui/material";
-import Flex from "@/components/flex";
+
 import { ChartPanel } from "@/components/chart-panel";
 import { ChartPublished } from "@/components/chart-published";
+import Flex from "@/components/flex";
 import { ContentLayout } from "@/components/layout";
 import { Config } from "@/configurator";
 import { getAllConfigs } from "@/db/config";

--- a/app/pages/_document.tsx
+++ b/app/pages/_document.tsx
@@ -1,4 +1,5 @@
 import Document, { Head, Html, Main, NextScript } from "next/document";
+
 import { GA_TRACKING_ID } from "@/domain/env";
 
 class MyDocument extends Document {

--- a/app/pages/api/config.ts
+++ b/app/pages/api/config.ts
@@ -1,4 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
+
 import { createConfig } from "../../db/config";
 
 /**

--- a/app/pages/api/config/[key].ts
+++ b/app/pages/api/config/[key].ts
@@ -1,4 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
+
 import { getConfig } from "../../../db/config";
 
 /**

--- a/app/pages/api/config/all.ts
+++ b/app/pages/api/config/all.ts
@@ -1,4 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
+
 import { getAllConfigs } from "../../../db/config";
 
 /**

--- a/app/pages/api/cube-view-test.ts
+++ b/app/pages/api/cube-view-test.ts
@@ -1,4 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
+
 import { getCubeDimensions, getCubes } from "../../rdf/queries";
 
 /**

--- a/app/pages/api/download.ts
+++ b/app/pages/api/download.ts
@@ -1,5 +1,6 @@
 import { Workbook } from "exceljs";
 import { NextApiRequest, NextApiResponse } from "next";
+
 import { FileFormat } from "../../components/data-download";
 import { Observation } from "../../domain/data";
 

--- a/app/pages/api/embed-aem-ext/[locale]/[chartId].ts
+++ b/app/pages/api/embed-aem-ext/[locale]/[chartId].ts
@@ -1,4 +1,5 @@
 import { NextApiRequest, NextApiResponse } from "next";
+
 import { renderEmbedMarkup } from "../../../../embed-templates/embed-aem-ext";
 import { parseLocaleString } from "../../../../locales/locales";
 

--- a/app/pages/api/graphql.ts
+++ b/app/pages/api/graphql.ts
@@ -3,6 +3,7 @@ import configureCors from "cors";
 import DataLoader from "dataloader";
 import "global-agent/bootstrap";
 import { NextApiRequest, NextApiResponse } from "next";
+
 import { resolvers } from "../../graphql/resolvers";
 import typeDefs from "../../graphql/schema.graphql";
 import { runMiddleware } from "../../lib/run-middleware";

--- a/app/pages/browse/[type]/[iri].tsx
+++ b/app/pages/browse/[type]/[iri].tsx
@@ -1,7 +1,8 @@
 import { GetServerSideProps } from "next";
+
+import { DatasetBrowser } from "@/browser";
 import { queryLatestPublishedCubeFromUnversionedIri } from "@/rdf/query-cube-metadata";
 import { defaultLocale } from "@/src";
-import { DatasetBrowser } from "@/browser";
 export default DatasetBrowser;
 /**
  * Heuristic to check if a dataset IRI is versioned.

--- a/app/pages/create/[chartId].tsx
+++ b/app/pages/create/[chartId].tsx
@@ -1,6 +1,7 @@
 import { GetServerSideProps, NextPage } from "next";
 import Head from "next/head";
 import * as React from "react";
+
 import { AppLayout } from "@/components/layout";
 import { Configurator, ConfiguratorStateProvider } from "@/configurator";
 

--- a/app/pages/docs/index.tsx
+++ b/app/pages/docs/index.tsx
@@ -17,9 +17,10 @@ import {
   TableSpecimen,
   TypeSpecimen,
 } from "catalog";
-import { useEffect, useMemo, useState } from "react";
-import { i18n, I18nProvider, parseLocaleString } from "@/src";
 import Slugger from "github-slugger";
+import { useEffect, useMemo, useState } from "react";
+
+import { i18n, I18nProvider, parseLocaleString } from "@/src";
 
 const slugger = new Slugger();
 

--- a/app/pages/embed/[chartId].tsx
+++ b/app/pages/embed/[chartId].tsx
@@ -1,9 +1,10 @@
 import "iframe-resizer/js/iframeResizer.contentWindow.js";
 import { GetServerSideProps } from "next";
 import ErrorPage from "next/error";
+
 import { ChartPublished } from "@/components/chart-published";
-import { getConfig } from "@/db/config";
 import { Config } from "@/configurator";
+import { getConfig } from "@/db/config";
 
 type PageProps =
   | {

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -1,4 +1,5 @@
 import { GetStaticProps } from "next";
+
 import { staticPages } from "@/static-pages";
 
 /**

--- a/app/pages/v/[chartId].tsx
+++ b/app/pages/v/[chartId].tsx
@@ -1,11 +1,3 @@
-import { ChartPanel } from "@/components/chart-panel";
-import { ChartPublished } from "@/components/chart-published";
-import { Success } from "@/components/hint";
-import { ContentLayout } from "@/components/layout";
-import { PublishActions } from "@/components/publish-actions";
-import { Config } from "@/configurator";
-import { getConfig } from "@/db/config";
-import { useLocale } from "@/locales/use-locale";
 import { Trans } from "@lingui/macro";
 import { Box, Button, Stack, Typography } from "@mui/material";
 import { GetServerSideProps } from "next";
@@ -14,6 +6,15 @@ import Head from "next/head";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
+
+import { ChartPanel } from "@/components/chart-panel";
+import { ChartPublished } from "@/components/chart-published";
+import { Success } from "@/components/hint";
+import { ContentLayout } from "@/components/layout";
+import { PublishActions } from "@/components/publish-actions";
+import { Config } from "@/configurator";
+import { getConfig } from "@/db/config";
+import { useLocale } from "@/locales/use-locale";
 
 type PageProps =
   | {

--- a/app/rdf/batch-load.ts
+++ b/app/rdf/batch-load.ts
@@ -2,6 +2,7 @@ import { SparqlQueryExecutable } from "@tpluscode/sparql-builder/lib";
 import { groups } from "d3";
 import { NamedNode, Term } from "rdf-js";
 import ParsingClient from "sparql-http-client/ParsingClient";
+
 import { sparqlClient } from "./sparql-client";
 
 const BATCH_SIZE = 500;

--- a/app/rdf/parse.ts
+++ b/app/rdf/parse.ts
@@ -12,10 +12,12 @@ import {
 } from "d3";
 import { Cube, CubeDimension } from "rdf-cube-view-query";
 import { NamedNode, Term } from "rdf-js";
+
 import { DataCubePublicationStatus, TimeUnit } from "../graphql/resolver-types";
 import { ResolvedDataCube, ResolvedDimension } from "../graphql/shared-types";
 import { locales } from "../locales/locales";
 import truthy from "../utils/truthy";
+
 import * as ns from "./namespace";
 
 export const getQueryLocales = (locale: string): string[] => [

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -10,6 +10,7 @@ import {
 } from "rdf-cube-view-query";
 import rdf from "rdf-ext";
 import { Literal, NamedNode } from "rdf-js";
+
 import { Filters } from "../configurator";
 import {
   DimensionValue,
@@ -22,6 +23,7 @@ import { DataCubeSearchFilter } from "../graphql/query-hooks";
 import { ResolvedDataCube, ResolvedDimension } from "../graphql/shared-types";
 import isAttrEqual from "../utils/is-attr-equal";
 import truthy from "../utils/truthy";
+
 import * as ns from "./namespace";
 import {
   getQueryLocales,

--- a/app/rdf/query-cube-metadata.ts
+++ b/app/rdf/query-cube-metadata.ts
@@ -1,11 +1,12 @@
+import * as RDF from "@rdfjs/data-model";
 import { SELECT, sparql } from "@tpluscode/sparql-builder";
+import { keyBy } from "lodash";
 
-import { sparqlClient } from "./sparql-client";
 import { schema, dcat, dcterms } from "../../app/rdf/namespace";
 import { DataCubeOrganization, DataCubeTheme } from "../graphql/query-hooks";
-import { keyBy } from "lodash";
+
 import { makeLocalesFilter } from "./query-labels";
-import * as RDF from "@rdfjs/data-model";
+import { sparqlClient } from "./sparql-client";
 
 type RawDataCubeTheme = Omit<DataCubeTheme, "__typename">;
 type RawDataCubeOrganization = Omit<DataCubeOrganization, "__typename">;

--- a/app/rdf/query-dimension-values.ts
+++ b/app/rdf/query-dimension-values.ts
@@ -1,13 +1,16 @@
 import { SELECT, sparql } from "@tpluscode/sparql-builder";
-import { Literal, NamedNode, Term } from "rdf-js";
-import { Filters } from "../configurator";
-import { cube as cubeNs } from "./namespace";
-import { sparqlClient } from "./sparql-client";
+import { keyBy, mapValues } from "lodash";
 import { Cube, CubeDimension } from "rdf-cube-view-query";
-import { dimensionIsVersioned } from "./queries";
+import { Literal, NamedNode, Term } from "rdf-js";
+
+import { Filters } from "../configurator";
+
+import { cube as cubeNs } from "./namespace";
 import * as ns from "./namespace";
 import { parseDimensionDatatype } from "./parse";
-import { keyBy, mapValues } from "lodash";
+import { dimensionIsVersioned } from "./queries";
+import { sparqlClient } from "./sparql-client";
+
 
 interface DimensionValue {
   value: Literal | NamedNode<string>;

--- a/app/rdf/query-geo-coordinates.ts
+++ b/app/rdf/query-geo-coordinates.ts
@@ -1,5 +1,7 @@
 import { SELECT, sparql } from "@tpluscode/sparql-builder";
+
 import { ResolvedDimension } from "../graphql/shared-types";
+
 import * as ns from "./namespace";
 import { dimensionIsVersioned } from "./queries";
 import { sparqlClient } from "./sparql-client";

--- a/app/rdf/query-geo-shapes.ts
+++ b/app/rdf/query-geo-shapes.ts
@@ -1,6 +1,8 @@
 import { SELECT } from "@tpluscode/sparql-builder";
 import { groupBy } from "lodash";
+
 import { SPARQL_GEO_ENDPOINT } from "../domain/env";
+
 import * as ns from "./namespace";
 import { sparqlClient } from "./sparql-client";
 

--- a/app/rdf/query-labels.ts
+++ b/app/rdf/query-labels.ts
@@ -4,9 +4,10 @@ import { TemplateResult } from "@tpluscode/rdf-string/lib/TemplateResult";
 import { SELECT } from "@tpluscode/sparql-builder";
 import { Literal, NamedNode } from "rdf-js";
 import ParsingClient from "sparql-http-client/ParsingClient";
+
+import batchLoad from "./batch-load";
 import { getQueryLocales } from "./parse";
 import { sparqlClient } from "./sparql-client";
-import batchLoad from "./batch-load";
 
 interface ResourceLabel {
   iri: NamedNode;

--- a/app/rdf/query-positions.ts
+++ b/app/rdf/query-positions.ts
@@ -2,6 +2,7 @@ import { schema } from "@tpluscode/rdf-ns-builders";
 import { SELECT } from "@tpluscode/sparql-builder";
 import { NamedNode, Literal } from "rdf-js";
 import ParsingClient from "sparql-http-client/ParsingClient";
+
 import batchLoad from "./batch-load";
 import { sparqlClient } from "./sparql-client";
 

--- a/app/rdf/query-sameas.ts
+++ b/app/rdf/query-sameas.ts
@@ -2,6 +2,7 @@ import { schema } from "@tpluscode/rdf-ns-builders";
 import { SELECT } from "@tpluscode/sparql-builder";
 import { NamedNode } from "rdf-js";
 import ParsingClient from "sparql-http-client/ParsingClient";
+
 import batchLoad from "./batch-load";
 import { sparqlClient } from "./sparql-client";
 

--- a/app/rdf/query-unit-labels.ts
+++ b/app/rdf/query-unit-labels.ts
@@ -1,9 +1,10 @@
 import { SELECT } from "@tpluscode/sparql-builder";
 import { Term } from "rdf-js";
 import ParsingClient from "sparql-http-client/ParsingClient";
-import { sparqlClient } from "./sparql-client";
-import * as ns from "./namespace";
+
 import batchLoad from "./batch-load";
+import * as ns from "./namespace";
+import { sparqlClient } from "./sparql-client";
 
 interface ResourceLabel {
   iri: Term;

--- a/app/scripts/cube.ts
+++ b/app/scripts/cube.ts
@@ -1,6 +1,10 @@
 // @ts-ignore
 import { build, completionHandler } from "@cozy/cli-tree";
+import { config } from "dotenv";
+// @ts-ignore
+import fetch from "node-fetch";
 import { Client } from "urql";
+
 import { GRAPHQL_ENDPOINT } from "../domain/env";
 import {
   DataCubeMetadataDocument,
@@ -9,10 +13,6 @@ import {
   DataCubePreviewObservationsDocument,
   DataCubePreviewObservationsQuery,
 } from "../graphql/query-hooks";
-
-// @ts-ignore
-import fetch from "node-fetch";
-import { config } from "dotenv";
 
 config();
 

--- a/app/test/utils.ts
+++ b/app/test/utils.ts
@@ -1,5 +1,6 @@
-import * as fs from "fs-extra";
 import * as path from "path";
+
+import * as fs from "fs-extra";
 
 // Needs to be relative to CWD because webpack will replace __dirname with "/"
 const FIXTURES_DIR = path.join("app", "test", "__fixtures", "prod");

--- a/app/themes/federal.tsx
+++ b/app/themes/federal.tsx
@@ -6,11 +6,12 @@
  *
  * - `theme` should be a plain object, conforming to the `Theme` type.
  */
-import { Icon } from "@/icons";
-import shadows from "@/themes/shadows";
 import { Fade, Grow } from "@mui/material";
 import { Breakpoint, createTheme, Theme } from "@mui/material/styles";
 import { merge, omit } from "lodash";
+
+import { Icon } from "@/icons";
+import shadows from "@/themes/shadows";
 
 const isSafari15 =
   typeof navigator !== "undefined" && navigator.vendor.indexOf("Apple") >= 0

--- a/app/utils/dimension-hierarchy.spec.ts
+++ b/app/utils/dimension-hierarchy.spec.ts
@@ -2,6 +2,7 @@ import {
   DataCubeObservationsQuery,
 } from "../graphql/query-hooks";
 import { default as observationsFixture } from "../test/__fixtures/api/bathingsite-observations.json";
+
 import {
   DimensionHierarchy,
   getHierarchyDimensionPath,

--- a/app/utils/dimension-hierarchy.ts
+++ b/app/utils/dimension-hierarchy.ts
@@ -1,10 +1,12 @@
 import { ascending } from "d3";
 import flowRight from "lodash/flowRight";
 import { useMemo } from "react";
+
 import {
   DataCubeObservationsQuery,
   useDataCubeObservationsQuery,
 } from "../graphql/query-hooks";
+
 import { defaultSorter, makeOrdinalDimensionSorter } from "./sorting-values";
 
 export type DimensionHierarchy = {

--- a/app/utils/l10n-provider.tsx
+++ b/app/utils/l10n-provider.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from "react";
-import DateAdapter from "@mui/lab/AdapterDateFns";
 import { LocalizationProvider } from "@mui/lab";
+import DateAdapter from "@mui/lab/AdapterDateFns";
+import React, { useEffect, useState } from "react";
 
 const AsyncLocalizationProvider = ({
   locale,

--- a/app/utils/search.spec.ts
+++ b/app/utils/search.spec.ts
@@ -1,7 +1,9 @@
-import { makeCubeIndex, searchCubes, wrap } from "./search";
-import cubesListRaw from "../test/__fixtures/api/cubes-list.json";
-import { ResolvedDataCube } from "../graphql/shared-types";
 import keyBy from "lodash/keyBy";
+
+import { ResolvedDataCube } from "../graphql/shared-types";
+import cubesListRaw from "../test/__fixtures/api/cubes-list.json";
+
+import { makeCubeIndex, searchCubes, wrap } from "./search";
 
 const cubesList = cubesListRaw as ResolvedDataCube["data"][];
 

--- a/app/utils/search.ts
+++ b/app/utils/search.ts
@@ -1,5 +1,6 @@
 import { flatten } from "lodash";
 import lunr from "lunr";
+
 import { ResolvedDataCube } from "../graphql/shared-types";
 
 export const wrap = (


### PR DESCRIPTION
- chore: Configure eslint to sort and group imports
- chore: Run yarn lint --fix

Eslint is used to sort imports as the import/order plugin can be configured
and it does not seem like Organize imports from Vscode can.

`@/` imports are correctly recognized as "internal" and not from node_modules.

Here is the relevant VSCode config:

```
  "editor.codeActionsOnSave": {
    "source.fixAll.eslint": true
  }
```
