### PR TITLE
Cell value formatters

### DIFF
--- a/app/charts/table/cell-desktop.tsx
+++ b/app/charts/table/cell-desktop.tsx
@@ -1,4 +1,3 @@
-
 import { Box } from "@mui/material";
 import { hcl, ScaleLinear } from "d3";
 import * as React from "react";
@@ -8,10 +7,6 @@ import { BAR_CELL_PADDING } from "@/charts/table/constants";
 import { ColumnMeta } from "@/charts/table/table-state";
 import { Tag } from "@/charts/table/tag";
 import Flex from "@/components/flex";
-import {
-  useFormatFullDateAuto,
-  useFormatNumber,
-} from "@/configurator/components/ui-helpers";
 import { Observation } from "@/domain/data";
 
 export const CellDesktop = ({
@@ -21,9 +16,6 @@ export const CellDesktop = ({
   cell: Cell<Observation>;
   columnMeta: ColumnMeta;
 }) => {
-  const formatNumber = useFormatNumber();
-  const formatDateAuto = useFormatFullDateAuto();
-
   const {
     columnComponentType,
     type,
@@ -53,11 +45,7 @@ export const CellDesktop = ({
           }}
           {...cell.getCellProps()}
         >
-          {columnComponentType === "Measure"
-            ? formatNumber(cell.value)
-            : columnComponentType === "TemporalDimension"
-            ? formatDateAuto(cell.value)
-            : cell.render("Cell")}
+          {columnMeta.formatter(cell)}
         </Flex>
       );
     case "category":
@@ -67,9 +55,7 @@ export const CellDesktop = ({
           {...cell.getCellProps()}
         >
           <Tag tagColor={colorScale ? colorScale(cell.value) : "primaryLight"}>
-            {columnComponentType === "TemporalDimension"
-              ? formatDateAuto(cell.value)
-              : cell.render("Cell")}
+            {columnMeta.formatter(cell)}
           </Tag>
         </Flex>
       );
@@ -96,7 +82,7 @@ export const CellDesktop = ({
           }}
           {...cell.getCellProps()}
         >
-          {formatNumber(cell.value)}
+          {columnMeta.formatter(cell)}
         </Flex>
       );
     case "bar":
@@ -111,7 +97,7 @@ export const CellDesktop = ({
           }}
           {...cell.getCellProps()}
         >
-          <Box>{formatNumber(cell.value)}</Box>
+          <Box>{columnMeta.formatter(cell)}</Box>
           {cell.value !== null && widthScale && (
             <Box
               sx={{
@@ -172,11 +158,7 @@ export const CellDesktop = ({
           }}
           {...cell.getCellProps()}
         >
-          {columnComponentType === "Measure"
-            ? formatNumber(cell.value)
-            : columnComponentType === "TemporalDimension"
-            ? formatDateAuto(cell.value)
-            : cell.render("Cell")}
+          {columnMeta.formatter(cell)}
         </Flex>
       );
   }

--- a/app/charts/table/table-state.tsx
+++ b/app/charts/table/table-state.tsx
@@ -241,7 +241,7 @@ const useTableState = ({
           };
         } else if (columnStyleType === "category") {
           const { colorMapping } = columnStyle as ColumnStyleCategory;
-          const dimensionValues = dimensions.find(
+          const dimension = dimensions.find(
             (d) => d.iri === iri
           ) as DimensionMetaDataFragment;
 
@@ -252,7 +252,7 @@ const useTableState = ({
           const labelsAndColor = Object.keys(colorMapping).map(
             (colorMappingIri) => {
               const dvLabel = (
-                dimensionValues.values.find((s) => {
+                dimension.values.find((s) => {
                   return s.value === colorMappingIri;
                 }) || { label: "unknown" }
               ).label;

--- a/app/charts/table/table-state.tsx
+++ b/app/charts/table/table-state.tsx
@@ -9,7 +9,7 @@ import {
   ScaleSequential,
 } from "d3";
 import { ReactNode, useMemo } from "react";
-import { Column } from "react-table";
+import { Cell, Column } from "react-table";
 
 import {
   getLabelWithUnit,
@@ -27,6 +27,7 @@ import {
 import {
   getColorInterpolator,
   mkNumber,
+  useDimensionFormatters,
   useFormatNumber,
   useOrderedTableColumns,
 } from "@/configurator/components/ui-helpers";
@@ -49,6 +50,7 @@ export interface ColumnMeta {
   barColorNegative: string;
   barColorBackground: string;
   barShowBackground: boolean;
+  formatter: (cell: Cell<Observation, any>) => string;
 }
 
 export interface TableChartState {
@@ -208,6 +210,8 @@ const useTableState = ({
     ];
   }, [sorting, orderedTableColumns]);
 
+  const formatters = useDimensionFormatters([...dimensions, ...measures]);
+
   const hiddenIris = useMemo(
     () =>
       orderedTableColumns
@@ -229,6 +233,8 @@ const useTableState = ({
         const columnStyle = columnMeta.columnStyle;
         const columnStyleType = columnStyle.type;
         const columnComponentType = columnMeta.componentType;
+        const formatter = formatters[iri];
+        const cellFormatter = (x: Cell<Observation>) => formatter(x.value);
 
         if (columnStyleType === "text") {
           return {
@@ -236,6 +242,7 @@ const useTableState = ({
             [slugifiedIri]: {
               slugifiedIri,
               columnComponentType,
+              formatter: cellFormatter,
               ...columnStyle,
             },
           };
@@ -274,6 +281,8 @@ const useTableState = ({
               slugifiedIri,
               columnComponentType,
               colorScale,
+              formatter: (cell: Cell<Observation>) =>
+                formatters[dimension.iri](cell.value),
               ...columnStyle,
             },
           };
@@ -310,10 +319,8 @@ const useTableState = ({
             ),
           ];
           const columnItemSizes = columnItems.map((item) => {
-            const itemAsString =
-              columnComponentType === "Measure"
-                ? formatNumber(item as number)
-                : item;
+            // @ts-ignore
+            const itemAsString = formatter(item);
             return estimateTextWidth(`${itemAsString}`, 16) + 80;
           });
           const width =
@@ -344,7 +351,14 @@ const useTableState = ({
           };
         }
       }, {}),
-    [data, dimensions, fields, formatNumber, theme.palette.primary.main]
+    [
+      data,
+      dimensions,
+      fields,
+      formatNumber,
+      formatters,
+      theme.palette.primary.main,
+    ]
   );
 
   return {

--- a/app/configurator/components/ui-helpers.spec.ts
+++ b/app/configurator/components/ui-helpers.spec.ts
@@ -1,10 +1,11 @@
 import { renderHook } from "@testing-library/react-hooks";
 
-import { TimeUnit } from "../../graphql/query-hooks";
+import { DimensionMetaDataFragment, TimeUnit } from "../../graphql/query-hooks";
 
 import {
   getTimeIntervalFormattedSelectOptions,
   getTimeIntervalWithProps,
+  useDimensionFormatters,
   useFormatFullDateAuto,
   useTimeFormatLocale,
 } from "./ui-helpers";
@@ -25,6 +26,54 @@ describe("useFormatFullDateAuto", () => {
   it("should work with null dates", () => {
     const { formatFullDateAuto } = setup();
     expect(formatFullDateAuto(null)).toEqual("-");
+  });
+});
+
+describe("useDimensionFormatters", () => {
+  const setup = () => {
+    const {
+      result: { current: formatters },
+    } = renderHook(() =>
+      useDimensionFormatters([
+        {
+          iri: "iri-monthly",
+          timeFormat: "%Y-%m",
+          timeUnit: TimeUnit.Month,
+          isNumerical: false,
+          isKeyDimension: false,
+          __typename: "TemporalDimension",
+        } as DimensionMetaDataFragment,
+        {
+          iri: "iri-yearly",
+          timeFormat: "%Y",
+          timeUnit: TimeUnit.Year,
+          isNumerical: false,
+          isKeyDimension: false,
+          __typename: "TemporalDimension",
+        } as DimensionMetaDataFragment,
+        {
+          iri: "iri-number",
+          isNumerical: true,
+          isKeyDimension: false,
+        } as DimensionMetaDataFragment,
+      ])
+    );
+    return { formatters };
+  };
+
+  it("should work with monthly dates", () => {
+    const { formatters } = setup();
+    expect(formatters["iri-monthly"]("2021-05")).toEqual("05.2021");
+  });
+
+  it("should work with yearly dates", () => {
+    const { formatters } = setup();
+    expect(formatters["iri-yearly"]("2021")).toEqual("2021");
+  });
+
+  it("should work with numbers", () => {
+    const { formatters } = setup();
+    expect(formatters["iri-number"]("2.33333")).toEqual("2,33");
   });
 });
 


### PR DESCRIPTION
Fixes https://github.com/visualize-admin/visualization-tool/issues/556

To allow for proper formatting of values inside cells, we instantiate
dimension values formatters at a high level (parent table) instead
of relying on useFormatDateAuto. The metadata of the column (dimension.timeUnit
to know which format to apply, dimension.timeFormat to parse) is used
to create the proper formatter.
