### PR TITLE
fix: Clicking on a time brush

### DIFF
--- a/app/charts/shared/brush.tsx
+++ b/app/charts/shared/brush.tsx
@@ -136,19 +136,26 @@ export const BrushTime = () => {
     ])
     .on("start brush", brushed)
     .on("end", function (event) {
+      // Happens when snapping to actual values.
       if (!event.sourceEvent) {
         updateBrushEndedStatus(false);
       } else {
-        updateBrushEndedStatus(true);
-      }
+        if (event.selection) {
+          setSelectionExtent(event.selection[1] - event.selection[0]);
+        } else {
+          // End event fires twice on touchend (MouseEvent and TouchEvent),
+          // we want to compute mx basing on MouseEvent.
+          if (event.sourceEvent instanceof MouseEvent) {
+            const g = select(ref.current);
+            const [mx] = pointer(event, this);
+            const x = mx < 0 ? 0 : mx > brushWidth ? brushWidth : mx;
+            g.call(brush.move as any, [x, x]);
+          }
 
-      if (event.selection) {
-        setSelectionExtent(event.selection[1] - event.selection[0]);
-      } else {
-        const g = select(ref.current);
-        const [mx] = pointer(event, this);
-        g.call(brush.move as any, [mx, mx]);
-        setSelectionExtent(0);
+          setSelectionExtent(0);
+        }
+
+        updateBrushEndedStatus(true);
       }
     });
 


### PR DESCRIPTION
Closes #183.

It turned out that the brush's handle was disappearing not only on mobile, but also on desktop – when the user clicked the brush outside the current selection.

It was due to the fact that the event's selection was empty in such cases, and d3's brush internally sets visibility and position of handles to none then. To overcome this, there is a need to check for empty selections and if they appear, move the brush "in-place", so it doesn't disappear and snaps to actual dates.

Also, as consulted with @AnninaWalker, there is a new default behavior when clicking outside the current selection – the current selection is then moved to the center of user's click.