### PR TITLE
Cube checker

### DIFF
--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -136,7 +136,7 @@ msgstr "Diese Visualisierung veröffentlichen"
 msgid "button.share"
 msgstr "Teilen"
 
-#: app/configurator/components/ui-helpers.ts:548
+#: app/configurator/components/ui-helpers.ts:562
 #: app/configurator/map/map-chart-options.tsx:163
 msgid "chart.map.layers.area"
 msgstr "Flächen"
@@ -162,7 +162,7 @@ msgid "chart.map.layers.area.discretization.quantize"
 msgstr "Quantisierung (gleiche Wertebereiche)"
 
 #: app/configurator/components/chart-configurator.tsx:553
-#: app/configurator/components/ui-helpers.ts:544
+#: app/configurator/components/ui-helpers.ts:558
 #: app/configurator/map/map-chart-options.tsx:64
 msgid "chart.map.layers.base"
 msgstr "Basis-Ebene"
@@ -176,7 +176,7 @@ msgstr "Anzeigen"
 msgid "chart.map.layers.show"
 msgstr "Ebene anzeigen"
 
-#: app/configurator/components/ui-helpers.ts:552
+#: app/configurator/components/ui-helpers.ts:566
 #: app/configurator/map/map-chart-options.tsx:387
 msgid "chart.map.layers.symbol"
 msgstr "Symbole"
@@ -185,11 +185,11 @@ msgstr "Symbole"
 msgid "chart.map.warning.noGeoDimensions"
 msgstr "In diesem Datenset können keine geografischen Dimensionen angezeigt werden."
 
-#: app/charts/table/table.tsx:265
+#: app/charts/table/table.tsx:281
 msgid "chart.published.toggle.mobile.view"
 msgstr "Kompakte Ansicht"
 
-#: app/charts/table/table.tsx:340
+#: app/charts/table/table.tsx:356
 msgid "chart.table.number.of.lines"
 msgstr "Anzahl Zeilen"
 
@@ -222,47 +222,47 @@ msgstr "Normal"
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Standardeinstellung"
 
-#: app/configurator/components/ui-helpers.ts:518
+#: app/configurator/components/ui-helpers.ts:532
 msgid "controls.axis.horizontal"
 msgstr "Horizontale Achse"
 
-#: app/configurator/components/ui-helpers.ts:526
+#: app/configurator/components/ui-helpers.ts:540
 msgid "controls.axis.vertical"
 msgstr "Vertikale Achse"
 
-#: app/configurator/components/ui-helpers.ts:620
+#: app/configurator/components/ui-helpers.ts:634
 msgid "controls.chart.type.area"
 msgstr "Flächen"
 
-#: app/configurator/components/ui-helpers.ts:612
+#: app/configurator/components/ui-helpers.ts:626
 msgid "controls.chart.type.bar"
 msgstr "Balken"
 
-#: app/configurator/components/ui-helpers.ts:608
+#: app/configurator/components/ui-helpers.ts:622
 msgid "controls.chart.type.column"
 msgstr "Säulen"
 
-#: app/configurator/components/ui-helpers.ts:616
+#: app/configurator/components/ui-helpers.ts:630
 msgid "controls.chart.type.line"
 msgstr "Linien"
 
-#: app/configurator/components/ui-helpers.ts:636
+#: app/configurator/components/ui-helpers.ts:650
 msgid "controls.chart.type.map"
 msgstr "Karte"
 
-#: app/configurator/components/ui-helpers.ts:628
+#: app/configurator/components/ui-helpers.ts:642
 msgid "controls.chart.type.pie"
 msgstr "Kreis"
 
-#: app/configurator/components/ui-helpers.ts:624
+#: app/configurator/components/ui-helpers.ts:638
 msgid "controls.chart.type.scatterplot"
 msgstr "Scatterplot"
 
-#: app/configurator/components/ui-helpers.ts:632
+#: app/configurator/components/ui-helpers.ts:646
 msgid "controls.chart.type.table"
 msgstr "Tabelle"
 
-#: app/configurator/components/ui-helpers.ts:530
+#: app/configurator/components/ui-helpers.ts:544
 #: app/configurator/map/map-chart-options.tsx:236
 #: app/configurator/map/map-chart-options.tsx:441
 msgid "controls.color"
@@ -293,15 +293,15 @@ msgstr "Farbe auswählen"
 msgid "controls.colorpicker.open"
 msgstr "Farbauswahl öffnen"
 
-#: app/configurator/components/ui-helpers.ts:540
+#: app/configurator/components/ui-helpers.ts:554
 msgid "controls.column.grouped"
 msgstr "Gruppiert"
 
-#: app/configurator/components/ui-helpers.ts:536
+#: app/configurator/components/ui-helpers.ts:550
 msgid "controls.column.stacked"
 msgstr "Gestapelt"
 
-#: app/configurator/components/ui-helpers.ts:532
+#: app/configurator/components/ui-helpers.ts:546
 msgid "controls.description"
 msgstr "Beschreibung hinzufügen"
 
@@ -321,15 +321,15 @@ msgstr "Keine"
 msgid "controls.dimensionvalue.none"
 msgstr "Kein Filter"
 
-#: app/configurator/components/filters.tsx:78
+#: app/configurator/components/filters.tsx:72
 msgid "controls.filter.nb-elements"
 msgstr "{0} von {1}"
 
-#: app/configurator/components/filters.tsx:57
+#: app/configurator/components/filters.tsx:51
 msgid "controls.filter.select.all"
 msgstr "Alle auswählen"
 
-#: app/configurator/components/filters.tsx:69
+#: app/configurator/components/filters.tsx:63
 msgid "controls.filter.select.none"
 msgstr "Alle abwählen"
 
@@ -353,23 +353,23 @@ msgstr "Bitte eine Designoption oder Datendimension auswählen, um diese zu bear
 msgid "controls.hint.describing.chart"
 msgstr "Bitte ein Beschreibungsfeld auswählen, um dieses zu bearbeiten."
 
-#: app/configurator/components/ui-helpers.ts:592
+#: app/configurator/components/ui-helpers.ts:606
 msgid "controls.imputation"
 msgstr "Imputationstyp"
 
 #: app/configurator/components/chart-options-selector.tsx:528
-#: app/configurator/components/ui-helpers.ts:604
+#: app/configurator/components/ui-helpers.ts:618
 msgid "controls.imputation.type.linear"
 msgstr "Lineare Interpolation"
 
 #: app/configurator/components/chart-options-selector.tsx:521
 #: app/configurator/components/chart-options-selector.tsx:533
-#: app/configurator/components/ui-helpers.ts:596
+#: app/configurator/components/ui-helpers.ts:610
 msgid "controls.imputation.type.none"
 msgstr "-"
 
 #: app/configurator/components/chart-options-selector.tsx:523
-#: app/configurator/components/ui-helpers.ts:600
+#: app/configurator/components/ui-helpers.ts:614
 msgid "controls.imputation.type.zeros"
 msgstr "Nullen"
 
@@ -393,23 +393,23 @@ msgstr "Keine Zeitdimension verfügbar!"
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Zeitfilter anzeigen"
 
-#: app/configurator/components/ui-helpers.ts:640
+#: app/configurator/components/ui-helpers.ts:654
 msgid "controls.language.english"
 msgstr "Englisch"
 
-#: app/configurator/components/ui-helpers.ts:648
+#: app/configurator/components/ui-helpers.ts:662
 msgid "controls.language.french"
 msgstr "Französisch"
 
-#: app/configurator/components/ui-helpers.ts:644
+#: app/configurator/components/ui-helpers.ts:658
 msgid "controls.language.german"
 msgstr "Deutsch"
 
-#: app/configurator/components/ui-helpers.ts:652
+#: app/configurator/components/ui-helpers.ts:666
 msgid "controls.language.italian"
 msgstr "Italienisch"
 
-#: app/configurator/components/ui-helpers.ts:522
+#: app/configurator/components/ui-helpers.ts:536
 #: app/configurator/map/map-chart-options.tsx:218
 #: app/configurator/map/map-chart-options.tsx:423
 msgid "controls.measure"
@@ -576,11 +576,11 @@ msgstr "Dimension hinzufügen"
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Name"
 
-#: app/configurator/components/ui-helpers.ts:560
+#: app/configurator/components/ui-helpers.ts:574
 msgid "controls.sorting.byDimensionLabel.ascending"
 msgstr "A → Z"
 
-#: app/configurator/components/ui-helpers.ts:564
+#: app/configurator/components/ui-helpers.ts:578
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
@@ -588,11 +588,11 @@ msgstr "Z → A"
 msgid "controls.sorting.byMeasure"
 msgstr "Messwert"
 
