### PR TITLE
feat: Do not hierarchy level section for maps as this is handled in filters

### DIFF
--- a/app/charts/map/map-state.tsx
+++ b/app/charts/map/map-state.tsx
@@ -221,10 +221,9 @@ const useMapState = (
     [symbolErrorDimension?.unit, formatNumber, getSymbolError]
   );
 
-  const getDataByHierarchyLevel = useCallback(
+  const getData = useCallback(
     ({
       geoDimensionIri,
-      hierarchyLevel,
       getLabel,
     }: {
       geoDimensionIri: string;
@@ -238,9 +237,9 @@ const useMapState = (
         isGeoShapesDimension(dimension) &&
         features.areaLayer?.shapes?.features
       ) {
-        const hierarchyLabels = features.areaLayer.shapes.features
-          .filter((d) => d.properties.hierarchyLevel === hierarchyLevel)
-          .map((d) => d.properties.label);
+        const hierarchyLabels = features.areaLayer.shapes.features.map(
+          (d) => d.properties.label
+        );
 
         return data.filter((d) => hierarchyLabels.includes(getLabel(d)));
       }
@@ -253,24 +252,19 @@ const useMapState = (
   const areaData = useMemo(
     () =>
       areaLayer.componentIri !== ""
-        ? getDataByHierarchyLevel({
+        ? getData({
             geoDimensionIri: areaLayer.componentIri,
             hierarchyLevel: areaLayer.hierarchyLevel,
             getLabel: getAreaLabel,
           })
         : [],
-    [
-      areaLayer.componentIri,
-      areaLayer.hierarchyLevel,
-      getAreaLabel,
-      getDataByHierarchyLevel,
-    ]
+    [areaLayer.componentIri, areaLayer.hierarchyLevel, getAreaLabel, getData]
   );
 
   const symbolData = useMemo(
     () =>
       symbolLayer.componentIri !== ""
-        ? getDataByHierarchyLevel({
+        ? getData({
             geoDimensionIri: symbolLayer.componentIri,
             hierarchyLevel: symbolLayer.hierarchyLevel,
             getLabel: getSymbolLabel,
@@ -280,7 +274,7 @@ const useMapState = (
       symbolLayer.componentIri,
       symbolLayer.hierarchyLevel,
       getSymbolLabel,
-      getDataByHierarchyLevel,
+      getData,
     ]
   );
 

--- a/app/configurator/map/map-chart-options.tsx
+++ b/app/configurator/map/map-chart-options.tsx
@@ -19,11 +19,7 @@ import {
 } from "@/configurator/components/field";
 import { DimensionValuesMultiFilter } from "@/configurator/components/filters";
 import { DataSource } from "@/configurator/config-types";
-import {
-  GeoFeature,
-  getGeoDimensions,
-  getGeoShapesDimensions,
-} from "@/domain/data";
+import { getGeoDimensions, getGeoShapesDimensions } from "@/domain/data";
 import { useGeoShapesByDimensionIriQuery } from "@/graphql/query-hooks";
 import { DataCubeMetadata } from "@/graphql/types";
 import { useLocale } from "@/src";
@@ -119,18 +115,6 @@ export const AreaLayerSettings = memo(
         ? (fetchedGeoShapes.dataCubeByIri.dimensionByIri.geoShapes as any)
         : undefined;
 
-    const hierarchyLevelOptions = useMemo(
-      () =>
-        [
-          ...new Set(
-            (
-              geoShapes?.topology?.objects?.shapes?.geometries as GeoFeature[]
-            )?.map((d) => d.properties.hierarchyLevel)
-          ),
-        ]?.map((d) => ({ value: d, label: `${d}` })),
-      [geoShapes]
-    );
-
     const measuresOptions = useMemo(
       () =>
         metaData.measures.map((d) => ({
@@ -195,25 +179,6 @@ export const AreaLayerSettings = memo(
               field={activeField}
               path="componentIri"
               options={geoShapesDimensionsOptions}
-              disabled={isHidden}
-            />
-          </ControlSectionContent>
-        </ControlSection>
-        <ControlSection>
-          <SectionTitle iconName="list">
-            {t({ id: "controls.hierarchy", message: "Hierarchy level" })}
-          </SectionTitle>
-          <ControlSectionContent side="right">
-            <ChartOptionSelectField<number>
-              id="areaLayer.hierarchyLevel"
-              label={t({
-                id: "controls.hierarchy.select",
-                message: "Select a hierarchy level",
-              })}
-              field={activeField}
-              path="hierarchyLevel"
-              options={hierarchyLevelOptions}
-              getValue={(d) => +d}
               disabled={isHidden}
             />
           </ControlSectionContent>

--- a/app/configurator/map/map-chart-options.tsx
+++ b/app/configurator/map/map-chart-options.tsx
@@ -1,5 +1,5 @@
 import { t, Trans } from "@lingui/macro";
-import { Box } from "@mui/material";
+import { Box, Stack } from "@mui/material";
 import React, { memo, useMemo } from "react";
 
 import Flex from "@/components/flex";
@@ -289,45 +289,47 @@ export const AreaLayerSettings = memo(
               numberOfGeoShapes >= 3 && (
                 <>
                   <FieldSetLegend legendTitle="Interpolation" />
-                  <ChartOptionSelectField
-                    id="areaLayer.colorScaleInterpolationType"
-                    label={null}
-                    field={activeField}
-                    path="colorScaleInterpolationType"
-                    options={[
-                      {
-                        label: t({
-                          id: "chart.map.layers.area.discretization.quantize",
-                          message: "Quantize (equal intervals)",
-                        }),
-                        value: "quantize",
-                      },
-                      {
-                        label: t({
-                          id: "chart.map.layers.area.discretization.quantiles",
-                          message: "Quantiles (equal distribution of values)",
-                        }),
-                        value: "quantile",
-                      },
-                      {
-                        label: t({
-                          id: "chart.map.layers.area.discretization.jenks",
-                          message: "Jenks (natural breaks)",
-                        }),
-                        value: "jenks",
-                      },
-                    ]}
-                    disabled={isHidden}
-                  />
-                  <ChartOptionSelectField<number>
-                    id="areaLayer.nbClass"
-                    label="Number of classes"
-                    field={activeField}
-                    path="nbClass"
-                    options={numberOfColorScaleClasses}
-                    getValue={(d) => +d}
-                    disabled={isHidden}
-                  />
+                  <Stack spacing={2}>
+                    <ChartOptionSelectField
+                      id="areaLayer.colorScaleInterpolationType"
+                      label={null}
+                      field={activeField}
+                      path="colorScaleInterpolationType"
+                      options={[
+                        {
+                          label: t({
+                            id: "chart.map.layers.area.discretization.quantize",
+                            message: "Quantize (equal intervals)",
+                          }),
+                          value: "quantize",
+                        },
+                        {
+                          label: t({
+                            id: "chart.map.layers.area.discretization.quantiles",
+                            message: "Quantiles (equal distribution of values)",
+                          }),
+                          value: "quantile",
+                        },
+                        {
+                          label: t({
+                            id: "chart.map.layers.area.discretization.jenks",
+                            message: "Jenks (natural breaks)",
+                          }),
+                          value: "jenks",
+                        },
+                      ]}
+                      disabled={isHidden}
+                    />
+                    <ChartOptionSelectField<number>
+                      id="areaLayer.nbClass"
+                      label="Number of classes"
+                      field={activeField}
+                      path="nbClass"
+                      options={numberOfColorScaleClasses}
+                      getValue={(d) => +d}
+                      disabled={isHidden}
+                    />
+                  </Stack>
                 </>
               )}
           </ControlSectionContent>


### PR DESCRIPTION
As hierarchy is now handled at dimension level and not anymore as part of the geoshapes, we do not need the hierarchy options for the maps.
Fixes were made on the multi filters display so that they handle cases without color mapping