### PR TITLE
fix: Show opendata.swiss link only if it is published there

### DIFF
--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -17,6 +17,7 @@ query DataCubes(
     dataCube {
       iri
       title
+      workExamples
       creator {
         iri
         label
@@ -91,6 +92,7 @@ query DataCubeMetadata($iri: String!, $locale: String!, $latest: Boolean) {
     description
     publisher
     version
+    workExamples
     contactName
     contactEmail
     landingPage
@@ -119,6 +121,7 @@ query DataCubeMetadataWithComponentValues(
     title
     publisher
     identifier
+    workExamples
     creator {
       iri
     }

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -30,6 +30,7 @@ export type DataCube = {
   contactEmail?: Maybe<Scalars['String']>;
   creator?: Maybe<DataCubeOrganization>;
   landingPage?: Maybe<Scalars['String']>;
+  workExamples?: Maybe<Array<Maybe<Scalars['String']>>>;
   publisher?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   datePublished?: Maybe<Scalars['String']>;
@@ -334,7 +335,7 @@ export type DataCubesQueryVariables = Exact<{
 }>;
 
 
-export type DataCubesQuery = { __typename: 'Query', dataCubes: Array<{ __typename: 'DataCubeResult', highlightedTitle?: Maybe<string>, highlightedDescription?: Maybe<string>, dataCube: { __typename: 'DataCube', iri: string, title: string, description?: Maybe<string>, publicationStatus: DataCubePublicationStatus, datePublished?: Maybe<string>, creator?: Maybe<{ __typename: 'DataCubeOrganization', iri: string, label?: Maybe<string> }>, themes: Array<{ __typename: 'DataCubeTheme', iri: string, label?: Maybe<string> }> } }> };
+export type DataCubesQuery = { __typename: 'Query', dataCubes: Array<{ __typename: 'DataCubeResult', highlightedTitle?: Maybe<string>, highlightedDescription?: Maybe<string>, dataCube: { __typename: 'DataCube', iri: string, title: string, workExamples?: Maybe<Array<Maybe<string>>>, description?: Maybe<string>, publicationStatus: DataCubePublicationStatus, datePublished?: Maybe<string>, creator?: Maybe<{ __typename: 'DataCubeOrganization', iri: string, label?: Maybe<string> }>, themes: Array<{ __typename: 'DataCubeTheme', iri: string, label?: Maybe<string> }> } }> };
 
 type DimensionMetaData_GeoCoordinatesDimension_Fragment = { __typename: 'GeoCoordinatesDimension', iri: string, label: string, isNumerical: boolean, isKeyDimension: boolean, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
 
@@ -398,7 +399,7 @@ export type DataCubeMetadataQueryVariables = Exact<{
 }>;
 
 
-export type DataCubeMetadataQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', iri: string, identifier?: Maybe<string>, title: string, description?: Maybe<string>, publisher?: Maybe<string>, version?: Maybe<string>, contactName?: Maybe<string>, contactEmail?: Maybe<string>, landingPage?: Maybe<string>, expires?: Maybe<string>, datePublished?: Maybe<string>, publicationStatus: DataCubePublicationStatus, themes: Array<{ __typename: 'DataCubeTheme', iri: string, label?: Maybe<string> }>, creator?: Maybe<{ __typename: 'DataCubeOrganization', iri: string, label?: Maybe<string> }> }> };
+export type DataCubeMetadataQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', iri: string, identifier?: Maybe<string>, title: string, description?: Maybe<string>, publisher?: Maybe<string>, version?: Maybe<string>, workExamples?: Maybe<Array<Maybe<string>>>, contactName?: Maybe<string>, contactEmail?: Maybe<string>, landingPage?: Maybe<string>, expires?: Maybe<string>, datePublished?: Maybe<string>, publicationStatus: DataCubePublicationStatus, themes: Array<{ __typename: 'DataCubeTheme', iri: string, label?: Maybe<string> }>, creator?: Maybe<{ __typename: 'DataCubeOrganization', iri: string, label?: Maybe<string> }> }> };
 
 export type DataCubeMetadataWithComponentValuesQueryVariables = Exact<{
   iri: Scalars['String'];
@@ -408,7 +409,7 @@ export type DataCubeMetadataWithComponentValuesQueryVariables = Exact<{
 }>;
 
 
-export type DataCubeMetadataWithComponentValuesQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', iri: string, title: string, publisher?: Maybe<string>, identifier?: Maybe<string>, creator?: Maybe<{ __typename: 'DataCubeOrganization', iri: string }>, dimensions: Array<(
+export type DataCubeMetadataWithComponentValuesQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', iri: string, title: string, publisher?: Maybe<string>, identifier?: Maybe<string>, workExamples?: Maybe<Array<Maybe<string>>>, creator?: Maybe<{ __typename: 'DataCubeOrganization', iri: string }>, dimensions: Array<(
       { __typename: 'GeoCoordinatesDimension' }
       & DimensionMetaData_GeoCoordinatesDimension_Fragment
     ) | (
@@ -599,6 +600,7 @@ export const DataCubesDocument = gql`
     dataCube {
       iri
       title
+      workExamples
       creator {
         iri
         label
@@ -661,6 +663,7 @@ export const DataCubeMetadataDocument = gql`
     description
     publisher
     version
+    workExamples
     contactName
     contactEmail
     landingPage
@@ -689,6 +692,7 @@ export const DataCubeMetadataWithComponentValuesDocument = gql`
     title
     publisher
     identifier
+    workExamples
     creator {
       iri
     }

--- a/app/graphql/resolver-types.ts
+++ b/app/graphql/resolver-types.ts
@@ -35,6 +35,7 @@ export type DataCube = {
   contactEmail?: Maybe<Scalars['String']>;
   creator?: Maybe<DataCubeOrganization>;
   landingPage?: Maybe<Scalars['String']>;
+  workExamples?: Maybe<Array<Maybe<Scalars['String']>>>;
   publisher?: Maybe<Scalars['String']>;
   description?: Maybe<Scalars['String']>;
   datePublished?: Maybe<Scalars['String']>;
@@ -470,6 +471,7 @@ export type DataCubeResolvers<ContextType = any, ParentType extends ResolversPar
   contactEmail?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   creator?: Resolver<Maybe<ResolversTypes['DataCubeOrganization']>, ParentType, ContextType>;
   landingPage?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  workExamples?: Resolver<Maybe<Array<Maybe<ResolversTypes['String']>>>, ParentType, ContextType>;
   publisher?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   datePublished?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/app/graphql/resolvers.ts
+++ b/app/graphql/resolvers.ts
@@ -227,6 +227,7 @@ const DataCube: DataCubeResolvers = {
   title: ({ data: { title } }) => title,
   version: ({ data: { version } }) => version ?? null,
   identifier: ({ data: { identifier } }) => identifier ?? null,
+  workExamples: ({ data: { workExamples } }) => workExamples ?? null,
   publisher: ({ data: { publisher } }) => publisher ?? null,
   contactName: ({ data: { contactPoint } }) => contactPoint?.name ?? null,
   contactEmail: ({ data: { contactPoint } }) => contactPoint?.email ?? null,

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -30,6 +30,7 @@ type DataCube {
   contactEmail: String
   creator: DataCubeOrganization
   landingPage: String
+  workExamples: [String]
   publisher: String
   description: String
   datePublished: String

--- a/app/graphql/shared-types.ts
+++ b/app/graphql/shared-types.ts
@@ -35,6 +35,7 @@ export type ResolvedDataCube = {
     landingPage?: string;
     expires?: string;
     keywords?: string[];
+    workExamples?: string[];
   };
 };
 

--- a/app/rdf/parse.ts
+++ b/app/rdf/parse.ts
@@ -78,6 +78,7 @@ export const parseCube = ({
       landingPage: cube.out(ns.dcat.landingPage)?.value,
       expires: cube.out(ns.schema.expires)?.value,
       keywords: cube.out(ns.dcat.keyword)?.values,
+      workExamples: cube.out(ns.schema.workExample)?.values,
     },
   };
 };

--- a/app/utils/opendata.ts
+++ b/app/utils/opendata.ts
@@ -11,7 +11,10 @@ const makeOpenDataLink = (
 ) => {
   const identifier = cube?.identifier;
   const creatorIri = cube?.creator?.iri;
-  if (!identifier || !creatorIri) {
+  const isPublished = cube?.workExamples?.includes(
+    "https://ld.admin.ch/application/opendataswiss"
+  );
+  if (!identifier || !creatorIri || !isPublished) {
     return;
   }
   return `https://opendata.swiss/${lang}/perma/${encodeURIComponent(


### PR DESCRIPTION
We have to look at the workExamples predicates to know if a cube has been
published on open data swiss.

Documentation on cube creator: https://github.com/zazuko/cube-creator/wiki/LINDAS-Specifics#needed-attributes-that-a-cube-shows-up-on-opendataswiss

fix #135
﻿