-#: app/configurator/components/ui-helpers.ts:584
+#: app/configurator/components/ui-helpers.ts:598
 msgid "controls.sorting.byMeasure.ascending"
 msgstr "1 → 9"
 
-#: app/configurator/components/ui-helpers.ts:588
+#: app/configurator/components/ui-helpers.ts:602
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
@@ -600,19 +600,19 @@ msgstr "9 → 1"
 msgid "controls.sorting.byTotalSize"
 msgstr "Gesamtgrösse"
 
-#: app/configurator/components/ui-helpers.ts:568
+#: app/configurator/components/ui-helpers.ts:582
 msgid "controls.sorting.byTotalSize.ascending"
 msgstr "Kleinste zuerst"
 
-#: app/configurator/components/ui-helpers.ts:580
+#: app/configurator/components/ui-helpers.ts:594
 msgid "controls.sorting.byTotalSize.largestBottom"
 msgstr "Grösste unten"
 
-#: app/configurator/components/ui-helpers.ts:572
+#: app/configurator/components/ui-helpers.ts:586
 msgid "controls.sorting.byTotalSize.largestFirst"
 msgstr "Grösste zuerst"
 
-#: app/configurator/components/ui-helpers.ts:576
+#: app/configurator/components/ui-helpers.ts:590
 msgid "controls.sorting.byTotalSize.largestTop"
 msgstr "Kleinste unten"
 
@@ -624,7 +624,7 @@ msgstr "Sortierung entfernen"
 msgid "controls.sorting.selectDimension"
 msgstr "Wählen Sie eine Dimension aus …"
 
-#: app/configurator/components/ui-helpers.ts:556
+#: app/configurator/components/ui-helpers.ts:570
 #: app/configurator/table/table-chart-sorting-options.tsx:307
 msgid "controls.sorting.sortBy"
 msgstr "Sortieren nach"
@@ -653,9 +653,21 @@ msgstr "Sortierung"
 msgid "controls.tableSettings.showSearch"
 msgstr "Suche anzeigen"
 
-#: app/configurator/components/ui-helpers.ts:531
+#: app/configurator/components/ui-helpers.ts:545
 msgid "controls.title"
 msgstr "Titel hinzufügen"
+
+#: app/pages/_cube-checker.tsx:116
+msgid "cube-checker.cube-checker"
+msgstr "Cube Prüfer"
+
+#: app/pages/_cube-checker.tsx:119
+msgid "cube-checker.description"
+msgstr "Cube Checker hilft Ihnen zu verstehen, ob ein Cube alle hat notwendige Attribute und Eigenschaften, um angezeigt zu werden visualize.admin.ch."
+
+#: app/pages/_cube-checker.tsx:133
+msgid "cube-checker.field-placeholder"
+msgstr "Cube IRI"
 
 #: app/configurator/components/select-dataset-step.tsx:118
 msgid "dataset-preview.back-to-results"
@@ -673,27 +685,27 @@ msgstr "Einige Daten in diesem Datensatz fehlen und wurden interpoliert, um die 
 msgid "dataset.includeDrafts"
 msgstr "Entwürfe einschließen"
 
-#: app/configurator/components/dataset-metadata.tsx:71
+#: app/configurator/components/dataset-metadata.tsx:73
 msgid "dataset.metadata.date.created"
 msgstr "Erstellungsdatum"
 
-#: app/configurator/components/dataset-metadata.tsx:83
+#: app/configurator/components/dataset-metadata.tsx:85
 msgid "dataset.metadata.email"
 msgstr "Kontaktstellen"
 
-#: app/configurator/components/dataset-metadata.tsx:97
+#: app/configurator/components/dataset-metadata.tsx:99
 msgid "dataset.metadata.furtherinformation"
 msgstr "Weitere Informationen"
 
-#: app/configurator/components/dataset-metadata.tsx:104
+#: app/configurator/components/dataset-metadata.tsx:109
 msgid "dataset.metadata.landingpage"
 msgstr "Zielseite"
 
-#: app/configurator/components/dataset-metadata.tsx:57
+#: app/configurator/components/dataset-metadata.tsx:59
 msgid "dataset.metadata.source"
 msgstr "Quelle"
 
-#: app/configurator/components/dataset-metadata.tsx:78
+#: app/configurator/components/dataset-metadata.tsx:80
 msgid "dataset.metadata.version"
 msgstr "Version"
 
@@ -742,6 +754,14 @@ msgstr "Entwurf"
 #: app/configurator/components/dataset-preview.tsx:112
 msgid "datatable.showing.first.rows"
 msgstr "Die ersten 10 Zeilen werden angezeigt"
+
+#: app/utils/flashes.tsx:31
+msgid "flashes.couldnt-load-cube.title"
+msgstr "Der Cube konnte nicht geladen werden"
+
+#: app/utils/flashes.tsx:37
+msgid "flashes.couldnt-load-cube.view-cube-checker"
+msgstr "Ansicht im Cube Checker"
 
 #: app/components/footer.tsx:69
 msgid "footer.institution.name"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -136,7 +136,7 @@ msgstr "Publish this visualization"
 msgid "button.share"
 msgstr "Share"
 
-#: app/configurator/components/ui-helpers.ts:548
+#: app/configurator/components/ui-helpers.ts:562
 #: app/configurator/map/map-chart-options.tsx:163
 msgid "chart.map.layers.area"
 msgstr "Areas"
@@ -162,7 +162,7 @@ msgid "chart.map.layers.area.discretization.quantize"
 msgstr "Quantize (equal intervals)"
 
 #: app/configurator/components/chart-configurator.tsx:553
-#: app/configurator/components/ui-helpers.ts:544
+#: app/configurator/components/ui-helpers.ts:558
 #: app/configurator/map/map-chart-options.tsx:64
 msgid "chart.map.layers.base"
 msgstr "Base Layer"
@@ -176,7 +176,7 @@ msgstr "Show"
 msgid "chart.map.layers.show"
 msgstr "Show layer"
 
-#: app/configurator/components/ui-helpers.ts:552
+#: app/configurator/components/ui-helpers.ts:566
 #: app/configurator/map/map-chart-options.tsx:387
 msgid "chart.map.layers.symbol"
 msgstr "Symbols"
@@ -185,11 +185,11 @@ msgstr "Symbols"
 msgid "chart.map.warning.noGeoDimensions"
 msgstr "In this dataset there are no geographical dimensions to display."
 
-#: app/charts/table/table.tsx:265
+#: app/charts/table/table.tsx:281
 msgid "chart.published.toggle.mobile.view"
 msgstr "Compact view"
 
-#: app/charts/table/table.tsx:340
+#: app/charts/table/table.tsx:356
 msgid "chart.table.number.of.lines"
 msgstr "Total number of lines:"
 
@@ -222,47 +222,47 @@ msgstr "Regular"
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Default Settings"
 
-#: app/configurator/components/ui-helpers.ts:518
+#: app/configurator/components/ui-helpers.ts:532
 msgid "controls.axis.horizontal"
 msgstr "Horizontal Axis"
 
-#: app/configurator/components/ui-helpers.ts:526
+#: app/configurator/components/ui-helpers.ts:540
 msgid "controls.axis.vertical"
 msgstr "Vertical Axis"
 
-#: app/configurator/components/ui-helpers.ts:620
+#: app/configurator/components/ui-helpers.ts:634
 msgid "controls.chart.type.area"
 msgstr "Areas"
 
-#: app/configurator/components/ui-helpers.ts:612
+#: app/configurator/components/ui-helpers.ts:626
 msgid "controls.chart.type.bar"
 msgstr "Bars"
 
-#: app/configurator/components/ui-helpers.ts:608
+#: app/configurator/components/ui-helpers.ts:622
 msgid "controls.chart.type.column"
 msgstr "Columns"
 
-#: app/configurator/components/ui-helpers.ts:616
+#: app/configurator/components/ui-helpers.ts:630
 msgid "controls.chart.type.line"
 msgstr "Lines"
 
-#: app/configurator/components/ui-helpers.ts:636
+#: app/configurator/components/ui-helpers.ts:650
 msgid "controls.chart.type.map"
 msgstr "Map"
 
-#: app/configurator/components/ui-helpers.ts:628
+#: app/configurator/components/ui-helpers.ts:642
 msgid "controls.chart.type.pie"
 msgstr "Pie"
 
-#: app/configurator/components/ui-helpers.ts:624
+#: app/configurator/components/ui-helpers.ts:638
 msgid "controls.chart.type.scatterplot"
 msgstr "Scatterplot"
 
-#: app/configurator/components/ui-helpers.ts:632
+#: app/configurator/components/ui-helpers.ts:646
 msgid "controls.chart.type.table"
 msgstr "Table"
 
