### PR TITLE
Better initial state for segment

### DIFF
--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -23,7 +23,7 @@ import {
   Droppable,
   OnDragEndResponder,
 } from "react-beautiful-dnd";
-import { CombinedError, useClient } from "urql";
+import { useClient } from "urql";
 
 import { getFieldComponentIris } from "@/charts";
 import { chartConfigOptionsUISpec } from "@/charts/chart-config-ui-options";
@@ -64,6 +64,7 @@ import {
   HierarchyValue,
   PossibleFiltersDocument,
   PossibleFiltersQuery,
+  PossibleFiltersQueryVariables,
   useDataCubeMetadataWithComponentValuesQuery,
 } from "@/graphql/query-hooks";
 import { DataCubeMetadata } from "@/graphql/types";
@@ -212,17 +213,19 @@ const useEnsurePossibleFilters = ({
       lastFilters.current = unmappedFilters;
 
       setFetching(true);
-      const {
-        data,
-        error,
-      }: { data?: PossibleFiltersQuery; error?: CombinedError } = await client
-        .query(PossibleFiltersDocument, {
-          iri: state.dataSet,
-          sourceType: state.dataSource.type,
-          sourceUrl: state.dataSource.url,
-          filters: unmappedFilters,
-          filterKey: Object.keys(unmappedFilters).join(", "),
-        })
+      const { data, error } = await client
+        .query<PossibleFiltersQuery, PossibleFiltersQueryVariables>(
+          PossibleFiltersDocument,
+          {
+            iri: state.dataSet,
+            sourceType: state.dataSource.type,
+            sourceUrl: state.dataSource.url,
+            filters: unmappedFilters,
+
+            // @ts-ignore This is to make urql requery
+            filterKey: Object.keys(unmappedFilters).join(", "),
+          }
+        )
         .toPromise();
       if (error || !data) {
         setError(error);

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -79,52 +79,49 @@ export const useChartFieldField = ({
   const client = useClient();
   const locale = useLocale();
 
-  const onChange = useCallback<(e: SelectChangeEvent<unknown>) => void>(
-    async (e) => {
-      if (!state.dataSet) {
-        return;
-      }
-      if (e.target.value !== FIELD_VALUE_NONE) {
-        const dimensionIri = e.target.value as string;
-        const { data: hierarchyData } = await client
-          .query<DimensionHierarchyQuery, DimensionHierarchyQueryVariables>(
-            DimensionHierarchyDocument,
-            {
-              locale,
-              cubeIri: state.dataSet,
-              dimensionIri,
-              sourceUrl: state.dataSource.url,
-              sourceType: state.dataSource.type,
-            }
-          )
-          .toPromise();
-        const tree = hierarchyData?.dataCubeByIri?.dimensionByIri
-          ?.hierarchy as HierarchyValue[];
+  const onChange = useEvent(async (e: SelectChangeEvent<unknown>) => {
+    if (!state.dataSet) {
+      return;
+    }
+    if (e.target.value !== FIELD_VALUE_NONE) {
+      const dimensionIri = e.target.value as string;
+      const { data: hierarchyData } = await client
+        .query<DimensionHierarchyQuery, DimensionHierarchyQueryVariables>(
+          DimensionHierarchyDocument,
+          {
+            locale,
+            cubeIri: state.dataSet,
+            dimensionIri,
+            sourceUrl: state.dataSource.url,
+            sourceType: state.dataSource.type,
+          }
+        )
+        .toPromise();
+      const tree = hierarchyData?.dataCubeByIri?.dimensionByIri
+        ?.hierarchy as HierarchyValue[];
 
-        // If the dimension has a hierarchy, we select 7 leaves
-        const leafs = getLeafs(tree, 7);
+      // If the dimension has a hierarchy, we select 7 leaves
+      const leafs = getLeafs(tree, 7);
 
-        dispatch({
-          type: "CHART_FIELD_CHANGED",
-          value: {
-            field,
-            dataSetMetadata,
-            componentIri: dimensionIri,
-            selectedValues: leafs,
-          },
-        });
-      } else {
-        dispatch({
-          type: "CHART_FIELD_DELETED",
-          value: {
-            field,
-            dataSetMetadata,
-          },
-        });
-      }
-    },
-    [client, locale, state.dataSet, dispatch, field, dataSetMetadata]
-  );
+      dispatch({
+        type: "CHART_FIELD_CHANGED",
+        value: {
+          field,
+          dataSetMetadata,
+          componentIri: dimensionIri,
+          selectedValues: leafs,
+        },
+      });
+    } else {
+      dispatch({
+        type: "CHART_FIELD_DELETED",
+        value: {
+          field,
+          dataSetMetadata,
+        },
+      });
+    }
+  });
 
   let value: string | undefined;
   if (state.state === "CONFIGURING_CHART") {

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -21,6 +21,7 @@ import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import {
   DimensionHierarchyDocument,
   DimensionHierarchyQuery,
+  DimensionHierarchyQueryVariables,
   DimensionValuesQuery,
 } from "@/graphql/query-hooks";
 import { HierarchyValue } from "@/graphql/resolver-types";
@@ -86,11 +87,16 @@ export const useChartFieldField = ({
       if (e.target.value !== FIELD_VALUE_NONE) {
         const dimensionIri = e.target.value as string;
         const { data: hierarchyData } = await client
-          .query(DimensionHierarchyDocument, {
-            locale,
-            cubeIri: state.dataSet,
-            dimensionIri,
-          })
+          .query<DimensionHierarchyQuery, DimensionHierarchyQueryVariables>(
+            DimensionHierarchyDocument,
+            {
+              locale,
+              cubeIri: state.dataSet,
+              dimensionIri,
+              sourceUrl: state.dataSource.url,
+              sourceType: state.dataSource.type,
+            }
+          )
           .toPromise();
         const tree = hierarchyData?.dataCubeByIri?.dimensionByIri
           ?.hierarchy as HierarchyValue[];

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -80,6 +80,9 @@ export const useChartFieldField = ({
 
   const onChange = useCallback<(e: SelectChangeEvent<unknown>) => void>(
     async (e) => {
+      if (!state.dataSet) {
+        return;
+      }
       if (e.target.value !== FIELD_VALUE_NONE) {
         const dimensionIri = e.target.value as string;
         const { data: hierarchyData } = await client

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -678,16 +678,15 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
           dataSetMetadata,
           selectedValues: actionSelectedValues,
         } = action.value;
+        const component = dataSetMetadata.dimensions.find(
+          (dim) => dim.iri === componentIri
+        );
+        const selectedValues = actionSelectedValues
+          ? actionSelectedValues
+          : component?.values.slice(0, SEGMENT_CHILDREN_INITIAL_LIMIT) || [];
         if (!f) {
           // The field was not defined before
           if (field === "segment") {
-            const component = dataSetMetadata.dimensions.find(
-              (dim) => dim.iri === componentIri
-            );
-            const selectedValues = actionSelectedValues
-              ? actionSelectedValues
-              : component?.values.slice(0, SEGMENT_CHILDREN_INITIAL_LIMIT) ||
-                [];
             const colorMapping =
               component?.values &&
               mapValueIrisToColor({
@@ -735,9 +734,6 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
             draft.chartConfig.fields.segment &&
             "palette" in draft.chartConfig.fields.segment
           ) {
-            const component = dataSetMetadata.dimensions.find(
-              (dim) => dim.iri === componentIri
-            );
             const colorMapping =
               component &&
               mapValueIrisToColor({
@@ -748,6 +744,12 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
 
             draft.chartConfig.fields.segment.componentIri = componentIri;
             draft.chartConfig.fields.segment.colorMapping = colorMapping;
+            draft.chartConfig.filters[componentIri] = {
+              type: "multi",
+              values: Object.fromEntries(
+                selectedValues.map((v) => v.value).map((x) => [x, true])
+              ),
+            };
 
             // Remove this component from the interactive filter, if it is there
             if (draft.chartConfig.interactiveFiltersConfig) {
@@ -757,9 +759,6 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
                 );
             }
           } else {
-            const component = dataSetMetadata.dimensions.find(
-              (dim) => dim.iri === componentIri
-            );
             // Reset other field options
             (draft.chartConfig.fields as GenericFields)[field] = {
               componentIri: componentIri,

--- a/app/scripts/cube.ts
+++ b/app/scripts/cube.ts
@@ -10,8 +10,11 @@ import { DataSource } from "@/configurator";
 import { GRAPHQL_ENDPOINT } from "../domain/env";
 import {
   DataCubeMetadataDocument,
+  DataCubeMetadataQuery,
+  DataCubeMetadataQueryVariables,
   DataCubeMetadataWithComponentValuesDocument,
   DataCubeMetadataWithComponentValuesQuery,
+  DataCubeMetadataWithComponentValuesQueryVariables,
   DataCubePreviewObservationsDocument,
   DataCubePreviewObservationsQuery,
 } from "../graphql/query-hooks";
@@ -34,17 +37,22 @@ const showCubeInfo = async ({
   client,
   iri,
   sourceType,
+  sourceUrl,
   locale,
   latest,
   report,
 }: Args<CubeQueryOptions>) => {
   const res = await client
-    .query(DataCubeMetadataDocument, {
-      iri,
-      sourceType,
-      locale,
-      latest,
-    })
+    .query<DataCubeMetadataQuery, DataCubeMetadataQueryVariables>(
+      DataCubeMetadataDocument,
+      {
+        iri,
+        sourceType,
+        sourceUrl,
+        locale,
+        latest,
+      }
+    )
     .toPromise();
 
   if (res.error) {
@@ -53,7 +61,7 @@ const showCubeInfo = async ({
 
   const cube = res.data?.dataCubeByIri;
 
-  if (cube.iri !== iri) {
+  if (cube?.iri !== iri) {
     console.warn(
       "warn: Cube has been resolved to its latest version, pass --no-latest if you want the exact version"
     );
@@ -65,14 +73,19 @@ const showCubeComponents = async ({
   client,
   iri,
   sourceType,
+  sourceUrl,
   locale,
   latest,
   report,
 }: Args<CubeQueryOptions>) => {
   const res = await client
-    .query(DataCubeMetadataWithComponentValuesDocument, {
+    .query<
+      DataCubeMetadataWithComponentValuesQuery,
+      DataCubeMetadataWithComponentValuesQueryVariables
+    >(DataCubeMetadataWithComponentValuesDocument, {
       iri,
       sourceType,
+      sourceUrl,
       locale,
       latest,
     })


### PR DESCRIPTION
When selecting a dimension for segmentation, due to missing sourceUrl and sourceType in the client.query call, we would not retrieve the hierarchy and select 7 values without care for the hierarchy. Now we select 7 leaves.
I've added also proper types to client.query calls so now we are warned.