### PR TITLE
feat: Add link to opendata.swiss

### DIFF
--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -1,6 +1,6 @@
 import { Trans } from "@lingui/macro";
-import { Box, Button, Typography } from "@mui/material";
-import { useEffect, useState } from "react";
+import { Box, Button, Link, Typography } from "@mui/material";
+import { useEffect, useState, useMemo } from "react";
 
 import { useChartTablePreview } from "@/components/chart-table-preview";
 import { DataDownloadMenu, RunSparqlQuery } from "@/components/data-download";
@@ -11,6 +11,7 @@ import {
 } from "@/graphql/query-hooks";
 import { getChartIcon, Icon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
+import { makeOpenDataLink } from "@/utils/opendata";
 
 import { useQueryFilters } from "../charts/shared/chart-helpers";
 
@@ -47,13 +48,29 @@ export const ChartFootnotes = ({
   const sparqlEditorUrl =
     visibleData?.dataCubeByIri?.observations.sparqlEditorUrl;
 
+  const cubeLink = useMemo(() => {
+    return makeOpenDataLink(locale, data?.dataCubeByIri);
+  }, [locale, data?.dataCubeByIri]);
+
   if (data?.dataCubeByIri) {
     const { dataCubeByIri } = data;
 
     return (
       <Box sx={{ mt: 2 }}>
         <Typography component="div" variant="caption" color="grey.600">
-          <Trans id="metadata.dataset">Dataset</Trans>: {dataCubeByIri.title}
+          <Trans id="metadata.dataset">Dataset</Trans>:{" "}
+          {cubeLink ? (
+            <Link target="_blank" href={cubeLink} rel="noreferrer">
+              {dataCubeByIri.title}{" "}
+              <Icon
+                name="linkExternal"
+                size={12}
+                style={{ display: "inline" }}
+              />
+            </Link>
+          ) : (
+            dataCubeByIri.title
+          )}
         </Typography>
 
         <Typography component="div" variant="caption" color="grey.600">

--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -62,7 +62,7 @@ export const Radio = ({
 }: { label: string; disabled?: boolean } & FieldProps) => {
   return (
     <FormControlLabel
-      label={label}
+      label={label || "-"}
       htmlFor={`${name}-${value}`}
       componentsProps={{
         typography: {
@@ -117,7 +117,7 @@ export const Checkbox = ({
   smaller?: boolean;
 } & FieldProps) => (
   <FormControlLabel
-    label={label}
+    label={label || "-"}
     htmlFor={`${name}-${label}`}
     disabled={disabled}
     sx={{ display: "flex" }}

--- a/app/configurator/components/dataset-metadata.tsx
+++ b/app/configurator/components/dataset-metadata.tsx
@@ -1,5 +1,12 @@
 import { Trans } from "@lingui/macro";
-import { Box, BoxProps, Link, Typography } from "@mui/material";
+import {
+  Box,
+  BoxProps,
+  Link,
+  LinkProps,
+  Typography,
+  TypographyProps,
+} from "@mui/material";
 import { Stack } from "@mui/material";
 import { Link as MUILink } from "@mui/material";
 import NextLink from "next/link";
@@ -15,7 +22,9 @@ import {
   DataCubeMetadataQuery,
   useDataCubeMetadataQuery,
 } from "@/graphql/query-hooks";
+import { Icon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
+import { makeOpenDataLink } from "@/utils/opendata";
 import truthy from "@/utils/truthy";
 
 export const DataSetMetadata = ({
@@ -31,6 +40,7 @@ export const DataSetMetadata = ({
     variables: { iri: dataSetIri, locale },
   });
   const cube = data?.dataCubeByIri;
+  const openDataLink = makeOpenDataLink(locale, cube);
   if (fetching || error || !cube) {
     // The error and loading are managed by the component
     // displayed in the middle panel
@@ -86,17 +96,33 @@ export const DataSetMetadata = ({
       </DatasetMetadataBody>
 
       <DatasetMetadataTitle>
-        <Trans id="dataset.metadata.landingPage">Further information</Trans>
+        <Trans id="dataset.metadata.furtherinformation">
+          Further information
+        </Trans>
       </DatasetMetadataTitle>
-      <DatasetMetadataBody>
+      <DatasetMetadataBody sx={{ mb: 5 }}>
         {cube.landingPage ? (
           <DatasetMetadataLink
             href={cube.landingPage}
-            label={cube.landingPage}
+            external
+            label={
+              <Trans id="dataset.metadata.landingpage">Landing page</Trans>
+            }
           />
         ) : (
           "–"
         )}
+
+        {openDataLink ? (
+          <>
+            <br />
+            <DatasetMetadataLink
+              external
+              label="OpenData.swiss"
+              href={openDataLink}
+            />
+          </>
+        ) : null}
       </DatasetMetadataBody>
       <DatasetTags cube={cube} />
     </MotionBox>
@@ -116,7 +142,13 @@ const DatasetMetadataTitle = ({ children }: { children: ReactNode }) => (
     {children}
   </Typography>
 );
-const DatasetMetadataBody = ({ children }: { children: ReactNode }) => (
+const DatasetMetadataBody = ({
+  children,
+  sx,
+}: {
+  children: ReactNode;
+  sx?: TypographyProps["sx"];
+}) => (
   <Typography
     variant="body2"
     sx={{
@@ -125,6 +157,7 @@ const DatasetMetadataBody = ({ children }: { children: ReactNode }) => (
       fontSize: ["0.875rem", "0.875rem", "0.875rem"],
       color: "grey.900",
       mb: 3,
+      ...sx,
     }}
   >
     {children}
@@ -134,18 +167,24 @@ const DatasetMetadataBody = ({ children }: { children: ReactNode }) => (
 const DatasetMetadataLink = ({
   href,
   label,
+  external,
+  ...props
 }: {
   href: string;
-  label: string;
-}) => (
+  label: string | React.ReactElement;
+  external?: boolean;
+} & LinkProps) => (
   <Link
     underline="hover"
     color="primary"
     href={href}
     target="_blank"
     rel="noopener noreferrer"
+    sx={{ display: "inline-flex", alignItems: "center", gap: 1 }}
+    {...props}
   >
     {label}
+    {external ? <Icon name="linkExternal" size={12} /> : null}
   </Link>
 );
 

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -87,6 +87,9 @@ const renderDimensionTree = (tree: HierarchyValue[], depth = 0) => {
   return (
     <>
       {tree.map((tv) => {
+        if (!tv.label) {
+          return null;
+        }
         return (
           <Accordion key={tv.value} initialExpanded>
             <Stack spacing={0.5}>

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -86,6 +86,7 @@ query DataCubePreviewObservations(
 query DataCubeMetadata($iri: String!, $locale: String!, $latest: Boolean) {
   dataCubeByIri(iri: $iri, locale: $locale, latest: $latest) {
     iri
+    identifier
     title
     description
     publisher
@@ -117,6 +118,10 @@ query DataCubeMetadataWithComponentValues(
     iri
     title
     publisher
+    identifier
+    creator {
+      iri
+    }
     dimensions {
       ...dimensionMetaData
     }

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -23,6 +23,7 @@ export type Scalars = {
 export type DataCube = {
   __typename: 'DataCube';
   iri: Scalars['String'];
+  identifier?: Maybe<Scalars['String']>;
   title: Scalars['String'];
   version?: Maybe<Scalars['String']>;
   contactName?: Maybe<Scalars['String']>;
@@ -397,7 +398,7 @@ export type DataCubeMetadataQueryVariables = Exact<{
 }>;
 
 
-export type DataCubeMetadataQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', iri: string, title: string, description?: Maybe<string>, publisher?: Maybe<string>, version?: Maybe<string>, contactName?: Maybe<string>, contactEmail?: Maybe<string>, landingPage?: Maybe<string>, expires?: Maybe<string>, datePublished?: Maybe<string>, publicationStatus: DataCubePublicationStatus, themes: Array<{ __typename: 'DataCubeTheme', iri: string, label?: Maybe<string> }>, creator?: Maybe<{ __typename: 'DataCubeOrganization', iri: string, label?: Maybe<string> }> }> };
+export type DataCubeMetadataQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', iri: string, identifier?: Maybe<string>, title: string, description?: Maybe<string>, publisher?: Maybe<string>, version?: Maybe<string>, contactName?: Maybe<string>, contactEmail?: Maybe<string>, landingPage?: Maybe<string>, expires?: Maybe<string>, datePublished?: Maybe<string>, publicationStatus: DataCubePublicationStatus, themes: Array<{ __typename: 'DataCubeTheme', iri: string, label?: Maybe<string> }>, creator?: Maybe<{ __typename: 'DataCubeOrganization', iri: string, label?: Maybe<string> }> }> };
 
 export type DataCubeMetadataWithComponentValuesQueryVariables = Exact<{
   iri: Scalars['String'];
@@ -407,7 +408,7 @@ export type DataCubeMetadataWithComponentValuesQueryVariables = Exact<{
 }>;
 
 
-export type DataCubeMetadataWithComponentValuesQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', iri: string, title: string, publisher?: Maybe<string>, dimensions: Array<(
+export type DataCubeMetadataWithComponentValuesQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', iri: string, title: string, publisher?: Maybe<string>, identifier?: Maybe<string>, creator?: Maybe<{ __typename: 'DataCubeOrganization', iri: string }>, dimensions: Array<(
       { __typename: 'GeoCoordinatesDimension' }
       & DimensionMetaData_GeoCoordinatesDimension_Fragment
     ) | (
@@ -655,6 +656,7 @@ export const DataCubeMetadataDocument = gql`
     query DataCubeMetadata($iri: String!, $locale: String!, $latest: Boolean) {
   dataCubeByIri(iri: $iri, locale: $locale, latest: $latest) {
     iri
+    identifier
     title
     description
     publisher
@@ -686,6 +688,10 @@ export const DataCubeMetadataWithComponentValuesDocument = gql`
     iri
     title
     publisher
+    identifier
+    creator {
+      iri
+    }
     dimensions {
       ...dimensionMetaData
     }

--- a/app/graphql/resolver-types.ts
+++ b/app/graphql/resolver-types.ts
@@ -28,6 +28,7 @@ export type Scalars = {
 export type DataCube = {
   __typename?: 'DataCube';
   iri: Scalars['String'];
+  identifier?: Maybe<Scalars['String']>;
   title: Scalars['String'];
   version?: Maybe<Scalars['String']>;
   contactName?: Maybe<Scalars['String']>;
@@ -462,6 +463,7 @@ export type ResolversParentTypes = ResolversObject<{
 
 export type DataCubeResolvers<ContextType = any, ParentType extends ResolversParentTypes['DataCube'] = ResolversParentTypes['DataCube']> = ResolversObject<{
   iri?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  identifier?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   title?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   version?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   contactName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/app/graphql/resolvers.ts
+++ b/app/graphql/resolvers.ts
@@ -226,6 +226,7 @@ const DataCube: DataCubeResolvers = {
   iri: ({ data: { iri } }) => iri,
   title: ({ data: { title } }) => title,
   version: ({ data: { version } }) => version ?? null,
+  identifier: ({ data: { identifier } }) => identifier ?? null,
   publisher: ({ data: { publisher } }) => publisher ?? null,
   contactName: ({ data: { contactPoint } }) => contactPoint?.name ?? null,
   contactEmail: ({ data: { contactPoint } }) => contactPoint?.email ?? null,

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -23,6 +23,7 @@ enum DataCubePublicationStatus {
 
 type DataCube {
   iri: String!
+  identifier: String
   title: String!
   version: String
   contactName: String

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:502
+#: app/configurator/components/chart-configurator.tsx:497
 msgid "Add filter"
 msgstr "Filter hinzufügen"
 
@@ -21,15 +21,15 @@ msgstr "Filter hinzufügen"
 msgid "Browse {0}"
 msgstr "{0} durchsuchen"
 
-#: app/configurator/components/chart-configurator.tsx:457
+#: app/configurator/components/chart-configurator.tsx:452
 msgid "Drag filters to reorganize"
 msgstr "Ziehen Sie die Filter per Drag & Drop, um sie neu zu organisieren"
 
-#: app/configurator/components/chart-configurator.tsx:454
+#: app/configurator/components/chart-configurator.tsx:449
 msgid "Move filter down"
 msgstr "Filter nach unten verschieben"
 
-#: app/configurator/components/chart-configurator.tsx:451
+#: app/configurator/components/chart-configurator.tsx:446
 msgid "Move filter up"
 msgstr "Filter nach oben verschieben"
 
@@ -42,11 +42,11 @@ msgstr "Kein Ergebnis"
 msgid "Search “{0}”"
 msgstr "Suche “{0}”"
 
-#: app/components/chart-preview.tsx:102
+#: app/components/chart-preview.tsx:112
 msgid "annotation.add.description"
 msgstr "[ Ohne Beschreibung ]"
 
-#: app/components/chart-preview.tsx:80
+#: app/components/chart-preview.tsx:90
 msgid "annotation.add.title"
 msgstr "[ Ohne Titel ]"
 
@@ -75,23 +75,23 @@ msgstr "Erkunden Sie die vom LINDAS Linked Data Service bereitgestellten Datens�
 msgid "button.back"
 msgstr "Zurück"
 
-#: app/pages/v/[chartId].tsx:153
+#: app/pages/v/[chartId].tsx:167
 msgid "button.copy.visualization"
 msgstr "Diese Visualisierung kopieren und editieren"
 
-#: app/components/data-download.tsx:182
+#: app/components/data-download.tsx:186
 msgid "button.download"
 msgstr "Herunterladen"
 
-#: app/components/data-download.tsx:172
+#: app/components/data-download.tsx:176
 msgid "button.download.data"
 msgstr "Daten herunterladen"
 
-#: app/components/data-download.tsx:199
+#: app/components/data-download.tsx:203
 msgid "button.download.data.all"
 msgstr "Vollständiger Datensatz"
 
-#: app/components/data-download.tsx:191
+#: app/components/data-download.tsx:195
 msgid "button.download.data.visible"
 msgstr "Gefilterter Datensatz"
 
@@ -103,24 +103,24 @@ msgstr "Gefilterter Datensatz"
 #~ msgid "button.download.runsparqlquery.all"
 #~ msgstr "SPARQL-Abfrage ausführen (alle)"
 
-#: app/components/data-download.tsx:343
+#: app/components/data-download.tsx:347
 msgid "button.download.runsparqlquery.visible"
 msgstr "SPARQL-Abfrage ausführen"
 
-#: app/components/publish-actions.tsx:230
+#: app/components/publish-actions.tsx:204
 msgid "button.embed"
 msgstr "Einbetten"
 
-#: app/components/publish-actions.tsx:260
-#: app/components/publish-actions.tsx:266
+#: app/components/publish-actions.tsx:229
+#: app/components/publish-actions.tsx:235
 msgid "button.hint.click.to.copy"
 msgstr "Kopieren"
 
-#: app/components/publish-actions.tsx:303
+#: app/components/publish-actions.tsx:272
 msgid "button.hint.copied"
 msgstr "Kopiert!"
 
-#: app/pages/v/[chartId].tsx:138
+#: app/pages/v/[chartId].tsx:152
 msgid "button.new.visualization"
 msgstr "Neue Visualisierung erstellen"
 
@@ -132,11 +132,11 @@ msgstr "Weiter"
 msgid "button.publish"
 msgstr "Diese Visualisierung veröffentlichen"
 
-#: app/components/publish-actions.tsx:116
+#: app/components/publish-actions.tsx:94
 msgid "button.share"
 msgstr "Teilen"
 
-#: app/configurator/components/ui-helpers.ts:485
+#: app/configurator/components/ui-helpers.ts:548
 #: app/configurator/map/map-chart-options.tsx:163
 msgid "chart.map.layers.area"
 msgstr "Flächen"
@@ -161,8 +161,8 @@ msgstr "Quantile (gleiche Anzahl Werte)"
 msgid "chart.map.layers.area.discretization.quantize"
 msgstr "Quantisierung (gleiche Wertebereiche)"
 
-#: app/configurator/components/chart-configurator.tsx:554
-#: app/configurator/components/ui-helpers.ts:481
+#: app/configurator/components/chart-configurator.tsx:553
+#: app/configurator/components/ui-helpers.ts:544
 #: app/configurator/map/map-chart-options.tsx:64
 msgid "chart.map.layers.base"
 msgstr "Basis-Ebene"
@@ -176,7 +176,7 @@ msgstr "Anzeigen"
 msgid "chart.map.layers.show"
 msgstr "Ebene anzeigen"
 
-#: app/configurator/components/ui-helpers.ts:489
+#: app/configurator/components/ui-helpers.ts:552
 #: app/configurator/map/map-chart-options.tsx:387
 msgid "chart.map.layers.symbol"
 msgstr "Symbole"
@@ -222,47 +222,47 @@ msgstr "Normal"
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Standardeinstellung"
 
-#: app/configurator/components/ui-helpers.ts:455
+#: app/configurator/components/ui-helpers.ts:518
 msgid "controls.axis.horizontal"
 msgstr "Horizontale Achse"
 
-#: app/configurator/components/ui-helpers.ts:463
+#: app/configurator/components/ui-helpers.ts:526
 msgid "controls.axis.vertical"
 msgstr "Vertikale Achse"
 
-#: app/configurator/components/ui-helpers.ts:557
+#: app/configurator/components/ui-helpers.ts:620
 msgid "controls.chart.type.area"
 msgstr "Flächen"
 
-#: app/configurator/components/ui-helpers.ts:549
+#: app/configurator/components/ui-helpers.ts:612
 msgid "controls.chart.type.bar"
 msgstr "Balken"
 
-#: app/configurator/components/ui-helpers.ts:545
+#: app/configurator/components/ui-helpers.ts:608
 msgid "controls.chart.type.column"
 msgstr "Säulen"
 
-#: app/configurator/components/ui-helpers.ts:553
+#: app/configurator/components/ui-helpers.ts:616
 msgid "controls.chart.type.line"
 msgstr "Linien"
 
-#: app/configurator/components/ui-helpers.ts:573
+#: app/configurator/components/ui-helpers.ts:636
 msgid "controls.chart.type.map"
 msgstr "Karte"
 
-#: app/configurator/components/ui-helpers.ts:565
+#: app/configurator/components/ui-helpers.ts:628
 msgid "controls.chart.type.pie"
 msgstr "Kreis"
 
-#: app/configurator/components/ui-helpers.ts:561
+#: app/configurator/components/ui-helpers.ts:624
 msgid "controls.chart.type.scatterplot"
 msgstr "Scatterplot"
 
-#: app/configurator/components/ui-helpers.ts:569
+#: app/configurator/components/ui-helpers.ts:632
 msgid "controls.chart.type.table"
 msgstr "Tabelle"
 
-#: app/configurator/components/ui-helpers.ts:467
+#: app/configurator/components/ui-helpers.ts:530
 #: app/configurator/map/map-chart-options.tsx:236
 #: app/configurator/map/map-chart-options.tsx:441
 msgid "controls.color"
@@ -277,8 +277,7 @@ msgstr "Hinzufügen …"
 msgid "controls.color.palette"
 msgstr "Farbpalette"
 
-#: app/configurator/components/chart-controls/color-palette.tsx:238
-#: app/configurator/components/chart-controls/color-palette.tsx:244
+#: app/configurator/components/chart-controls/color-palette.tsx:240
 msgid "controls.color.palette.reset"
 msgstr "Farbpalette zurücksetzen"
 
@@ -294,15 +293,15 @@ msgstr "Farbe auswählen"
 msgid "controls.colorpicker.open"
 msgstr "Farbauswahl öffnen"
 
-#: app/configurator/components/ui-helpers.ts:477
+#: app/configurator/components/ui-helpers.ts:540
 msgid "controls.column.grouped"
 msgstr "Gruppiert"
 
-#: app/configurator/components/ui-helpers.ts:473
+#: app/configurator/components/ui-helpers.ts:536
 msgid "controls.column.stacked"
 msgstr "Gestapelt"
 
-#: app/configurator/components/ui-helpers.ts:469
+#: app/configurator/components/ui-helpers.ts:532
 msgid "controls.description"
 msgstr "Beschreibung hinzufügen"
 
@@ -315,7 +314,7 @@ msgstr "Geografische Dimension"
 msgid "controls.dimension.none"
 msgstr "Keine"
 
-#: app/charts/shared/chart-data-filters.tsx:193
+#: app/charts/shared/chart-data-filters.tsx:198
 #: app/configurator/components/field.tsx:122
 #: app/configurator/components/field.tsx:179
 #: app/configurator/components/field.tsx:279
@@ -334,7 +333,7 @@ msgstr "Alle auswählen"
 msgid "controls.filter.select.none"
 msgstr "Alle abwählen"
 
-#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:137
+#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:123
 msgid "controls.filters.time.range"
 msgstr "Zeitspanne"
 
@@ -354,23 +353,23 @@ msgstr "Bitte eine Designoption oder Datendimension auswählen, um diese zu bear
 msgid "controls.hint.describing.chart"
 msgstr "Bitte ein Beschreibungsfeld auswählen, um dieses zu bearbeiten."
 
-#: app/configurator/components/ui-helpers.ts:529
+#: app/configurator/components/ui-helpers.ts:592
 msgid "controls.imputation"
 msgstr "Imputationstyp"
 
 #: app/configurator/components/chart-options-selector.tsx:528
-#: app/configurator/components/ui-helpers.ts:541
+#: app/configurator/components/ui-helpers.ts:604
 msgid "controls.imputation.type.linear"
 msgstr "Lineare Interpolation"
 
 #: app/configurator/components/chart-options-selector.tsx:521
 #: app/configurator/components/chart-options-selector.tsx:533
-#: app/configurator/components/ui-helpers.ts:533
+#: app/configurator/components/ui-helpers.ts:596
 msgid "controls.imputation.type.none"
 msgstr "-"
 
 #: app/configurator/components/chart-options-selector.tsx:523
-#: app/configurator/components/ui-helpers.ts:537
+#: app/configurator/components/ui-helpers.ts:600
 msgid "controls.imputation.type.zeros"
 msgstr "Nullen"
 
@@ -394,23 +393,23 @@ msgstr "Keine Zeitdimension verfügbar!"
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Zeitfilter anzeigen"
 
-#: app/configurator/components/ui-helpers.ts:577
+#: app/configurator/components/ui-helpers.ts:640
 msgid "controls.language.english"
 msgstr "Englisch"
 
-#: app/configurator/components/ui-helpers.ts:585
+#: app/configurator/components/ui-helpers.ts:648
 msgid "controls.language.french"
 msgstr "Französisch"
 
-#: app/configurator/components/ui-helpers.ts:581
+#: app/configurator/components/ui-helpers.ts:644
 msgid "controls.language.german"
 msgstr "Deutsch"
 
-#: app/configurator/components/ui-helpers.ts:589
+#: app/configurator/components/ui-helpers.ts:652
 msgid "controls.language.italian"
 msgstr "Italienisch"
 
-#: app/configurator/components/ui-helpers.ts:459
+#: app/configurator/components/ui-helpers.ts:522
 #: app/configurator/map/map-chart-options.tsx:218
 #: app/configurator/map/map-chart-options.tsx:423
 msgid "controls.measure"
@@ -425,8 +424,8 @@ msgid "controls.option.isNotActive"
 msgstr "Aus"
 
 #: app/configurator/components/chart-type-selector.tsx:193
-msgid "controls.remove.visualization"
-msgstr "Diese Visualisierung entfernen"
+#~ msgid "controls.remove.visualization"
+#~ msgstr "Diese Visualisierung entfernen"
 
 #: app/configurator/map/map-chart-options.tsx:240
 msgid "controls.scale.type"
@@ -440,7 +439,7 @@ msgstr "Suche zurücksetzen"
 msgid "controls.section.additional-information"
 msgstr "Zusätzliche Informationen"
 
-#: app/configurator/components/chart-configurator.tsx:365
+#: app/configurator/components/chart-configurator.tsx:360
 msgid "controls.section.chart.options"
 msgstr "Diagramm-Einstellungen"
 
@@ -452,7 +451,7 @@ msgstr "Spalten"
 msgid "controls.section.columnstyle"
 msgstr "Spaltenstil"
 
-#: app/configurator/components/chart-configurator.tsx:380
+#: app/configurator/components/chart-configurator.tsx:375
 msgid "controls.section.data.filters"
 msgstr "Filter"
 
@@ -509,7 +508,7 @@ msgstr "Tabellensortierung"
 msgid "controls.section.tableoptions"
 msgstr "Tabellenoptionen"
 
-#: app/configurator/components/chart-type-selector.tsx:146
+#: app/configurator/components/chart-type-selector.tsx:136
 msgid "controls.select.chart.type"
 msgstr "Diagrammtyp"
 
@@ -577,11 +576,11 @@ msgstr "Dimension hinzufügen"
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Name"
 
-#: app/configurator/components/ui-helpers.ts:497
+#: app/configurator/components/ui-helpers.ts:560
 msgid "controls.sorting.byDimensionLabel.ascending"
 msgstr "A → Z"
 
-#: app/configurator/components/ui-helpers.ts:501
+#: app/configurator/components/ui-helpers.ts:564
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
@@ -589,11 +588,11 @@ msgstr "Z → A"
 msgid "controls.sorting.byMeasure"
 msgstr "Messwert"
 
-#: app/configurator/components/ui-helpers.ts:521
+#: app/configurator/components/ui-helpers.ts:584
 msgid "controls.sorting.byMeasure.ascending"
 msgstr "1 → 9"
 
-#: app/configurator/components/ui-helpers.ts:525
+#: app/configurator/components/ui-helpers.ts:588
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
@@ -601,19 +600,19 @@ msgstr "9 → 1"
 msgid "controls.sorting.byTotalSize"
 msgstr "Gesamtgrösse"
 
-#: app/configurator/components/ui-helpers.ts:505
+#: app/configurator/components/ui-helpers.ts:568
 msgid "controls.sorting.byTotalSize.ascending"
 msgstr "Kleinste zuerst"
 
-#: app/configurator/components/ui-helpers.ts:517
+#: app/configurator/components/ui-helpers.ts:580
 msgid "controls.sorting.byTotalSize.largestBottom"
 msgstr "Grösste unten"
 
-#: app/configurator/components/ui-helpers.ts:509
+#: app/configurator/components/ui-helpers.ts:572
 msgid "controls.sorting.byTotalSize.largestFirst"
 msgstr "Grösste zuerst"
 
-#: app/configurator/components/ui-helpers.ts:513
+#: app/configurator/components/ui-helpers.ts:576
 msgid "controls.sorting.byTotalSize.largestTop"
 msgstr "Kleinste unten"
 
@@ -625,12 +624,12 @@ msgstr "Sortierung entfernen"
 msgid "controls.sorting.selectDimension"
 msgstr "Wählen Sie eine Dimension aus …"
 
-#: app/configurator/components/ui-helpers.ts:493
+#: app/configurator/components/ui-helpers.ts:556
 #: app/configurator/table/table-chart-sorting-options.tsx:307
 msgid "controls.sorting.sortBy"
 msgstr "Sortieren nach"
 
-#: app/configurator/components/chart-type-selector.tsx:150
+#: app/configurator/components/chart-type-selector.tsx:140
 msgid "controls.switch.chart.type"
 msgstr "Wechseln Sie zu einem anderen Diagrammtyp unter Beibehaltung der meisten Filtereinstellungen"
 
@@ -654,7 +653,7 @@ msgstr "Sortierung"
 msgid "controls.tableSettings.showSearch"
 msgstr "Suche anzeigen"
 
-#: app/configurator/components/ui-helpers.ts:468
+#: app/configurator/components/ui-helpers.ts:531
 msgid "controls.title"
 msgstr "Titel hinzufügen"
 
@@ -666,7 +665,7 @@ msgstr "Zurück zu den Datensätzen"
 #~ msgid "dataset-selector.choose-another-dataset"
 #~ msgstr "Wählen Sie einen anderen Datensatz"
 
-#: app/components/chart-published.tsx:109
+#: app/components/chart-published.tsx:117
 msgid "dataset.hasImputedValues"
 msgstr "Einige Daten in diesem Datensatz fehlen und wurden interpoliert, um die Lücken zu füllen."
 
@@ -674,23 +673,27 @@ msgstr "Einige Daten in diesem Datensatz fehlen und wurden interpoliert, um die 
 msgid "dataset.includeDrafts"
 msgstr "Entwürfe einschließen"
 
-#: app/configurator/components/dataset-metadata.tsx:63
+#: app/configurator/components/dataset-metadata.tsx:71
 msgid "dataset.metadata.date.created"
 msgstr "Erstellungsdatum"
 
-#: app/configurator/components/dataset-metadata.tsx:75
+#: app/configurator/components/dataset-metadata.tsx:83
 msgid "dataset.metadata.email"
 msgstr "Kontaktstellen"
 
-#: app/configurator/components/dataset-metadata.tsx:89
-msgid "dataset.metadata.landingPage"
+#: app/configurator/components/dataset-metadata.tsx:97
+msgid "dataset.metadata.furtherinformation"
 msgstr "Weitere Informationen"
 
-#: app/configurator/components/dataset-metadata.tsx:49
+#: app/configurator/components/dataset-metadata.tsx:104
+msgid "dataset.metadata.landingpage"
+msgstr "Zielseite"
+
+#: app/configurator/components/dataset-metadata.tsx:57
 msgid "dataset.metadata.source"
 msgstr "Quelle"
 
-#: app/configurator/components/dataset-metadata.tsx:70
+#: app/configurator/components/dataset-metadata.tsx:78
 msgid "dataset.metadata.version"
 msgstr "Version"
 
@@ -706,13 +709,13 @@ msgstr "Relevanz"
 msgid "dataset.order.title"
 msgstr "Titel"
 
-#: app/components/chart-preview.tsx:59
-#: app/components/chart-published.tsx:87
+#: app/components/chart-preview.tsx:69
+#: app/components/chart-published.tsx:95
 #: app/configurator/components/dataset-preview.tsx:41
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Achtung, dieser Datensatz ist im Entwurfs-Stadium.<0/><1>Diese Grafik nicht für Berichte verwenden.</1>"
 
-#: app/components/chart-published.tsx:98
+#: app/components/chart-published.tsx:106
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Achtung, dieser Datensatz ist abgelaufen.<0/><1>Diese Grafik nicht für Berichte verwenden.</1>"
 
@@ -736,7 +739,7 @@ msgstr "Sortieren nach"
 msgid "dataset.tag.draft"
 msgstr "Entwurf"
 
-#: app/configurator/components/dataset-preview.tsx:108
+#: app/configurator/components/dataset-preview.tsx:112
 msgid "datatable.showing.first.rows"
 msgstr "Die ersten 10 Zeilen werden angezeigt"
 
@@ -748,79 +751,79 @@ msgstr "Bundesamt für Umwelt BAFU"
 msgid "footer.institution.url"
 msgstr "https://www.bafu.admin.ch/bafu/de/home.html"
 
-#: app/components/footer.tsx:125
+#: app/components/footer.tsx:126
 msgid "footer.status"
 msgstr "Status"
 
-#: app/components/hint.tsx:158
+#: app/components/hint.tsx:174
 msgid "hint.chartunexpected.message"
 msgstr ""
 
-#: app/components/hint.tsx:156
+#: app/components/hint.tsx:172
 msgid "hint.chartunexpected.title"
 msgstr ""
 
-#: app/components/hint.tsx:144
+#: app/components/hint.tsx:160
 msgid "hint.coordinatesloadingerror.message"
 msgstr "Es gab ein Problem beim Laden der Koordinaten aus den geografischen Dimensionen. Bitte später erneut versuchen."
 
-#: app/components/hint.tsx:140
+#: app/components/hint.tsx:156
 msgid "hint.coordinatesloadingerror.title"
 msgstr "Koordinaten-Ladefehler"
 
-#: app/pages/v/[chartId].tsx:122
+#: app/pages/v/[chartId].tsx:129
 msgid "hint.create.your.own.chart"
 msgstr "Kopieren Sie diese Visualisierung oder erstellen Sie eine neue Visualisierung mit Swiss Open Government Data."
 
-#: app/components/hint.tsx:128
+#: app/components/hint.tsx:130
 msgid "hint.dataloadingerror.message"
 msgstr "Die Daten konnten nicht geladen werden."
 
-#: app/components/hint.tsx:137
+#: app/components/hint.tsx:139
 msgid "hint.dataloadingerror.status"
 msgstr "Weitere Informationen finden Sie auf der Statusseite"
 
-#: app/components/hint.tsx:126
+#: app/components/hint.tsx:128
 msgid "hint.dataloadingerror.title"
 msgstr "Daten-Ladefehler"
 
-#: app/pages/v/[chartId].tsx:116
+#: app/pages/v/[chartId].tsx:123
 msgid "hint.how.to.share"
 msgstr "Sie können diese Visualisierung teilen oder sie einbetten. Zudem können Sie eine neue Visualisierung erstellen oder die gezeigte Visualisierung kopieren."
 
-#: app/components/hint.tsx:91
+#: app/components/hint.tsx:92
 msgid "hint.loading.data"
 msgstr "Lade Daten …"
 
-#: app/configurator/components/chart-type-selector.tsx:167
+#: app/configurator/components/chart-type-selector.tsx:150
 msgid "hint.no.visualization.with.dataset"
 msgstr "Mit dem ausgewählten Datensatz kann keine Visualisierung erstellt werden."
 
-#: app/components/hint.tsx:118
+#: app/components/hint.tsx:119
 msgid "hint.nodata.message"
 msgstr "Bitte versuchen Sie es mit einer anderen Filterkombination."
 
-#: app/components/hint.tsx:114
+#: app/components/hint.tsx:115
 msgid "hint.nodata.title"
 msgstr "Keine Daten für die aktuelle Filterauswahl"
 
-#: app/components/hint.tsx:180
+#: app/components/hint.tsx:196
 msgid "hint.only.negative.data.message"
 msgstr "Negative Datenwerte können mit diesem Diagrammtyp nicht dargestellt werden."
 
-#: app/components/hint.tsx:178
+#: app/components/hint.tsx:194
 msgid "hint.only.negative.data.title"
 msgstr "Negative Werte"
 
-#: app/components/hint.tsx:188
+#: app/components/hint.tsx:204
 msgid "hint.publication.success"
 msgstr "Die Visualisierung ist jetzt veröffentlicht. Sie können sie teilen oder einbetten, indem Sie die URL kopieren oder das Menü unten verwenden."
 
-#: app/charts/shared/chart-data-filters.tsx:72
+#: app/charts/shared/chart-data-filters.tsx:75
 msgid "interactive.data.filters.hide"
 msgstr "Filter ausblenden"
 
-#: app/charts/shared/chart-data-filters.tsx:70
+#: app/charts/shared/chart-data-filters.tsx:77
 msgid "interactive.data.filters.show"
 msgstr "Filter anzeigen"
 
@@ -829,63 +832,63 @@ msgstr "Filter anzeigen"
 msgid "logo.swiss.confederation"
 msgstr "Logo der Schweizerischen Eidgenossenschaft"
 
-#: app/components/chart-footnotes.tsx:56
+#: app/components/chart-footnotes.tsx:61
 msgid "metadata.dataset"
 msgstr "Datensatz"
 
-#: app/components/chart-footnotes.tsx:131
+#: app/components/chart-footnotes.tsx:162
 msgid "metadata.link.created.with.visualize"
 msgstr "Erstellt mit visualize.admin.ch"
 
-#: app/components/chart-footnotes.tsx:60
+#: app/components/chart-footnotes.tsx:77
 msgid "metadata.source"
 msgstr "Quelle"
 
-#: app/components/chart-footnotes.tsx:99
+#: app/components/chart-footnotes.tsx:140
 msgid "metadata.switch.chart"
 msgstr "Zur Diagrammansicht wechseln"
 
-#: app/components/chart-footnotes.tsx:103
+#: app/components/chart-footnotes.tsx:142
 msgid "metadata.switch.table"
 msgstr "Zur Tabellenansicht wechseln"
 
-#: app/components/publish-actions.tsx:245
+#: app/components/publish-actions.tsx:216
 msgid "publication.embed.AEM"
 msgstr "Einbett-Code für AEM «Externe Applikation»:"
 
-#: app/components/publish-actions.tsx:238
+#: app/components/publish-actions.tsx:209
 msgid "publication.embed.iframe"
 msgstr "Einbett-Code:"
 
-#: app/components/publish-actions.tsx:135
+#: app/components/publish-actions.tsx:109
 msgid "publication.popup.share"
 msgstr "Teilen"
 
-#: app/components/publish-actions.tsx:182
+#: app/components/publish-actions.tsx:157
 msgid "publication.share.chart.url"
 msgstr "Diagramm-URL:"
 
-#: app/components/publish-actions.tsx:141
+#: app/components/publish-actions.tsx:115
 msgid "publication.share.linktitle.facebook"
 msgstr "Teilen via Facebook"
 
-#: app/components/publish-actions.tsx:161
+#: app/components/publish-actions.tsx:135
 msgid "publication.share.linktitle.mail"
 msgstr "Versenden via E-Mail"
 
-#: app/components/publish-actions.tsx:151
+#: app/components/publish-actions.tsx:125
 msgid "publication.share.linktitle.twitter"
 msgstr "Teilen via Twitter"
 
-#: app/components/publish-actions.tsx:172
+#: app/components/publish-actions.tsx:146
 msgid "publication.share.mail.body"
 msgstr "Hier ist eine Visualisierung, die ich mit visualize.admin.ch erstellt habe"
 
-#: app/components/publish-actions.tsx:167
+#: app/components/publish-actions.tsx:141
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
-#: app/configurator/components/stepper.tsx:187
+#: app/configurator/components/stepper.tsx:191
 msgid "step.annotate"
 msgstr "Bevor Sie Veröffentlichen, fügen Sie Ihrem Diagramm einen Titel und eine Beschreibung hinzu, und wählen Sie, welche Elemente interaktiv sein sollen."
 
@@ -893,7 +896,7 @@ msgstr "Bevor Sie Veröffentlichen, fügen Sie Ihrem Diagramm einen Titel und ei
 #~ msgid "step.visualization.type"
 #~ msgstr "Wählen Sie den gewünschten Diagrammtypen für Ihren Datensatz aus."
 
-#: app/configurator/components/stepper.tsx:176
+#: app/configurator/components/stepper.tsx:180
 msgid "step.visualize"
 msgstr "Passen Sie Ihre Visualisierung an, indem Sie die Filter- und Farbsegmentierungsoptionen in den Seitenleisten verwenden."
 

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:502
+#: app/configurator/components/chart-configurator.tsx:497
 msgid "Add filter"
 msgstr "Add filter"
 
@@ -21,15 +21,15 @@ msgstr "Add filter"
 msgid "Browse {0}"
 msgstr "Browse {0}"
 
-#: app/configurator/components/chart-configurator.tsx:457
+#: app/configurator/components/chart-configurator.tsx:452
 msgid "Drag filters to reorganize"
 msgstr "Drag filters to reorganize"
 
-#: app/configurator/components/chart-configurator.tsx:454
+#: app/configurator/components/chart-configurator.tsx:449
 msgid "Move filter down"
 msgstr "Move filter down"
 
-#: app/configurator/components/chart-configurator.tsx:451
+#: app/configurator/components/chart-configurator.tsx:446
 msgid "Move filter up"
 msgstr "Move filter up"
 
@@ -42,11 +42,11 @@ msgstr "No results"
 msgid "Search “{0}”"
 msgstr "Search “{0}”"
 
-#: app/components/chart-preview.tsx:102
+#: app/components/chart-preview.tsx:112
 msgid "annotation.add.description"
 msgstr "[ No Description ]"
 
-#: app/components/chart-preview.tsx:80
+#: app/components/chart-preview.tsx:90
 msgid "annotation.add.title"
 msgstr "[ No Title ]"
 
@@ -75,23 +75,23 @@ msgstr "Explore datasets provided by the LINDAS Linked Data Service by either fi
 msgid "button.back"
 msgstr "Back"
 
-#: app/pages/v/[chartId].tsx:153
+#: app/pages/v/[chartId].tsx:167
 msgid "button.copy.visualization"
 msgstr "Copy and edit this visualization"
 
-#: app/components/data-download.tsx:182
+#: app/components/data-download.tsx:186
 msgid "button.download"
 msgstr "Download"
 
-#: app/components/data-download.tsx:172
+#: app/components/data-download.tsx:176
 msgid "button.download.data"
 msgstr "Download data"
 
-#: app/components/data-download.tsx:199
+#: app/components/data-download.tsx:203
 msgid "button.download.data.all"
 msgstr "Full dataset"
 
-#: app/components/data-download.tsx:191
+#: app/components/data-download.tsx:195
 msgid "button.download.data.visible"
 msgstr "Filtered dataset"
 
@@ -103,24 +103,24 @@ msgstr "Filtered dataset"
 #~ msgid "button.download.runsparqlquery.all"
 #~ msgstr "Run SPARQL query (all)"
 
-#: app/components/data-download.tsx:343
+#: app/components/data-download.tsx:347
 msgid "button.download.runsparqlquery.visible"
 msgstr "Run SPARQL query"
 
-#: app/components/publish-actions.tsx:230
+#: app/components/publish-actions.tsx:204
 msgid "button.embed"
 msgstr "Embed"
 
-#: app/components/publish-actions.tsx:260
-#: app/components/publish-actions.tsx:266
+#: app/components/publish-actions.tsx:229
+#: app/components/publish-actions.tsx:235
 msgid "button.hint.click.to.copy"
 msgstr "Click to copy"
 
-#: app/components/publish-actions.tsx:303
+#: app/components/publish-actions.tsx:272
 msgid "button.hint.copied"
 msgstr "Copied!"
 
-#: app/pages/v/[chartId].tsx:138
+#: app/pages/v/[chartId].tsx:152
 msgid "button.new.visualization"
 msgstr "Create New Visualization"
 
@@ -132,11 +132,11 @@ msgstr "Next"
 msgid "button.publish"
 msgstr "Publish this visualization"
 
-#: app/components/publish-actions.tsx:116
+#: app/components/publish-actions.tsx:94
 msgid "button.share"
 msgstr "Share"
 
-#: app/configurator/components/ui-helpers.ts:485
+#: app/configurator/components/ui-helpers.ts:548
 #: app/configurator/map/map-chart-options.tsx:163
 msgid "chart.map.layers.area"
 msgstr "Areas"
@@ -161,8 +161,8 @@ msgstr "Quantiles (equal distribution of values)"
 msgid "chart.map.layers.area.discretization.quantize"
 msgstr "Quantize (equal intervals)"
 
-#: app/configurator/components/chart-configurator.tsx:554
-#: app/configurator/components/ui-helpers.ts:481
+#: app/configurator/components/chart-configurator.tsx:553
+#: app/configurator/components/ui-helpers.ts:544
 #: app/configurator/map/map-chart-options.tsx:64
 msgid "chart.map.layers.base"
 msgstr "Base Layer"
@@ -176,7 +176,7 @@ msgstr "Show"
 msgid "chart.map.layers.show"
 msgstr "Show layer"
 
-#: app/configurator/components/ui-helpers.ts:489
+#: app/configurator/components/ui-helpers.ts:552
 #: app/configurator/map/map-chart-options.tsx:387
 msgid "chart.map.layers.symbol"
 msgstr "Symbols"
@@ -222,47 +222,47 @@ msgstr "Regular"
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Default Settings"
 
-#: app/configurator/components/ui-helpers.ts:455
+#: app/configurator/components/ui-helpers.ts:518
 msgid "controls.axis.horizontal"
 msgstr "Horizontal Axis"
 
-#: app/configurator/components/ui-helpers.ts:463
+#: app/configurator/components/ui-helpers.ts:526
 msgid "controls.axis.vertical"
 msgstr "Vertical Axis"
 
-#: app/configurator/components/ui-helpers.ts:557
+#: app/configurator/components/ui-helpers.ts:620
 msgid "controls.chart.type.area"
 msgstr "Areas"
 
-#: app/configurator/components/ui-helpers.ts:549
+#: app/configurator/components/ui-helpers.ts:612
 msgid "controls.chart.type.bar"
 msgstr "Bars"
 
-#: app/configurator/components/ui-helpers.ts:545
+#: app/configurator/components/ui-helpers.ts:608
 msgid "controls.chart.type.column"
 msgstr "Columns"
 
-#: app/configurator/components/ui-helpers.ts:553
+#: app/configurator/components/ui-helpers.ts:616
 msgid "controls.chart.type.line"
 msgstr "Lines"
 
-#: app/configurator/components/ui-helpers.ts:573
+#: app/configurator/components/ui-helpers.ts:636
 msgid "controls.chart.type.map"
 msgstr "Map"
 
-#: app/configurator/components/ui-helpers.ts:565
+#: app/configurator/components/ui-helpers.ts:628
 msgid "controls.chart.type.pie"
 msgstr "Pie"
 
-#: app/configurator/components/ui-helpers.ts:561
+#: app/configurator/components/ui-helpers.ts:624
 msgid "controls.chart.type.scatterplot"
 msgstr "Scatterplot"
 
-#: app/configurator/components/ui-helpers.ts:569
+#: app/configurator/components/ui-helpers.ts:632
 msgid "controls.chart.type.table"
 msgstr "Table"
 
-#: app/configurator/components/ui-helpers.ts:467
+#: app/configurator/components/ui-helpers.ts:530
 #: app/configurator/map/map-chart-options.tsx:236
 #: app/configurator/map/map-chart-options.tsx:441
 msgid "controls.color"
@@ -281,8 +281,7 @@ msgstr "Color palette"
 #~ msgid "controls.color.palette.diverging"
 #~ msgstr "Diverging"
 
-#: app/configurator/components/chart-controls/color-palette.tsx:238
-#: app/configurator/components/chart-controls/color-palette.tsx:244
+#: app/configurator/components/chart-controls/color-palette.tsx:240
 msgid "controls.color.palette.reset"
 msgstr "Reset color palette"
 
@@ -298,15 +297,15 @@ msgstr "Select a color"
 msgid "controls.colorpicker.open"
 msgstr "Open Color Picker"
 
-#: app/configurator/components/ui-helpers.ts:477
+#: app/configurator/components/ui-helpers.ts:540
 msgid "controls.column.grouped"
 msgstr "Grouped"
 
-#: app/configurator/components/ui-helpers.ts:473
+#: app/configurator/components/ui-helpers.ts:536
 msgid "controls.column.stacked"
 msgstr "Stacked"
 
-#: app/configurator/components/ui-helpers.ts:469
+#: app/configurator/components/ui-helpers.ts:532
 msgid "controls.description"
 msgstr "Description"
 
@@ -319,7 +318,7 @@ msgstr "Geographical dimension"
 msgid "controls.dimension.none"
 msgstr "None"
 
-#: app/charts/shared/chart-data-filters.tsx:193
+#: app/charts/shared/chart-data-filters.tsx:198
 #: app/configurator/components/field.tsx:122
 #: app/configurator/components/field.tsx:179
 #: app/configurator/components/field.tsx:279
@@ -338,7 +337,7 @@ msgstr "Select all"
 msgid "controls.filter.select.none"
 msgstr "Select none"
 
-#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:137
+#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:123
 msgid "controls.filters.time.range"
 msgstr "Time Range"
 
@@ -358,23 +357,23 @@ msgstr "Select a design element or a data dimension to modify its options."
 msgid "controls.hint.describing.chart"
 msgstr "Select an annotation field to modify its content."
 
-#: app/configurator/components/ui-helpers.ts:529
+#: app/configurator/components/ui-helpers.ts:592
 msgid "controls.imputation"
 msgstr "Imputation type"
 
 #: app/configurator/components/chart-options-selector.tsx:528
-#: app/configurator/components/ui-helpers.ts:541
+#: app/configurator/components/ui-helpers.ts:604
 msgid "controls.imputation.type.linear"
 msgstr "Linear interpolation"
 
 #: app/configurator/components/chart-options-selector.tsx:521
 #: app/configurator/components/chart-options-selector.tsx:533
-#: app/configurator/components/ui-helpers.ts:533
+#: app/configurator/components/ui-helpers.ts:596
 msgid "controls.imputation.type.none"
 msgstr "-"
 
 #: app/configurator/components/chart-options-selector.tsx:523
-#: app/configurator/components/ui-helpers.ts:537
+#: app/configurator/components/ui-helpers.ts:600
 msgid "controls.imputation.type.zeros"
 msgstr "Zeros"
 
@@ -398,23 +397,23 @@ msgstr "There is no time dimension!"
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Show time filter"
 
-#: app/configurator/components/ui-helpers.ts:577
+#: app/configurator/components/ui-helpers.ts:640
 msgid "controls.language.english"
 msgstr "English"
 
-#: app/configurator/components/ui-helpers.ts:585
+#: app/configurator/components/ui-helpers.ts:648
 msgid "controls.language.french"
 msgstr "French"
 
-#: app/configurator/components/ui-helpers.ts:581
+#: app/configurator/components/ui-helpers.ts:644
 msgid "controls.language.german"
 msgstr "German"
 
-#: app/configurator/components/ui-helpers.ts:589
+#: app/configurator/components/ui-helpers.ts:652
 msgid "controls.language.italian"
 msgstr "Italian"
 
-#: app/configurator/components/ui-helpers.ts:459
+#: app/configurator/components/ui-helpers.ts:522
 #: app/configurator/map/map-chart-options.tsx:218
 #: app/configurator/map/map-chart-options.tsx:423
 msgid "controls.measure"
@@ -429,8 +428,8 @@ msgid "controls.option.isNotActive"
 msgstr "Off"
 
 #: app/configurator/components/chart-type-selector.tsx:193
-msgid "controls.remove.visualization"
-msgstr "Remove this visualization"
+#~ msgid "controls.remove.visualization"
+#~ msgstr "Remove this visualization"
 
 #: app/configurator/map/map-chart-options.tsx:240
 msgid "controls.scale.type"
@@ -444,7 +443,7 @@ msgstr "Clear search field"
 msgid "controls.section.additional-information"
 msgstr "Additional information"
 
-#: app/configurator/components/chart-configurator.tsx:365
+#: app/configurator/components/chart-configurator.tsx:360
 msgid "controls.section.chart.options"
 msgstr "Chart Options"
 
@@ -456,7 +455,7 @@ msgstr "Columns"
 msgid "controls.section.columnstyle"
 msgstr "Column Style"
 
-#: app/configurator/components/chart-configurator.tsx:380
+#: app/configurator/components/chart-configurator.tsx:375
 msgid "controls.section.data.filters"
 msgstr "Filters"
 
@@ -513,7 +512,7 @@ msgstr "Table Sorting"
 msgid "controls.section.tableoptions"
 msgstr "Table Options"
 
-#: app/configurator/components/chart-type-selector.tsx:146
+#: app/configurator/components/chart-type-selector.tsx:136
 msgid "controls.select.chart.type"
 msgstr "Chart Type"
 
@@ -581,11 +580,11 @@ msgstr "Add dimension"
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Name"
 
-#: app/configurator/components/ui-helpers.ts:497
+#: app/configurator/components/ui-helpers.ts:560
 msgid "controls.sorting.byDimensionLabel.ascending"
 msgstr "A → Z"
 
-#: app/configurator/components/ui-helpers.ts:501
+#: app/configurator/components/ui-helpers.ts:564
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
@@ -593,11 +592,11 @@ msgstr "Z → A"
 msgid "controls.sorting.byMeasure"
 msgstr "Measure"
 
-#: app/configurator/components/ui-helpers.ts:521
+#: app/configurator/components/ui-helpers.ts:584
 msgid "controls.sorting.byMeasure.ascending"
 msgstr "1 → 9"
 
-#: app/configurator/components/ui-helpers.ts:525
+#: app/configurator/components/ui-helpers.ts:588
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
@@ -605,19 +604,19 @@ msgstr "9 → 1"
 msgid "controls.sorting.byTotalSize"
 msgstr "Total size"
 
-#: app/configurator/components/ui-helpers.ts:505
+#: app/configurator/components/ui-helpers.ts:568
 msgid "controls.sorting.byTotalSize.ascending"
 msgstr "Largest last"
 
-#: app/configurator/components/ui-helpers.ts:517
+#: app/configurator/components/ui-helpers.ts:580
 msgid "controls.sorting.byTotalSize.largestBottom"
 msgstr "Ascending"
 
-#: app/configurator/components/ui-helpers.ts:509
+#: app/configurator/components/ui-helpers.ts:572
 msgid "controls.sorting.byTotalSize.largestFirst"
 msgstr "Largest first"
 
-#: app/configurator/components/ui-helpers.ts:513
+#: app/configurator/components/ui-helpers.ts:576
 msgid "controls.sorting.byTotalSize.largestTop"
 msgstr "Descending"
 
@@ -629,12 +628,12 @@ msgstr "Remove sorting dimension"
 msgid "controls.sorting.selectDimension"
 msgstr "Select a dimension …"
 
-#: app/configurator/components/ui-helpers.ts:493
+#: app/configurator/components/ui-helpers.ts:556
 #: app/configurator/table/table-chart-sorting-options.tsx:307
 msgid "controls.sorting.sortBy"
 msgstr "Sort by"
 
-#: app/configurator/components/chart-type-selector.tsx:150
+#: app/configurator/components/chart-type-selector.tsx:140
 msgid "controls.switch.chart.type"
 msgstr "Switch to another chart type while maintaining most filter settings."
 
@@ -658,7 +657,7 @@ msgstr "Sorting"
 msgid "controls.tableSettings.showSearch"
 msgstr "Show search field"
 
-#: app/configurator/components/ui-helpers.ts:468
+#: app/configurator/components/ui-helpers.ts:531
 msgid "controls.title"
 msgstr "Title"
 
@@ -670,7 +669,7 @@ msgstr "Back to the datasets"
 #~ msgid "dataset-selector.choose-another-dataset"
 #~ msgstr "Choose another dataset"
 
-#: app/components/chart-published.tsx:109
+#: app/components/chart-published.tsx:117
 msgid "dataset.hasImputedValues"
 msgstr "Some data in this dataset is missing and has been interpolated to fill the gaps."
 
@@ -678,23 +677,27 @@ msgstr "Some data in this dataset is missing and has been interpolated to fill t
 msgid "dataset.includeDrafts"
 msgstr "Include draft datasets"
 
-#: app/configurator/components/dataset-metadata.tsx:63
+#: app/configurator/components/dataset-metadata.tsx:71
 msgid "dataset.metadata.date.created"
 msgstr "Date created"
 
-#: app/configurator/components/dataset-metadata.tsx:75
+#: app/configurator/components/dataset-metadata.tsx:83
 msgid "dataset.metadata.email"
 msgstr "Contact points"
 
-#: app/configurator/components/dataset-metadata.tsx:89
-msgid "dataset.metadata.landingPage"
+#: app/configurator/components/dataset-metadata.tsx:97
+msgid "dataset.metadata.furtherinformation"
 msgstr "Further information"
 
-#: app/configurator/components/dataset-metadata.tsx:49
+#: app/configurator/components/dataset-metadata.tsx:104
+msgid "dataset.metadata.landingpage"
+msgstr "Landing page"
+
+#: app/configurator/components/dataset-metadata.tsx:57
 msgid "dataset.metadata.source"
 msgstr "Source"
 
-#: app/configurator/components/dataset-metadata.tsx:70
+#: app/configurator/components/dataset-metadata.tsx:78
 msgid "dataset.metadata.version"
 msgstr "Version"
 
@@ -710,13 +713,13 @@ msgstr "Relevance"
 msgid "dataset.order.title"
 msgstr "Title"
 
-#: app/components/chart-preview.tsx:59
-#: app/components/chart-published.tsx:87
+#: app/components/chart-preview.tsx:69
+#: app/components/chart-published.tsx:95
 #: app/configurator/components/dataset-preview.tsx:41
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Careful, this dataset is only a draft.<0/><1>Don't use for reporting!</1>"
 
-#: app/components/chart-published.tsx:98
+#: app/components/chart-published.tsx:106
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Careful, the data for this chart has expired.<0/><1>Don't use for reporting!</1>"
 
@@ -740,7 +743,7 @@ msgstr "Sort by"
 msgid "dataset.tag.draft"
 msgstr "Draft"
 
-#: app/configurator/components/dataset-preview.tsx:108
+#: app/configurator/components/dataset-preview.tsx:112
 msgid "datatable.showing.first.rows"
 msgstr "Showing first 10 rows"
 
@@ -752,79 +755,79 @@ msgstr "Federal Office for the Environment FOEN"
 msgid "footer.institution.url"
 msgstr "https://www.bafu.admin.ch/bafu/en/home.html"
 
-#: app/components/footer.tsx:124
-#~ msgid "footer.status"
-#~ msgstr "Status"
+#: app/components/footer.tsx:126
+msgid "footer.status"
+msgstr "Status"
 
-#: app/components/hint.tsx:158
+#: app/components/hint.tsx:174
 msgid "hint.chartunexpected.message"
 msgstr "An unexpected error occurred while displaying this chart."
 
-#: app/components/hint.tsx:156
+#: app/components/hint.tsx:172
 msgid "hint.chartunexpected.title"
 msgstr "Unexpected error"
 
-#: app/components/hint.tsx:144
+#: app/components/hint.tsx:160
 msgid "hint.coordinatesloadingerror.message"
 msgstr "There was a problem with loading the coordinates from geographical dimensions. Please try again later."
 
-#: app/components/hint.tsx:140
+#: app/components/hint.tsx:156
 msgid "hint.coordinatesloadingerror.title"
 msgstr "Coordinates loading error"
 
-#: app/pages/v/[chartId].tsx:122
+#: app/pages/v/[chartId].tsx:129
 msgid "hint.create.your.own.chart"
 msgstr "Copy this visualization or make a new visualization using Swiss Open Government Data."
 
-#: app/components/hint.tsx:128
+#: app/components/hint.tsx:130
 msgid "hint.dataloadingerror.message"
 msgstr "The data could not be loaded."
 
-#: app/components/hint.tsx:137
+#: app/components/hint.tsx:139
 msgid "hint.dataloadingerror.status"
 msgstr "Check the status page for more information"
 
-#: app/components/hint.tsx:126
+#: app/components/hint.tsx:128
 msgid "hint.dataloadingerror.title"
 msgstr "Data loading error"
 
-#: app/pages/v/[chartId].tsx:116
+#: app/pages/v/[chartId].tsx:123
 msgid "hint.how.to.share"
 msgstr "You can share this visualization by copying the URL or by embedding it on your own website. You can also create a new visualization from scratch or start by copying the visualization above."
 
-#: app/components/hint.tsx:91
+#: app/components/hint.tsx:92
 msgid "hint.loading.data"
 msgstr "Loading data..."
 
-#: app/configurator/components/chart-type-selector.tsx:167
+#: app/configurator/components/chart-type-selector.tsx:150
 msgid "hint.no.visualization.with.dataset"
 msgstr "No visualization can be created with the selected dataset."
 
-#: app/components/hint.tsx:118
+#: app/components/hint.tsx:119
 msgid "hint.nodata.message"
 msgstr "Please try with another combination of filters."
 
-#: app/components/hint.tsx:114
+#: app/components/hint.tsx:115
 msgid "hint.nodata.title"
 msgstr "No data available for current filter selection"
 
-#: app/components/hint.tsx:180
+#: app/components/hint.tsx:196
 msgid "hint.only.negative.data.message"
 msgstr "Negative data values cannot be displayed with this chart type."
 
-#: app/components/hint.tsx:178
+#: app/components/hint.tsx:194
 msgid "hint.only.negative.data.title"
 msgstr "Negative Values"
 
-#: app/components/hint.tsx:188
+#: app/components/hint.tsx:204
 msgid "hint.publication.success"
 msgstr "Your visualization is now published. Share it by copying the URL or use the Embed menu below."
 
-#: app/charts/shared/chart-data-filters.tsx:72
+#: app/charts/shared/chart-data-filters.tsx:75
 msgid "interactive.data.filters.hide"
 msgstr "Hide Filters"
 
-#: app/charts/shared/chart-data-filters.tsx:70
+#: app/charts/shared/chart-data-filters.tsx:77
 msgid "interactive.data.filters.show"
 msgstr "Show Filters"
 
@@ -833,63 +836,63 @@ msgstr "Show Filters"
 msgid "logo.swiss.confederation"
 msgstr "Logo of the Swiss Confederation"
 
-#: app/components/chart-footnotes.tsx:56
+#: app/components/chart-footnotes.tsx:61
 msgid "metadata.dataset"
 msgstr "Dataset"
 
-#: app/components/chart-footnotes.tsx:131
+#: app/components/chart-footnotes.tsx:162
 msgid "metadata.link.created.with.visualize"
 msgstr "Created with visualize.admin.ch"
 
-#: app/components/chart-footnotes.tsx:60
+#: app/components/chart-footnotes.tsx:77
 msgid "metadata.source"
 msgstr "Source"
 
-#: app/components/chart-footnotes.tsx:99
+#: app/components/chart-footnotes.tsx:140
 msgid "metadata.switch.chart"
 msgstr "Switch to chart view"
 
-#: app/components/chart-footnotes.tsx:103
+#: app/components/chart-footnotes.tsx:142
 msgid "metadata.switch.table"
 msgstr "Switch to table view"
 
-#: app/components/publish-actions.tsx:245
+#: app/components/publish-actions.tsx:216
 msgid "publication.embed.AEM"
 msgstr "Embed Code for AEM \"External Application\":"
 
-#: app/components/publish-actions.tsx:238
+#: app/components/publish-actions.tsx:209
 msgid "publication.embed.iframe"
 msgstr "Embed Code:"
 
-#: app/components/publish-actions.tsx:135
+#: app/components/publish-actions.tsx:109
 msgid "publication.popup.share"
 msgstr "Share"
 
-#: app/components/publish-actions.tsx:182
+#: app/components/publish-actions.tsx:157
 msgid "publication.share.chart.url"
 msgstr "Chart URL:"
 
-#: app/components/publish-actions.tsx:141
+#: app/components/publish-actions.tsx:115
 msgid "publication.share.linktitle.facebook"
 msgstr "Share on Facebook"
 
-#: app/components/publish-actions.tsx:161
+#: app/components/publish-actions.tsx:135
 msgid "publication.share.linktitle.mail"
 msgstr "Share via Email"
 
-#: app/components/publish-actions.tsx:151
+#: app/components/publish-actions.tsx:125
 msgid "publication.share.linktitle.twitter"
 msgstr "Share on Twitter"
 
-#: app/components/publish-actions.tsx:172
+#: app/components/publish-actions.tsx:146
 msgid "publication.share.mail.body"
 msgstr "Here is a visualization I created using visualize.admin.ch"
 
-#: app/components/publish-actions.tsx:167
+#: app/components/publish-actions.tsx:141
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
-#: app/configurator/components/stepper.tsx:187
+#: app/configurator/components/stepper.tsx:191
 msgid "step.annotate"
 msgstr "Before publishing, add a title and description to your chart, and choose which elements should be interactive."
 
@@ -897,7 +900,7 @@ msgstr "Before publishing, add a title and description to your chart, and choose
 #~ msgid "step.visualization.type"
 #~ msgstr "Select the desired chart type for your dataset."
 
-#: app/configurator/components/stepper.tsx:176
+#: app/configurator/components/stepper.tsx:180
 msgid "step.visualize"
 msgstr "Customize your visualization by using the filter and color segmentation options in the sidebars."
 

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:502
+#: app/configurator/components/chart-configurator.tsx:497
 msgid "Add filter"
 msgstr "Ajouter un filtre"
 
@@ -21,15 +21,15 @@ msgstr "Ajouter un filtre"
 msgid "Browse {0}"
 msgstr "Parcourir {0}"
 
-#: app/configurator/components/chart-configurator.tsx:457
+#: app/configurator/components/chart-configurator.tsx:452
 msgid "Drag filters to reorganize"
 msgstr "Faites glisser les filtres pour les réorganiser"
 
-#: app/configurator/components/chart-configurator.tsx:454
+#: app/configurator/components/chart-configurator.tsx:449
 msgid "Move filter down"
 msgstr "Déplacer le filtre vers le bas"
 
-#: app/configurator/components/chart-configurator.tsx:451
+#: app/configurator/components/chart-configurator.tsx:446
 msgid "Move filter up"
 msgstr "Déplacer le filtre vers le haut"
 
@@ -42,11 +42,11 @@ msgstr "Aucun résultat"
 msgid "Search “{0}”"
 msgstr "Chercher “{0}”"
 
-#: app/components/chart-preview.tsx:102
+#: app/components/chart-preview.tsx:112
 msgid "annotation.add.description"
 msgstr "[ Pas de description ]"
 
-#: app/components/chart-preview.tsx:80
+#: app/components/chart-preview.tsx:90
 msgid "annotation.add.title"
 msgstr "[ Pas de titre ]"
 
@@ -75,23 +75,23 @@ msgstr "Explorez les jeux de données liés fournis par LINDAS, en filtrant par 
 msgid "button.back"
 msgstr "Précédent"
 
-#: app/pages/v/[chartId].tsx:153
+#: app/pages/v/[chartId].tsx:167
 msgid "button.copy.visualization"
 msgstr "Copier et éditer cette visualisation"
 
-#: app/components/data-download.tsx:182
+#: app/components/data-download.tsx:186
 msgid "button.download"
 msgstr "Télécharger"
 
-#: app/components/data-download.tsx:172
+#: app/components/data-download.tsx:176
 msgid "button.download.data"
 msgstr "Télécharger des données"
 
-#: app/components/data-download.tsx:199
+#: app/components/data-download.tsx:203
 msgid "button.download.data.all"
 msgstr "Jeu de données complet"
 
-#: app/components/data-download.tsx:191
+#: app/components/data-download.tsx:195
 msgid "button.download.data.visible"
 msgstr "Jeu de données filtrées"
 
@@ -103,24 +103,24 @@ msgstr "Jeu de données filtrées"
 #~ msgid "button.download.runsparqlquery.all"
 #~ msgstr "Lancer la requête SPARQL (toutes)"
 
-#: app/components/data-download.tsx:343
+#: app/components/data-download.tsx:347
 msgid "button.download.runsparqlquery.visible"
 msgstr "Lancer la requête SPARQL"
 
-#: app/components/publish-actions.tsx:230
+#: app/components/publish-actions.tsx:204
 msgid "button.embed"
 msgstr "Intégrer"
 
-#: app/components/publish-actions.tsx:260
-#: app/components/publish-actions.tsx:266
+#: app/components/publish-actions.tsx:229
+#: app/components/publish-actions.tsx:235
 msgid "button.hint.click.to.copy"
 msgstr "Cliquer pour copier"
 
-#: app/components/publish-actions.tsx:303
+#: app/components/publish-actions.tsx:272
 msgid "button.hint.copied"
 msgstr "Copié!"
 
-#: app/pages/v/[chartId].tsx:138
+#: app/pages/v/[chartId].tsx:152
 msgid "button.new.visualization"
 msgstr "Créer une nouvelle visualisation"
 
@@ -132,11 +132,11 @@ msgstr "Suivant"
 msgid "button.publish"
 msgstr "Publier cette visualisation"
 
-#: app/components/publish-actions.tsx:116
+#: app/components/publish-actions.tsx:94
 msgid "button.share"
 msgstr "Partager"
 
-#: app/configurator/components/ui-helpers.ts:485
+#: app/configurator/components/ui-helpers.ts:548
 #: app/configurator/map/map-chart-options.tsx:163
 msgid "chart.map.layers.area"
 msgstr "Zones"
@@ -161,8 +161,8 @@ msgstr "Quantiles (distribution homogène des valeurs)"
 msgid "chart.map.layers.area.discretization.quantize"
 msgstr "Intervalles égaux"
 
-#: app/configurator/components/chart-configurator.tsx:554
-#: app/configurator/components/ui-helpers.ts:481
+#: app/configurator/components/chart-configurator.tsx:553
+#: app/configurator/components/ui-helpers.ts:544
 #: app/configurator/map/map-chart-options.tsx:64
 msgid "chart.map.layers.base"
 msgstr "Couche de base"
@@ -176,7 +176,7 @@ msgstr "Afficher"
 msgid "chart.map.layers.show"
 msgstr "Afficher la couche"
 
-#: app/configurator/components/ui-helpers.ts:489
+#: app/configurator/components/ui-helpers.ts:552
 #: app/configurator/map/map-chart-options.tsx:387
 msgid "chart.map.layers.symbol"
 msgstr "Symboles"
@@ -222,47 +222,47 @@ msgstr "Normal"
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Paramètres d'origine"
 
-#: app/configurator/components/ui-helpers.ts:455
+#: app/configurator/components/ui-helpers.ts:518
 msgid "controls.axis.horizontal"
 msgstr "Axe horizontal"
 
-#: app/configurator/components/ui-helpers.ts:463
+#: app/configurator/components/ui-helpers.ts:526
 msgid "controls.axis.vertical"
 msgstr "Axe vertical"
 
-#: app/configurator/components/ui-helpers.ts:557
+#: app/configurator/components/ui-helpers.ts:620
 msgid "controls.chart.type.area"
 msgstr "Surfaces"
 
-#: app/configurator/components/ui-helpers.ts:549
+#: app/configurator/components/ui-helpers.ts:612
 msgid "controls.chart.type.bar"
 msgstr "Barres"
 
-#: app/configurator/components/ui-helpers.ts:545
+#: app/configurator/components/ui-helpers.ts:608
 msgid "controls.chart.type.column"
 msgstr "Colonnes"
 
-#: app/configurator/components/ui-helpers.ts:553
+#: app/configurator/components/ui-helpers.ts:616
 msgid "controls.chart.type.line"
 msgstr "Lignes"
 
-#: app/configurator/components/ui-helpers.ts:573
+#: app/configurator/components/ui-helpers.ts:636
 msgid "controls.chart.type.map"
 msgstr "Carte"
 
-#: app/configurator/components/ui-helpers.ts:565
+#: app/configurator/components/ui-helpers.ts:628
 msgid "controls.chart.type.pie"
 msgstr "Secteurs"
 
-#: app/configurator/components/ui-helpers.ts:561
+#: app/configurator/components/ui-helpers.ts:624
 msgid "controls.chart.type.scatterplot"
 msgstr "Nuage de points"
 
-#: app/configurator/components/ui-helpers.ts:569
+#: app/configurator/components/ui-helpers.ts:632
 msgid "controls.chart.type.table"
 msgstr "Tableau"
 
-#: app/configurator/components/ui-helpers.ts:467
+#: app/configurator/components/ui-helpers.ts:530
 #: app/configurator/map/map-chart-options.tsx:236
 #: app/configurator/map/map-chart-options.tsx:441
 msgid "controls.color"
@@ -277,8 +277,7 @@ msgstr "Ajouter…"
 msgid "controls.color.palette"
 msgstr "Couleurs"
 
-#: app/configurator/components/chart-controls/color-palette.tsx:238
-#: app/configurator/components/chart-controls/color-palette.tsx:244
+#: app/configurator/components/chart-controls/color-palette.tsx:240
 msgid "controls.color.palette.reset"
 msgstr "Réinitialiser la palette de couleurs"
 
@@ -294,15 +293,15 @@ msgstr "Sélectionner une couleur"
 msgid "controls.colorpicker.open"
 msgstr "Ouvrir la pipette à couleur"
 
-#: app/configurator/components/ui-helpers.ts:477
+#: app/configurator/components/ui-helpers.ts:540
 msgid "controls.column.grouped"
 msgstr "groupées"
 
-#: app/configurator/components/ui-helpers.ts:473
+#: app/configurator/components/ui-helpers.ts:536
 msgid "controls.column.stacked"
 msgstr "empilées"
 
-#: app/configurator/components/ui-helpers.ts:469
+#: app/configurator/components/ui-helpers.ts:532
 msgid "controls.description"
 msgstr "Description"
 
@@ -315,7 +314,7 @@ msgstr "Dimension géographique"
 msgid "controls.dimension.none"
 msgstr "Aucune"
 
-#: app/charts/shared/chart-data-filters.tsx:193
+#: app/charts/shared/chart-data-filters.tsx:198
 #: app/configurator/components/field.tsx:122
 #: app/configurator/components/field.tsx:179
 #: app/configurator/components/field.tsx:279
@@ -334,7 +333,7 @@ msgstr "Tout sélectionner"
 msgid "controls.filter.select.none"
 msgstr "Tout déselectionner"
 
-#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:137
+#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:123
 msgid "controls.filters.time.range"
 msgstr "Intervalle de temps"
 
@@ -354,23 +353,23 @@ msgstr "Sélectionnez un élément de design ou une dimension du jeu de données
 msgid "controls.hint.describing.chart"
 msgstr "Sélectionnez une des annotations proposées pour la modifier."
 
-#: app/configurator/components/ui-helpers.ts:529
+#: app/configurator/components/ui-helpers.ts:592
 msgid "controls.imputation"
 msgstr "Type d'imputation"
 
 #: app/configurator/components/chart-options-selector.tsx:528
-#: app/configurator/components/ui-helpers.ts:541
+#: app/configurator/components/ui-helpers.ts:604
 msgid "controls.imputation.type.linear"
 msgstr "Interpolation linéaire"
 
 #: app/configurator/components/chart-options-selector.tsx:521
 #: app/configurator/components/chart-options-selector.tsx:533
-#: app/configurator/components/ui-helpers.ts:533
+#: app/configurator/components/ui-helpers.ts:596
 msgid "controls.imputation.type.none"
 msgstr "-"
 
 #: app/configurator/components/chart-options-selector.tsx:523
-#: app/configurator/components/ui-helpers.ts:537
+#: app/configurator/components/ui-helpers.ts:600
 msgid "controls.imputation.type.zeros"
 msgstr "Zéros"
 
@@ -394,23 +393,23 @@ msgstr "Il n'y a pas de dimension temporelle!"
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Afficher le filtre temporel"
 
-#: app/configurator/components/ui-helpers.ts:577
+#: app/configurator/components/ui-helpers.ts:640
 msgid "controls.language.english"
 msgstr "Anglais"
 
-#: app/configurator/components/ui-helpers.ts:585
+#: app/configurator/components/ui-helpers.ts:648
 msgid "controls.language.french"
 msgstr "Français"
 
-#: app/configurator/components/ui-helpers.ts:581
+#: app/configurator/components/ui-helpers.ts:644
 msgid "controls.language.german"
 msgstr "Allemand"
 
-#: app/configurator/components/ui-helpers.ts:589
+#: app/configurator/components/ui-helpers.ts:652
 msgid "controls.language.italian"
 msgstr "Italien"
 
-#: app/configurator/components/ui-helpers.ts:459
+#: app/configurator/components/ui-helpers.ts:522
 #: app/configurator/map/map-chart-options.tsx:218
 #: app/configurator/map/map-chart-options.tsx:423
 msgid "controls.measure"
@@ -425,8 +424,8 @@ msgid "controls.option.isNotActive"
 msgstr "Inactif"
 
 #: app/configurator/components/chart-type-selector.tsx:193
-msgid "controls.remove.visualization"
-msgstr "Supprimer cette visualisation"
+#~ msgid "controls.remove.visualization"
+#~ msgstr "Supprimer cette visualisation"
 
 #: app/configurator/map/map-chart-options.tsx:240
 msgid "controls.scale.type"
@@ -440,7 +439,7 @@ msgstr "Effacer la recherche"
 msgid "controls.section.additional-information"
 msgstr "Informations supplémentaires"
 
-#: app/configurator/components/chart-configurator.tsx:365
+#: app/configurator/components/chart-configurator.tsx:360
 msgid "controls.section.chart.options"
 msgstr "Paramètres graphiques"
 
@@ -452,7 +451,7 @@ msgstr "Colonnes"
 msgid "controls.section.columnstyle"
 msgstr "Style de la colonne"
 
-#: app/configurator/components/chart-configurator.tsx:380
+#: app/configurator/components/chart-configurator.tsx:375
 msgid "controls.section.data.filters"
 msgstr "Filtres"
 
@@ -509,7 +508,7 @@ msgstr "Tri du tableau"
 msgid "controls.section.tableoptions"
 msgstr "Options du tableau"
 
-#: app/configurator/components/chart-type-selector.tsx:146
+#: app/configurator/components/chart-type-selector.tsx:136
 msgid "controls.select.chart.type"
 msgstr "Type de graphique"
 
@@ -577,11 +576,11 @@ msgstr "Ajouter une dimension"
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Nom"
 
-#: app/configurator/components/ui-helpers.ts:497
+#: app/configurator/components/ui-helpers.ts:560
 msgid "controls.sorting.byDimensionLabel.ascending"
 msgstr "A → Z"
 
-#: app/configurator/components/ui-helpers.ts:501
+#: app/configurator/components/ui-helpers.ts:564
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
@@ -589,11 +588,11 @@ msgstr "Z → A"
 msgid "controls.sorting.byMeasure"
 msgstr "Mesure"
 
-#: app/configurator/components/ui-helpers.ts:521
+#: app/configurator/components/ui-helpers.ts:584
 msgid "controls.sorting.byMeasure.ascending"
 msgstr "1 → 9"
 
-#: app/configurator/components/ui-helpers.ts:525
+#: app/configurator/components/ui-helpers.ts:588
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
@@ -601,19 +600,19 @@ msgstr "9 → 1"
 msgid "controls.sorting.byTotalSize"
 msgstr "Taille totale"
 
-#: app/configurator/components/ui-helpers.ts:505
+#: app/configurator/components/ui-helpers.ts:568
 msgid "controls.sorting.byTotalSize.ascending"
 msgstr "Croissant"
 
-#: app/configurator/components/ui-helpers.ts:517
+#: app/configurator/components/ui-helpers.ts:580
 msgid "controls.sorting.byTotalSize.largestBottom"
 msgstr "Décroissant de bas en haut"
 
-#: app/configurator/components/ui-helpers.ts:509
+#: app/configurator/components/ui-helpers.ts:572
 msgid "controls.sorting.byTotalSize.largestFirst"
 msgstr "Décroissant"
 
-#: app/configurator/components/ui-helpers.ts:513
+#: app/configurator/components/ui-helpers.ts:576
 msgid "controls.sorting.byTotalSize.largestTop"
 msgstr "Décroissant de haut en bas"
 
@@ -625,12 +624,12 @@ msgstr "Supprimer la dimension de tri"
 msgid "controls.sorting.selectDimension"
 msgstr "Sélectionner une dimension…"
 
-#: app/configurator/components/ui-helpers.ts:493
+#: app/configurator/components/ui-helpers.ts:556
 #: app/configurator/table/table-chart-sorting-options.tsx:307
 msgid "controls.sorting.sortBy"
 msgstr "Trier par"
 
-#: app/configurator/components/chart-type-selector.tsx:150
+#: app/configurator/components/chart-type-selector.tsx:140
 msgid "controls.switch.chart.type"
 msgstr "Passer à une autre visualisation tout en conservant la plupart des filtres"
 
@@ -654,7 +653,7 @@ msgstr "Tri"
 msgid "controls.tableSettings.showSearch"
 msgstr "Afficher le champ de recherche"
 
-#: app/configurator/components/ui-helpers.ts:468
+#: app/configurator/components/ui-helpers.ts:531
 msgid "controls.title"
 msgstr "Titre"
 
@@ -666,7 +665,7 @@ msgstr "Revenir aux jeux de données"
 #~ msgid "dataset-selector.choose-another-dataset"
 #~ msgstr "Choisir un autre jeu de données"
 
-#: app/components/chart-published.tsx:109
+#: app/components/chart-published.tsx:117
 msgid "dataset.hasImputedValues"
 msgstr "Certaines données de cet ensemble de données sont manquantes et ont été interpolées pour combler les lacunes."
 
@@ -674,23 +673,27 @@ msgstr "Certaines données de cet ensemble de données sont manquantes et ont é
 msgid "dataset.includeDrafts"
 msgstr "Inclure les brouillons"
 
-#: app/configurator/components/dataset-metadata.tsx:63
+#: app/configurator/components/dataset-metadata.tsx:71
 msgid "dataset.metadata.date.created"
 msgstr "Date de création"
 
-#: app/configurator/components/dataset-metadata.tsx:75
+#: app/configurator/components/dataset-metadata.tsx:83
 msgid "dataset.metadata.email"
 msgstr "Points de contact"
 
-#: app/configurator/components/dataset-metadata.tsx:89
-msgid "dataset.metadata.landingPage"
+#: app/configurator/components/dataset-metadata.tsx:97
+msgid "dataset.metadata.furtherinformation"
 msgstr "Informations complémentaires"
 
-#: app/configurator/components/dataset-metadata.tsx:49
+#: app/configurator/components/dataset-metadata.tsx:104
+msgid "dataset.metadata.landingpage"
+msgstr "Page d'accueil"
+
+#: app/configurator/components/dataset-metadata.tsx:57
 msgid "dataset.metadata.source"
 msgstr "Source"
 
-#: app/configurator/components/dataset-metadata.tsx:70
+#: app/configurator/components/dataset-metadata.tsx:78
 msgid "dataset.metadata.version"
 msgstr "Version"
 
@@ -706,13 +709,13 @@ msgstr "Pertinence"
 msgid "dataset.order.title"
 msgstr "Titre"
 
-#: app/components/chart-preview.tsx:59
-#: app/components/chart-published.tsx:87
+#: app/components/chart-preview.tsx:69
+#: app/components/chart-published.tsx:95
 #: app/configurator/components/dataset-preview.tsx:41
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Attention, ce jeu de données est à l'état d'ébauche.<0/><1>Ne l'utilisez pas pour une publication!</1>"
 
-#: app/components/chart-published.tsx:98
+#: app/components/chart-published.tsx:106
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Attention, ce jeu de données est expiré.<0/><1>Ne l'utilisez pas pour une publication!</1>"
 
@@ -736,7 +739,7 @@ msgstr "Trier par"
 msgid "dataset.tag.draft"
 msgstr "Brouillon"
 
-#: app/configurator/components/dataset-preview.tsx:108
+#: app/configurator/components/dataset-preview.tsx:112
 msgid "datatable.showing.first.rows"
 msgstr "Seules les 10 premières lignes sont affichées"
 
@@ -748,80 +751,79 @@ msgstr "Office fédéral de l'environnement OFEV"
 msgid "footer.institution.url"
 msgstr "https://www.bafu.admin.ch/bafu/fr/home.html"
 
-#: app/components/footer.tsx:125
+#: app/components/footer.tsx:126
 msgid "footer.status"
 msgstr "Statut"
 
-#: app/components/hint.tsx:158
+#: app/components/hint.tsx:174
 msgid "hint.chartunexpected.message"
 msgstr ""
 
-#: app/components/hint.tsx:156
+#: app/components/hint.tsx:172
 msgid "hint.chartunexpected.title"
 msgstr ""
 
-#: app/components/hint.tsx:144
+#: app/components/hint.tsx:160
 msgid "hint.coordinatesloadingerror.message"
 msgstr "Les données géographiques n’ont pas pu être chargées, merci de réessayer plus tard."
 
-#: app/components/hint.tsx:140
+#: app/components/hint.tsx:156
 msgid "hint.coordinatesloadingerror.title"
 msgstr "Erreur de chargement des coordonnées"
 
-#: app/pages/v/[chartId].tsx:122
+#: app/pages/v/[chartId].tsx:129
 msgid "hint.create.your.own.chart"
 msgstr "Copiez cette visualisation ou créez une nouvelle visualisation à partir des données ouvertes de l’administration publique suisse."
 
-#: app/components/hint.tsx:128
+#: app/components/hint.tsx:130
 msgid "hint.dataloadingerror.message"
 msgstr "Les données n'ont pas pu être téléchargées."
 
-
-#: app/components/hint.tsx:137
+#: app/components/hint.tsx:139
 msgid "hint.dataloadingerror.status"
 msgstr "Consultez la page de statut pour plus d'informations"
 
-#: app/components/hint.tsx:126
+#: app/components/hint.tsx:128
 msgid "hint.dataloadingerror.title"
 msgstr "Problème de téléchargement des données"
 
-#: app/pages/v/[chartId].tsx:116
+#: app/pages/v/[chartId].tsx:123
 msgid "hint.how.to.share"
 msgstr "Vous pouvez partager cette visualisation en copiant l'URL ou en l'intégrant sur votre site Web. Vous pouvez également créer une toute nouvelle visualisation, ou bien copier et modifier la visualisation ci-dessus."
 
-#: app/components/hint.tsx:91
+#: app/components/hint.tsx:92
 msgid "hint.loading.data"
 msgstr "Chargement des données..."
 
-#: app/configurator/components/chart-type-selector.tsx:167
+#: app/configurator/components/chart-type-selector.tsx:150
 msgid "hint.no.visualization.with.dataset"
 msgstr "Aucune visualisation ne peut être créée avec le jeu de données sélectionné."
 
-#: app/components/hint.tsx:118
+#: app/components/hint.tsx:119
 msgid "hint.nodata.message"
 msgstr "Veuillez essayer avec une autre combinaison de filtres."
 
-#: app/components/hint.tsx:114
+#: app/components/hint.tsx:115
 msgid "hint.nodata.title"
 msgstr "Il n'y a pas de données correspondant aux filtres sélectionnés"
 
-#: app/components/hint.tsx:180
+#: app/components/hint.tsx:196
 msgid "hint.only.negative.data.message"
 msgstr "Ce type de graphique ne permet pas de représenter des données négatives."
 
-#: app/components/hint.tsx:178
+#: app/components/hint.tsx:194
 msgid "hint.only.negative.data.title"
 msgstr "Valeurs négatives"
 
-#: app/components/hint.tsx:188
+#: app/components/hint.tsx:204
 msgid "hint.publication.success"
 msgstr "Votre visualisation est à présent publiée. Partagez-là en copiant l'URL ou en utilisant les options d'intégration."
 
-#: app/charts/shared/chart-data-filters.tsx:72
+#: app/charts/shared/chart-data-filters.tsx:75
 msgid "interactive.data.filters.hide"
 msgstr "Masquer les filtres"
 
-#: app/charts/shared/chart-data-filters.tsx:70
+#: app/charts/shared/chart-data-filters.tsx:77
 msgid "interactive.data.filters.show"
 msgstr "Afficher les filtres"
 
@@ -830,63 +832,63 @@ msgstr "Afficher les filtres"
 msgid "logo.swiss.confederation"
 msgstr "Logo de la Confédération Suisse"
 
-#: app/components/chart-footnotes.tsx:56
+#: app/components/chart-footnotes.tsx:61
 msgid "metadata.dataset"
 msgstr "Jeu de données"
 
-#: app/components/chart-footnotes.tsx:131
+#: app/components/chart-footnotes.tsx:162
 msgid "metadata.link.created.with.visualize"
 msgstr "Créé avec visualize.admin.ch"
 
-#: app/components/chart-footnotes.tsx:60
+#: app/components/chart-footnotes.tsx:77
 msgid "metadata.source"
 msgstr "Source"
 
-#: app/components/chart-footnotes.tsx:99
+#: app/components/chart-footnotes.tsx:140
 msgid "metadata.switch.chart"
 msgstr "Passer à la vue graphique"
 
-#: app/components/chart-footnotes.tsx:103
+#: app/components/chart-footnotes.tsx:142
 msgid "metadata.switch.table"
 msgstr "Passer à la vue en tableau"
 
-#: app/components/publish-actions.tsx:245
+#: app/components/publish-actions.tsx:216
 msgid "publication.embed.AEM"
 msgstr "Code pour intégrer sur AEM comme \"External Application\":"
 
-#: app/components/publish-actions.tsx:238
+#: app/components/publish-actions.tsx:209
 msgid "publication.embed.iframe"
 msgstr "Code pour intégrer:"
 
-#: app/components/publish-actions.tsx:135
+#: app/components/publish-actions.tsx:109
 msgid "publication.popup.share"
 msgstr "Partager"
 
-#: app/components/publish-actions.tsx:182
+#: app/components/publish-actions.tsx:157
 msgid "publication.share.chart.url"
 msgstr "URL du graphique:"
 
-#: app/components/publish-actions.tsx:141
+#: app/components/publish-actions.tsx:115
 msgid "publication.share.linktitle.facebook"
 msgstr "Partager sur Facebook"
 
-#: app/components/publish-actions.tsx:161
+#: app/components/publish-actions.tsx:135
 msgid "publication.share.linktitle.mail"
 msgstr "Partager par courriel"
 
-#: app/components/publish-actions.tsx:151
+#: app/components/publish-actions.tsx:125
 msgid "publication.share.linktitle.twitter"
 msgstr "Partager sur Twitter"
 
-#: app/components/publish-actions.tsx:172
+#: app/components/publish-actions.tsx:146
 msgid "publication.share.mail.body"
 msgstr "Voici une visualisation que j'ai créée sur visualize.admin.ch"
 
-#: app/components/publish-actions.tsx:167
+#: app/components/publish-actions.tsx:141
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
-#: app/configurator/components/stepper.tsx:187
+#: app/configurator/components/stepper.tsx:191
 msgid "step.annotate"
 msgstr "Avant de publier, ajoutez un titre et une description à votre tableau et choisissez quels éléments doivent être interactifs."
 
@@ -894,7 +896,7 @@ msgstr "Avant de publier, ajoutez un titre et une description à votre tableau e
 #~ msgid "step.visualization.type"
 #~ msgstr "Sélectionnez le type de graphique souhaité pour votre jeu de données."
 
-#: app/configurator/components/stepper.tsx:176
+#: app/configurator/components/stepper.tsx:180
 msgid "step.visualize"
 msgstr "Personnalisez votre visualisation en utilisant les options de filtrage et de segmentation des couleurs dans les barres latérales."
 

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -13,7 +13,7 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:502
+#: app/configurator/components/chart-configurator.tsx:497
 msgid "Add filter"
 msgstr "Aggiungi filtro"
 
@@ -21,15 +21,15 @@ msgstr "Aggiungi filtro"
 msgid "Browse {0}"
 msgstr "Sfoglia {0}"
 
-#: app/configurator/components/chart-configurator.tsx:457
+#: app/configurator/components/chart-configurator.tsx:452
 msgid "Drag filters to reorganize"
 msgstr "Trascina i filtri per riorganizzarli"
 
-#: app/configurator/components/chart-configurator.tsx:454
+#: app/configurator/components/chart-configurator.tsx:449
 msgid "Move filter down"
 msgstr "Sposta il filtro in basso"
 
-#: app/configurator/components/chart-configurator.tsx:451
+#: app/configurator/components/chart-configurator.tsx:446
 msgid "Move filter up"
 msgstr "Sposta il filtro in alto"
 
@@ -42,11 +42,11 @@ msgstr "Nessun risultato"
 msgid "Search “{0}”"
 msgstr "Cerca “{0}”"
 
-#: app/components/chart-preview.tsx:102
+#: app/components/chart-preview.tsx:112
 msgid "annotation.add.description"
 msgstr "[ Nessuna descrizione ]"
 
-#: app/components/chart-preview.tsx:80
+#: app/components/chart-preview.tsx:90
 msgid "annotation.add.title"
 msgstr "[ Nessun titolo ]"
 
@@ -75,23 +75,23 @@ msgstr "Esplora i set di dati forniti dal LINDAS Linked Data Service filtrando p
 msgid "button.back"
 msgstr "Torna indietro"
 
-#: app/pages/v/[chartId].tsx:153
+#: app/pages/v/[chartId].tsx:167
 msgid "button.copy.visualization"
 msgstr "Copia e modifica questa visualizzazione"
 
-#: app/components/data-download.tsx:182
+#: app/components/data-download.tsx:186
 msgid "button.download"
 msgstr "Scarica"
 
-#: app/components/data-download.tsx:172
+#: app/components/data-download.tsx:176
 msgid "button.download.data"
 msgstr "Scaricare i dati"
 
-#: app/components/data-download.tsx:199
+#: app/components/data-download.tsx:203
 msgid "button.download.data.all"
 msgstr "Set di dati completo"
 
-#: app/components/data-download.tsx:191
+#: app/components/data-download.tsx:195
 msgid "button.download.data.visible"
 msgstr "Set di dati filtrati"
 
@@ -103,24 +103,24 @@ msgstr "Set di dati filtrati"
 #~ msgid "button.download.runsparqlquery.all"
 #~ msgstr "Esegui query SPARQL (tutti)"
 
-#: app/components/data-download.tsx:343
+#: app/components/data-download.tsx:347
 msgid "button.download.runsparqlquery.visible"
 msgstr "Esegui query SPARQL"
 
-#: app/components/publish-actions.tsx:230
+#: app/components/publish-actions.tsx:204
 msgid "button.embed"
 msgstr "Incorpora"
 
-#: app/components/publish-actions.tsx:260
-#: app/components/publish-actions.tsx:266
+#: app/components/publish-actions.tsx:229
+#: app/components/publish-actions.tsx:235
 msgid "button.hint.click.to.copy"
 msgstr "Clicca per copiare"
 
-#: app/components/publish-actions.tsx:303
+#: app/components/publish-actions.tsx:272
 msgid "button.hint.copied"
 msgstr "Copiato!"
 
-#: app/pages/v/[chartId].tsx:138
+#: app/pages/v/[chartId].tsx:152
 msgid "button.new.visualization"
 msgstr "Crea una nuova visualizzazione"
 
@@ -132,11 +132,11 @@ msgstr "Successivo"
 msgid "button.publish"
 msgstr "Pubblica questa visualizzazione"
 
-#: app/components/publish-actions.tsx:116
+#: app/components/publish-actions.tsx:94
 msgid "button.share"
 msgstr "Condividi"
 
-#: app/configurator/components/ui-helpers.ts:485
+#: app/configurator/components/ui-helpers.ts:548
 #: app/configurator/map/map-chart-options.tsx:163
 msgid "chart.map.layers.area"
 msgstr "Aree"
@@ -161,8 +161,8 @@ msgstr "Quantili (distribuzione omogenea dei valori)"
 msgid "chart.map.layers.area.discretization.quantize"
 msgstr "Intervalli uguali"
 
-#: app/configurator/components/chart-configurator.tsx:554
-#: app/configurator/components/ui-helpers.ts:481
+#: app/configurator/components/chart-configurator.tsx:553
+#: app/configurator/components/ui-helpers.ts:544
 #: app/configurator/map/map-chart-options.tsx:64
 msgid "chart.map.layers.base"
 msgstr "Livello di base"
@@ -176,7 +176,7 @@ msgstr "Mostra"
 msgid "chart.map.layers.show"
 msgstr "Mostra il livello"
 
-#: app/configurator/components/ui-helpers.ts:489
+#: app/configurator/components/ui-helpers.ts:552
 #: app/configurator/map/map-chart-options.tsx:387
 msgid "chart.map.layers.symbol"
 msgstr "Simboli"
@@ -222,47 +222,47 @@ msgstr "Regular"
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Impostazioni predefinite"
 
-#: app/configurator/components/ui-helpers.ts:455
+#: app/configurator/components/ui-helpers.ts:518
 msgid "controls.axis.horizontal"
 msgstr "Asse orizzontale"
 
-#: app/configurator/components/ui-helpers.ts:463
+#: app/configurator/components/ui-helpers.ts:526
 msgid "controls.axis.vertical"
 msgstr "Asse verticale"
 
-#: app/configurator/components/ui-helpers.ts:557
+#: app/configurator/components/ui-helpers.ts:620
 msgid "controls.chart.type.area"
 msgstr "Aree"
 
-#: app/configurator/components/ui-helpers.ts:549
+#: app/configurator/components/ui-helpers.ts:612
 msgid "controls.chart.type.bar"
 msgstr "Barre"
 
-#: app/configurator/components/ui-helpers.ts:545
+#: app/configurator/components/ui-helpers.ts:608
 msgid "controls.chart.type.column"
 msgstr "Colonne"
 
-#: app/configurator/components/ui-helpers.ts:553
+#: app/configurator/components/ui-helpers.ts:616
 msgid "controls.chart.type.line"
 msgstr "Linee"
 
-#: app/configurator/components/ui-helpers.ts:573
+#: app/configurator/components/ui-helpers.ts:636
 msgid "controls.chart.type.map"
 msgstr "Mappa"
 
-#: app/configurator/components/ui-helpers.ts:565
+#: app/configurator/components/ui-helpers.ts:628
 msgid "controls.chart.type.pie"
 msgstr "Torta"
 
-#: app/configurator/components/ui-helpers.ts:561
+#: app/configurator/components/ui-helpers.ts:624
 msgid "controls.chart.type.scatterplot"
 msgstr "Scatterplot"
 
-#: app/configurator/components/ui-helpers.ts:569
+#: app/configurator/components/ui-helpers.ts:632
 msgid "controls.chart.type.table"
 msgstr "Tabella"
 
-#: app/configurator/components/ui-helpers.ts:467
+#: app/configurator/components/ui-helpers.ts:530
 #: app/configurator/map/map-chart-options.tsx:236
 #: app/configurator/map/map-chart-options.tsx:441
 msgid "controls.color"
@@ -277,8 +277,7 @@ msgstr "Aggiungi ..."
 msgid "controls.color.palette"
 msgstr "Palette di colori"
 
-#: app/configurator/components/chart-controls/color-palette.tsx:238
-#: app/configurator/components/chart-controls/color-palette.tsx:244
+#: app/configurator/components/chart-controls/color-palette.tsx:240
 msgid "controls.color.palette.reset"
 msgstr "Ripristina la tavolozza dei colori"
 
@@ -294,15 +293,15 @@ msgstr "Seleziona un colore"
 msgid "controls.colorpicker.open"
 msgstr "Apri il selettore di colore"
 
-#: app/configurator/components/ui-helpers.ts:477
+#: app/configurator/components/ui-helpers.ts:540
 msgid "controls.column.grouped"
 msgstr "raggruppate"
 
-#: app/configurator/components/ui-helpers.ts:473
+#: app/configurator/components/ui-helpers.ts:536
 msgid "controls.column.stacked"
 msgstr "impilate"
 
-#: app/configurator/components/ui-helpers.ts:469
+#: app/configurator/components/ui-helpers.ts:532
 msgid "controls.description"
 msgstr "Descrizione"
 
@@ -315,7 +314,7 @@ msgstr "Dimensione geografica"
 msgid "controls.dimension.none"
 msgstr "Nessuno"
 
-#: app/charts/shared/chart-data-filters.tsx:193
+#: app/charts/shared/chart-data-filters.tsx:198
 #: app/configurator/components/field.tsx:122
 #: app/configurator/components/field.tsx:179
 #: app/configurator/components/field.tsx:279
@@ -334,7 +333,7 @@ msgstr "Seleziona tutti"
 msgid "controls.filter.select.none"
 msgstr "Deseleziona tutto"
 
-#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:137
+#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:123
 msgid "controls.filters.time.range"
 msgstr "intervallo di tempo"
 
@@ -354,23 +353,23 @@ msgstr "Seleziona un elemento di design o una dimensione dei dati per modificarn
 msgid "controls.hint.describing.chart"
 msgstr "Seleziona una delle annotazioni proposte per modificarla."
 
-#: app/configurator/components/ui-helpers.ts:529
+#: app/configurator/components/ui-helpers.ts:592
 msgid "controls.imputation"
 msgstr "Tipo di imputazione"
 
 #: app/configurator/components/chart-options-selector.tsx:528
-#: app/configurator/components/ui-helpers.ts:541
+#: app/configurator/components/ui-helpers.ts:604
 msgid "controls.imputation.type.linear"
 msgstr "Interpolazione lineare"
 
 #: app/configurator/components/chart-options-selector.tsx:521
 #: app/configurator/components/chart-options-selector.tsx:533
-#: app/configurator/components/ui-helpers.ts:533
+#: app/configurator/components/ui-helpers.ts:596
 msgid "controls.imputation.type.none"
 msgstr "-"
 
 #: app/configurator/components/chart-options-selector.tsx:523
-#: app/configurator/components/ui-helpers.ts:537
+#: app/configurator/components/ui-helpers.ts:600
 msgid "controls.imputation.type.zeros"
 msgstr "Zeri"
 
@@ -394,23 +393,23 @@ msgstr "Nessuna dimensione temporale disponibile!"
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Mostra i filtri temporali"
 
-#: app/configurator/components/ui-helpers.ts:577
+#: app/configurator/components/ui-helpers.ts:640
 msgid "controls.language.english"
 msgstr "Inglese"
 
-#: app/configurator/components/ui-helpers.ts:585
+#: app/configurator/components/ui-helpers.ts:648
 msgid "controls.language.french"
 msgstr "Francese"
 
-#: app/configurator/components/ui-helpers.ts:581
+#: app/configurator/components/ui-helpers.ts:644
 msgid "controls.language.german"
 msgstr "Tedesco"
 
-#: app/configurator/components/ui-helpers.ts:589
+#: app/configurator/components/ui-helpers.ts:652
 msgid "controls.language.italian"
 msgstr "Italiano"
 
-#: app/configurator/components/ui-helpers.ts:459
+#: app/configurator/components/ui-helpers.ts:522
 #: app/configurator/map/map-chart-options.tsx:218
 #: app/configurator/map/map-chart-options.tsx:423
 msgid "controls.measure"
@@ -425,8 +424,8 @@ msgid "controls.option.isNotActive"
 msgstr "Inattivo"
 
 #: app/configurator/components/chart-type-selector.tsx:193
-msgid "controls.remove.visualization"
-msgstr "Rimuovi questa visualizzazione"
+#~ msgid "controls.remove.visualization"
+#~ msgstr "Rimuovi questa visualizzazione"
 
 #: app/configurator/map/map-chart-options.tsx:240
 msgid "controls.scale.type"
@@ -440,7 +439,7 @@ msgstr "Cancella la ricerca"
 msgid "controls.section.additional-information"
 msgstr "Informazioni aggiuntive"
 
-#: app/configurator/components/chart-configurator.tsx:365
+#: app/configurator/components/chart-configurator.tsx:360
 msgid "controls.section.chart.options"
 msgstr "Opzioni del grafico"
 
@@ -452,7 +451,7 @@ msgstr "Colonne"
 msgid "controls.section.columnstyle"
 msgstr "Stile della colonna"
 
-#: app/configurator/components/chart-configurator.tsx:380
+#: app/configurator/components/chart-configurator.tsx:375
 msgid "controls.section.data.filters"
 msgstr "Filtri"
 
@@ -509,7 +508,7 @@ msgstr "Ordinamento della tabella"
 msgid "controls.section.tableoptions"
 msgstr "Opzioni della tabella"
 
-#: app/configurator/components/chart-type-selector.tsx:146
+#: app/configurator/components/chart-type-selector.tsx:136
 msgid "controls.select.chart.type"
 msgstr "Tipo di grafico"
 
@@ -577,11 +576,11 @@ msgstr "Aggiungi una dimensione"
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Nome"
 
-#: app/configurator/components/ui-helpers.ts:497
+#: app/configurator/components/ui-helpers.ts:560
 msgid "controls.sorting.byDimensionLabel.ascending"
 msgstr "A → Z"
 
-#: app/configurator/components/ui-helpers.ts:501
+#: app/configurator/components/ui-helpers.ts:564
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
@@ -589,11 +588,11 @@ msgstr "Z → A"
 msgid "controls.sorting.byMeasure"
 msgstr "Misura"
 
-#: app/configurator/components/ui-helpers.ts:521
+#: app/configurator/components/ui-helpers.ts:584
 msgid "controls.sorting.byMeasure.ascending"
 msgstr "1 → 9"
 
-#: app/configurator/components/ui-helpers.ts:525
+#: app/configurator/components/ui-helpers.ts:588
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
@@ -601,19 +600,19 @@ msgstr "9 → 1"
 msgid "controls.sorting.byTotalSize"
 msgstr "Grandezza totale"
 
-#: app/configurator/components/ui-helpers.ts:505
+#: app/configurator/components/ui-helpers.ts:568
 msgid "controls.sorting.byTotalSize.ascending"
 msgstr "Il più grande per ultimo"
 
-#: app/configurator/components/ui-helpers.ts:517
+#: app/configurator/components/ui-helpers.ts:580
 msgid "controls.sorting.byTotalSize.largestBottom"
 msgstr "Il più grande sotto"
 
-#: app/configurator/components/ui-helpers.ts:509
+#: app/configurator/components/ui-helpers.ts:572
 msgid "controls.sorting.byTotalSize.largestFirst"
 msgstr "Il più grande per primo"
 
-#: app/configurator/components/ui-helpers.ts:513
+#: app/configurator/components/ui-helpers.ts:576
 msgid "controls.sorting.byTotalSize.largestTop"
 msgstr "Il più grande sopra"
 
@@ -625,12 +624,12 @@ msgstr "Rimuovi l'ordinamento"
 msgid "controls.sorting.selectDimension"
 msgstr "Seleziona una dimensione ..."
 
-#: app/configurator/components/ui-helpers.ts:493
+#: app/configurator/components/ui-helpers.ts:556
 #: app/configurator/table/table-chart-sorting-options.tsx:307
 msgid "controls.sorting.sortBy"
 msgstr "Ordina per"
 
-#: app/configurator/components/chart-type-selector.tsx:150
+#: app/configurator/components/chart-type-selector.tsx:140
 msgid "controls.switch.chart.type"
 msgstr "Passa a un altro tipo di grafico mantenendo la maggior parte delle impostazioni dei filtri"
 
@@ -654,7 +653,7 @@ msgstr "Ordinamento"
 msgid "controls.tableSettings.showSearch"
 msgstr "Mostra il campo di ricerca"
 
-#: app/configurator/components/ui-helpers.ts:468
+#: app/configurator/components/ui-helpers.ts:531
 msgid "controls.title"
 msgstr "Titolo"
 
@@ -666,7 +665,7 @@ msgstr "Torna ai set di dati"
 #~ msgid "dataset-selector.choose-another-dataset"
 #~ msgstr "Scegli un altro set di dati"
 
-#: app/components/chart-published.tsx:109
+#: app/components/chart-published.tsx:117
 msgid "dataset.hasImputedValues"
 msgstr "In questo set di dati mancano alcuni dati. Questi sono stati interpolati per colmare le lacune.."
 
@@ -674,23 +673,27 @@ msgstr "In questo set di dati mancano alcuni dati. Questi sono stati interpolati
 msgid "dataset.includeDrafts"
 msgstr "Includere le bozze"
 
-#: app/configurator/components/dataset-metadata.tsx:63
+#: app/configurator/components/dataset-metadata.tsx:71
 msgid "dataset.metadata.date.created"
 msgstr "Data di creazione"
 
-#: app/configurator/components/dataset-metadata.tsx:75
+#: app/configurator/components/dataset-metadata.tsx:83
 msgid "dataset.metadata.email"
 msgstr "Punti di contatto"
 
-#: app/configurator/components/dataset-metadata.tsx:89
-msgid "dataset.metadata.landingPage"
+#: app/configurator/components/dataset-metadata.tsx:97
+msgid "dataset.metadata.furtherinformation"
 msgstr "Addizionali informazioni"
 
-#: app/configurator/components/dataset-metadata.tsx:49
+#: app/configurator/components/dataset-metadata.tsx:104
+msgid "dataset.metadata.landingpage"
+msgstr "Pagina di destinazione"
+
+#: app/configurator/components/dataset-metadata.tsx:57
 msgid "dataset.metadata.source"
 msgstr "Fonte"
 
-#: app/configurator/components/dataset-metadata.tsx:70
+#: app/configurator/components/dataset-metadata.tsx:78
 msgid "dataset.metadata.version"
 msgstr "versione"
 
@@ -706,13 +709,13 @@ msgstr "Rilevanza"
 msgid "dataset.order.title"
 msgstr "Titolo"
 
-#: app/components/chart-preview.tsx:59
-#: app/components/chart-published.tsx:87
+#: app/components/chart-preview.tsx:69
+#: app/components/chart-published.tsx:95
 #: app/configurator/components/dataset-preview.tsx:41
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Attenzione, questo set di dati è una bozza.<0/><1>Non utilizzare questo grafico per un rapporto!</1>"
 
-#: app/components/chart-published.tsx:98
+#: app/components/chart-published.tsx:106
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Attenzione, questo set di dati è scaduto.<0/><1>Non utilizzare questo grafico per un rapporto!</1>"
 
@@ -736,7 +739,7 @@ msgstr "Ordina per"
 msgid "dataset.tag.draft"
 msgstr "Bozza"
 
-#: app/configurator/components/dataset-preview.tsx:108
+#: app/configurator/components/dataset-preview.tsx:112
 msgid "datatable.showing.first.rows"
 msgstr "Sono mostrate soltanto le prime 10 righe"
 
@@ -748,84 +751,79 @@ msgstr "Ufficio federale dell'ambiente UFAM"
 msgid "footer.institution.url"
 msgstr "https://www.bafu.admin.ch/bafu/it/home.html"
 
-#: app/components/footer.tsx:124
-#~ msgid "footer.status"
-#~ msgstr "Status"
-
-#: app/components/hint.tsx:158
-msgid "hint.chartunexpected.message"
-msgstr ""
-
-#: app/components/hint.tsx:156
-msgid "hint.chartunexpected.title"
-msgstr ""
-
-#: app/components/hint.tsx:144
-msgid "hint.coordinatesloadingerror.message"
-msgstr "C'è stato un problema con il caricamento delle coordinate dalle dimensioni geografiche. Per favore riprova più tardi."
-
-#: app/components/hint.tsx:140
-
-#: app/components/footer.tsx:125
+#: app/components/footer.tsx:126
 msgid "footer.status"
 msgstr "Stato"
 
+#: app/components/hint.tsx:174
+msgid "hint.chartunexpected.message"
+msgstr ""
+
+#: app/components/hint.tsx:172
+msgid "hint.chartunexpected.title"
+msgstr ""
+
+#: app/components/hint.tsx:160
+msgid "hint.coordinatesloadingerror.message"
+msgstr "C'è stato un problema con il caricamento delle coordinate dalle dimensioni geografiche. Per favore riprova più tardi."
+
+#: app/components/hint.tsx:156
 msgid "hint.coordinatesloadingerror.title"
 msgstr "Errore di caricamento delle coordinate"
 
-#: app/pages/v/[chartId].tsx:122
+#: app/pages/v/[chartId].tsx:129
 msgid "hint.create.your.own.chart"
 msgstr "Copia questa visualizzazione o crea una nuova visualizzazione usando «dati aperti» dell’amministrazione pubblica svizzera"
 
-#: app/components/hint.tsx:128
+#: app/components/hint.tsx:130
 msgid "hint.dataloadingerror.message"
 msgstr "I dati non possono essere caricati."
 
-#: app/components/hint.tsx:137
+#: app/components/hint.tsx:139
 msgid "hint.dataloadingerror.status"
 msgstr "Controlla la pagina di stato per ulteriori informazioni”"
 
-#: app/components/hint.tsx:126
+#: app/components/hint.tsx:128
 msgid "hint.dataloadingerror.title"
 msgstr "Problema di caricamento dei dati"
 
-#: app/pages/v/[chartId].tsx:116
+#: app/pages/v/[chartId].tsx:123
 msgid "hint.how.to.share"
 msgstr "È possibile condividere questa visualizzazione copiando l'URL o incorporandola nel vostro sito Web. Puoi anche creare una nuova visualizzazione partendo da zero oppure copiando e modificando la visualizzazione sopra."
 
-#: app/components/hint.tsx:91
+#: app/components/hint.tsx:92
 msgid "hint.loading.data"
 msgstr "Caricamento dei dati..."
 
-#: app/configurator/components/chart-type-selector.tsx:167
+#: app/configurator/components/chart-type-selector.tsx:150
 msgid "hint.no.visualization.with.dataset"
 msgstr "Nessuna visualizzazione può essere creata con il dataset selezionato."
 
-#: app/components/hint.tsx:118
+#: app/components/hint.tsx:119
 msgid "hint.nodata.message"
 msgstr "Prova con un'altra combinazione di filtri."
 
-#: app/components/hint.tsx:114
+#: app/components/hint.tsx:115
 msgid "hint.nodata.title"
 msgstr "Non ci sono dati corrispondenti ai filtri selezionati"
 
-#: app/components/hint.tsx:180
+#: app/components/hint.tsx:196
 msgid "hint.only.negative.data.message"
 msgstr "Dati con valori negativi non possono essere visualizzati con questo tipo di grafico."
 
-#: app/components/hint.tsx:178
+#: app/components/hint.tsx:194
 msgid "hint.only.negative.data.title"
 msgstr "Valori negativi"
 
-#: app/components/hint.tsx:188
+#: app/components/hint.tsx:204
 msgid "hint.publication.success"
 msgstr "La tua visualizzazione è ora pubblicata. Condividila copiando l'URL o utilizzando le opzioni di incorporamento."
 
-#: app/charts/shared/chart-data-filters.tsx:72
+#: app/charts/shared/chart-data-filters.tsx:75
 msgid "interactive.data.filters.hide"
 msgstr "Nascondi i filtri"
 
-#: app/charts/shared/chart-data-filters.tsx:70
+#: app/charts/shared/chart-data-filters.tsx:77
 msgid "interactive.data.filters.show"
 msgstr "Mostra i filtri"
 
@@ -834,63 +832,63 @@ msgstr "Mostra i filtri"
 msgid "logo.swiss.confederation"
 msgstr "Logo della Confederazione svizzera"
 
-#: app/components/chart-footnotes.tsx:56
+#: app/components/chart-footnotes.tsx:61
 msgid "metadata.dataset"
 msgstr "Dataset"
 
-#: app/components/chart-footnotes.tsx:131
+#: app/components/chart-footnotes.tsx:162
 msgid "metadata.link.created.with.visualize"
 msgstr "Creato con visualize.admin.ch"
 
-#: app/components/chart-footnotes.tsx:60
+#: app/components/chart-footnotes.tsx:77
 msgid "metadata.source"
 msgstr "Fonte"
 
-#: app/components/chart-footnotes.tsx:99
+#: app/components/chart-footnotes.tsx:140
 msgid "metadata.switch.chart"
 msgstr "Passare alla visualizzazione del grafico"
 
-#: app/components/chart-footnotes.tsx:103
+#: app/components/chart-footnotes.tsx:142
 msgid "metadata.switch.table"
 msgstr "Passare alla vista tabella"
 
-#: app/components/publish-actions.tsx:245
+#: app/components/publish-actions.tsx:216
 msgid "publication.embed.AEM"
 msgstr "Codice da incorporare su AEM come \"External Application\":"
 
-#: app/components/publish-actions.tsx:238
+#: app/components/publish-actions.tsx:209
 msgid "publication.embed.iframe"
 msgstr "Codice di incorporamento:"
 
-#: app/components/publish-actions.tsx:135
+#: app/components/publish-actions.tsx:109
 msgid "publication.popup.share"
 msgstr "Condividi"
 
-#: app/components/publish-actions.tsx:182
+#: app/components/publish-actions.tsx:157
 msgid "publication.share.chart.url"
 msgstr "URL del grafico:"
 
-#: app/components/publish-actions.tsx:141
+#: app/components/publish-actions.tsx:115
 msgid "publication.share.linktitle.facebook"
 msgstr "Condividi su Facebook"
 
-#: app/components/publish-actions.tsx:161
+#: app/components/publish-actions.tsx:135
 msgid "publication.share.linktitle.mail"
 msgstr "Condividi via Email"
 
-#: app/components/publish-actions.tsx:151
+#: app/components/publish-actions.tsx:125
 msgid "publication.share.linktitle.twitter"
 msgstr "Condividi su Twitter"
 
-#: app/components/publish-actions.tsx:172
+#: app/components/publish-actions.tsx:146
 msgid "publication.share.mail.body"
 msgstr "Ecco una visualizzazione che ho creato usando visualize.admin.ch"
 
-#: app/components/publish-actions.tsx:167
+#: app/components/publish-actions.tsx:141
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
-#: app/configurator/components/stepper.tsx:187
+#: app/configurator/components/stepper.tsx:191
 msgid "step.annotate"
 msgstr "Prima di pubblicare, aggiungere un titolo e una descrizione al tuo grafico e scegliere quali elementi possono essere interattivi."
 
@@ -898,7 +896,7 @@ msgstr "Prima di pubblicare, aggiungere un titolo e una descrizione al tuo grafi
 #~ msgid "step.visualization.type"
 #~ msgstr "Seleziona il tipo di grafico desiderato per i tuoi dati."
 
-#: app/configurator/components/stepper.tsx:176
+#: app/configurator/components/stepper.tsx:180
 msgid "step.visualize"
 msgstr "Personalizza la tua visualizzazione utilizzando le opzioni di segmentazione del filtro e del colore, nelle barre laterali."
 

--- a/app/utils/opendata.ts
+++ b/app/utils/opendata.ts
@@ -1,0 +1,25 @@
+import {
+  DataCubeMetadataWithComponentValuesQuery,
+  DataCubeMetadataQuery,
+} from "@/graphql/query-hooks";
+
+const makeOpenDataLink = (
+  lang: string,
+  cube:
+    | DataCubeMetadataWithComponentValuesQuery["dataCubeByIri"]
+    | DataCubeMetadataQuery["dataCubeByIri"]
+) => {
+  const identifier = cube?.identifier;
+  const creatorIri = cube?.creator?.iri;
+  if (!identifier || !creatorIri) {
+    return;
+  }
+  return `https://opendata.swiss/${lang}/perma/${encodeURIComponent(
+    `${identifier}@${creatorIri.replace(
+      "https://register.ld.admin.ch/opendataswiss/org/",
+      ""
+    )}`
+  )}`;
+};
+
+export { makeOpenDataLink };


### PR DESCRIPTION
Inside footnotes, the dataset title is now a link to opendata.swiss.
There, the user can have more information on the dataset.
Since the link is external, it opens in a new tab.

fix #135