-#: app/configurator/components/ui-helpers.ts:530
+#: app/configurator/components/ui-helpers.ts:544
 #: app/configurator/map/map-chart-options.tsx:236
 #: app/configurator/map/map-chart-options.tsx:441
 msgid "controls.color"
@@ -297,15 +297,15 @@ msgstr "Select a color"
 msgid "controls.colorpicker.open"
 msgstr "Open Color Picker"
 
-#: app/configurator/components/ui-helpers.ts:540
+#: app/configurator/components/ui-helpers.ts:554
 msgid "controls.column.grouped"
 msgstr "Grouped"
 
-#: app/configurator/components/ui-helpers.ts:536
+#: app/configurator/components/ui-helpers.ts:550
 msgid "controls.column.stacked"
 msgstr "Stacked"
 
-#: app/configurator/components/ui-helpers.ts:532
+#: app/configurator/components/ui-helpers.ts:546
 msgid "controls.description"
 msgstr "Description"
 
@@ -325,15 +325,15 @@ msgstr "None"
 msgid "controls.dimensionvalue.none"
 msgstr "No Filter"
 
-#: app/configurator/components/filters.tsx:78
+#: app/configurator/components/filters.tsx:72
 msgid "controls.filter.nb-elements"
 msgstr "{0} of {1}"
 
-#: app/configurator/components/filters.tsx:57
+#: app/configurator/components/filters.tsx:51
 msgid "controls.filter.select.all"
 msgstr "Select all"
 
-#: app/configurator/components/filters.tsx:69
+#: app/configurator/components/filters.tsx:63
 msgid "controls.filter.select.none"
 msgstr "Select none"
 
@@ -357,23 +357,23 @@ msgstr "Select a design element or a data dimension to modify its options."
 msgid "controls.hint.describing.chart"
 msgstr "Select an annotation field to modify its content."
 
-#: app/configurator/components/ui-helpers.ts:592
+#: app/configurator/components/ui-helpers.ts:606
 msgid "controls.imputation"
 msgstr "Imputation type"
 
 #: app/configurator/components/chart-options-selector.tsx:528
-#: app/configurator/components/ui-helpers.ts:604
+#: app/configurator/components/ui-helpers.ts:618
 msgid "controls.imputation.type.linear"
 msgstr "Linear interpolation"
 
 #: app/configurator/components/chart-options-selector.tsx:521
 #: app/configurator/components/chart-options-selector.tsx:533
-#: app/configurator/components/ui-helpers.ts:596
+#: app/configurator/components/ui-helpers.ts:610
 msgid "controls.imputation.type.none"
 msgstr "-"
 
 #: app/configurator/components/chart-options-selector.tsx:523
-#: app/configurator/components/ui-helpers.ts:600
+#: app/configurator/components/ui-helpers.ts:614
 msgid "controls.imputation.type.zeros"
 msgstr "Zeros"
 
@@ -397,23 +397,23 @@ msgstr "There is no time dimension!"
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Show time filter"
 
-#: app/configurator/components/ui-helpers.ts:640
+#: app/configurator/components/ui-helpers.ts:654
 msgid "controls.language.english"
 msgstr "English"
 
-#: app/configurator/components/ui-helpers.ts:648
+#: app/configurator/components/ui-helpers.ts:662
 msgid "controls.language.french"
 msgstr "French"
 
-#: app/configurator/components/ui-helpers.ts:644
+#: app/configurator/components/ui-helpers.ts:658
 msgid "controls.language.german"
 msgstr "German"
 
-#: app/configurator/components/ui-helpers.ts:652
+#: app/configurator/components/ui-helpers.ts:666
 msgid "controls.language.italian"
 msgstr "Italian"
 
-#: app/configurator/components/ui-helpers.ts:522
+#: app/configurator/components/ui-helpers.ts:536
 #: app/configurator/map/map-chart-options.tsx:218
 #: app/configurator/map/map-chart-options.tsx:423
 msgid "controls.measure"
@@ -580,11 +580,11 @@ msgstr "Add dimension"
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Name"
 
-#: app/configurator/components/ui-helpers.ts:560
+#: app/configurator/components/ui-helpers.ts:574
 msgid "controls.sorting.byDimensionLabel.ascending"
 msgstr "A → Z"
 
-#: app/configurator/components/ui-helpers.ts:564
+#: app/configurator/components/ui-helpers.ts:578
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
@@ -592,11 +592,11 @@ msgstr "Z → A"
 msgid "controls.sorting.byMeasure"
 msgstr "Measure"
 
-#: app/configurator/components/ui-helpers.ts:584
+#: app/configurator/components/ui-helpers.ts:598
 msgid "controls.sorting.byMeasure.ascending"
 msgstr "1 → 9"
 
-#: app/configurator/components/ui-helpers.ts:588
+#: app/configurator/components/ui-helpers.ts:602
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
@@ -604,19 +604,19 @@ msgstr "9 → 1"
 msgid "controls.sorting.byTotalSize"
 msgstr "Total size"
 
-#: app/configurator/components/ui-helpers.ts:568
+#: app/configurator/components/ui-helpers.ts:582
 msgid "controls.sorting.byTotalSize.ascending"
 msgstr "Largest last"
 
-#: app/configurator/components/ui-helpers.ts:580
+#: app/configurator/components/ui-helpers.ts:594
 msgid "controls.sorting.byTotalSize.largestBottom"
 msgstr "Ascending"
 
-#: app/configurator/components/ui-helpers.ts:572
+#: app/configurator/components/ui-helpers.ts:586
 msgid "controls.sorting.byTotalSize.largestFirst"
 msgstr "Largest first"
 
-#: app/configurator/components/ui-helpers.ts:576
+#: app/configurator/components/ui-helpers.ts:590
 msgid "controls.sorting.byTotalSize.largestTop"
 msgstr "Descending"
 
@@ -628,7 +628,7 @@ msgstr "Remove sorting dimension"
 msgid "controls.sorting.selectDimension"
 msgstr "Select a dimension …"
 
-#: app/configurator/components/ui-helpers.ts:556
+#: app/configurator/components/ui-helpers.ts:570
 #: app/configurator/table/table-chart-sorting-options.tsx:307
 msgid "controls.sorting.sortBy"
 msgstr "Sort by"
@@ -657,9 +657,21 @@ msgstr "Sorting"
 msgid "controls.tableSettings.showSearch"
 msgstr "Show search field"
 
-#: app/configurator/components/ui-helpers.ts:531
+#: app/configurator/components/ui-helpers.ts:545
 msgid "controls.title"
 msgstr "Title"
+
+#: app/pages/_cube-checker.tsx:116
+msgid "cube-checker.cube-checker"
+msgstr "Cube checker"
+
+#: app/pages/_cube-checker.tsx:119
+msgid "cube-checker.description"
+msgstr "Cube checker helps you understand if a cube has all the necessary attributes and properties to be viewable in visualize.admin.ch."
+
+#: app/pages/_cube-checker.tsx:133
+msgid "cube-checker.field-placeholder"
+msgstr "Cube IRI"
 
 #: app/configurator/components/select-dataset-step.tsx:118
 msgid "dataset-preview.back-to-results"
@@ -677,27 +689,27 @@ msgstr "Some data in this dataset is missing and has been interpolated to fill t
 msgid "dataset.includeDrafts"
 msgstr "Include draft datasets"
 
-#: app/configurator/components/dataset-metadata.tsx:71
+#: app/configurator/components/dataset-metadata.tsx:73
 msgid "dataset.metadata.date.created"
 msgstr "Date created"
 
-#: app/configurator/components/dataset-metadata.tsx:83
+#: app/configurator/components/dataset-metadata.tsx:85
 msgid "dataset.metadata.email"
 msgstr "Contact points"
 
-#: app/configurator/components/dataset-metadata.tsx:97
+#: app/configurator/components/dataset-metadata.tsx:99
 msgid "dataset.metadata.furtherinformation"
 msgstr "Further information"
 
-#: app/configurator/components/dataset-metadata.tsx:104
+#: app/configurator/components/dataset-metadata.tsx:109
 msgid "dataset.metadata.landingpage"
 msgstr "Landing page"
 
-#: app/configurator/components/dataset-metadata.tsx:57
+#: app/configurator/components/dataset-metadata.tsx:59
 msgid "dataset.metadata.source"
 msgstr "Source"
 
-#: app/configurator/components/dataset-metadata.tsx:78
+#: app/configurator/components/dataset-metadata.tsx:80
 msgid "dataset.metadata.version"
 msgstr "Version"
 
@@ -746,6 +758,14 @@ msgstr "Draft"
 #: app/configurator/components/dataset-preview.tsx:112
 msgid "datatable.showing.first.rows"
 msgstr "Showing first 10 rows"
