### PR TITLE
feat: Include tables in chart config retaining logic

### DIFF
--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -259,26 +259,26 @@ export const getInitialConfig = ({
 
 export const getChartConfigAdjustedToChartType = ({
   chartConfig,
-  chartType,
+  newChartType,
   dimensions,
   measures,
 }: {
   chartConfig: ChartConfig;
-  chartType: ChartType;
+  newChartType: ChartType;
   dimensions: DataCubeMetadata["dimensions"];
   measures: DataCubeMetadata["measures"];
 }): ChartConfig => {
+  const oldChartType = chartConfig.chartType;
   const initialConfig = getInitialConfig({
-    chartType,
+    chartType: newChartType,
     dimensions,
     measures,
   });
-
   const newChartConfig = getAdjustedChartConfig({
     path: "",
     field: chartConfig,
-    adjusters: chartConfigsAdjusters[chartType],
-    pathOverrides: chartConfigsPathOverrides[chartType],
+    adjusters: chartConfigsAdjusters[newChartType],
+    pathOverrides: chartConfigsPathOverrides[newChartType],
     oldChartConfig: chartConfig,
     newChartConfig: initialConfig,
     dimensions,

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -278,7 +278,7 @@ export const getChartConfigAdjustedToChartType = ({
     path: "",
     field: chartConfig,
     adjusters: chartConfigsAdjusters[newChartType],
-    pathOverrides: chartConfigsPathOverrides[newChartType],
+    pathOverrides: chartConfigsPathOverrides[newChartType][oldChartType],
     oldChartConfig: chartConfig,
     newChartConfig: initialConfig,
     dimensions,
@@ -639,37 +639,96 @@ const chartConfigsAdjusters: ChartConfigsAdjusters = {
 };
 type ChartConfigAdjusters = typeof chartConfigsAdjusters[ChartType];
 
-// Needed to correctly retain chart options when switching to maps (and tables?).
+// Needed to correctly retain chart options when switching to maps and tables.
 const chartConfigsPathOverrides: {
-  [chartType in ChartType]: {
-    [fieldToOverride: string]: string;
+  [newChartType in ChartType]: {
+    [oldChartType in ChartType]?: {
+      [oldFieldToOverride: string]: string;
+    };
   };
 } = {
   bar: {},
   column: {
+    map: {
     "fields.areaLayer.componentIri": "fields.x.componentIri",
     "fields.areaLayer.measureIri": "fields.y.componentIri",
+    },
+    table: {
+      fields: "fields.segment",
+    },
   },
   line: {
+    map: {
     "fields.areaLayer.measureIri": "fields.y.componentIri",
+    },
+    table: {
+      fields: "fields.segment",
+    },
   },
   area: {
+    map: {
     "fields.areaLayer.measureIri": "fields.y.componentIri",
+    },
+    table: {
+      fields: "fields.segment",
+    },
   },
   scatterplot: {
+    map: {
     "fields.areaLayer.measureIri": "fields.y.componentIri",
+    },
+    table: {
+      fields: "fields.segment",
+    },
   },
   pie: {
+    map: {
     "fields.areaLayer.componentIri": "fields.x.componentIri",
     "fields.areaLayer.measureIri": "fields.y.componentIri",
+    },
+    table: {
+      fields: "fields.segment",
+    },
   },
-  table: {},
+  table: {
+    column: {
+      "fields.segment": "fields",
+    },
+    line: {
+      "fields.segment": "fields",
+    },
+    area: {
+      "fields.segment": "fields",
+    },
+    scatterplot: {
+      "fields.segment": "fields",
+    },
+    pie: {
+      "fields.segment": "fields",
+    },
+  },
   map: {
+    column: {
     "fields.x.componentIri": "fields.areaLayer.componentIri",
     "fields.y.componentIri": "fields.areaLayer.measureIri",
+    },
+    line: {
+      "fields.y.componentIri": "fields.areaLayer.measureIri",
+    },
+    area: {
+      "fields.y.componentIri": "fields.areaLayer.measureIri",
+    },
+    scatterplot: {
+      "fields.y.componentIri": "fields.areaLayer.measureIri",
+    },
+    pie: {
+      "fields.x.componentIri": "fields.areaLayer.componentIri",
+      "fields.y.componentIri": "fields.areaLayer.measureIri",
+    },
   },
 };
-type ChartConfigPathOverrides = typeof chartConfigsPathOverrides[ChartType];
+type ChartConfigPathOverrides =
+  typeof chartConfigsPathOverrides[ChartType][ChartType];
 
 // Helpers
 export const getPossibleChartType = ({

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -21,7 +21,8 @@ import {
   SortingType,
   TableColumn,
   TableFields,
-} from "../configurator";
+} from "@/configurator/config-types";
+
 import { mapColorsToComponentValuesIris } from "../configurator/components/ui-helpers";
 import {
   getCategoricalDimensions,

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -738,10 +738,11 @@ const chartConfigsAdjusters: ChartConfigsAdjusters = {
       });
     },
     fields: ({ oldValue, newChartConfig }) => {
-      for (const [componentIri, v] of Object.entries(newChartConfig.fields)) {
+      for (const componentIri of Object.keys(newChartConfig.fields)) {
         if (componentIri === oldValue.componentIri) {
-          v.isGroup = true;
-          break;
+          return produce(newChartConfig, (draft) => {
+            draft.fields[componentIri].isGroup = true;
+          });
         }
       }
 

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -325,7 +325,9 @@ const getAdjustedChartConfig = ({
           const getChartConfigWithAdjustedField: FieldAdjuster<
             ChartConfig,
             unknown
-          > = get(adjusters, newPath) || get(adjusters, pathOverrides[newPath]);
+          > =
+            (pathOverrides && get(adjusters, pathOverrides[newPath])) ||
+            get(adjusters, newPath);
 
           if (getChartConfigWithAdjustedField) {
             newChartConfig = getChartConfigWithAdjustedField({

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -949,7 +949,8 @@ const convertTableFieldsToSegmentField = ({
         d.componentType !== "Attribute" &&
         d.componentType !== "Measure" &&
         d.componentType !== "TemporalDimension"
-    );
+    )
+    .sort((a, b) => a.index - b.index);
   const component = groupedColumns?.[0];
 
   if (component) {

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -732,6 +732,11 @@ const chartConfigsAdjusters: ChartConfigsAdjusters = {
     interactiveFiltersConfig: interactiveFiltersAdjusters,
   },
   table: {
+    filters: ({ oldValue, newChartConfig }) => {
+      return produce(newChartConfig, (draft) => {
+        draft.filters = oldValue;
+      });
+    },
     fields: ({ oldValue, newChartConfig }) => {
       for (const [componentIri, v] of Object.entries(newChartConfig.fields)) {
         if (componentIri === oldValue.componentIri) {

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -308,13 +308,27 @@ const getAdjustedChartConfig = ({
   measures: DataCubeMetadata["measures"];
 }) => {
   // For filters & segments we can't reach a primitive level as we need to
-  // pass the whole object.
-  const isConfigLeaf = (path: string, configValue: any) =>
-    typeof configValue !== "object" ||
-    Array.isArray(configValue) ||
-    ["filters", "fields.segment", "interactiveFiltersConfig.legend"].includes(
-      path
+  // pass the whole object. Table fields have an [iri: Config] structure,
+  // so we also pass a whole field in such case (used in segments).
+  const isConfigLeaf = (path: string, configValue: any) => {
+    if (typeof configValue !== "object" || Array.isArray(configValue)) {
+      return true;
+    } else {
+      switch (path) {
+        case "fields":
+          return (
+            oldChartConfig.chartType === "table" &&
+            isSegmentInConfig(newChartConfig)
     );
+        case "filters":
+        case "fields.segment":
+        case "interactiveFiltersConfig.legend":
+          return true;
+        default:
+          return false;
+      }
+    }
+  };
 
   const go = ({ path, field }: { path: string; field: Object }) => {
     for (const [k, v] of Object.entries(field)) {

--- a/app/configurator/config-types.ts
+++ b/app/configurator/config-types.ts
@@ -705,6 +705,7 @@ type PieAdjusters = BaseAdjusters<PieConfig> & {
 };
 
 type TableAdjusters = {
+  filters: FieldAdjuster<TableConfig, Filters>;
   fields: FieldAdjuster<
     TableConfig,
     | ColumnSegmentField

--- a/app/configurator/config-types.ts
+++ b/app/configurator/config-types.ts
@@ -641,6 +641,7 @@ type ColumnAdjusters = BaseAdjusters<ColumnConfig> & {
       | AreaSegmentField
       | ScatterPlotSegmentField
       | PieSegmentField
+      | TableFields
     >;
   };
 };
@@ -655,6 +656,7 @@ type LineAdjusters = BaseAdjusters<LineConfig> & {
       | AreaSegmentField
       | ScatterPlotSegmentField
       | PieSegmentField
+      | TableFields
     >;
   };
 };
@@ -669,6 +671,7 @@ type AreaAdjusters = BaseAdjusters<AreaConfig> & {
       | LineSegmentField
       | ScatterPlotSegmentField
       | PieSegmentField
+      | TableFields
     >;
   };
 };
@@ -678,7 +681,11 @@ type ScatterPlotAdjusters = BaseAdjusters<ScatterPlotConfig> & {
     y: { componentIri: FieldAdjuster<ScatterPlotConfig, string> };
     segment: FieldAdjuster<
       ScatterPlotConfig,
-      ColumnSegmentField | LineSegmentField | AreaSegmentField | PieSegmentField
+      | ColumnSegmentField
+      | LineSegmentField
+      | AreaSegmentField
+      | PieSegmentField
+      | TableFields
     >;
   };
 };
@@ -692,8 +699,20 @@ type PieAdjusters = BaseAdjusters<PieConfig> & {
       | LineSegmentField
       | AreaSegmentField
       | ScatterPlotSegmentField
+      | TableFields
     >;
   };
+};
+
+type TableAdjusters = {
+  fields: FieldAdjuster<
+    TableConfig,
+    | ColumnSegmentField
+    | LineSegmentField
+    | AreaSegmentField
+    | ScatterPlotSegmentField
+    | PieSegmentField
+  >;
 };
 
 type MapAdjusters = BaseAdjusters<MapConfig> & {
@@ -712,7 +731,7 @@ export type ChartConfigsAdjusters = {
   area: AreaAdjusters;
   scatterplot: ScatterPlotAdjusters;
   pie: PieAdjusters;
-  table: {};
+  table: TableAdjusters;
   map: MapAdjusters;
 };
 

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -386,7 +386,7 @@ describe("retainChartConfigWhenSwitchingChartType", () => {
     const newConfig = createDraft(
       getChartConfigAdjustedToChartType({
         chartConfig: oldConfig,
-        chartType: newChartType,
+        newChartType,
         dimensions: dataSetMetadata.dimensions,
         measures: dataSetMetadata.measures,
       })

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -607,7 +607,7 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
 
         draft.chartConfig = getChartConfigAdjustedToChartType({
           chartConfig: current(draft.chartConfig),
-          chartType,
+          newChartType: chartType,
           dimensions: dataSetMetadata.dimensions,
           measures: dataSetMetadata.measures,
         });

--- a/app/test/__fixtures/dev/chartConfig-table-covid19.json
+++ b/app/test/__fixtures/dev/chartConfig-table-covid19.json
@@ -37,7 +37,7 @@
       "componentIri": "https://environment.ld.admin.ch/foen/COVID19VaccPersons_v2/pop",
       "componentType": "NominalDimension",
       "index": 2,
-      "isGroup": false,
+      "isGroup": true,
       "isHidden": false,
       "columnStyle": {
         "textStyle": "regular",

--- a/app/test/__fixtures/dev/chartConfig-table-covid19.json
+++ b/app/test/__fixtures/dev/chartConfig-table-covid19.json
@@ -1,0 +1,102 @@
+{
+  "chartType": "table",
+  "filters": {},
+  "settings": {
+    "showSearch": true,
+    "showAllRows": false
+  },
+  "sorting": [],
+  "fields": {
+    "https://environment.ld.admin.ch/foen/COVID19VaccPersons_v2/date": {
+      "componentIri": "https://environment.ld.admin.ch/foen/COVID19VaccPersons_v2/date",
+      "componentType": "TemporalDimension",
+      "index": 0,
+      "isGroup": true,
+      "isHidden": false,
+      "columnStyle": {
+        "textStyle": "regular",
+        "type": "text",
+        "textColor": "#000",
+        "columnColor": "#fff"
+      }
+    },
+    "https://environment.ld.admin.ch/foen/COVID19VaccPersons_v2/georegion": {
+      "componentIri": "https://environment.ld.admin.ch/foen/COVID19VaccPersons_v2/georegion",
+      "componentType": "GeoShapesDimension",
+      "index": 1,
+      "isGroup": true,
+      "isHidden": false,
+      "columnStyle": {
+        "textStyle": "regular",
+        "type": "text",
+        "textColor": "#000",
+        "columnColor": "#fff"
+      }
+    },
+    "https://environment.ld.admin.ch/foen/COVID19VaccPersons_v2/pop": {
+      "componentIri": "https://environment.ld.admin.ch/foen/COVID19VaccPersons_v2/pop",
+      "componentType": "NominalDimension",
+      "index": 2,
+      "isGroup": false,
+      "isHidden": false,
+      "columnStyle": {
+        "textStyle": "regular",
+        "type": "text",
+        "textColor": "#000",
+        "columnColor": "#fff"
+      }
+    },
+    "https://environment.ld.admin.ch/foen/COVID19VaccPersons_v2/type": {
+      "componentIri": "https://environment.ld.admin.ch/foen/COVID19VaccPersons_v2/type",
+      "componentType": "NominalDimension",
+      "index": 3,
+      "isGroup": false,
+      "isHidden": false,
+      "columnStyle": {
+        "textStyle": "regular",
+        "type": "text",
+        "textColor": "#000",
+        "columnColor": "#fff"
+      }
+    },
+    "https://environment.ld.admin.ch/foen/COVID19VaccPersons_v2/entries": {
+      "componentIri": "https://environment.ld.admin.ch/foen/COVID19VaccPersons_v2/entries",
+      "componentType": "Measure",
+      "index": 4,
+      "isGroup": false,
+      "isHidden": false,
+      "columnStyle": {
+        "textStyle": "regular",
+        "type": "text",
+        "textColor": "#000",
+        "columnColor": "#fff"
+      }
+    },
+    "https://environment.ld.admin.ch/foen/COVID19VaccPersons_v2/sumtotal": {
+      "componentIri": "https://environment.ld.admin.ch/foen/COVID19VaccPersons_v2/sumtotal",
+      "componentType": "Measure",
+      "index": 5,
+      "isGroup": false,
+      "isHidden": false,
+      "columnStyle": {
+        "textStyle": "regular",
+        "type": "text",
+        "textColor": "#000",
+        "columnColor": "#fff"
+      }
+    },
+    "https://environment.ld.admin.ch/foen/COVID19VaccPersons_v2/mean7d": {
+      "componentIri": "https://environment.ld.admin.ch/foen/COVID19VaccPersons_v2/mean7d",
+      "componentType": "Measure",
+      "index": 6,
+      "isGroup": false,
+      "isHidden": false,
+      "columnStyle": {
+        "textStyle": "regular",
+        "type": "text",
+        "textColor": "#000",
+        "columnColor": "#fff"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces segment retaining when switching from and to a table chart.

**Non table chart with segment -> Table chart:** _Segment is used to choose a grouping column_
**Table chart with at least one grouping column -> Non table chart that supports segment:** _First grouping column is used as a segment (if possible, in tables it's possible to use TemporalDimensions or Measures as grouping columns, which is not permitted in segments)_