### PR TITLE
Remove outline for elements non navigable by keyboard

### DIFF
--- a/app/themes/federal.tsx
+++ b/app/themes/federal.tsx
@@ -679,7 +679,7 @@ theme.components = {
   MuiCssBaseline: {
     styleOverrides: `
         svg {
-          display: block"
+          display: block
         }
   
         *:focus: {

--- a/app/themes/federal.tsx
+++ b/app/themes/federal.tsx
@@ -682,9 +682,11 @@ theme.components = {
           display: block
         }
   
-        *:focus: {
+        *:focus {
           outline: 3px solid #333333;
         }
+
+        [tabindex="-1"]:focus { outline: 0; }.
     
         fieldset {
           border: 0;


### PR DESCRIPTION
- fix: Re-enable svg block rule that was deactivated due to extra "
- fix: Set focus outline to none for elements with tabindex=-1