+
+#: app/utils/flashes.tsx:31
+msgid "flashes.couldnt-load-cube.title"
+msgstr "Could not load cube"
+
+#: app/utils/flashes.tsx:37
+msgid "flashes.couldnt-load-cube.view-cube-checker"
+msgstr "View in cube checker"
 
 #: app/components/footer.tsx:69
 msgid "footer.institution.name"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -136,7 +136,7 @@ msgstr "Publier cette visualisation"
 msgid "button.share"
 msgstr "Partager"
 
-#: app/configurator/components/ui-helpers.ts:548
+#: app/configurator/components/ui-helpers.ts:562
 #: app/configurator/map/map-chart-options.tsx:163
 msgid "chart.map.layers.area"
 msgstr "Zones"
@@ -162,7 +162,7 @@ msgid "chart.map.layers.area.discretization.quantize"
 msgstr "Intervalles égaux"
 
 #: app/configurator/components/chart-configurator.tsx:553
-#: app/configurator/components/ui-helpers.ts:544
+#: app/configurator/components/ui-helpers.ts:558
 #: app/configurator/map/map-chart-options.tsx:64
 msgid "chart.map.layers.base"
 msgstr "Couche de base"
@@ -176,7 +176,7 @@ msgstr "Afficher"
 msgid "chart.map.layers.show"
 msgstr "Afficher la couche"
 
-#: app/configurator/components/ui-helpers.ts:552
+#: app/configurator/components/ui-helpers.ts:566
 #: app/configurator/map/map-chart-options.tsx:387
 msgid "chart.map.layers.symbol"
 msgstr "Symboles"
@@ -185,11 +185,11 @@ msgstr "Symboles"
 msgid "chart.map.warning.noGeoDimensions"
 msgstr "Dans cet ensemble de données, il n'y a pas de dimensions géographiques à afficher!"
 
-#: app/charts/table/table.tsx:265
+#: app/charts/table/table.tsx:281
 msgid "chart.published.toggle.mobile.view"
 msgstr "Vue compacte"
 
-#: app/charts/table/table.tsx:340
+#: app/charts/table/table.tsx:356
 msgid "chart.table.number.of.lines"
 msgstr "Nombre total de lignes:"
 
@@ -222,47 +222,47 @@ msgstr "Normal"
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Paramètres d'origine"
 
-#: app/configurator/components/ui-helpers.ts:518
+#: app/configurator/components/ui-helpers.ts:532
 msgid "controls.axis.horizontal"
 msgstr "Axe horizontal"
 
-#: app/configurator/components/ui-helpers.ts:526
+#: app/configurator/components/ui-helpers.ts:540
 msgid "controls.axis.vertical"
 msgstr "Axe vertical"
 
-#: app/configurator/components/ui-helpers.ts:620
+#: app/configurator/components/ui-helpers.ts:634
 msgid "controls.chart.type.area"
 msgstr "Surfaces"
 
-#: app/configurator/components/ui-helpers.ts:612
+#: app/configurator/components/ui-helpers.ts:626
 msgid "controls.chart.type.bar"
 msgstr "Barres"
 
-#: app/configurator/components/ui-helpers.ts:608
+#: app/configurator/components/ui-helpers.ts:622
 msgid "controls.chart.type.column"
 msgstr "Colonnes"
 
-#: app/configurator/components/ui-helpers.ts:616
+#: app/configurator/components/ui-helpers.ts:630
 msgid "controls.chart.type.line"
 msgstr "Lignes"
 
-#: app/configurator/components/ui-helpers.ts:636
+#: app/configurator/components/ui-helpers.ts:650
 msgid "controls.chart.type.map"
 msgstr "Carte"
 
-#: app/configurator/components/ui-helpers.ts:628
+#: app/configurator/components/ui-helpers.ts:642
 msgid "controls.chart.type.pie"
 msgstr "Secteurs"
 
-#: app/configurator/components/ui-helpers.ts:624
+#: app/configurator/components/ui-helpers.ts:638
 msgid "controls.chart.type.scatterplot"
 msgstr "Nuage de points"
 
-#: app/configurator/components/ui-helpers.ts:632
+#: app/configurator/components/ui-helpers.ts:646
 msgid "controls.chart.type.table"
 msgstr "Tableau"
 
-#: app/configurator/components/ui-helpers.ts:530
+#: app/configurator/components/ui-helpers.ts:544
 #: app/configurator/map/map-chart-options.tsx:236
 #: app/configurator/map/map-chart-options.tsx:441
 msgid "controls.color"
@@ -293,15 +293,15 @@ msgstr "Sélectionner une couleur"
 msgid "controls.colorpicker.open"
 msgstr "Ouvrir la pipette à couleur"
 
-#: app/configurator/components/ui-helpers.ts:540
+#: app/configurator/components/ui-helpers.ts:554
 msgid "controls.column.grouped"
 msgstr "groupées"
 
-#: app/configurator/components/ui-helpers.ts:536
+#: app/configurator/components/ui-helpers.ts:550
 msgid "controls.column.stacked"
 msgstr "empilées"
 
-#: app/configurator/components/ui-helpers.ts:532
+#: app/configurator/components/ui-helpers.ts:546
 msgid "controls.description"
 msgstr "Description"
 
@@ -321,15 +321,15 @@ msgstr "Aucune"
 msgid "controls.dimensionvalue.none"
 msgstr "Aucune filtre"
 
-#: app/configurator/components/filters.tsx:78
+#: app/configurator/components/filters.tsx:72
 msgid "controls.filter.nb-elements"
 msgstr "{0} sur {1}"
 
-#: app/configurator/components/filters.tsx:57
+#: app/configurator/components/filters.tsx:51
 msgid "controls.filter.select.all"
 msgstr "Tout sélectionner"
 
-#: app/configurator/components/filters.tsx:69
+#: app/configurator/components/filters.tsx:63
 msgid "controls.filter.select.none"
 msgstr "Tout déselectionner"
 
@@ -353,23 +353,23 @@ msgstr "Sélectionnez un élément de design ou une dimension du jeu de données
 msgid "controls.hint.describing.chart"
 msgstr "Sélectionnez une des annotations proposées pour la modifier."
 
-#: app/configurator/components/ui-helpers.ts:592
+#: app/configurator/components/ui-helpers.ts:606
 msgid "controls.imputation"
 msgstr "Type d'imputation"
 
 #: app/configurator/components/chart-options-selector.tsx:528
-#: app/configurator/components/ui-helpers.ts:604
+#: app/configurator/components/ui-helpers.ts:618
 msgid "controls.imputation.type.linear"
 msgstr "Interpolation linéaire"
 
 #: app/configurator/components/chart-options-selector.tsx:521
 #: app/configurator/components/chart-options-selector.tsx:533
-#: app/configurator/components/ui-helpers.ts:596
+#: app/configurator/components/ui-helpers.ts:610
 msgid "controls.imputation.type.none"
 msgstr "-"
 
 #: app/configurator/components/chart-options-selector.tsx:523
-#: app/configurator/components/ui-helpers.ts:600
+#: app/configurator/components/ui-helpers.ts:614
 msgid "controls.imputation.type.zeros"
 msgstr "Zéros"
 
@@ -393,23 +393,23 @@ msgstr "Il n'y a pas de dimension temporelle!"
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Afficher le filtre temporel"
 
-#: app/configurator/components/ui-helpers.ts:640
+#: app/configurator/components/ui-helpers.ts:654
 msgid "controls.language.english"
 msgstr "Anglais"
 
-#: app/configurator/components/ui-helpers.ts:648
+#: app/configurator/components/ui-helpers.ts:662
 msgid "controls.language.french"
 msgstr "Français"
 
-#: app/configurator/components/ui-helpers.ts:644
+#: app/configurator/components/ui-helpers.ts:658
 msgid "controls.language.german"
 msgstr "Allemand"
 
-#: app/configurator/components/ui-helpers.ts:652
+#: app/configurator/components/ui-helpers.ts:666
 msgid "controls.language.italian"
 msgstr "Italien"
 
-#: app/configurator/components/ui-helpers.ts:522
+#: app/configurator/components/ui-helpers.ts:536
 #: app/configurator/map/map-chart-options.tsx:218
 #: app/configurator/map/map-chart-options.tsx:423
 msgid "controls.measure"
@@ -576,11 +576,11 @@ msgstr "Ajouter une dimension"
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Nom"
 
-#: app/configurator/components/ui-helpers.ts:560
+#: app/configurator/components/ui-helpers.ts:574
 msgid "controls.sorting.byDimensionLabel.ascending"
 msgstr "A → Z"
 
-#: app/configurator/components/ui-helpers.ts:564
+#: app/configurator/components/ui-helpers.ts:578
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
@@ -588,11 +588,11 @@ msgstr "Z → A"
 msgid "controls.sorting.byMeasure"
 msgstr "Mesure"
 
