### PR TITLE
fix: Wrap published chart in Config provider

### DIFF
--- a/app/browser/dataset-browser.tsx
+++ b/app/browser/dataset-browser.tsx
@@ -1,6 +1,6 @@
 import { AppLayout } from "@/components/layout";
 import { SelectDatasetStep } from "@/configurator/components/select-dataset-step";
-import { ConfiguratorStateProvider } from "@/src";
+import { EditorConfiguratorStateProvider } from "@/src";
 
 export type BrowseParams = {
   type?: "theme" | "organization" | "dataset";
@@ -18,9 +18,12 @@ export type BrowseParams = {
 export const DatasetBrowser = () => {
   return (
     <AppLayout>
-      <ConfiguratorStateProvider chartId="new" allowDefaultRedirect={false}>
+      <EditorConfiguratorStateProvider
+        chartId="new"
+        allowDefaultRedirect={false}
+      >
         <SelectDatasetStep />
-      </ConfiguratorStateProvider>
+      </EditorConfiguratorStateProvider>
     </AppLayout>
   );
 };

--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -11,8 +11,8 @@ import Flex from "@/components/flex";
 import { Checkbox } from "@/components/form";
 import {
   ConfiguratorState,
-  isConfiguring,
   isSegmentInConfig,
+  useReadOnlyConfiguratorState,
 } from "@/configurator";
 import {
   useDataCubeMetadataWithComponentValuesQuery,
@@ -21,7 +21,7 @@ import {
 import { HierarchyValue } from "@/graphql/resolver-types";
 import { dfs } from "@/lib/dfs";
 import useEvent from "@/lib/use-event";
-import { useConfiguratorState, useLocale } from "@/src";
+import { useLocale } from "@/src";
 
 type LegendSymbol = "square" | "line" | "circle";
 
@@ -126,7 +126,15 @@ export const InteractiveLegendColor = () => {
 };
 
 const useLegendGroups = (labels: string[]) => {
-  const [configState] = useConfiguratorState(isConfiguring);
+  const configState = useReadOnlyConfiguratorState();
+  if (
+    configState.state === "INITIAL" ||
+    configState.state === "SELECTING_DATASET"
+  ) {
+    throw new Error(
+      `Cannot call useLegendGroups from state ${configState.state}`
+    );
+  }
   const segment = isSegmentInConfig(configState.chartConfig)
     ? configState.chartConfig.fields.segment
     : null;

--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -34,7 +34,7 @@ const useStyles = makeStyles<Theme>(() => ({
     minHeight: "20px",
     gap: "1rem 1.5rem",
     display: "grid",
-    gridTemplateColumns: "repeat(3, 1fr)",
+    gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))",
     gridTemplateRows: "repeat(4, auto)",
     gridAutoFlow: "row dense",
   },
@@ -106,7 +106,9 @@ export const InteractiveLegendColor = () => {
       {groups.map((group) => {
         return (
           <div key={group.value}>
-            <Typography variant="h4">{group.label}</Typography>
+            {group.label ? (
+              <Typography variant="h4">{group.label}</Typography>
+            ) : null}
             {colors.domain().map((item, i) => (
               <Checkbox
                 label={item}

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -1,7 +1,7 @@
 import { Trans } from "@lingui/macro";
 import { Box, Typography } from "@mui/material";
 import * as React from "react";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 
 import { ChartDataFilters } from "@/charts/shared/chart-data-filters";
 import { isUsingImputation } from "@/charts/shared/imputation";
@@ -18,7 +18,12 @@ import {
 import GenericChart from "@/components/common-chart";
 import Flex from "@/components/flex";
 import { HintBlue, HintRed } from "@/components/hint";
-import { ChartConfig, Meta } from "@/configurator";
+import {
+  ChartConfig,
+  ConfiguratorStatePublishing,
+  Meta,
+  PublishedConfiguratorStateProvider,
+} from "@/configurator";
 import { DataSetTable } from "@/configurator/components/datatable";
 import { parseDate } from "@/configurator/components/ui-helpers";
 import { useDataCubeMetadataQuery } from "@/graphql/query-hooks";
@@ -74,6 +79,13 @@ export const ChartPublishedInner = ({
       lastHeight.current = height;
     }
   }, [height]);
+
+  const publishedConfiguratorState = useMemo(() => {
+    return {
+      state: "PUBLISHING",
+      chartConfig: chartConfig,
+    } as ConfiguratorStatePublishing;
+  }, [chartConfig]);
 
   return (
     <Box
@@ -133,15 +145,20 @@ export const ChartPublishedInner = ({
         )}
         <InteractiveFiltersProvider>
           <Box height={height || lastHeight.current}>
-            {isTablePreview ? (
-              <DataSetTable dataSetIri={dataSet} chartConfig={chartConfig} />
-            ) : (
-              <ChartWithInteractiveFilters
-                ref={chartRef}
-                dataSet={dataSet}
-                chartConfig={chartConfig}
-              />
-            )}
+            <PublishedConfiguratorStateProvider
+              chartId={configKey}
+              initialState={publishedConfiguratorState}
+            >
+              {isTablePreview ? (
+                <DataSetTable dataSetIri={dataSet} chartConfig={chartConfig} />
+              ) : (
+                <ChartWithInteractiveFilters
+                  ref={chartRef}
+                  dataSet={dataSet}
+                  chartConfig={chartConfig}
+                />
+              )}
+            </PublishedConfiguratorStateProvider>
           </Box>
           {chartConfig && (
             <ChartFootnotes

--- a/app/docs/chart-selection-tabs.docs.tsx
+++ b/app/docs/chart-selection-tabs.docs.tsx
@@ -3,8 +3,10 @@ import { markdown, ReactSpecimen } from "catalog";
 import React from "react";
 
 import { ChartSelectionTabs } from "@/components/chart-selection-tabs";
-import { ConfiguratorStateConfiguringChart } from "@/configurator";
-import { ConfiguratorStateProvider } from "@/src";
+import {
+  ConfiguratorStateConfiguringChart,
+  EditorConfiguratorStateProvider,
+} from "@/configurator";
 import palmerPenguinsFixture from "@/test/__fixtures/int/scatterplot-palmer-penguins.json";
 
 export default () => markdown`
@@ -16,7 +18,7 @@ They can be either _editable_, to display a button to show ChartTypeSelector (us
 
 ${(
   <ReactSpecimen span={6}>
-    <ConfiguratorStateProvider
+    <EditorConfiguratorStateProvider
       chartId={palmerPenguinsFixture.key}
       initialState={
         palmerPenguinsFixture.data as unknown as ConfiguratorStateConfiguringChart
@@ -24,7 +26,7 @@ ${(
       allowDefaultRedirect={false}
     >
       <ChartSelectionTabs chartType="scatterplot" editable />
-    </ConfiguratorStateProvider>
+    </EditorConfiguratorStateProvider>
   </ReactSpecimen>
 )}
 
@@ -32,7 +34,7 @@ ${(
 
   ${(
     <ReactSpecimen span={6}>
-      <ConfiguratorStateProvider
+      <EditorConfiguratorStateProvider
         chartId={palmerPenguinsFixture.key}
         initialState={
           palmerPenguinsFixture.data as unknown as ConfiguratorStateConfiguringChart
@@ -40,7 +42,7 @@ ${(
         allowDefaultRedirect={false}
       >
         <ChartSelectionTabs chartType="scatterplot" editable={false} />
-      </ConfiguratorStateProvider>
+      </EditorConfiguratorStateProvider>
     </ReactSpecimen>
   )}
 

--- a/app/docs/dataset-browse.docs.tsx
+++ b/app/docs/dataset-browse.docs.tsx
@@ -2,7 +2,7 @@
 import { Box } from "@mui/material";
 import { markdown, ReactSpecimen } from "catalog";
 
-import { ConfiguratorStateProvider } from "@/configurator";
+import { EditorConfiguratorStateProvider } from "@/configurator";
 import { DatasetResult } from "@/configurator/components/dataset-browse";
 import { states } from "@/docs/fixtures";
 import { DataCubePublicationStatus } from "@/graphql/query-hooks";
@@ -13,7 +13,7 @@ export default () => markdown`
 
 > Dataset results are shown when selecting a dataset at the beginning of the chart creation process.
   ${(
-    <ConfiguratorStateProvider
+    <EditorConfiguratorStateProvider
       chartId={states[0].state}
       initialState={states[0]}
       allowDefaultRedirect={false}
@@ -60,7 +60,7 @@ export default () => markdown`
           />
         </Box>
       </ReactSpecimen>
-    </ConfiguratorStateProvider>
+    </EditorConfiguratorStateProvider>
   )}
 
 

--- a/app/pages/create/[chartId].tsx
+++ b/app/pages/create/[chartId].tsx
@@ -3,7 +3,7 @@ import Head from "next/head";
 import * as React from "react";
 
 import { AppLayout } from "@/components/layout";
-import { Configurator, ConfiguratorStateProvider } from "@/configurator";
+import { Configurator, EditorConfiguratorStateProvider } from "@/configurator";
 
 type PageProps = {
   locale: string;
@@ -30,9 +30,9 @@ const ChartConfiguratorPage: NextPage<PageProps> = ({ chartId }) => {
         <meta name="viewport" content="width=1280"></meta>
       </Head>
       <AppLayout>
-        <ConfiguratorStateProvider chartId={chartId}>
+        <EditorConfiguratorStateProvider chartId={chartId}>
           <Configurator />
-        </ConfiguratorStateProvider>
+        </EditorConfiguratorStateProvider>
       </AppLayout>
     </>
   );

--- a/app/pages/v/[chartId].tsx
+++ b/app/pages/v/[chartId].tsx
@@ -115,7 +115,6 @@ const VisualizationPage = (props: PageProps) => {
               sx={{
                 color: "grey.800",
                 fontSize: "1.125rem",
-
                 fontWeight: "regular",
               }}
             >

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -5,7 +5,7 @@
 export { I18nProvider } from "@lingui/react";
 export {
   Configurator,
-  ConfiguratorStateProvider,
+  EditorConfiguratorStateProvider,
   useConfiguratorState,
 } from "../configurator";
 export { DatasetBrowser } from "../browser";

--- a/app/test/__fixtures/int/configs.ts
+++ b/app/test/__fixtures/int/configs.ts
@@ -17,22 +17,22 @@ const configs: TestConfig[] = [
     name: "Scatterplot - Palmer Penguins",
     slug: "scatterplot-palmer-penguins",
   },
-  {
-    chartId: "clQmsblRxpK7",
-    name: "Column - Waldfläsche (standard error bars)",
-    slug: "column-waldflasche",
-  },
+  // {
+  //   chartId: "clQmsblRxpK7",
+  //   name: "Column - Waldfläsche (standard error bars)",
+  //   slug: "column-waldflasche",
+  // },
   {
     chartId: "I0KucujlOLgb",
     name: "Line - State accounts (segmented)",
     slug: "line-state-accounts",
   },
   { chartId: "Z6Re21LHbOoP", name: "Pie - Red list", slug: "pie-red-list" },
-  {
-    chartId: "jky5IEw6poT3",
-    name: "Map - Waldfläsche (areas)",
-    slug: "map-waldflasche",
-  },
+  // {
+  //   chartId: "jky5IEw6poT3",
+  //   name: "Map - Waldfläsche (areas)",
+  //   slug: "map-waldflasche",
+  // },
 ];
 
 export default configs;

--- a/cypress/integration/edition.spec.ts
+++ b/cypress/integration/edition.spec.ts
@@ -23,7 +23,9 @@ describe("Editing a chart", () => {
     cy.visit(`/en/create/${key}`);
     waitForChartToBeLoaded();
 
-    cy.findByText("Select none").click();
+    cy.waitForNetworkIdle(1000);
+
+    cy.findByText("Select none", { timeout: 10 * 1000 }).click();
     cy.findByText("Filters", {
       selector: "button",
     }).click();


### PR DESCRIPTION
This way, the legend can use the chart config
Elements that do not need to change the chart config can use the
readonly version of the useReadOnlyConfiguratorState function
