### PR TITLE
fix: Formatter can be optional

### DIFF
--- a/app/charts/table/cell-desktop.tsx
+++ b/app/charts/table/cell-desktop.tsx
@@ -93,7 +93,7 @@ export const CellDesktop = ({
             justifyContent: "center",
             // Padding is a constant accounted for in the
             // widthScale domain (see table state).
-            px: BAR_CELL_PADDING,
+            px: `${BAR_CELL_PADDING}px`,
           }}
           {...cell.getCellProps()}
         >

--- a/app/charts/table/cell-desktop.tsx
+++ b/app/charts/table/cell-desktop.tsx
@@ -113,8 +113,8 @@ export const CellDesktop = ({
                 sx={{
                   position: "absolute",
                   top: 0,
-                  left: getBarLeftOffset(cell.value, widthScale),
-                  width: getBarWidth(cell.value, widthScale),
+                  left: `${getBarLeftOffset(cell.value, widthScale)}px`,
+                  width: `${getBarWidth(cell.value, widthScale)}px`,
                   height: 18,
                   backgroundColor:
                     cell.value > 0 ? barColorPositive : barColorNegative,
@@ -124,10 +124,11 @@ export const CellDesktop = ({
                 sx={{
                   position: "absolute",
                   top: "-2px",
-                  left:
+                  left: `${
                     cell.value < 0
                       ? widthScale(0)
-                      : getBarLeftOffset(cell.value, widthScale),
+                      : getBarLeftOffset(cell.value, widthScale)
+                  }px`,
                   width: "1px",
                   height: 22,
                   backgroundColor: "grey.700",

--- a/app/charts/table/cell-mobile.tsx
+++ b/app/charts/table/cell-mobile.tsx
@@ -195,8 +195,8 @@ export const DDContent = ({
                 sx={{
                   position: "absolute",
                   top: 0,
-                  left: getBarLeftOffset(cell.value, widthScale),
-                  width: getBarWidth(cell.value, widthScale),
+                  left: `${getBarLeftOffset(cell.value, widthScale)}px`,
+                  width: `${getBarWidth(cell.value, widthScale)}px`,
                   height: 14,
                   backgroundColor:
                     cell.value > 0 ? barColorPositive : barColorNegative,
@@ -206,10 +206,11 @@ export const DDContent = ({
                 sx={{
                   position: "absolute",
                   top: "-2px",
-                  left:
+                  left: `${
                     cell.value < 0
                       ? widthScale(0)
-                      : getBarLeftOffset(cell.value, widthScale),
+                      : getBarLeftOffset(cell.value, widthScale)
+                  }px`,
                   width: "1px",
                   height: 18,
                   backgroundColor: "grey.700",

--- a/app/charts/table/table-state.tsx
+++ b/app/charts/table/table-state.tsx
@@ -281,8 +281,7 @@ const useTableState = ({
               slugifiedIri,
               columnComponentType,
               colorScale,
-              formatter: (cell: Cell<Observation>) =>
-                formatters[dimension.iri](cell.value),
+              formatter: cellFormatter,
               ...columnStyle,
             },
           };
@@ -305,6 +304,7 @@ const useTableState = ({
               slugifiedIri,
               columnComponentType,
               colorScale,
+              formatter: cellFormatter,
               ...columnStyle,
             },
           };
@@ -337,6 +337,7 @@ const useTableState = ({
               slugifiedIri,
               columnComponentType,
               widthScale,
+              formatter: cellFormatter,
               ...columnStyle,
             },
           };
@@ -346,19 +347,14 @@ const useTableState = ({
             [slugifiedIri]: {
               slugifiedIri,
               columnComponentType,
+              formatter: cellFormatter,
+              // @ts-ignore
               ...columnStyle,
             },
           };
         }
       }, {}),
-    [
-      data,
-      dimensions,
-      fields,
-      formatNumber,
-      formatters,
-      theme.palette.primary.main,
-    ]
+    [data, dimensions, fields, formatters, theme.palette.primary.main]
   );
 
   return {


### PR DESCRIPTION
I am not sure if this is a proper fix, it seems like it works, but I would really appreciate if @ptbrowne you could test and adjust if necessary (I've seen that before your changes in some places there were "formatNumber(cell)" instead of cell.render("Cell") as currently, and I'm not sure if it's ok?

Also, I discovered and fixed a bug in widths of the bars in the table bar cells – we missed "px" at the end and Visualize was sometimes treating the values as "px", but sometimes as "%" and this leads to strange results – you can see them if you revert the change and select bar cells styles in any dataset (e.g. Bathing water quality :)).