-#: app/configurator/components/ui-helpers.ts:584
+#: app/configurator/components/ui-helpers.ts:598
 msgid "controls.sorting.byMeasure.ascending"
 msgstr "1 → 9"
 
-#: app/configurator/components/ui-helpers.ts:588
+#: app/configurator/components/ui-helpers.ts:602
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
@@ -600,19 +600,19 @@ msgstr "9 → 1"
 msgid "controls.sorting.byTotalSize"
 msgstr "Taille totale"
 
-#: app/configurator/components/ui-helpers.ts:568
+#: app/configurator/components/ui-helpers.ts:582
 msgid "controls.sorting.byTotalSize.ascending"
 msgstr "Croissant"
 
-#: app/configurator/components/ui-helpers.ts:580
+#: app/configurator/components/ui-helpers.ts:594
 msgid "controls.sorting.byTotalSize.largestBottom"
 msgstr "Décroissant de bas en haut"
 
-#: app/configurator/components/ui-helpers.ts:572
+#: app/configurator/components/ui-helpers.ts:586
 msgid "controls.sorting.byTotalSize.largestFirst"
 msgstr "Décroissant"
 
-#: app/configurator/components/ui-helpers.ts:576
+#: app/configurator/components/ui-helpers.ts:590
 msgid "controls.sorting.byTotalSize.largestTop"
 msgstr "Décroissant de haut en bas"
 
@@ -624,7 +624,7 @@ msgstr "Supprimer la dimension de tri"
 msgid "controls.sorting.selectDimension"
 msgstr "Sélectionner une dimension…"
 
-#: app/configurator/components/ui-helpers.ts:556
+#: app/configurator/components/ui-helpers.ts:570
 #: app/configurator/table/table-chart-sorting-options.tsx:307
 msgid "controls.sorting.sortBy"
 msgstr "Trier par"
@@ -653,9 +653,21 @@ msgstr "Tri"
 msgid "controls.tableSettings.showSearch"
 msgstr "Afficher le champ de recherche"
 
-#: app/configurator/components/ui-helpers.ts:531
+#: app/configurator/components/ui-helpers.ts:545
 msgid "controls.title"
 msgstr "Titre"
+
+#: app/pages/_cube-checker.tsx:116
+msgid "cube-checker.cube-checker"
+msgstr "Vérificateur de cube"
+
+#: app/pages/_cube-checker.tsx:119
+msgid "cube-checker.description"
+msgstr "Cet outil vous permet de vérifier qu'un cube a tous les attributs nécessaires pour être affiché dans visualize.admin.ch"
+
+#: app/pages/_cube-checker.tsx:133
+msgid "cube-checker.field-placeholder"
+msgstr "IRI du cube"
 
 #: app/configurator/components/select-dataset-step.tsx:118
 msgid "dataset-preview.back-to-results"
@@ -673,27 +685,27 @@ msgstr "Certaines données de cet ensemble de données sont manquantes et ont é
 msgid "dataset.includeDrafts"
 msgstr "Inclure les brouillons"
 
-#: app/configurator/components/dataset-metadata.tsx:71
+#: app/configurator/components/dataset-metadata.tsx:73
 msgid "dataset.metadata.date.created"
 msgstr "Date de création"
 
-#: app/configurator/components/dataset-metadata.tsx:83
+#: app/configurator/components/dataset-metadata.tsx:85
 msgid "dataset.metadata.email"
 msgstr "Points de contact"
 
-#: app/configurator/components/dataset-metadata.tsx:97
+#: app/configurator/components/dataset-metadata.tsx:99
 msgid "dataset.metadata.furtherinformation"
 msgstr "Informations complémentaires"
 
-#: app/configurator/components/dataset-metadata.tsx:104
+#: app/configurator/components/dataset-metadata.tsx:109
 msgid "dataset.metadata.landingpage"
 msgstr "Page d'accueil"
 
-#: app/configurator/components/dataset-metadata.tsx:57
+#: app/configurator/components/dataset-metadata.tsx:59
 msgid "dataset.metadata.source"
 msgstr "Source"
 
-#: app/configurator/components/dataset-metadata.tsx:78
+#: app/configurator/components/dataset-metadata.tsx:80
 msgid "dataset.metadata.version"
 msgstr "Version"
 
@@ -742,6 +754,14 @@ msgstr "Brouillon"
 #: app/configurator/components/dataset-preview.tsx:112
 msgid "datatable.showing.first.rows"
 msgstr "Seules les 10 premières lignes sont affichées"
+
+#: app/utils/flashes.tsx:31
+msgid "flashes.couldnt-load-cube.title"
+msgstr "Impossible de charger le cube"
+
+#: app/utils/flashes.tsx:37
+msgid "flashes.couldnt-load-cube.view-cube-checker"
+msgstr "Voir dans le vérificateur de cube"
 
 #: app/components/footer.tsx:69
 msgid "footer.institution.name"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -136,7 +136,7 @@ msgstr "Pubblica questa visualizzazione"
 msgid "button.share"
 msgstr "Condividi"
 
-#: app/configurator/components/ui-helpers.ts:548
+#: app/configurator/components/ui-helpers.ts:562
 #: app/configurator/map/map-chart-options.tsx:163
 msgid "chart.map.layers.area"
 msgstr "Aree"
@@ -162,7 +162,7 @@ msgid "chart.map.layers.area.discretization.quantize"
 msgstr "Intervalli uguali"
 
 #: app/configurator/components/chart-configurator.tsx:553
-#: app/configurator/components/ui-helpers.ts:544
+#: app/configurator/components/ui-helpers.ts:558
 #: app/configurator/map/map-chart-options.tsx:64
 msgid "chart.map.layers.base"
 msgstr "Livello di base"
@@ -176,7 +176,7 @@ msgstr "Mostra"
 msgid "chart.map.layers.show"
 msgstr "Mostra il livello"
 
-#: app/configurator/components/ui-helpers.ts:552
+#: app/configurator/components/ui-helpers.ts:566
 #: app/configurator/map/map-chart-options.tsx:387
 msgid "chart.map.layers.symbol"
 msgstr "Simboli"
@@ -185,11 +185,11 @@ msgstr "Simboli"
 msgid "chart.map.warning.noGeoDimensions"
 msgstr "In questo set di dati non ci sono dimensioni geografiche da mostrare!"
 
-#: app/charts/table/table.tsx:265
+#: app/charts/table/table.tsx:281
 msgid "chart.published.toggle.mobile.view"
 msgstr "Vista compatta"
 
-#: app/charts/table/table.tsx:340
+#: app/charts/table/table.tsx:356
 msgid "chart.table.number.of.lines"
 msgstr "Numero totale di linee:"
 
@@ -222,47 +222,47 @@ msgstr "Regular"
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Impostazioni predefinite"
 
-#: app/configurator/components/ui-helpers.ts:518
+#: app/configurator/components/ui-helpers.ts:532
 msgid "controls.axis.horizontal"
 msgstr "Asse orizzontale"
 
-#: app/configurator/components/ui-helpers.ts:526
+#: app/configurator/components/ui-helpers.ts:540
 msgid "controls.axis.vertical"
 msgstr "Asse verticale"
 
-#: app/configurator/components/ui-helpers.ts:620
+#: app/configurator/components/ui-helpers.ts:634
 msgid "controls.chart.type.area"
 msgstr "Aree"
 
-#: app/configurator/components/ui-helpers.ts:612
+#: app/configurator/components/ui-helpers.ts:626
 msgid "controls.chart.type.bar"
 msgstr "Barre"
 
-#: app/configurator/components/ui-helpers.ts:608
+#: app/configurator/components/ui-helpers.ts:622
 msgid "controls.chart.type.column"
 msgstr "Colonne"
 
-#: app/configurator/components/ui-helpers.ts:616
+#: app/configurator/components/ui-helpers.ts:630
 msgid "controls.chart.type.line"
 msgstr "Linee"
 
-#: app/configurator/components/ui-helpers.ts:636
+#: app/configurator/components/ui-helpers.ts:650
 msgid "controls.chart.type.map"
 msgstr "Mappa"
 
-#: app/configurator/components/ui-helpers.ts:628
+#: app/configurator/components/ui-helpers.ts:642
 msgid "controls.chart.type.pie"
 msgstr "Torta"
 
-#: app/configurator/components/ui-helpers.ts:624
+#: app/configurator/components/ui-helpers.ts:638
 msgid "controls.chart.type.scatterplot"
 msgstr "Scatterplot"
 
-#: app/configurator/components/ui-helpers.ts:632
+#: app/configurator/components/ui-helpers.ts:646
 msgid "controls.chart.type.table"
 msgstr "Tabella"
 
