### PR TITLE
Show all monthly values inside filter

### DIFF
--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -82,46 +82,35 @@ const DataFilterSelectGeneric = ({
       </IconButton>
     </Box>
   );
+
+  const sharedProps = {
+    dimensionIri: dimension.iri,
+    label: `${index + 1}. ${dimension.label}`,
+    controls: controls,
+    id: `select-single-filter-${index}`,
+    disabled: disabled,
+    isOptional: !dimension.isKeyDimension,
+  };
+
   return (
     <Box sx={{ pl: 2, flexGrow: 1 }}>
       {dimension.__typename === "TemporalDimension" &&
       dimension.timeUnit !== "Day" ? (
         <DataFilterSelectTime
-          dimensionIri={dimension.iri}
-          label={`${index + 1}. ${dimension.label}`}
-          controls={controls}
+          {...sharedProps}
           from={dimension.values[0].value}
           to={dimension.values[1].value}
           timeUnit={dimension.timeUnit}
           timeFormat={dimension.timeFormat}
-          disabled={disabled}
-          id={`select-single-filter-${index}`}
-          isOptional={!dimension.isKeyDimension}
         />
       ) : null}
       {dimension.__typename === "TemporalDimension" &&
       dimension.timeUnit === "Day" &&
       dimension.values ? (
-        <DataFilterSelectDay
-          dimensionIri={dimension.iri}
-          label={`${index + 1}. ${dimension.label}`}
-          controls={controls}
-          options={dimension.values}
-          disabled={disabled}
-          id={`select-single-filter-${index}`}
-          isOptional={!dimension.isKeyDimension}
-        />
+        <DataFilterSelectDay {...sharedProps} options={dimension.values} />
       ) : null}
       {dimension.__typename !== "TemporalDimension" ? (
-        <DataFilterSelect
-          dimensionIri={dimension.iri}
-          label={`${index + 1}. ${dimension.label}`}
-          controls={controls}
-          options={dimension.values}
-          disabled={disabled}
-          id={`select-single-filter-${index}`}
-          isOptional={!dimension.isKeyDimension}
-        />
+        <DataFilterSelect {...sharedProps} options={dimension.values} />
       ) : null}
     </Box>
   );

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -92,10 +92,18 @@ const DataFilterSelectGeneric = ({
     isOptional: !dimension.isKeyDimension,
   };
 
-  return (
-    <Box sx={{ pl: 2, flexGrow: 1 }}>
-      {dimension.__typename === "TemporalDimension" &&
-      dimension.timeUnit !== "Day" ? (
+  let component: React.ReactElement;
+  if (dimension.__typename === "TemporalDimension") {
+    if (dimension.timeUnit === "Day") {
+      component = (
+        <DataFilterSelectDay {...sharedProps} options={dimension.values} />
+      );
+    } else if (dimension.timeUnit === "Month") {
+      component = (
+        <DataFilterSelect {...sharedProps} options={dimension.values} />
+      );
+    } else {
+      component = (
         <DataFilterSelectTime
           {...sharedProps}
           from={dimension.values[0].value}
@@ -103,17 +111,15 @@ const DataFilterSelectGeneric = ({
           timeUnit={dimension.timeUnit}
           timeFormat={dimension.timeFormat}
         />
-      ) : null}
-      {dimension.__typename === "TemporalDimension" &&
-      dimension.timeUnit === "Day" &&
-      dimension.values ? (
-        <DataFilterSelectDay {...sharedProps} options={dimension.values} />
-      ) : null}
-      {dimension.__typename !== "TemporalDimension" ? (
-        <DataFilterSelect {...sharedProps} options={dimension.values} />
-      ) : null}
-    </Box>
-  );
+      );
+    }
+  } else {
+    component = (
+      <DataFilterSelect {...sharedProps} options={dimension.values} />
+    );
+  }
+
+  return <Box sx={{ pl: 2, flexGrow: 1 }}>{component}</Box>;
 };
 
 const orderedIsEqual = (

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -261,7 +261,8 @@ export const getCubeDimensionValues = async (
   if (
     typeof dimension.minInclusive !== "undefined" &&
     typeof dimension.maxInclusive !== "undefined" &&
-    data.timeUnit !== "Day"
+    data.timeUnit !== "Day" &&
+    data.timeUnit !== "Month"
   ) {
     const min = parseObservationValue({ value: dimension.minInclusive }) ?? 0;
     const max = parseObservationValue({ value: dimension.maxInclusive }) ?? 0;


### PR DESCRIPTION
Fix https://github.com/visualize-admin/visualization-tool/issues/564

Previously, only the min / max values were shown inside a temporal filter with timeUnit='Month'. Now we use a select for this case.

You can test by starting from [this dataset](https://visualization-tool-git-filter-month-select-ixt1.vercel.app/browse/dataset/https%3A%2F%2Fenvironment.ld.admin.ch%2Ffoen%2FUBD010705%2F3?previous=%7B%22includeDrafts%22%3Atrue%2C%22order%22%3A%22SCORE%22%2C%22search%22%3A%22Luftbelastung%22%7D) and selecting a x-axis different from the date, so that the date is available in the filters.