### PR TITLE
feat: Cache node_modules and .next/cache folder

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -16,6 +16,16 @@ jobs:
         with:
           node-version: 12.x
           cache: yarn
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.npm
+            ${{ github.workspace }}/app/.next/cache
+          # Generate a new cache whenever packages or source files change.
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/yarn.lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          # If source files changed but packages didn't, rebuild from a prior cache.
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-
       - run: yarn install --frozen-lockfile
       - run: yarn lint
       - run: yarn typecheck

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -12,9 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js 12.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 12.x
+          cache: yarn
       - run: yarn install --frozen-lockfile
       - run: yarn lint
       - run: yarn typecheck


### PR DESCRIPTION
I saw a warning during build from next telling we should cache things.
Apparently we did not cache node_modules.
Using a cache should speed things up.

* I upgrade setup-node action and tells to cache things related to yarn.
* I also cache .next/cache and the cache key depends on yarn.lock and source files