-#: app/configurator/components/ui-helpers.ts:530
+#: app/configurator/components/ui-helpers.ts:544
 #: app/configurator/map/map-chart-options.tsx:236
 #: app/configurator/map/map-chart-options.tsx:441
 msgid "controls.color"
@@ -293,15 +293,15 @@ msgstr "Seleziona un colore"
 msgid "controls.colorpicker.open"
 msgstr "Apri il selettore di colore"
 
-#: app/configurator/components/ui-helpers.ts:540
+#: app/configurator/components/ui-helpers.ts:554
 msgid "controls.column.grouped"
 msgstr "raggruppate"
 
-#: app/configurator/components/ui-helpers.ts:536
+#: app/configurator/components/ui-helpers.ts:550
 msgid "controls.column.stacked"
 msgstr "impilate"
 
-#: app/configurator/components/ui-helpers.ts:532
+#: app/configurator/components/ui-helpers.ts:546
 msgid "controls.description"
 msgstr "Descrizione"
 
@@ -321,15 +321,15 @@ msgstr "Nessuno"
 msgid "controls.dimensionvalue.none"
 msgstr "Nessun filtro"
 
-#: app/configurator/components/filters.tsx:78
+#: app/configurator/components/filters.tsx:72
 msgid "controls.filter.nb-elements"
 msgstr "{0} di {1}"
 
-#: app/configurator/components/filters.tsx:57
+#: app/configurator/components/filters.tsx:51
 msgid "controls.filter.select.all"
 msgstr "Seleziona tutti"
 
-#: app/configurator/components/filters.tsx:69
+#: app/configurator/components/filters.tsx:63
 msgid "controls.filter.select.none"
 msgstr "Deseleziona tutto"
 
@@ -353,23 +353,23 @@ msgstr "Seleziona un elemento di design o una dimensione dei dati per modificarn
 msgid "controls.hint.describing.chart"
 msgstr "Seleziona una delle annotazioni proposte per modificarla."
 
-#: app/configurator/components/ui-helpers.ts:592
+#: app/configurator/components/ui-helpers.ts:606
 msgid "controls.imputation"
 msgstr "Tipo di imputazione"
 
 #: app/configurator/components/chart-options-selector.tsx:528
-#: app/configurator/components/ui-helpers.ts:604
+#: app/configurator/components/ui-helpers.ts:618
 msgid "controls.imputation.type.linear"
 msgstr "Interpolazione lineare"
 
 #: app/configurator/components/chart-options-selector.tsx:521
 #: app/configurator/components/chart-options-selector.tsx:533
-#: app/configurator/components/ui-helpers.ts:596
+#: app/configurator/components/ui-helpers.ts:610
 msgid "controls.imputation.type.none"
 msgstr "-"
 
 #: app/configurator/components/chart-options-selector.tsx:523
-#: app/configurator/components/ui-helpers.ts:600
+#: app/configurator/components/ui-helpers.ts:614
 msgid "controls.imputation.type.zeros"
 msgstr "Zeri"
 
@@ -393,23 +393,23 @@ msgstr "Nessuna dimensione temporale disponibile!"
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Mostra i filtri temporali"
 
-#: app/configurator/components/ui-helpers.ts:640
+#: app/configurator/components/ui-helpers.ts:654
 msgid "controls.language.english"
 msgstr "Inglese"
 
-#: app/configurator/components/ui-helpers.ts:648
+#: app/configurator/components/ui-helpers.ts:662
 msgid "controls.language.french"
 msgstr "Francese"
 
-#: app/configurator/components/ui-helpers.ts:644
+#: app/configurator/components/ui-helpers.ts:658
 msgid "controls.language.german"
 msgstr "Tedesco"
 
-#: app/configurator/components/ui-helpers.ts:652
+#: app/configurator/components/ui-helpers.ts:666
 msgid "controls.language.italian"
 msgstr "Italiano"
 
-#: app/configurator/components/ui-helpers.ts:522
+#: app/configurator/components/ui-helpers.ts:536
 #: app/configurator/map/map-chart-options.tsx:218
 #: app/configurator/map/map-chart-options.tsx:423
 msgid "controls.measure"
@@ -576,11 +576,11 @@ msgstr "Aggiungi una dimensione"
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Nome"
 
-#: app/configurator/components/ui-helpers.ts:560
+#: app/configurator/components/ui-helpers.ts:574
 msgid "controls.sorting.byDimensionLabel.ascending"
 msgstr "A → Z"
 
-#: app/configurator/components/ui-helpers.ts:564
+#: app/configurator/components/ui-helpers.ts:578
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
@@ -588,11 +588,11 @@ msgstr "Z → A"
 msgid "controls.sorting.byMeasure"
 msgstr "Misura"
 
-#: app/configurator/components/ui-helpers.ts:584
+#: app/configurator/components/ui-helpers.ts:598
 msgid "controls.sorting.byMeasure.ascending"
 msgstr "1 → 9"
 
-#: app/configurator/components/ui-helpers.ts:588
+#: app/configurator/components/ui-helpers.ts:602
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
@@ -600,19 +600,19 @@ msgstr "9 → 1"
 msgid "controls.sorting.byTotalSize"
 msgstr "Grandezza totale"
 
-#: app/configurator/components/ui-helpers.ts:568
+#: app/configurator/components/ui-helpers.ts:582
 msgid "controls.sorting.byTotalSize.ascending"
 msgstr "Il più grande per ultimo"
 
-#: app/configurator/components/ui-helpers.ts:580
+#: app/configurator/components/ui-helpers.ts:594
 msgid "controls.sorting.byTotalSize.largestBottom"
 msgstr "Il più grande sotto"
 
-#: app/configurator/components/ui-helpers.ts:572
+#: app/configurator/components/ui-helpers.ts:586
 msgid "controls.sorting.byTotalSize.largestFirst"
 msgstr "Il più grande per primo"
 
-#: app/configurator/components/ui-helpers.ts:576
+#: app/configurator/components/ui-helpers.ts:590
 msgid "controls.sorting.byTotalSize.largestTop"
 msgstr "Il più grande sopra"
 
@@ -624,7 +624,7 @@ msgstr "Rimuovi l'ordinamento"
 msgid "controls.sorting.selectDimension"
 msgstr "Seleziona una dimensione ..."
 
-#: app/configurator/components/ui-helpers.ts:556
+#: app/configurator/components/ui-helpers.ts:570
 #: app/configurator/table/table-chart-sorting-options.tsx:307
 msgid "controls.sorting.sortBy"
 msgstr "Ordina per"
@@ -653,9 +653,21 @@ msgstr "Ordinamento"
 msgid "controls.tableSettings.showSearch"
 msgstr "Mostra il campo di ricerca"
 
-#: app/configurator/components/ui-helpers.ts:531
+#: app/configurator/components/ui-helpers.ts:545
 msgid "controls.title"
 msgstr "Titolo"
+
+#: app/pages/_cube-checker.tsx:116
+msgid "cube-checker.cube-checker"
+msgstr "Cube checker"
+
+#: app/pages/_cube-checker.tsx:119
+msgid "cube-checker.description"
+msgstr "Cube checker ti aiuta a capire se un cubo ha tutti i attributi e proprietà necessari per essere visualizzati su visualizza.admin.ch."
+
+#: app/pages/_cube-checker.tsx:133
+msgid "cube-checker.field-placeholder"
+msgstr "Cubo IRI"
 
 #: app/configurator/components/select-dataset-step.tsx:118
 msgid "dataset-preview.back-to-results"
@@ -673,27 +685,27 @@ msgstr "In questo set di dati mancano alcuni dati. Questi sono stati interpolati
 msgid "dataset.includeDrafts"
 msgstr "Includere le bozze"
 
-#: app/configurator/components/dataset-metadata.tsx:71
+#: app/configurator/components/dataset-metadata.tsx:73
 msgid "dataset.metadata.date.created"
 msgstr "Data di creazione"
 
-#: app/configurator/components/dataset-metadata.tsx:83
+#: app/configurator/components/dataset-metadata.tsx:85
 msgid "dataset.metadata.email"
 msgstr "Punti di contatto"
 
-#: app/configurator/components/dataset-metadata.tsx:97
+#: app/configurator/components/dataset-metadata.tsx:99
 msgid "dataset.metadata.furtherinformation"
 msgstr "Addizionali informazioni"
 
-#: app/configurator/components/dataset-metadata.tsx:104
+#: app/configurator/components/dataset-metadata.tsx:109
 msgid "dataset.metadata.landingpage"
 msgstr "Pagina di destinazione"
 
