### PR TITLE
fix: Infinite loop when hovering over chart

### DIFF
--- a/app/charts/shared/interaction/tooltip-box.tsx
+++ b/app/charts/shared/interaction/tooltip-box.tsx
@@ -17,7 +17,6 @@ import {
   Yplacement,
 } from "@/charts/shared/interaction/tooltip";
 import { Margins } from "@/charts/shared/use-width";
-import { useTheme } from "@/themes";
 
 export interface TooltipBoxProps {
   x: number | undefined;
@@ -74,8 +73,6 @@ export const TooltipBox = ({
   children,
 }: TooltipBoxProps) => {
   const triangle = mkTriangle(placement);
-  const theme = useTheme();
-
   const [pos, posRef] = usePosition();
   return (
     <>

--- a/app/charts/shared/interaction/tooltip-box.tsx
+++ b/app/charts/shared/interaction/tooltip-box.tsx
@@ -36,12 +36,14 @@ const useScroll = () => {
     const handleScroll = throttle(() => {
       setState([window.scrollX, window.scrollY]);
     }, 16);
+
     document.scrollingElement?.addEventListener("scroll", handleScroll);
     handleScroll();
     return () => {
       document.scrollingElement?.removeEventListener("scroll", handleScroll);
     };
-  });
+  }, []);
+
   return state;
 };
 
@@ -53,6 +55,7 @@ const usePosition = () => {
       if (bcr || !node) {
         return;
       }
+
       const nbcr = node.getBoundingClientRect();
       setBcr([nbcr.left, nbcr.top]);
     },
@@ -62,6 +65,7 @@ const usePosition = () => {
   const box = useMemo(() => {
     return { left: bcrX + scrollX, top: bcrY + scrollY };
   }, [bcrX, bcrY, scrollX, scrollY]);
+
   return [box, handleRef] as const;
 };
 

--- a/app/charts/shared/interaction/tooltip.tsx
+++ b/app/charts/shared/interaction/tooltip.tsx
@@ -44,15 +44,7 @@ export interface TooltipInfo {
   values: TooltipValue[] | undefined;
 }
 
-const TooltipInner = ({
-  d,
-  mouse,
-  type,
-}: {
-  d: Observation;
-  mouse?: { x: number; y: number };
-  type: TooltipType;
-}) => {
+const TooltipInner = ({ d, type }: { d: Observation; type: TooltipType }) => {
   const { bounds, getAnnotationInfo } = useChartState() as LinesState;
   const { margins } = bounds;
   const { xAnchor, yAnchor, placement, xValue, tooltipContent, datum, values } =

--- a/app/charts/shared/interaction/tooltip.tsx
+++ b/app/charts/shared/interaction/tooltip.tsx
@@ -15,10 +15,8 @@ export const TOOLTIP_OFFSET = 4;
 
 export const Tooltip = ({ type = "single" }: { type: TooltipType }) => {
   const [state] = useInteraction();
-  const { visible, mouse, d } = state.interaction;
-  return (
-    <>{visible && d && <TooltipInner d={d} mouse={mouse} type={type} />}</>
-  );
+  const { visible, d } = state.interaction;
+  return <>{visible && d && <TooltipInner d={d} type={type} />}</>;
 };
 
 export type Xplacement = "left" | "center" | "right";

--- a/app/charts/shared/overlay-horizontal.tsx
+++ b/app/charts/shared/overlay-horizontal.tsx
@@ -13,7 +13,7 @@ export const InteractionHorizontal = memo(function InteractionHorizontal({
 }: {
   debug?: boolean;
 }) {
-  const [, dispatch] = useInteraction();
+  const [state, dispatch] = useInteraction();
   const ref = useRef<SVGGElement>(null);
 
   const { data, bounds, getX, xScale, chartWideData } = useChartState() as
@@ -41,19 +41,26 @@ export const InteractionHorizontal = memo(function InteractionHorizontal({
         : dLeft;
 
     if (closestDatum) {
-      dispatch({
-        type: "INTERACTION_UPDATE",
-        value: {
-          interaction: {
-            visible: true,
-            mouse: { x, y },
-            d: data.find(
-              // FIXME: we should also filter on y
-              (d) => getX(closestDatum).getTime() === getX(d).getTime()
-            ),
+      const closestDatumTime = getX(closestDatum).getTime();
+      const datumToUpdate = data.find(
+        (d) => closestDatumTime === getX(d).getTime()
+      ) as Observation;
+
+      if (
+        !state.interaction.d ||
+        closestDatumTime !== getX(state.interaction.d).getTime()
+      ) {
+        dispatch({
+          type: "INTERACTION_UPDATE",
+          value: {
+            interaction: {
+              visible: true,
+              mouse: { x, y },
+              d: datumToUpdate,
+            },
           },
-        },
-      });
+        });
+      }
     }
   };
   const hideTooltip = () => {


### PR DESCRIPTION
Although it probably wasn't noticeable by the end user (but surely by developers as lots of console errors), we had an infinite loop running when hovering over a chart (even when the mouse stopped moving). It was due to useState + useEffect without an empty dependency array. In addition, this PR improves performance of finding closest value for horizontal tooltip by only looking for these when X values changes (and not on every mouse move as previously).