### PR TITLE
fix: Scroll jumping problem when switching from table to chat view in published chart

### DIFF
--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -132,21 +132,17 @@ export const ChartPublishedInner = ({
           </Typography>
         )}
         <InteractiveFiltersProvider>
-          {isTablePreview ? (
-            <DataSetTable
-              sx={{
-                height: height || lastHeight.current,
-              }}
-              dataSetIri={dataSet}
-              chartConfig={chartConfig}
-            />
-          ) : (
-            <ChartWithInteractiveFilters
-              ref={chartRef}
-              dataSet={dataSet}
-              chartConfig={chartConfig}
-            />
-          )}
+          <Box height={height || lastHeight.current}>
+            {isTablePreview ? (
+              <DataSetTable dataSetIri={dataSet} chartConfig={chartConfig} />
+            ) : (
+              <ChartWithInteractiveFilters
+                ref={chartRef}
+                dataSet={dataSet}
+                chartConfig={chartConfig}
+              />
+            )}
+          </Box>
           {chartConfig && (
             <ChartFootnotes
               dataSetIri={dataSet}


### PR DESCRIPTION
Wrap both chart and table with a box that takes the height of the chart