-#: app/configurator/components/dataset-metadata.tsx:57
+#: app/configurator/components/dataset-metadata.tsx:59
 msgid "dataset.metadata.source"
 msgstr "Fonte"
 
-#: app/configurator/components/dataset-metadata.tsx:78
+#: app/configurator/components/dataset-metadata.tsx:80
 msgid "dataset.metadata.version"
 msgstr "versione"
 
@@ -742,6 +754,14 @@ msgstr "Bozza"
 #: app/configurator/components/dataset-preview.tsx:112
 msgid "datatable.showing.first.rows"
 msgstr "Sono mostrate soltanto le prime 10 righe"
+
+#: app/utils/flashes.tsx:31
+msgid "flashes.couldnt-load-cube.title"
+msgstr "Impossibile caricare il cubo"
+
+#: app/utils/flashes.tsx:37
+msgid "flashes.couldnt-load-cube.view-cube-checker"
+msgstr "Visualizza nel controllo del cubo"
 
 #: app/components/footer.tsx:69
 msgid "footer.institution.name"

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -16,6 +16,7 @@ import { useNProgress } from "@/lib/use-nprogress";
 import { i18n, parseLocaleString } from "@/locales/locales";
 import { LocaleProvider } from "@/locales/use-locale";
 import * as federalTheme from "@/themes/federal";
