### PR TITLE
Support unversioned cubes

### DIFF
--- a/app/pages/browse/[type]/[iri].tsx
+++ b/app/pages/browse/[type]/[iri].tsx
@@ -31,6 +31,8 @@ const getServerSideProps: GetServerSideProps = async function (ctx) {
           destination: "/",
         },
       };
+    } else if (params.iri === resp.iri) {
+      return { props: {} };
     }
     return {
       redirect: {

--- a/app/typings/rdf.d.ts
+++ b/app/typings/rdf.d.ts
@@ -112,6 +112,7 @@ declare module "rdf-cube-view-query" {
       noShape?: boolean;
       filters: $FixMe;
     }): Promise<Cube[]>;
+    async cubesQuery(options?: { filters: $FixMe }): string;
     client: ParsingClient;
     queryOperation?: "get" | "postUrlencoded" | "postDirect";
   }


### PR DESCRIPTION
When looking at the dataset preview /browse/dataset/[iri], we try to redirect (server side) to the latest published IRI (in case the person comes from an external link where the cube version is not there). Some cubes do not have a version. Here, to make sure it is a valid cube, we make an extra request to check if the IRI has a shape. If the iri returned by the function looking for the last versioned iri is the same as the query passed in parameter, we do not do any redirect.

Previously, it was working when going first to a theme since the route for theme/iri and dataset/iri is "the same", and no server side redirect was triggered when going from /browse/theme/[iri] to /browse/dataset/[iri] (whereas the server side redirect was triggered by going from /browse to /browse/dataset/[iri]).

cc @l00mi for the explanation ;)