+import Flashes from "@/utils/flashes";
 import AsyncLocalizationProvider from "@/utils/l10n-provider";
 
 export default function App({ Component, pageProps }: AppProps) {
@@ -74,6 +75,7 @@ export default function App({ Component, pageProps }: AppProps) {
           <GraphqlProvider>
             <ThemeProvider theme={federalTheme.theme}>
               <CssBaseline />
+              <Flashes />
               <ContentMDXProvider>
                 <AsyncLocalizationProvider locale={locale}>
                   <Component {...pageProps} />

--- a/app/pages/_cube-checker.tsx
+++ b/app/pages/_cube-checker.tsx
@@ -1,10 +1,10 @@
+import { t, Trans } from "@lingui/macro";
 import { Button, Link, Stack, TextField, Typography } from "@mui/material";
 import { DESCRIBE } from "@tpluscode/sparql-builder";
 import clownface, { AnyPointer } from "clownface";
 import DataLoader from "dataloader";
 import { omit } from "lodash";
 import { GetServerSideProps, NextPage } from "next";
-import { parseBody } from "next/dist/server/api-utils";
 import rdf from "rdf-ext";
 import React from "react";
 
@@ -40,7 +40,6 @@ type PageProps = {
 const describeCubes = async (cubeIris: readonly string[]) => {
   return Promise.all(
     cubeIris.map(async (cubeIri) => {
-      console.log("DESCRIBING CUBE");
       const query = DESCRIBE`<${cubeIri}>`;
       const stream = await query.execute(sparqlClientStream.query);
       const dataset = await fromStream(rdf.dataset(), stream);
@@ -112,17 +111,32 @@ const Page: NextPage<PageProps> = ({ checks, cubeIri }) => {
     <>
       <ContentLayout>
         <Stack maxWidth={1024} mx="auto" mt={8} spacing={4}>
-          <Stack spacing={1}>
-            <Typography variant="h1">Cube checker</Typography>
-            <form method="post">
+          <Stack spacing={2}>
+            <Typography variant="h1">
+              <Trans id="cube-checker.cube-checker">Cube checker</Trans>
+            </Typography>
+            <Typography variant="body1" gutterBottom>
+              <Trans id="cube-checker.description">
+                Cube checker helps you understand if a cube has all the
+                necessary attributes and properties to be viewable in
+                visualize.admin.ch.
+              </Trans>
+            </Typography>
+            <form>
               <Stack spacing={1} alignItems="start">
                 <TextField
                   type="text"
                   name="cubeIri"
                   defaultValue={cubeIri}
-                  inputProps={{ size: 50 }}
+                  inputProps={{
+                    size: 50,
+                    placeholder: t({
+                      id: "cube-checker.field-placeholder",
+                      message: "Cube IRI",
+                    }),
+                  }}
                 />
-                <Button type="submit" variant="contained">
+                <Button type="submit" variant="contained" size="large">
                   Check
                 </Button>
               </Stack>
@@ -157,14 +171,12 @@ const Page: NextPage<PageProps> = ({ checks, cubeIri }) => {
   );
 };
 
-export const getServerSideProps: GetServerSideProps = async ({ req }) => {
-  if (req.method === "POST") {
-    // @ts-ignore TODO
-    const { cubeIri } = await parseBody(req, "1mb");
-    if (!cubeIri) {
-      throw new Error("Form data should have cubeIri");
-    }
-
+export const getServerSideProps: GetServerSideProps = async ({
+  req,
+  query,
+}) => {
+  if (query.cubeIri) {
+    const cubeIri = query.cubeIri as string;
     const context = {
       cubeIri,
       loaders: {
@@ -186,6 +198,7 @@ export const getServerSideProps: GetServerSideProps = async ({ req }) => {
   }
   return {
     props: {
+      cubeIri: "",
       checks: [],
     },
   };

--- a/app/pages/_cube-health.tsx
+++ b/app/pages/_cube-health.tsx
@@ -1,0 +1,194 @@
+import { Button, Link, Stack, TextField, Typography } from "@mui/material";
+import { DESCRIBE } from "@tpluscode/sparql-builder";
+import clownface, { AnyPointer } from "clownface";
+import DataLoader from "dataloader";
+import { omit } from "lodash";
+import { GetServerSideProps, NextPage } from "next";
+import { parseBody } from "next/dist/server/api-utils";
+import rdf from "rdf-ext";
+import React from "react";
+
+import { ContentLayout } from "@/components/layout";
+import { fromStream, sparqlClientStream } from "@/rdf/sparql-client";
+
+import * as ns from "../rdf/namespace";
+
+type CheckResult = {
+  ok: boolean;
+  message: string;
+  link?: string;
+};
+
+type CheckRunContext = {
+  cubeIri: string;
+  loaders: {
+    describeCubes: DataLoader<string, AnyPointer, unknown>;
+  };
+};
+
+type Check = {
+  name: string;
+  description: string;
+  run: (ctx: CheckRunContext) => Promise<CheckResult>;
+};
+
+type PageProps = {
+  cubeIri?: string;
+  checks: { check: Omit<Check, "run">; result: CheckResult }[];
+};
+
+const describeCubes = async (cubeIris: readonly string[]) => {
+  return Promise.all(
+    cubeIris.map(async (cubeIri) => {
+      console.log("DESCRIBING CUBE");
+      const query = DESCRIBE`<${cubeIri}>`;
+      const stream = await query.execute(sparqlClientStream.query);
+      const dataset = await fromStream(rdf.dataset(), stream);
+      console.log({ dataset });
+      return clownface({ dataset });
+    })
+  );
+};
+
+const checks: Check[] = [
+  {
+    name: "Has a shape",
+    description: "Should have a shape through cube:observationConstraint",
+    run: async ({ cubeIri, loaders }) => {
+      const cube = await loaders.describeCubes.load(cubeIri);
+      const shape = cube.out(ns.cube.observationConstraint).value;
+      if (shape) {
+        return { ok: true, message: "Has shape" };
+      } else {
+        return { ok: false, message: "No shape" };
+      }
+    },
+  },
+  {
+    name: "Is published",
+    description:
+      "Should have a status (schema:creativeWorkStatus: [Published, Draft])",
+    run: async ({ cubeIri, loaders }) => {
+      const cube = await loaders.describeCubes.load(cubeIri);
+      const status = cube.out(ns.schema.creativeWorkStatus).value;
+      if (
+        status === "https://ld.admin.ch/vocabulary/CreativeWorkStatus/Published"
+      ) {
+        return { ok: true, message: "Is published" };
+      } else if (
+        status === "https://ld.admin.ch/vocabulary/CreativeWorkStatus/Draft"
+      ) {
+        return { ok: true, message: "Is draft" };
+      } else {
+        return { ok: false, message: `Unknown status ${status}` };
+      }
+    },
+  },
+  {
+    name: "Is viewable on visualize.admin",
+    description:
+      "Should have a predicate schema:workExample <https://ld.admin.ch/application/visualize>",
+    run: async ({ cubeIri, loaders }) => {
+      const cube = await loaders.describeCubes.load(cubeIri);
+      const workExamples = cube.out(ns.schema.workExample).values;
+      console.log(workExamples);
+      if (
+        workExamples &&
+        workExamples.includes("https://ld.admin.ch/application/visualize")
+      ) {
+        return { ok: true, message: "Is viewable on visualize.admin.ch" };
+      } else {
+        return {
+          ok: false,
+          message: `Cube lacks the predicate schema:workExample <https://ld.admin.ch/application/visualize>`,
+        };
+      }
+    },
+  },
+];
+
+const Page: NextPage<PageProps> = ({ checks, cubeIri }) => {
+  return (
+    <>
+      <ContentLayout>
+        <Stack maxWidth={1024} mx="auto" mt={8} spacing={4}>
+          <Stack spacing={1}>
+            <Typography variant="h1">Cube checker</Typography>
+            <form method="post">
+              <Stack spacing={1} alignItems="start">
+                <TextField
+                  type="text"
+                  name="cubeIri"
+                  defaultValue={cubeIri}
+                  inputProps={{ size: 50 }}
+                />
+                <Button type="submit" variant="contained">
+                  Check
+                </Button>
+              </Stack>
+            </form>
+          </Stack>
+          <Stack spacing={3}>
+            {checks.map((check) => {
+              return (
+                <div key={check.check.name}>
+                  <Typography variant="h5">{check.check.name}</Typography>
+                  <Typography variant="body2" color="textSecondary">
+                    {check.check.description}
+                  </Typography>
+                  <Typography
+                    variant="body1"
+                    color={check.result.ok ? "success" : "error"}
+                  >
+                    {check.result.ok ? "✅" : "❌"} {check.result.message}
+                  </Typography>
+                  {check.result.link ? (
+                    <Link color="primary" href={check.result.link}>
+                      Query
+                    </Link>
+                  ) : null}
+                </div>
+              );
+            })}
+          </Stack>
+        </Stack>
+      </ContentLayout>
+    </>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  if (req.method === "POST") {
+    // @ts-ignore TODO
+    const { cubeIri } = await parseBody(req, "1mb");
+    if (!cubeIri) {
+      throw new Error("Form data should have cubeIri");
+    }
+
+    const context = {
+      cubeIri,
+      loaders: {
+        describeCubes: new DataLoader(describeCubes),
+      },
+    };
+    const propChecks = await Promise.all(
+      checks.map(async (c) => ({
+        check: omit(c, "run"),
+        result: await c.run(context),
+      }))
+    );
+    return {
+      props: {
+        cubeIri: cubeIri,
+        checks: propChecks,
+      },
+    };
+  }
+  return {
+    props: {
+      checks: [],
+    },
+  };
+};
+
+export default Page;

--- a/app/pages/browse/[type]/[iri].tsx
+++ b/app/pages/browse/[type]/[iri].tsx
@@ -3,6 +3,7 @@ import { GetServerSideProps } from "next";
 import { DatasetBrowser } from "@/browser";
 import { queryLatestPublishedCubeFromUnversionedIri } from "@/rdf/query-cube-metadata";
 import { defaultLocale } from "@/src";
+import { getQueryParams } from "@/utils/flashes";
 export default DatasetBrowser;
 /**
  * Heuristic to check if a dataset IRI is versioned.
@@ -28,7 +29,9 @@ const getServerSideProps: GetServerSideProps = async function (ctx) {
       return {
         redirect: {
           permanent: false,
-          destination: "/",
+          destination: `/?${getQueryParams("CANNOT_FIND_CUBE", {
+            iri: params.iri,
+          })}`,
         },
       };
     } else if (params.iri === resp.iri) {

--- a/app/rdf/query-hierarchies.ts
+++ b/app/rdf/query-hierarchies.ts
@@ -3,22 +3,12 @@ import clownface from "clownface";
 import { ascending } from "d3";
 import { uniqBy } from "lodash";
 import rdf from "rdf-ext";
-import { DatasetCore, NamedNode, Quad, Stream } from "rdf-js";
+import { NamedNode } from "rdf-js";
 
 import { HierarchyValue } from "@/graphql/resolver-types";
 
 import * as ns from "./namespace";
-import { sparqlClient, sparqlClientStream } from "./sparql-client";
-
-const fromStream = (
-  dataset: DatasetCore<Quad, Quad>,
-  stream: Stream<Quad>
-): Promise<DatasetCore<Quad, Quad>> => {
-  return new Promise((resolve) => {
-    stream.on("data", (quad: Quad) => dataset.add(quad));
-    stream.on("end", () => resolve(dataset));
-  });
-};
+import { fromStream, sparqlClient, sparqlClientStream } from "./sparql-client";
 
 const hasValueAndLabel = (
   o: Record<string, any>

--- a/app/rdf/sparql-client.ts
+++ b/app/rdf/sparql-client.ts
@@ -1,3 +1,4 @@
+import { DatasetCore, Quad, Stream } from "rdf-js";
 import StreamClient from "sparql-http-client";
 import ParsingClient from "sparql-http-client/ParsingClient";
 
@@ -10,3 +11,13 @@ export const sparqlClient = new ParsingClient({
 export const sparqlClientStream = new StreamClient({
   endpointUrl: SPARQL_ENDPOINT,
 });
+
+export const fromStream = (
+  dataset: DatasetCore<Quad, Quad>,
+  stream: Stream<Quad>
+): Promise<DatasetCore<Quad, Quad>> => {
+  return new Promise((resolve) => {
+    stream.on("data", (quad: Quad) => dataset.add(quad));
+    stream.on("end", () => resolve(dataset));
+  });
+};

--- a/app/utils/flashes.tsx
+++ b/app/utils/flashes.tsx
@@ -1,0 +1,90 @@
+import { Trans } from "@lingui/macro";
+import { Alert, AlertTitle, Box, Link } from "@mui/material";
+import { AnimatePresence, motion } from "framer-motion";
+import { useRouter } from "next/router";
+import React, { useMemo, useState } from "react";
+
+import { Icon } from "@/icons";
+
+export const flashes = {
+  CANNOT_FIND_CUBE: "CANNOT_FIND_CUBE",
+} as const;
+
+export const getQueryParams = (errorId: keyof typeof flashes, options: any) => {
+  return `errorId=${errorId}&errorOptions=${encodeURIComponent(
+    JSON.stringify(options)
+  )}`;
+};
+
+const CannotFindCubeContent = () => {
+  const { query } = useRouter();
+  const errorOptions = useMemo(() => {
+    try {
+      return JSON.parse(query?.errorOptions as string);
+    } catch (e) {
+      return {};
+    }
+  }, [query]);
+  return (
+    <>
+      <AlertTitle>
+        <Trans id="flashes.couldnt-load-cube.title">Could not load cube</Trans>
+      </AlertTitle>
+      <Link
+        href={`/_cube-checker?cubeIri=${errorOptions.iri}`}
+        sx={{ display: "flex", alignItems: "center", gap: 1 }}
+      >
+        <Trans id="flashes.couldnt-load-cube.view-cube-checker">
+          View in cube checker
+        </Trans>{" "}
+        <Icon name="arrowRight" size={16} />
+      </Link>
+    </>
+  );
+};
+
+const renderErrorContent: Record<
+  keyof typeof flashes,
+  (props: any) => React.ReactElement
+> = {
+  CANNOT_FIND_CUBE: CannotFindCubeContent,
+};
+
+const Flashes = () => {
+  const router = useRouter();
+  const query = router.query;
+  const [dismissed, setDismissed] = useState<Record<string, boolean>>({});
+  const errorId = query.errorId as keyof typeof flashes;
+  const ErrorComponent = renderErrorContent[errorId];
+  return (
+    <Box sx={{ position: "fixed", bottom: "1rem", right: "1rem" }}>
+      <AnimatePresence>
+        {errorId && !dismissed[errorId] ? (
+          <motion.div
+            initial={{ opacity: 0, y: "1rem" }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: "1rem" }}
+          >
+            <Alert
+              severity="error"
+              onClose={() =>
+                setDismissed((dismissed) => ({
+                  ...dismissed,
+                  [errorId]: true,
+                }))
+              }
+            >
+              {ErrorComponent ? (
+                <ErrorComponent />
+              ) : (
+                <Trans id={`flashes.error.${errorId}`} />
+              )}
+            </Alert>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+    </Box>
+  );
+};
+
+export default Flashes;


### PR DESCRIPTION
- feat: Add a way to check the cube health
- feat: When redirecting to home page due to bad cube, show an error message
- feat: Add translations

When cannot load a cube, we have a message on home page:

<img width="407" alt="image" src="https://user-images.githubusercontent.com/465582/173845222-642e822f-2c42-462c-b085-8c5dd3bf8797.png">

We can see the cube in a new cube checker page that checks some of the attributes of the cube to see if they are correct.

## Bad cube 

<img width="1094" alt="image" src="https://user-images.githubusercontent.com/465582/173845356-d842985d-f1ea-4641-bdbc-e095484cb47f.png">

## Good cube

<img width="1074" alt="image" src="https://user-images.githubusercontent.com/465582/173845460-1a470f88-a78a-48a0-aa8b-ce49002b7204.png">