### PR TITLE
DnD empty groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 You can also check the [release page](https://github.com/visualize-admin/visualization-tool/releases)
 
+## Unreleased
+
+- Fixed organization search
+- Explanation on how to create groups for tables
+
 ## [3.7.7] - 2022-08-17
 
 - Add an option to see cubes from different LINDAS environments within one Visualize instance

--- a/app/configurator/components/chart-controls/drag-and-drop-tab.tsx
+++ b/app/configurator/components/chart-controls/drag-and-drop-tab.tsx
@@ -22,6 +22,7 @@ type Props = {
   items: TableColumn[];
   metaData: DataCubeMetadata;
   isDropDisabled?: boolean;
+  emptyComponent?: React.ReactNode;
 };
 export const TabDropZone = ({
   id,
@@ -29,6 +30,7 @@ export const TabDropZone = ({
   title,
   metaData,
   isDropDisabled,
+  emptyComponent,
 }: Props) => {
   const { dimensions, measures } = metaData;
 
@@ -52,6 +54,7 @@ export const TabDropZone = ({
                 sx={{ p: 0, minHeight: 60, position: "relative" }}
                 ref={innerRef}
               >
+                {items.length === 0 && emptyComponent ? emptyComponent : null}
                 {items.map(({ componentIri, index, isHidden }, i) => {
                   return (
                     <Draggable

--- a/app/configurator/table/table-chart-configurator.tsx
+++ b/app/configurator/table/table-chart-configurator.tsx
@@ -1,5 +1,6 @@
 import { Trans } from "@lingui/macro";
-import { Divider } from "@mui/material";
+import { Divider, Theme, Typography } from "@mui/material";
+import { makeStyles } from "@mui/styles";
 import { useCallback, useState } from "react";
 import {
   DragDropContext,
@@ -24,6 +25,29 @@ import { useDataCubeMetadataWithComponentValuesQuery } from "@/graphql/query-hoo
 import { useLocale } from "@/locales/use-locale";
 
 import { ChartTypeSelector } from "../components/chart-type-selector";
+
+const useStyles = makeStyles((theme: Theme) => ({
+  emptyGroups: {
+    textAlign: "center",
+    border: "1px dashed",
+    borderColor: theme.palette.divider,
+    margin: theme.spacing(2),
+    color: theme.palette.text.secondary,
+    borderRadius: 8,
+    padding: theme.spacing(2),
+  },
+}));
+
+const EmptyGroups = () => {
+  const classes = useStyles();
+  return (
+    <Typography variant="body2" component="div" className={classes.emptyGroups}>
+      <Trans id="controls.groups.empty-help">
+        Drag and drop columns here to make groups.
+      </Trans>
+    </Typography>
+  );
+};
 
 export const ChartConfiguratorTable = ({
   state,
@@ -131,6 +155,7 @@ export const ChartConfiguratorTable = ({
             metaData={data.dataCubeByIri}
             items={groupFields}
             isDropDisabled={isGroupsDropDisabled}
+            emptyComponent={<EmptyGroups />}
           ></TabDropZone>
 
           <TabDropZone

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -13,23 +13,24 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:631
+#: app/configurator/components/chart-configurator.tsx:646
 msgid "Add filter"
 msgstr "Filter hinzufügen"
 
-#: app/configurator/components/chart-configurator.tsx:604
+#: app/configurator/components/chart-configurator.tsx:619
 msgid "Drag filters to reorganize"
 msgstr "Ziehen Sie die Filter per Drag & Drop, um sie neu zu organisieren"
 
-#: app/configurator/components/chart-configurator.tsx:601
+#: app/configurator/components/chart-configurator.tsx:616
 msgid "Move filter down"
 msgstr "Filter nach unten verschieben"
 
-#: app/configurator/components/chart-configurator.tsx:598
+#: app/configurator/components/chart-configurator.tsx:613
 msgid "Move filter up"
 msgstr "Filter nach oben verschieben"
 
 #: app/configurator/components/dataset-browse.tsx:970
+#: app/configurator/components/filters.tsx:654
 msgid "No results"
 msgstr "Kein Ergebnis"
 
@@ -70,23 +71,23 @@ msgstr "Zurück"
 msgid "button.copy.visualization"
 msgstr "Diese Visualisierung kopieren und editieren"
 
-#: app/components/data-download.tsx:192
+#: app/components/data-download.tsx:193
 msgid "button.download"
 msgstr "Herunterladen"
 
-#: app/components/data-download.tsx:182
+#: app/components/data-download.tsx:183
 msgid "button.download.data"
 msgstr "Daten herunterladen"
 
-#: app/components/data-download.tsx:212
+#: app/components/data-download.tsx:213
 msgid "button.download.data.all"
 msgstr "Vollständiger Datensatz"
 
-#: app/components/data-download.tsx:203
+#: app/components/data-download.tsx:204
 msgid "button.download.data.visible"
 msgstr "Gefilterter Datensatz"
 
-#: app/components/data-download.tsx:362
+#: app/components/data-download.tsx:366
 msgid "button.download.runsparqlquery.visible"
 msgstr "SPARQL-Abfrage ausführen"
 
@@ -120,55 +121,55 @@ msgid "button.share"
 msgstr "Teilen"
 
 #: app/configurator/components/ui-helpers.ts:562
-#: app/configurator/map/map-chart-options.tsx:168
+#: app/configurator/map/map-chart-options.tsx:187
 msgid "chart.map.layers.area"
 msgstr "Flächen"
 
-#: app/configurator/map/map-chart-options.tsx:252
+#: app/configurator/map/map-chart-options.tsx:253
 msgid "chart.map.layers.area.discretization.continuous"
 msgstr "Kontinuierlich"
 
-#: app/configurator/map/map-chart-options.tsx:265
+#: app/configurator/map/map-chart-options.tsx:266
 msgid "chart.map.layers.area.discretization.discrete"
 msgstr "Diskret"
 
-#: app/configurator/map/map-chart-options.tsx:313
+#: app/configurator/map/map-chart-options.tsx:311
 msgid "chart.map.layers.area.discretization.jenks"
 msgstr "Jenks (Natural Breaks)"
 
-#: app/configurator/map/map-chart-options.tsx:306
+#: app/configurator/map/map-chart-options.tsx:304
 msgid "chart.map.layers.area.discretization.quantiles"
 msgstr "Quantile (gleiche Anzahl Werte)"
 
-#: app/configurator/map/map-chart-options.tsx:299
+#: app/configurator/map/map-chart-options.tsx:297
 msgid "chart.map.layers.area.discretization.quantize"
 msgstr "Quantisierung (gleiche Wertebereiche)"
 
-#: app/configurator/components/chart-configurator.tsx:679
+#: app/configurator/components/chart-configurator.tsx:695
 #: app/configurator/components/ui-helpers.ts:558
-#: app/configurator/map/map-chart-options.tsx:65
+#: app/configurator/map/map-chart-options.tsx:97
 msgid "chart.map.layers.base"
 msgstr "Kartenanzeige"
 
-#: app/configurator/map/map-chart-options.tsx:69
+#: app/configurator/map/map-chart-options.tsx:101
 msgid "chart.map.layers.base.show"
 msgstr "Weltkarte anzeigen"
 
-#: app/configurator/map/map-chart-options.tsx:110
+#: app/configurator/map/map-chart-options.tsx:109
 msgid "chart.map.layers.base.view.locked"
 msgstr "Gesperrte Ansicht"
 
-#: app/configurator/map/map-chart-options.tsx:172
-#: app/configurator/map/map-chart-options.tsx:396
+#: app/configurator/map/map-chart-options.tsx:191
+#: app/configurator/map/map-chart-options.tsx:391
 msgid "chart.map.layers.show"
 msgstr "Ebene anzeigen"
 
 #: app/configurator/components/ui-helpers.ts:566
-#: app/configurator/map/map-chart-options.tsx:392
+#: app/configurator/map/map-chart-options.tsx:387
 msgid "chart.map.layers.symbol"
 msgstr "Symbole"
 
-#: app/configurator/map/map-chart-options.tsx:480
+#: app/configurator/map/map-chart-options.tsx:475
 msgid "chart.map.warning.noGeoDimensions"
 msgstr "In diesem Datenset können keine geografischen Dimensionen angezeigt werden."
 
@@ -251,7 +252,7 @@ msgstr "Tabelle"
 
 #: app/configurator/components/ui-helpers.ts:544
 #: app/configurator/map/map-chart-options.tsx:241
-#: app/configurator/map/map-chart-options.tsx:446
+#: app/configurator/map/map-chart-options.tsx:441
 msgid "controls.color"
 msgstr "Farbe"
 
@@ -264,7 +265,7 @@ msgstr "Hinzufügen …"
 msgid "controls.color.palette"
 msgstr "Farbpalette"
 
-#: app/configurator/components/chart-controls/color-palette.tsx:239
+#: app/configurator/components/chart-controls/color-palette.tsx:237
 msgid "controls.color.palette.reset"
 msgstr "Farbpalette zurücksetzen"
 
@@ -272,7 +273,7 @@ msgstr "Farbpalette zurücksetzen"
 msgid "controls.color.palette.sequential"
 msgstr "Sequentiell"
 
-#: app/configurator/map/map-chart-options.tsx:450
+#: app/configurator/map/map-chart-options.tsx:445
 msgid "controls.color.select"
 msgstr "Farbe auswählen"
 
@@ -292,8 +293,8 @@ msgstr "Gestapelt"
 msgid "controls.description"
 msgstr "Beschreibung hinzufügen"
 
-#: app/configurator/map/map-chart-options.tsx:183
-#: app/configurator/map/map-chart-options.tsx:407
+#: app/configurator/map/map-chart-options.tsx:202
+#: app/configurator/map/map-chart-options.tsx:402
 msgid "controls.dimension.geographical"
 msgstr "Geografische Dimension"
 
@@ -302,49 +303,53 @@ msgid "controls.dimension.none"
 msgstr "Keine"
 
 #: app/charts/shared/chart-data-filters.tsx:214
-#: app/configurator/components/field.tsx:125
-#: app/configurator/components/field.tsx:182
-#: app/configurator/components/field.tsx:282
+#: app/configurator/components/field.tsx:126
+#: app/configurator/components/field.tsx:183
+#: app/configurator/components/field.tsx:283
 msgid "controls.dimensionvalue.none"
 msgstr "Kein Filter"
 
-#: app/configurator/components/filters.tsx:383
+#: app/configurator/components/filters.tsx:412
 msgid "controls.filter.nb-elements"
 msgstr "{0} von {1}"
 
-#: app/configurator/components/filters.tsx:339
-#: app/configurator/components/filters.tsx:542
+#: app/configurator/components/filters.tsx:366
+#: app/configurator/components/filters.tsx:586
 msgid "controls.filter.select.all"
 msgstr "Alle auswählen"
 
-#: app/configurator/components/filters.tsx:346
-#: app/configurator/components/filters.tsx:540
+#: app/configurator/components/filters.tsx:373
+#: app/configurator/components/filters.tsx:584
 msgid "controls.filter.select.none"
 msgstr "Alle abwählen"
 
-#: app/configurator/components/filters.tsx:356
+#: app/configurator/components/filters.tsx:383
 msgid "controls.filters.select.filters"
 msgstr "Filter"
 
-#: app/configurator/components/filters.tsx:368
+#: app/configurator/components/filters.tsx:396
 msgid "controls.filters.select.refresh-colors"
 msgstr "Farben auffrischen"
 
-#: app/configurator/components/filters.tsx:363
+#: app/configurator/components/filters.tsx:390
 msgid "controls.filters.select.selected-filters"
 msgstr "Ausgewählte Filter"
 
-#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:123
+#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:127
 msgid "controls.filters.time.range"
 msgstr "Zeitspanne"
 
+#: app/configurator/table/table-chart-configurator.tsx:45
+msgid "controls.groups.empty-help"
+msgstr "Ziehen Sie Spalten hierher, um Gruppen zu erstellen."
+
 #: app/configurator/map/map-chart-options.tsx:204
-msgid "controls.hierarchy"
-msgstr "Hierarchie-Ebene"
+#~ msgid "controls.hierarchy"
+#~ msgstr "Hierarchie-Ebene"
 
 #: app/configurator/map/map-chart-options.tsx:209
-msgid "controls.hierarchy.select"
-msgstr "Hierarchie-Ebene auswählen"
+#~ msgid "controls.hierarchy.select"
+#~ msgstr "Hierarchie-Ebene auswählen"
 
 #: app/configurator/components/empty-right-panel.tsx:24
 msgid "controls.hint.configuring.chart"
@@ -358,18 +363,18 @@ msgstr "Bitte ein Beschreibungsfeld auswählen, um dieses zu bearbeiten."
 msgid "controls.imputation"
 msgstr "Imputationstyp"
 
-#: app/configurator/components/chart-options-selector.tsx:530
+#: app/configurator/components/chart-options-selector.tsx:531
 #: app/configurator/components/ui-helpers.ts:618
 msgid "controls.imputation.type.linear"
 msgstr "Lineare Interpolation"
 
-#: app/configurator/components/chart-options-selector.tsx:523
-#: app/configurator/components/chart-options-selector.tsx:535
+#: app/configurator/components/chart-options-selector.tsx:524
+#: app/configurator/components/chart-options-selector.tsx:536
 #: app/configurator/components/ui-helpers.ts:610
 msgid "controls.imputation.type.none"
 msgstr "-"
 
-#: app/configurator/components/chart-options-selector.tsx:525
+#: app/configurator/components/chart-options-selector.tsx:526
 #: app/configurator/components/ui-helpers.ts:614
 msgid "controls.imputation.type.zeros"
 msgstr "Nullen"
@@ -412,7 +417,7 @@ msgstr "Italienisch"
 
 #: app/configurator/components/ui-helpers.ts:536
 #: app/configurator/map/map-chart-options.tsx:223
-#: app/configurator/map/map-chart-options.tsx:428
+#: app/configurator/map/map-chart-options.tsx:423
 msgid "controls.measure"
 msgstr "Messwert"
 
@@ -424,11 +429,11 @@ msgstr "Ein"
 msgid "controls.option.isNotActive"
 msgstr "Aus"
 
-#: app/configurator/map/map-chart-options.tsx:245
+#: app/configurator/map/map-chart-options.tsx:246
 msgid "controls.scale.type"
 msgstr "Skalierungstyp"
 
-#: app/components/form.tsx:480
+#: app/components/form.tsx:470
 msgid "controls.search.clear"
 msgstr "Suche zurücksetzen"
 
@@ -436,11 +441,11 @@ msgstr "Suche zurücksetzen"
 msgid "controls.section.additional-information"
 msgstr "Zusätzliche Informationen"
 
-#: app/configurator/components/chart-configurator.tsx:542
+#: app/configurator/components/chart-configurator.tsx:552
 msgid "controls.section.chart.options"
 msgstr "Diagramm-Einstellungen"
 
-#: app/configurator/table/table-chart-configurator.tsx:128
+#: app/configurator/table/table-chart-configurator.tsx:163
 msgid "controls.section.columns"
 msgstr "Spalten"
 
@@ -448,7 +453,7 @@ msgstr "Spalten"
 msgid "controls.section.columnstyle"
 msgstr "Spaltenstil"
 
-#: app/configurator/components/chart-configurator.tsx:557
+#: app/configurator/components/chart-configurator.tsx:569
 msgid "controls.section.data.filters"
 msgstr "Filter"
 
@@ -465,15 +470,15 @@ msgstr "Titel & Beschreibung"
 msgid "controls.section.filter"
 msgstr "Filter"
 
-#: app/configurator/table/table-chart-configurator.tsx:120
+#: app/configurator/table/table-chart-configurator.tsx:154
 msgid "controls.section.groups"
 msgstr "Gruppierungen"
 
-#: app/configurator/components/chart-options-selector.tsx:564
+#: app/configurator/components/chart-options-selector.tsx:565
 msgid "controls.section.imputation"
 msgstr "Fehlende Werte"
 
-#: app/configurator/components/chart-options-selector.tsx:569
+#: app/configurator/components/chart-options-selector.tsx:570
 msgid "controls.section.imputation.explanation"
 msgstr "Für diesen Diagrammtyp sollten fehlenden Werten Ersatzwerte zugewiesen werden. Entscheiden Sie sich für die Imputationslogik oder wechseln Sie zu einem anderen Diagrammtyp."
 
@@ -489,7 +494,7 @@ msgstr "Datenfilter"
 msgid "controls.section.show-standard-error"
 msgstr "Standardfehler anzeigen"
 
-#: app/configurator/components/chart-options-selector.tsx:451
+#: app/configurator/components/chart-options-selector.tsx:452
 msgid "controls.section.sorting"
 msgstr "Sortieren"
 
@@ -501,15 +506,17 @@ msgstr "Tabelleneinstellungen"
 msgid "controls.section.tableSorting"
 msgstr "Tabellensortierung"
 
-#: app/configurator/table/table-chart-configurator.tsx:96
+#: app/configurator/table/table-chart-configurator.tsx:130
 msgid "controls.section.tableoptions"
 msgstr "Tabellenoptionen"
 
-#: app/configurator/components/chart-type-selector.tsx:141
+#: app/configurator/components/chart-configurator.tsx:545
+#: app/configurator/components/chart-type-selector.tsx:161
+#: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
 msgstr "Diagrammtyp"
 
-#: app/configurator/components/chart-options-selector.tsx:361
+#: app/configurator/components/chart-options-selector.tsx:362
 msgid "controls.select.column.layout"
 msgstr "Spaltenstil"
 
@@ -546,14 +553,14 @@ msgid "controls.select.columnStyle.textStyle"
 msgstr "Schriftstil"
 
 #: app/configurator/components/chart-options-selector.tsx:192
-#: app/configurator/map/map-chart-options.tsx:191
-#: app/configurator/map/map-chart-options.tsx:415
+#: app/configurator/map/map-chart-options.tsx:210
+#: app/configurator/map/map-chart-options.tsx:410
 msgid "controls.select.dimension"
 msgstr "Dimension auswählen"
 
 #: app/configurator/components/chart-options-selector.tsx:193
 #: app/configurator/map/map-chart-options.tsx:228
-#: app/configurator/map/map-chart-options.tsx:433
+#: app/configurator/map/map-chart-options.tsx:428
 msgid "controls.select.measure"
 msgstr "Messwert auswählen"
 
@@ -564,15 +571,15 @@ msgstr "Messwert auswählen"
 msgid "controls.select.optional"
 msgstr "optional"
 
-#: app/configurator/components/filters.tsx:584
+#: app/configurator/components/filters.tsx:636
 msgid "controls.set-filters"
 msgstr "Ausgewählte Filter"
 
-#: app/configurator/components/filters.tsx:591
+#: app/configurator/components/filters.tsx:643
 msgid "controls.set-filters-caption"
 msgstr "Für beste Ergebnisse wählen Sie nicht mehr als 7 Werte für die Visualisierung aus"
 
-#: app/configurator/components/filters.tsx:622
+#: app/configurator/components/filters.tsx:675
 msgid "controls.set-values-apply"
 msgstr "Filter anwenden"
 
@@ -580,8 +587,8 @@ msgstr "Filter anwenden"
 msgid "controls.sorting.addDimension"
 msgstr "Dimension hinzufügen"
 
-#: app/configurator/components/chart-options-selector.tsx:402
-#: app/configurator/components/chart-options-selector.tsx:408
+#: app/configurator/components/chart-options-selector.tsx:403
+#: app/configurator/components/chart-options-selector.tsx:409
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Name"
 
@@ -593,7 +600,7 @@ msgstr "A → Z"
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
-#: app/configurator/components/chart-options-selector.tsx:404
+#: app/configurator/components/chart-options-selector.tsx:405
 msgid "controls.sorting.byMeasure"
 msgstr "Messwert"
 
@@ -605,7 +612,7 @@ msgstr "1 → 9"
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
-#: app/configurator/components/chart-options-selector.tsx:406
+#: app/configurator/components/chart-options-selector.tsx:407
 msgid "controls.sorting.byTotalSize"
 msgstr "Gesamtgrösse"
 
@@ -638,7 +645,7 @@ msgstr "Wählen Sie eine Dimension aus …"
 msgid "controls.sorting.sortBy"
 msgstr "Sortieren nach"
 
-#: app/configurator/components/chart-type-selector.tsx:145
+#: app/configurator/components/chart-type-selector.tsx:166
 msgid "controls.switch.chart.type"
 msgstr "Wechseln Sie zu einem anderen Diagrammtyp unter Beibehaltung der meisten Filtereinstellungen"
 
@@ -650,11 +657,11 @@ msgstr "Gruppieren"
 msgid "controls.table.column.hide"
 msgstr "Spalte ausblenden"
 
-#: app/configurator/table/table-chart-configurator.tsx:107
+#: app/configurator/table/table-chart-configurator.tsx:141
 msgid "controls.table.settings"
 msgstr "Einstellungen"
 
-#: app/configurator/table/table-chart-configurator.tsx:113
+#: app/configurator/table/table-chart-configurator.tsx:147
 msgid "controls.table.sorting"
 msgstr "Sortierung"
 
@@ -678,7 +685,7 @@ msgstr "Cube Checker hilft Ihnen zu verstehen, ob ein Cube alle hat notwendige A
 msgid "cube-checker.field-placeholder"
 msgstr "Cube IRI"
 
-#: app/components/data-source-menu.tsx:113
+#: app/components/data-source-menu.tsx:119
 msgid "data.source"
 msgstr "Datenquelle"
 
@@ -829,7 +836,7 @@ msgstr "Sie können diese Visualisierung teilen oder sie einbetten. Zudem könne
 msgid "hint.loading.data"
 msgstr "Lade Daten …"
 
-#: app/configurator/components/chart-type-selector.tsx:155
+#: app/configurator/components/chart-type-selector.tsx:179
 msgid "hint.no.visualization.with.dataset"
 msgstr "Mit dem ausgewählten Datensatz kann keine Visualisierung erstellt werden."
 
@@ -922,7 +929,7 @@ msgstr "Hier ist eine Visualisierung, die ich mit visualize.admin.ch erstellt ha
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
-#: app/configurator/components/filters.tsx:516
+#: app/configurator/components/filters.tsx:560
 msgid "select.controls.filters.search"
 msgstr "Suche"
 
@@ -934,6 +941,6 @@ msgstr "Bevor Sie Veröffentlichen, fügen Sie Ihrem Diagramm einen Titel und ei
 msgid "step.visualize"
 msgstr "Passen Sie Ihre Visualisierung an, indem Sie die Filter- und Farbsegmentierungsoptionen in den Seitenleisten verwenden."
 
-#: app/configurator/components/chart-controls/drag-and-drop-tab.tsx:85
+#: app/configurator/components/chart-controls/drag-and-drop-tab.tsx:88
 msgid "table.column.no"
 msgstr "Spalte {0}"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -13,23 +13,24 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:631
+#: app/configurator/components/chart-configurator.tsx:646
 msgid "Add filter"
 msgstr "Add filter"
 
-#: app/configurator/components/chart-configurator.tsx:604
+#: app/configurator/components/chart-configurator.tsx:619
 msgid "Drag filters to reorganize"
 msgstr "Drag filters to reorganize"
 
-#: app/configurator/components/chart-configurator.tsx:601
+#: app/configurator/components/chart-configurator.tsx:616
 msgid "Move filter down"
 msgstr "Move filter down"
 
-#: app/configurator/components/chart-configurator.tsx:598
+#: app/configurator/components/chart-configurator.tsx:613
 msgid "Move filter up"
 msgstr "Move filter up"
 
 #: app/configurator/components/dataset-browse.tsx:970
+#: app/configurator/components/filters.tsx:654
 msgid "No results"
 msgstr "No results"
 
@@ -70,23 +71,23 @@ msgstr "Back"
 msgid "button.copy.visualization"
 msgstr "Copy and edit this visualization"
 
-#: app/components/data-download.tsx:192
+#: app/components/data-download.tsx:193
 msgid "button.download"
 msgstr "Download"
 
-#: app/components/data-download.tsx:182
+#: app/components/data-download.tsx:183
 msgid "button.download.data"
 msgstr "Download data"
 
-#: app/components/data-download.tsx:212
+#: app/components/data-download.tsx:213
 msgid "button.download.data.all"
 msgstr "Full dataset"
 
-#: app/components/data-download.tsx:203
+#: app/components/data-download.tsx:204
 msgid "button.download.data.visible"
 msgstr "Filtered dataset"
 
-#: app/components/data-download.tsx:362
+#: app/components/data-download.tsx:366
 msgid "button.download.runsparqlquery.visible"
 msgstr "Run SPARQL query"
 
@@ -120,55 +121,55 @@ msgid "button.share"
 msgstr "Share"
 
 #: app/configurator/components/ui-helpers.ts:562
-#: app/configurator/map/map-chart-options.tsx:168
+#: app/configurator/map/map-chart-options.tsx:187
 msgid "chart.map.layers.area"
 msgstr "Areas"
 
-#: app/configurator/map/map-chart-options.tsx:252
+#: app/configurator/map/map-chart-options.tsx:253
 msgid "chart.map.layers.area.discretization.continuous"
 msgstr "Continuous"
 
-#: app/configurator/map/map-chart-options.tsx:265
+#: app/configurator/map/map-chart-options.tsx:266
 msgid "chart.map.layers.area.discretization.discrete"
 msgstr "Discrete"
 
-#: app/configurator/map/map-chart-options.tsx:313
+#: app/configurator/map/map-chart-options.tsx:311
 msgid "chart.map.layers.area.discretization.jenks"
 msgstr "Jenks (natural breaks)"
 
-#: app/configurator/map/map-chart-options.tsx:306
+#: app/configurator/map/map-chart-options.tsx:304
 msgid "chart.map.layers.area.discretization.quantiles"
 msgstr "Quantiles (equal distribution of values)"
 
-#: app/configurator/map/map-chart-options.tsx:299
+#: app/configurator/map/map-chart-options.tsx:297
 msgid "chart.map.layers.area.discretization.quantize"
 msgstr "Quantize (equal intervals)"
 
-#: app/configurator/components/chart-configurator.tsx:679
+#: app/configurator/components/chart-configurator.tsx:695
 #: app/configurator/components/ui-helpers.ts:558
-#: app/configurator/map/map-chart-options.tsx:65
+#: app/configurator/map/map-chart-options.tsx:97
 msgid "chart.map.layers.base"
 msgstr "Map Display"
 
-#: app/configurator/map/map-chart-options.tsx:69
+#: app/configurator/map/map-chart-options.tsx:101
 msgid "chart.map.layers.base.show"
 msgstr "Show Worldmap"
 
-#: app/configurator/map/map-chart-options.tsx:110
+#: app/configurator/map/map-chart-options.tsx:109
 msgid "chart.map.layers.base.view.locked"
 msgstr "Locked view"
 
-#: app/configurator/map/map-chart-options.tsx:172
-#: app/configurator/map/map-chart-options.tsx:396
+#: app/configurator/map/map-chart-options.tsx:191
+#: app/configurator/map/map-chart-options.tsx:391
 msgid "chart.map.layers.show"
 msgstr "Show layer"
 
 #: app/configurator/components/ui-helpers.ts:566
-#: app/configurator/map/map-chart-options.tsx:392
+#: app/configurator/map/map-chart-options.tsx:387
 msgid "chart.map.layers.symbol"
 msgstr "Symbols"
 
-#: app/configurator/map/map-chart-options.tsx:480
+#: app/configurator/map/map-chart-options.tsx:475
 msgid "chart.map.warning.noGeoDimensions"
 msgstr "In this dataset there are no geographical dimensions to display."
 
@@ -251,7 +252,7 @@ msgstr "Table"
 
 #: app/configurator/components/ui-helpers.ts:544
 #: app/configurator/map/map-chart-options.tsx:241
-#: app/configurator/map/map-chart-options.tsx:446
+#: app/configurator/map/map-chart-options.tsx:441
 msgid "controls.color"
 msgstr "Color"
 
@@ -264,7 +265,7 @@ msgstr "Add ..."
 msgid "controls.color.palette"
 msgstr "Color palette"
 
-#: app/configurator/components/chart-controls/color-palette.tsx:239
+#: app/configurator/components/chart-controls/color-palette.tsx:237
 msgid "controls.color.palette.reset"
 msgstr "Reset color palette"
 
@@ -272,7 +273,7 @@ msgstr "Reset color palette"
 msgid "controls.color.palette.sequential"
 msgstr "Sequential"
 
-#: app/configurator/map/map-chart-options.tsx:450
+#: app/configurator/map/map-chart-options.tsx:445
 msgid "controls.color.select"
 msgstr "Select a color"
 
@@ -292,8 +293,8 @@ msgstr "Stacked"
 msgid "controls.description"
 msgstr "Description"
 
-#: app/configurator/map/map-chart-options.tsx:183
-#: app/configurator/map/map-chart-options.tsx:407
+#: app/configurator/map/map-chart-options.tsx:202
+#: app/configurator/map/map-chart-options.tsx:402
 msgid "controls.dimension.geographical"
 msgstr "Geographical dimension"
 
@@ -302,49 +303,53 @@ msgid "controls.dimension.none"
 msgstr "None"
 
 #: app/charts/shared/chart-data-filters.tsx:214
-#: app/configurator/components/field.tsx:125
-#: app/configurator/components/field.tsx:182
-#: app/configurator/components/field.tsx:282
+#: app/configurator/components/field.tsx:126
+#: app/configurator/components/field.tsx:183
+#: app/configurator/components/field.tsx:283
 msgid "controls.dimensionvalue.none"
 msgstr "No Filter"
 
-#: app/configurator/components/filters.tsx:383
+#: app/configurator/components/filters.tsx:412
 msgid "controls.filter.nb-elements"
 msgstr "{0} of {1}"
 
-#: app/configurator/components/filters.tsx:339
-#: app/configurator/components/filters.tsx:542
+#: app/configurator/components/filters.tsx:366
+#: app/configurator/components/filters.tsx:586
 msgid "controls.filter.select.all"
 msgstr "Select all"
 
-#: app/configurator/components/filters.tsx:346
-#: app/configurator/components/filters.tsx:540
+#: app/configurator/components/filters.tsx:373
+#: app/configurator/components/filters.tsx:584
 msgid "controls.filter.select.none"
 msgstr "Select none"
 
-#: app/configurator/components/filters.tsx:356
+#: app/configurator/components/filters.tsx:383
 msgid "controls.filters.select.filters"
 msgstr "Filters"
 
-#: app/configurator/components/filters.tsx:368
+#: app/configurator/components/filters.tsx:396
 msgid "controls.filters.select.refresh-colors"
 msgstr "Refresh colors"
 
-#: app/configurator/components/filters.tsx:363
+#: app/configurator/components/filters.tsx:390
 msgid "controls.filters.select.selected-filters"
 msgstr "Selected filters"
 
-#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:123
+#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:127
 msgid "controls.filters.time.range"
 msgstr "Time Range"
 
+#: app/configurator/table/table-chart-configurator.tsx:45
+msgid "controls.groups.empty-help"
+msgstr "Drag and drop columns here to make groups."
+
 #: app/configurator/map/map-chart-options.tsx:204
-msgid "controls.hierarchy"
-msgstr "Hierarchy level"
+#~ msgid "controls.hierarchy"
+#~ msgstr "Hierarchy level"
 
 #: app/configurator/map/map-chart-options.tsx:209
-msgid "controls.hierarchy.select"
-msgstr "Select a hierarchy level"
+#~ msgid "controls.hierarchy.select"
+#~ msgstr "Select a hierarchy level"
 
 #: app/configurator/components/empty-right-panel.tsx:24
 msgid "controls.hint.configuring.chart"
@@ -358,18 +363,18 @@ msgstr "Select an annotation field to modify its content."
 msgid "controls.imputation"
 msgstr "Imputation type"
 
-#: app/configurator/components/chart-options-selector.tsx:530
+#: app/configurator/components/chart-options-selector.tsx:531
 #: app/configurator/components/ui-helpers.ts:618
 msgid "controls.imputation.type.linear"
 msgstr "Linear interpolation"
 
-#: app/configurator/components/chart-options-selector.tsx:523
-#: app/configurator/components/chart-options-selector.tsx:535
+#: app/configurator/components/chart-options-selector.tsx:524
+#: app/configurator/components/chart-options-selector.tsx:536
 #: app/configurator/components/ui-helpers.ts:610
 msgid "controls.imputation.type.none"
 msgstr "-"
 
-#: app/configurator/components/chart-options-selector.tsx:525
+#: app/configurator/components/chart-options-selector.tsx:526
 #: app/configurator/components/ui-helpers.ts:614
 msgid "controls.imputation.type.zeros"
 msgstr "Zeros"
@@ -412,7 +417,7 @@ msgstr "Italian"
 
 #: app/configurator/components/ui-helpers.ts:536
 #: app/configurator/map/map-chart-options.tsx:223
-#: app/configurator/map/map-chart-options.tsx:428
+#: app/configurator/map/map-chart-options.tsx:423
 msgid "controls.measure"
 msgstr "Measure"
 
@@ -424,11 +429,11 @@ msgstr "On"
 msgid "controls.option.isNotActive"
 msgstr "Off"
 
-#: app/configurator/map/map-chart-options.tsx:245
+#: app/configurator/map/map-chart-options.tsx:246
 msgid "controls.scale.type"
 msgstr "Scale type"
 
-#: app/components/form.tsx:480
+#: app/components/form.tsx:470
 msgid "controls.search.clear"
 msgstr "Clear search field"
 
@@ -436,11 +441,11 @@ msgstr "Clear search field"
 msgid "controls.section.additional-information"
 msgstr "Additional information"
 
-#: app/configurator/components/chart-configurator.tsx:542
+#: app/configurator/components/chart-configurator.tsx:552
 msgid "controls.section.chart.options"
 msgstr "Chart Options"
 
-#: app/configurator/table/table-chart-configurator.tsx:128
+#: app/configurator/table/table-chart-configurator.tsx:163
 msgid "controls.section.columns"
 msgstr "Columns"
 
@@ -448,7 +453,7 @@ msgstr "Columns"
 msgid "controls.section.columnstyle"
 msgstr "Column Style"
 
-#: app/configurator/components/chart-configurator.tsx:557
+#: app/configurator/components/chart-configurator.tsx:569
 msgid "controls.section.data.filters"
 msgstr "Filters"
 
@@ -465,15 +470,15 @@ msgstr "Title & Description"
 msgid "controls.section.filter"
 msgstr "Filter"
 
-#: app/configurator/table/table-chart-configurator.tsx:120
+#: app/configurator/table/table-chart-configurator.tsx:154
 msgid "controls.section.groups"
 msgstr "Groups"
 
-#: app/configurator/components/chart-options-selector.tsx:564
+#: app/configurator/components/chart-options-selector.tsx:565
 msgid "controls.section.imputation"
 msgstr "Missing values"
 
-#: app/configurator/components/chart-options-selector.tsx:569
+#: app/configurator/components/chart-options-selector.tsx:570
 msgid "controls.section.imputation.explanation"
 msgstr "For this chart type, replacement values should be assigned to missing values. Decide on the imputation logic or switch to another chart type."
 
@@ -489,7 +494,7 @@ msgstr "Data Filters"
 msgid "controls.section.show-standard-error"
 msgstr "Show standard error"
 
-#: app/configurator/components/chart-options-selector.tsx:451
+#: app/configurator/components/chart-options-selector.tsx:452
 msgid "controls.section.sorting"
 msgstr "Sort"
 
@@ -501,15 +506,17 @@ msgstr "Table Settings"
 msgid "controls.section.tableSorting"
 msgstr "Table Sorting"
 
-#: app/configurator/table/table-chart-configurator.tsx:96
+#: app/configurator/table/table-chart-configurator.tsx:130
 msgid "controls.section.tableoptions"
 msgstr "Table Options"
 
-#: app/configurator/components/chart-type-selector.tsx:141
+#: app/configurator/components/chart-configurator.tsx:545
+#: app/configurator/components/chart-type-selector.tsx:161
+#: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
 msgstr "Chart Type"
 
-#: app/configurator/components/chart-options-selector.tsx:361
+#: app/configurator/components/chart-options-selector.tsx:362
 msgid "controls.select.column.layout"
 msgstr "Column layout"
 
@@ -546,14 +553,14 @@ msgid "controls.select.columnStyle.textStyle"
 msgstr "Text Style"
 
 #: app/configurator/components/chart-options-selector.tsx:192
-#: app/configurator/map/map-chart-options.tsx:191
-#: app/configurator/map/map-chart-options.tsx:415
+#: app/configurator/map/map-chart-options.tsx:210
+#: app/configurator/map/map-chart-options.tsx:410
 msgid "controls.select.dimension"
 msgstr "Select a dimension"
 
 #: app/configurator/components/chart-options-selector.tsx:193
 #: app/configurator/map/map-chart-options.tsx:228
-#: app/configurator/map/map-chart-options.tsx:433
+#: app/configurator/map/map-chart-options.tsx:428
 msgid "controls.select.measure"
 msgstr "Select a measure"
 
@@ -564,15 +571,15 @@ msgstr "Select a measure"
 msgid "controls.select.optional"
 msgstr "optional"
 
-#: app/configurator/components/filters.tsx:584
+#: app/configurator/components/filters.tsx:636
 msgid "controls.set-filters"
 msgstr "Set filters"
 
-#: app/configurator/components/filters.tsx:591
+#: app/configurator/components/filters.tsx:643
 msgid "controls.set-filters-caption"
 msgstr "For best results, do not select more than 7 values in the visualization."
 
-#: app/configurator/components/filters.tsx:622
+#: app/configurator/components/filters.tsx:675
 msgid "controls.set-values-apply"
 msgstr "Apply filters"
 
@@ -580,8 +587,8 @@ msgstr "Apply filters"
 msgid "controls.sorting.addDimension"
 msgstr "Add dimension"
 
-#: app/configurator/components/chart-options-selector.tsx:402
-#: app/configurator/components/chart-options-selector.tsx:408
+#: app/configurator/components/chart-options-selector.tsx:403
+#: app/configurator/components/chart-options-selector.tsx:409
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Name"
 
@@ -593,7 +600,7 @@ msgstr "A → Z"
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
-#: app/configurator/components/chart-options-selector.tsx:404
+#: app/configurator/components/chart-options-selector.tsx:405
 msgid "controls.sorting.byMeasure"
 msgstr "Measure"
 
@@ -605,7 +612,7 @@ msgstr "1 → 9"
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
-#: app/configurator/components/chart-options-selector.tsx:406
+#: app/configurator/components/chart-options-selector.tsx:407
 msgid "controls.sorting.byTotalSize"
 msgstr "Total size"
 
@@ -638,7 +645,7 @@ msgstr "Select a dimension …"
 msgid "controls.sorting.sortBy"
 msgstr "Sort by"
 
-#: app/configurator/components/chart-type-selector.tsx:145
+#: app/configurator/components/chart-type-selector.tsx:166
 msgid "controls.switch.chart.type"
 msgstr "Switch to another chart type while maintaining most filter settings."
 
@@ -650,11 +657,11 @@ msgstr "Use as group"
 msgid "controls.table.column.hide"
 msgstr "Hide column"
 
-#: app/configurator/table/table-chart-configurator.tsx:107
+#: app/configurator/table/table-chart-configurator.tsx:141
 msgid "controls.table.settings"
 msgstr "Settings"
 
-#: app/configurator/table/table-chart-configurator.tsx:113
+#: app/configurator/table/table-chart-configurator.tsx:147
 msgid "controls.table.sorting"
 msgstr "Sorting"
 
@@ -678,7 +685,7 @@ msgstr "Cube checker helps you understand if a cube has all the necessary attrib
 msgid "cube-checker.field-placeholder"
 msgstr "Cube IRI"
 
-#: app/components/data-source-menu.tsx:113
+#: app/components/data-source-menu.tsx:119
 msgid "data.source"
 msgstr "Data source"
 
@@ -829,7 +836,7 @@ msgstr "You can share this visualization by copying the URL or by embedding it o
 msgid "hint.loading.data"
 msgstr "Loading data..."
 
-#: app/configurator/components/chart-type-selector.tsx:155
+#: app/configurator/components/chart-type-selector.tsx:179
 msgid "hint.no.visualization.with.dataset"
 msgstr "No visualization can be created with the selected dataset."
 
@@ -922,7 +929,7 @@ msgstr "Here is a visualization I created using visualize.admin.ch"
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
-#: app/configurator/components/filters.tsx:516
+#: app/configurator/components/filters.tsx:560
 msgid "select.controls.filters.search"
 msgstr "Search"
 
@@ -934,6 +941,6 @@ msgstr "Before publishing, add a title and description to your chart, and choose
 msgid "step.visualize"
 msgstr "Customize your visualization by using the filter and color segmentation options in the sidebars."
 
-#: app/configurator/components/chart-controls/drag-and-drop-tab.tsx:85
+#: app/configurator/components/chart-controls/drag-and-drop-tab.tsx:88
 msgid "table.column.no"
 msgstr "Column {0}"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -13,23 +13,24 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:631
+#: app/configurator/components/chart-configurator.tsx:646
 msgid "Add filter"
 msgstr "Ajouter un filtre"
 
-#: app/configurator/components/chart-configurator.tsx:604
+#: app/configurator/components/chart-configurator.tsx:619
 msgid "Drag filters to reorganize"
 msgstr "Faites glisser les filtres pour les réorganiser"
 
-#: app/configurator/components/chart-configurator.tsx:601
+#: app/configurator/components/chart-configurator.tsx:616
 msgid "Move filter down"
 msgstr "Déplacer le filtre vers le bas"
 
-#: app/configurator/components/chart-configurator.tsx:598
+#: app/configurator/components/chart-configurator.tsx:613
 msgid "Move filter up"
 msgstr "Déplacer le filtre vers le haut"
 
 #: app/configurator/components/dataset-browse.tsx:970
+#: app/configurator/components/filters.tsx:654
 msgid "No results"
 msgstr "Aucun résultat"
 
@@ -70,23 +71,23 @@ msgstr "Précédent"
 msgid "button.copy.visualization"
 msgstr "Copier et éditer cette visualisation"
 
-#: app/components/data-download.tsx:192
+#: app/components/data-download.tsx:193
 msgid "button.download"
 msgstr "Télécharger"
 
-#: app/components/data-download.tsx:182
+#: app/components/data-download.tsx:183
 msgid "button.download.data"
 msgstr "Télécharger des données"
 
-#: app/components/data-download.tsx:212
+#: app/components/data-download.tsx:213
 msgid "button.download.data.all"
 msgstr "Jeu de données complet"
 
-#: app/components/data-download.tsx:203
+#: app/components/data-download.tsx:204
 msgid "button.download.data.visible"
 msgstr "Jeu de données filtrées"
 
-#: app/components/data-download.tsx:362
+#: app/components/data-download.tsx:366
 msgid "button.download.runsparqlquery.visible"
 msgstr "Lancer la requête SPARQL"
 
@@ -120,55 +121,55 @@ msgid "button.share"
 msgstr "Partager"
 
 #: app/configurator/components/ui-helpers.ts:562
-#: app/configurator/map/map-chart-options.tsx:168
+#: app/configurator/map/map-chart-options.tsx:187
 msgid "chart.map.layers.area"
 msgstr "Zones"
 
-#: app/configurator/map/map-chart-options.tsx:252
+#: app/configurator/map/map-chart-options.tsx:253
 msgid "chart.map.layers.area.discretization.continuous"
 msgstr "Continue"
 
-#: app/configurator/map/map-chart-options.tsx:265
+#: app/configurator/map/map-chart-options.tsx:266
 msgid "chart.map.layers.area.discretization.discrete"
 msgstr "Discrète"
 
-#: app/configurator/map/map-chart-options.tsx:313
+#: app/configurator/map/map-chart-options.tsx:311
 msgid "chart.map.layers.area.discretization.jenks"
 msgstr "Jenks (intervalles naturels)"
 
-#: app/configurator/map/map-chart-options.tsx:306
+#: app/configurator/map/map-chart-options.tsx:304
 msgid "chart.map.layers.area.discretization.quantiles"
 msgstr "Quantiles (distribution homogène des valeurs)"
 
-#: app/configurator/map/map-chart-options.tsx:299
+#: app/configurator/map/map-chart-options.tsx:297
 msgid "chart.map.layers.area.discretization.quantize"
 msgstr "Intervalles égaux"
 
-#: app/configurator/components/chart-configurator.tsx:679
+#: app/configurator/components/chart-configurator.tsx:695
 #: app/configurator/components/ui-helpers.ts:558
-#: app/configurator/map/map-chart-options.tsx:65
+#: app/configurator/map/map-chart-options.tsx:97
 msgid "chart.map.layers.base"
 msgstr "Affichage de la carte"
 
-#: app/configurator/map/map-chart-options.tsx:69
+#: app/configurator/map/map-chart-options.tsx:101
 msgid "chart.map.layers.base.show"
 msgstr "Afficher la carte du monde"
 
-#: app/configurator/map/map-chart-options.tsx:110
+#: app/configurator/map/map-chart-options.tsx:109
 msgid "chart.map.layers.base.view.locked"
 msgstr "Carte verrouillée"
 
-#: app/configurator/map/map-chart-options.tsx:172
-#: app/configurator/map/map-chart-options.tsx:396
+#: app/configurator/map/map-chart-options.tsx:191
+#: app/configurator/map/map-chart-options.tsx:391
 msgid "chart.map.layers.show"
 msgstr "Afficher la couche"
 
 #: app/configurator/components/ui-helpers.ts:566
-#: app/configurator/map/map-chart-options.tsx:392
+#: app/configurator/map/map-chart-options.tsx:387
 msgid "chart.map.layers.symbol"
 msgstr "Symboles"
 
-#: app/configurator/map/map-chart-options.tsx:480
+#: app/configurator/map/map-chart-options.tsx:475
 msgid "chart.map.warning.noGeoDimensions"
 msgstr "Dans cet ensemble de données, il n'y a pas de dimensions géographiques à afficher!"
 
@@ -251,7 +252,7 @@ msgstr "Tableau"
 
 #: app/configurator/components/ui-helpers.ts:544
 #: app/configurator/map/map-chart-options.tsx:241
-#: app/configurator/map/map-chart-options.tsx:446
+#: app/configurator/map/map-chart-options.tsx:441
 msgid "controls.color"
 msgstr "Couleur"
 
@@ -264,7 +265,7 @@ msgstr "Ajouter…"
 msgid "controls.color.palette"
 msgstr "Couleurs"
 
-#: app/configurator/components/chart-controls/color-palette.tsx:239
+#: app/configurator/components/chart-controls/color-palette.tsx:237
 msgid "controls.color.palette.reset"
 msgstr "Réinitialiser la palette de couleurs"
 
@@ -272,7 +273,7 @@ msgstr "Réinitialiser la palette de couleurs"
 msgid "controls.color.palette.sequential"
 msgstr "Séquentielle"
 
-#: app/configurator/map/map-chart-options.tsx:450
+#: app/configurator/map/map-chart-options.tsx:445
 msgid "controls.color.select"
 msgstr "Sélectionner une couleur"
 
@@ -292,8 +293,8 @@ msgstr "empilées"
 msgid "controls.description"
 msgstr "Description"
 
-#: app/configurator/map/map-chart-options.tsx:183
-#: app/configurator/map/map-chart-options.tsx:407
+#: app/configurator/map/map-chart-options.tsx:202
+#: app/configurator/map/map-chart-options.tsx:402
 msgid "controls.dimension.geographical"
 msgstr "Dimension géographique"
 
@@ -302,49 +303,53 @@ msgid "controls.dimension.none"
 msgstr "Aucune"
 
 #: app/charts/shared/chart-data-filters.tsx:214
-#: app/configurator/components/field.tsx:125
-#: app/configurator/components/field.tsx:182
-#: app/configurator/components/field.tsx:282
+#: app/configurator/components/field.tsx:126
+#: app/configurator/components/field.tsx:183
+#: app/configurator/components/field.tsx:283
 msgid "controls.dimensionvalue.none"
 msgstr "Aucune filtre"
 
-#: app/configurator/components/filters.tsx:383
+#: app/configurator/components/filters.tsx:412
 msgid "controls.filter.nb-elements"
 msgstr "{0} sur {1}"
 
-#: app/configurator/components/filters.tsx:339
-#: app/configurator/components/filters.tsx:542
+#: app/configurator/components/filters.tsx:366
+#: app/configurator/components/filters.tsx:586
 msgid "controls.filter.select.all"
 msgstr "Tout sélectionner"
 
-#: app/configurator/components/filters.tsx:346
-#: app/configurator/components/filters.tsx:540
+#: app/configurator/components/filters.tsx:373
+#: app/configurator/components/filters.tsx:584
 msgid "controls.filter.select.none"
 msgstr "Tout déselectionner"
 
-#: app/configurator/components/filters.tsx:356
+#: app/configurator/components/filters.tsx:383
 msgid "controls.filters.select.filters"
 msgstr "Filtres"
 
-#: app/configurator/components/filters.tsx:368
+#: app/configurator/components/filters.tsx:396
 msgid "controls.filters.select.refresh-colors"
 msgstr "Renouveller les couleurs"
 
-#: app/configurator/components/filters.tsx:363
+#: app/configurator/components/filters.tsx:390
 msgid "controls.filters.select.selected-filters"
 msgstr "Filtres sélectionnés"
 
-#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:123
+#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:127
 msgid "controls.filters.time.range"
 msgstr "Intervalle de temps"
 
+#: app/configurator/table/table-chart-configurator.tsx:45
+msgid "controls.groups.empty-help"
+msgstr "Glisser-déposer des colonnes ici pour créer des groupes."
+
 #: app/configurator/map/map-chart-options.tsx:204
-msgid "controls.hierarchy"
-msgstr "Niveau hiérarchique"
+#~ msgid "controls.hierarchy"
+#~ msgstr "Niveau hiérarchique"
 
 #: app/configurator/map/map-chart-options.tsx:209
-msgid "controls.hierarchy.select"
-msgstr "Sélectionner le niveau hiérarchique"
+#~ msgid "controls.hierarchy.select"
+#~ msgstr "Sélectionner le niveau hiérarchique"
 
 #: app/configurator/components/empty-right-panel.tsx:24
 msgid "controls.hint.configuring.chart"
@@ -358,18 +363,18 @@ msgstr "Sélectionnez une des annotations proposées pour la modifier."
 msgid "controls.imputation"
 msgstr "Type d'imputation"
 
-#: app/configurator/components/chart-options-selector.tsx:530
+#: app/configurator/components/chart-options-selector.tsx:531
 #: app/configurator/components/ui-helpers.ts:618
 msgid "controls.imputation.type.linear"
 msgstr "Interpolation linéaire"
 
-#: app/configurator/components/chart-options-selector.tsx:523
-#: app/configurator/components/chart-options-selector.tsx:535
+#: app/configurator/components/chart-options-selector.tsx:524
+#: app/configurator/components/chart-options-selector.tsx:536
 #: app/configurator/components/ui-helpers.ts:610
 msgid "controls.imputation.type.none"
 msgstr "-"
 
-#: app/configurator/components/chart-options-selector.tsx:525
+#: app/configurator/components/chart-options-selector.tsx:526
 #: app/configurator/components/ui-helpers.ts:614
 msgid "controls.imputation.type.zeros"
 msgstr "Zéros"
@@ -412,7 +417,7 @@ msgstr "Italien"
 
 #: app/configurator/components/ui-helpers.ts:536
 #: app/configurator/map/map-chart-options.tsx:223
-#: app/configurator/map/map-chart-options.tsx:428
+#: app/configurator/map/map-chart-options.tsx:423
 msgid "controls.measure"
 msgstr "Variable mesurée"
 
@@ -424,11 +429,11 @@ msgstr "Actif"
 msgid "controls.option.isNotActive"
 msgstr "Inactif"
 
-#: app/configurator/map/map-chart-options.tsx:245
+#: app/configurator/map/map-chart-options.tsx:246
 msgid "controls.scale.type"
 msgstr "Type d'échelle"
 
-#: app/components/form.tsx:480
+#: app/components/form.tsx:470
 msgid "controls.search.clear"
 msgstr "Effacer la recherche"
 
@@ -436,11 +441,11 @@ msgstr "Effacer la recherche"
 msgid "controls.section.additional-information"
 msgstr "Informations supplémentaires"
 
-#: app/configurator/components/chart-configurator.tsx:542
+#: app/configurator/components/chart-configurator.tsx:552
 msgid "controls.section.chart.options"
 msgstr "Paramètres graphiques"
 
-#: app/configurator/table/table-chart-configurator.tsx:128
+#: app/configurator/table/table-chart-configurator.tsx:163
 msgid "controls.section.columns"
 msgstr "Colonnes"
 
@@ -448,7 +453,7 @@ msgstr "Colonnes"
 msgid "controls.section.columnstyle"
 msgstr "Style de la colonne"
 
-#: app/configurator/components/chart-configurator.tsx:557
+#: app/configurator/components/chart-configurator.tsx:569
 msgid "controls.section.data.filters"
 msgstr "Filtres"
 
@@ -465,15 +470,15 @@ msgstr "Titre & description"
 msgid "controls.section.filter"
 msgstr "Filtre"
 
-#: app/configurator/table/table-chart-configurator.tsx:120
+#: app/configurator/table/table-chart-configurator.tsx:154
 msgid "controls.section.groups"
 msgstr "Groupes"
 
-#: app/configurator/components/chart-options-selector.tsx:564
+#: app/configurator/components/chart-options-selector.tsx:565
 msgid "controls.section.imputation"
 msgstr "Valeurs manquantes"
 
-#: app/configurator/components/chart-options-selector.tsx:569
+#: app/configurator/components/chart-options-selector.tsx:570
 msgid "controls.section.imputation.explanation"
 msgstr "En raison du type de graphique sélectionné, les valeurs manquantes doivent être remplies. Décidez de la logique d'imputation ou choisissez un autre type de graphique."
 
@@ -489,7 +494,7 @@ msgstr "Filtres de données"
 msgid "controls.section.show-standard-error"
 msgstr "Afficher l'erreur type"
 
-#: app/configurator/components/chart-options-selector.tsx:451
+#: app/configurator/components/chart-options-selector.tsx:452
 msgid "controls.section.sorting"
 msgstr "Trier"
 
@@ -501,15 +506,17 @@ msgstr "Paramètres du tableau"
 msgid "controls.section.tableSorting"
 msgstr "Tri du tableau"
 
-#: app/configurator/table/table-chart-configurator.tsx:96
+#: app/configurator/table/table-chart-configurator.tsx:130
 msgid "controls.section.tableoptions"
 msgstr "Options du tableau"
 
-#: app/configurator/components/chart-type-selector.tsx:141
+#: app/configurator/components/chart-configurator.tsx:545
+#: app/configurator/components/chart-type-selector.tsx:161
+#: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
 msgstr "Type de graphique"
 
-#: app/configurator/components/chart-options-selector.tsx:361
+#: app/configurator/components/chart-options-selector.tsx:362
 msgid "controls.select.column.layout"
 msgstr "Mise en forme de la colonne"
 
@@ -546,14 +553,14 @@ msgid "controls.select.columnStyle.textStyle"
 msgstr "Style du texte"
 
 #: app/configurator/components/chart-options-selector.tsx:192
-#: app/configurator/map/map-chart-options.tsx:191
-#: app/configurator/map/map-chart-options.tsx:415
+#: app/configurator/map/map-chart-options.tsx:210
+#: app/configurator/map/map-chart-options.tsx:410
 msgid "controls.select.dimension"
 msgstr "Sélectionner une dimension"
 
 #: app/configurator/components/chart-options-selector.tsx:193
 #: app/configurator/map/map-chart-options.tsx:228
-#: app/configurator/map/map-chart-options.tsx:433
+#: app/configurator/map/map-chart-options.tsx:428
 msgid "controls.select.measure"
 msgstr "Sélectionner une variable"
 
@@ -564,15 +571,15 @@ msgstr "Sélectionner une variable"
 msgid "controls.select.optional"
 msgstr "optionnel"
 
-#: app/configurator/components/filters.tsx:584
+#: app/configurator/components/filters.tsx:636
 msgid "controls.set-filters"
 msgstr "Appliquer les filtres"
 
-#: app/configurator/components/filters.tsx:591
+#: app/configurator/components/filters.tsx:643
 msgid "controls.set-filters-caption"
 msgstr "Pour de meilleurs résultats, ne sélectionnez pas plus de 7 valeurs dans la visualisation."
 
-#: app/configurator/components/filters.tsx:622
+#: app/configurator/components/filters.tsx:675
 msgid "controls.set-values-apply"
 msgstr "Appliquer les filtres"
 
@@ -580,8 +587,8 @@ msgstr "Appliquer les filtres"
 msgid "controls.sorting.addDimension"
 msgstr "Ajouter une dimension"
 
-#: app/configurator/components/chart-options-selector.tsx:402
-#: app/configurator/components/chart-options-selector.tsx:408
+#: app/configurator/components/chart-options-selector.tsx:403
+#: app/configurator/components/chart-options-selector.tsx:409
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Nom"
 
@@ -593,7 +600,7 @@ msgstr "A → Z"
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
-#: app/configurator/components/chart-options-selector.tsx:404
+#: app/configurator/components/chart-options-selector.tsx:405
 msgid "controls.sorting.byMeasure"
 msgstr "Mesure"
 
@@ -605,7 +612,7 @@ msgstr "1 → 9"
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
-#: app/configurator/components/chart-options-selector.tsx:406
+#: app/configurator/components/chart-options-selector.tsx:407
 msgid "controls.sorting.byTotalSize"
 msgstr "Taille totale"
 
@@ -638,7 +645,7 @@ msgstr "Sélectionner une dimension…"
 msgid "controls.sorting.sortBy"
 msgstr "Trier par"
 
-#: app/configurator/components/chart-type-selector.tsx:145
+#: app/configurator/components/chart-type-selector.tsx:166
 msgid "controls.switch.chart.type"
 msgstr "Passer à une autre visualisation tout en conservant la plupart des filtres"
 
@@ -650,11 +657,11 @@ msgstr "Grouper selon cette colonne"
 msgid "controls.table.column.hide"
 msgstr "Masquer la colonne"
 
-#: app/configurator/table/table-chart-configurator.tsx:107
+#: app/configurator/table/table-chart-configurator.tsx:141
 msgid "controls.table.settings"
 msgstr "Paramètres"
 
-#: app/configurator/table/table-chart-configurator.tsx:113
+#: app/configurator/table/table-chart-configurator.tsx:147
 msgid "controls.table.sorting"
 msgstr "Tri"
 
@@ -678,7 +685,7 @@ msgstr "Cet outil vous permet de vérifier qu'un cube a tous les attributs néce
 msgid "cube-checker.field-placeholder"
 msgstr "IRI du cube"
 
-#: app/components/data-source-menu.tsx:113
+#: app/components/data-source-menu.tsx:119
 msgid "data.source"
 msgstr "Source des données"
 
@@ -829,7 +836,7 @@ msgstr "Vous pouvez partager cette visualisation en copiant l'URL ou en l'intég
 msgid "hint.loading.data"
 msgstr "Chargement des données..."
 
-#: app/configurator/components/chart-type-selector.tsx:155
+#: app/configurator/components/chart-type-selector.tsx:179
 msgid "hint.no.visualization.with.dataset"
 msgstr "Aucune visualisation ne peut être créée avec le jeu de données sélectionné."
 
@@ -922,7 +929,7 @@ msgstr "Voici une visualisation que j'ai créée sur visualize.admin.ch"
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
-#: app/configurator/components/filters.tsx:516
+#: app/configurator/components/filters.tsx:560
 msgid "select.controls.filters.search"
 msgstr "Chercher"
 
@@ -934,6 +941,6 @@ msgstr "Avant de publier, ajoutez un titre et une description à votre tableau e
 msgid "step.visualize"
 msgstr "Personnalisez votre visualisation en utilisant les options de filtrage et de segmentation des couleurs dans les barres latérales."
 
-#: app/configurator/components/chart-controls/drag-and-drop-tab.tsx:85
+#: app/configurator/components/chart-controls/drag-and-drop-tab.tsx:88
 msgid "table.column.no"
 msgstr "Colonne {0}"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -13,23 +13,24 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:631
+#: app/configurator/components/chart-configurator.tsx:646
 msgid "Add filter"
 msgstr "Aggiungi filtro"
 
-#: app/configurator/components/chart-configurator.tsx:604
+#: app/configurator/components/chart-configurator.tsx:619
 msgid "Drag filters to reorganize"
 msgstr "Trascina i filtri per riorganizzarli"
 
-#: app/configurator/components/chart-configurator.tsx:601
+#: app/configurator/components/chart-configurator.tsx:616
 msgid "Move filter down"
 msgstr "Sposta il filtro in basso"
 
-#: app/configurator/components/chart-configurator.tsx:598
+#: app/configurator/components/chart-configurator.tsx:613
 msgid "Move filter up"
 msgstr "Sposta il filtro in alto"
 
 #: app/configurator/components/dataset-browse.tsx:970
+#: app/configurator/components/filters.tsx:654
 msgid "No results"
 msgstr "Nessun risultato"
 
@@ -70,23 +71,23 @@ msgstr "Torna indietro"
 msgid "button.copy.visualization"
 msgstr "Copia e modifica questa visualizzazione"
 
-#: app/components/data-download.tsx:192
+#: app/components/data-download.tsx:193
 msgid "button.download"
 msgstr "Scarica"
 
-#: app/components/data-download.tsx:182
+#: app/components/data-download.tsx:183
 msgid "button.download.data"
 msgstr "Scaricare i dati"
 
-#: app/components/data-download.tsx:212
+#: app/components/data-download.tsx:213
 msgid "button.download.data.all"
 msgstr "Set di dati completo"
 
-#: app/components/data-download.tsx:203
+#: app/components/data-download.tsx:204
 msgid "button.download.data.visible"
 msgstr "Set di dati filtrati"
 
-#: app/components/data-download.tsx:362
+#: app/components/data-download.tsx:366
 msgid "button.download.runsparqlquery.visible"
 msgstr "Esegui query SPARQL"
 
@@ -120,55 +121,55 @@ msgid "button.share"
 msgstr "Condividi"
 
 #: app/configurator/components/ui-helpers.ts:562
-#: app/configurator/map/map-chart-options.tsx:168
+#: app/configurator/map/map-chart-options.tsx:187
 msgid "chart.map.layers.area"
 msgstr "Aree"
 
-#: app/configurator/map/map-chart-options.tsx:252
+#: app/configurator/map/map-chart-options.tsx:253
 msgid "chart.map.layers.area.discretization.continuous"
 msgstr "Continuo"
 
-#: app/configurator/map/map-chart-options.tsx:265
+#: app/configurator/map/map-chart-options.tsx:266
 msgid "chart.map.layers.area.discretization.discrete"
 msgstr "Discreto"
 
-#: app/configurator/map/map-chart-options.tsx:313
+#: app/configurator/map/map-chart-options.tsx:311
 msgid "chart.map.layers.area.discretization.jenks"
 msgstr "Jenks (interruzioni naturali)"
 
-#: app/configurator/map/map-chart-options.tsx:306
+#: app/configurator/map/map-chart-options.tsx:304
 msgid "chart.map.layers.area.discretization.quantiles"
 msgstr "Quantili (distribuzione omogenea dei valori)"
 
-#: app/configurator/map/map-chart-options.tsx:299
+#: app/configurator/map/map-chart-options.tsx:297
 msgid "chart.map.layers.area.discretization.quantize"
 msgstr "Intervalli uguali"
 
-#: app/configurator/components/chart-configurator.tsx:679
+#: app/configurator/components/chart-configurator.tsx:695
 #: app/configurator/components/ui-helpers.ts:558
-#: app/configurator/map/map-chart-options.tsx:65
+#: app/configurator/map/map-chart-options.tsx:97
 msgid "chart.map.layers.base"
 msgstr "Visualizzazione della mappa"
 
-#: app/configurator/map/map-chart-options.tsx:69
+#: app/configurator/map/map-chart-options.tsx:101
 msgid "chart.map.layers.base.show"
 msgstr "Mostra mappa del mondo"
 
-#: app/configurator/map/map-chart-options.tsx:110
+#: app/configurator/map/map-chart-options.tsx:109
 msgid "chart.map.layers.base.view.locked"
 msgstr "Vista bloccata"
 
-#: app/configurator/map/map-chart-options.tsx:172
-#: app/configurator/map/map-chart-options.tsx:396
+#: app/configurator/map/map-chart-options.tsx:191
+#: app/configurator/map/map-chart-options.tsx:391
 msgid "chart.map.layers.show"
 msgstr "Mostra il livello"
 
 #: app/configurator/components/ui-helpers.ts:566
-#: app/configurator/map/map-chart-options.tsx:392
+#: app/configurator/map/map-chart-options.tsx:387
 msgid "chart.map.layers.symbol"
 msgstr "Simboli"
 
-#: app/configurator/map/map-chart-options.tsx:480
+#: app/configurator/map/map-chart-options.tsx:475
 msgid "chart.map.warning.noGeoDimensions"
 msgstr "In questo set di dati non ci sono dimensioni geografiche da mostrare!"
 
@@ -251,7 +252,7 @@ msgstr "Tabella"
 
 #: app/configurator/components/ui-helpers.ts:544
 #: app/configurator/map/map-chart-options.tsx:241
-#: app/configurator/map/map-chart-options.tsx:446
+#: app/configurator/map/map-chart-options.tsx:441
 msgid "controls.color"
 msgstr "Colore"
 
@@ -264,7 +265,7 @@ msgstr "Aggiungi ..."
 msgid "controls.color.palette"
 msgstr "Palette di colori"
 
-#: app/configurator/components/chart-controls/color-palette.tsx:239
+#: app/configurator/components/chart-controls/color-palette.tsx:237
 msgid "controls.color.palette.reset"
 msgstr "Ripristina la tavolozza dei colori"
 
@@ -272,7 +273,7 @@ msgstr "Ripristina la tavolozza dei colori"
 msgid "controls.color.palette.sequential"
 msgstr "Sequenziale"
 
-#: app/configurator/map/map-chart-options.tsx:450
+#: app/configurator/map/map-chart-options.tsx:445
 msgid "controls.color.select"
 msgstr "Seleziona un colore"
 
@@ -292,8 +293,8 @@ msgstr "impilate"
 msgid "controls.description"
 msgstr "Descrizione"
 
-#: app/configurator/map/map-chart-options.tsx:183
-#: app/configurator/map/map-chart-options.tsx:407
+#: app/configurator/map/map-chart-options.tsx:202
+#: app/configurator/map/map-chart-options.tsx:402
 msgid "controls.dimension.geographical"
 msgstr "Dimensione geografica"
 
@@ -302,49 +303,53 @@ msgid "controls.dimension.none"
 msgstr "Nessuno"
 
 #: app/charts/shared/chart-data-filters.tsx:214
-#: app/configurator/components/field.tsx:125
-#: app/configurator/components/field.tsx:182
-#: app/configurator/components/field.tsx:282
+#: app/configurator/components/field.tsx:126
+#: app/configurator/components/field.tsx:183
+#: app/configurator/components/field.tsx:283
 msgid "controls.dimensionvalue.none"
 msgstr "Nessun filtro"
 
-#: app/configurator/components/filters.tsx:383
+#: app/configurator/components/filters.tsx:412
 msgid "controls.filter.nb-elements"
 msgstr "{0} di {1}"
 
-#: app/configurator/components/filters.tsx:339
-#: app/configurator/components/filters.tsx:542
+#: app/configurator/components/filters.tsx:366
+#: app/configurator/components/filters.tsx:586
 msgid "controls.filter.select.all"
 msgstr "Seleziona tutti"
 
-#: app/configurator/components/filters.tsx:346
-#: app/configurator/components/filters.tsx:540
+#: app/configurator/components/filters.tsx:373
+#: app/configurator/components/filters.tsx:584
 msgid "controls.filter.select.none"
 msgstr "Deseleziona tutto"
 
-#: app/configurator/components/filters.tsx:356
+#: app/configurator/components/filters.tsx:383
 msgid "controls.filters.select.filters"
 msgstr "Filtri"
 
-#: app/configurator/components/filters.tsx:368
+#: app/configurator/components/filters.tsx:396
 msgid "controls.filters.select.refresh-colors"
 msgstr "Aggiorna i colori"
 
-#: app/configurator/components/filters.tsx:363
+#: app/configurator/components/filters.tsx:390
 msgid "controls.filters.select.selected-filters"
 msgstr "Filtri selezionati"
 
-#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:123
+#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:127
 msgid "controls.filters.time.range"
 msgstr "intervallo di tempo"
 
+#: app/configurator/table/table-chart-configurator.tsx:45
+msgid "controls.groups.empty-help"
+msgstr "Trascina qui le colonne per creare gruppi."
+
 #: app/configurator/map/map-chart-options.tsx:204
-msgid "controls.hierarchy"
-msgstr "Livello gerarchico"
+#~ msgid "controls.hierarchy"
+#~ msgstr "Livello gerarchico"
 
 #: app/configurator/map/map-chart-options.tsx:209
-msgid "controls.hierarchy.select"
-msgstr "Selezionare un livello gerarchico"
+#~ msgid "controls.hierarchy.select"
+#~ msgstr "Selezionare un livello gerarchico"
 
 #: app/configurator/components/empty-right-panel.tsx:24
 msgid "controls.hint.configuring.chart"
@@ -358,18 +363,18 @@ msgstr "Seleziona una delle annotazioni proposte per modificarla."
 msgid "controls.imputation"
 msgstr "Tipo di imputazione"
 
-#: app/configurator/components/chart-options-selector.tsx:530
+#: app/configurator/components/chart-options-selector.tsx:531
 #: app/configurator/components/ui-helpers.ts:618
 msgid "controls.imputation.type.linear"
 msgstr "Interpolazione lineare"
 
-#: app/configurator/components/chart-options-selector.tsx:523
-#: app/configurator/components/chart-options-selector.tsx:535
+#: app/configurator/components/chart-options-selector.tsx:524
+#: app/configurator/components/chart-options-selector.tsx:536
 #: app/configurator/components/ui-helpers.ts:610
 msgid "controls.imputation.type.none"
 msgstr "-"
 
-#: app/configurator/components/chart-options-selector.tsx:525
+#: app/configurator/components/chart-options-selector.tsx:526
 #: app/configurator/components/ui-helpers.ts:614
 msgid "controls.imputation.type.zeros"
 msgstr "Zeri"
@@ -412,7 +417,7 @@ msgstr "Italiano"
 
 #: app/configurator/components/ui-helpers.ts:536
 #: app/configurator/map/map-chart-options.tsx:223
-#: app/configurator/map/map-chart-options.tsx:428
+#: app/configurator/map/map-chart-options.tsx:423
 msgid "controls.measure"
 msgstr "Misura"
 
@@ -424,11 +429,11 @@ msgstr "Attivo"
 msgid "controls.option.isNotActive"
 msgstr "Inattivo"
 
-#: app/configurator/map/map-chart-options.tsx:245
+#: app/configurator/map/map-chart-options.tsx:246
 msgid "controls.scale.type"
 msgstr "Tipo di scala"
 
-#: app/components/form.tsx:480
+#: app/components/form.tsx:470
 msgid "controls.search.clear"
 msgstr "Cancella la ricerca"
 
@@ -436,11 +441,11 @@ msgstr "Cancella la ricerca"
 msgid "controls.section.additional-information"
 msgstr "Informazioni aggiuntive"
 
-#: app/configurator/components/chart-configurator.tsx:542
+#: app/configurator/components/chart-configurator.tsx:552
 msgid "controls.section.chart.options"
 msgstr "Opzioni del grafico"
 
-#: app/configurator/table/table-chart-configurator.tsx:128
+#: app/configurator/table/table-chart-configurator.tsx:163
 msgid "controls.section.columns"
 msgstr "Colonne"
 
@@ -448,7 +453,7 @@ msgstr "Colonne"
 msgid "controls.section.columnstyle"
 msgstr "Stile della colonna"
 
-#: app/configurator/components/chart-configurator.tsx:557
+#: app/configurator/components/chart-configurator.tsx:569
 msgid "controls.section.data.filters"
 msgstr "Filtri"
 
@@ -465,15 +470,15 @@ msgstr "Titolo e descrizione"
 msgid "controls.section.filter"
 msgstr "Filtro"
 
-#: app/configurator/table/table-chart-configurator.tsx:120
+#: app/configurator/table/table-chart-configurator.tsx:154
 msgid "controls.section.groups"
 msgstr "Gruppi"
 
-#: app/configurator/components/chart-options-selector.tsx:564
+#: app/configurator/components/chart-options-selector.tsx:565
 msgid "controls.section.imputation"
 msgstr "Valori mancanti"
 
-#: app/configurator/components/chart-options-selector.tsx:569
+#: app/configurator/components/chart-options-selector.tsx:570
 msgid "controls.section.imputation.explanation"
 msgstr "Per questo tipo di grafico, i valori di sostituzione devono essere assegnati ai valori mancanti. Decidi la logica di imputazione o passa a un altro tipo di grafico."
 
@@ -489,7 +494,7 @@ msgstr "Filtri di dati"
 msgid "controls.section.show-standard-error"
 msgstr "Mostra l'errore standard"
 
-#: app/configurator/components/chart-options-selector.tsx:451
+#: app/configurator/components/chart-options-selector.tsx:452
 msgid "controls.section.sorting"
 msgstr "Ordina"
 
@@ -501,15 +506,17 @@ msgstr "Impostazioni della tabella"
 msgid "controls.section.tableSorting"
 msgstr "Ordinamento della tabella"
 
-#: app/configurator/table/table-chart-configurator.tsx:96
+#: app/configurator/table/table-chart-configurator.tsx:130
 msgid "controls.section.tableoptions"
 msgstr "Opzioni della tabella"
 
-#: app/configurator/components/chart-type-selector.tsx:141
+#: app/configurator/components/chart-configurator.tsx:545
+#: app/configurator/components/chart-type-selector.tsx:161
+#: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
 msgstr "Tipo di grafico"
 
-#: app/configurator/components/chart-options-selector.tsx:361
+#: app/configurator/components/chart-options-selector.tsx:362
 msgid "controls.select.column.layout"
 msgstr "Layout a colonne"
 
@@ -546,14 +553,14 @@ msgid "controls.select.columnStyle.textStyle"
 msgstr "Stile del testo"
 
 #: app/configurator/components/chart-options-selector.tsx:192
-#: app/configurator/map/map-chart-options.tsx:191
-#: app/configurator/map/map-chart-options.tsx:415
+#: app/configurator/map/map-chart-options.tsx:210
+#: app/configurator/map/map-chart-options.tsx:410
 msgid "controls.select.dimension"
 msgstr "Seleziona una dimensione"
 
 #: app/configurator/components/chart-options-selector.tsx:193
 #: app/configurator/map/map-chart-options.tsx:228
-#: app/configurator/map/map-chart-options.tsx:433
+#: app/configurator/map/map-chart-options.tsx:428
 msgid "controls.select.measure"
 msgstr "Seleziona una misura"
 
@@ -564,15 +571,15 @@ msgstr "Seleziona una misura"
 msgid "controls.select.optional"
 msgstr "facoltativo"
 
-#: app/configurator/components/filters.tsx:584
+#: app/configurator/components/filters.tsx:636
 msgid "controls.set-filters"
 msgstr "Filtrer"
 
-#: app/configurator/components/filters.tsx:591
+#: app/configurator/components/filters.tsx:643
 msgid "controls.set-filters-caption"
 msgstr "Pour de meilleurs résultats, ne sélectionnez pas plus de 7 valeurs dans la visualisation"
 
-#: app/configurator/components/filters.tsx:622
+#: app/configurator/components/filters.tsx:675
 msgid "controls.set-values-apply"
 msgstr "Appliquer les filtres"
 
@@ -580,8 +587,8 @@ msgstr "Appliquer les filtres"
 msgid "controls.sorting.addDimension"
 msgstr "Aggiungi una dimensione"
 
-#: app/configurator/components/chart-options-selector.tsx:402
-#: app/configurator/components/chart-options-selector.tsx:408
+#: app/configurator/components/chart-options-selector.tsx:403
+#: app/configurator/components/chart-options-selector.tsx:409
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Nome"
 
@@ -593,7 +600,7 @@ msgstr "A → Z"
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
-#: app/configurator/components/chart-options-selector.tsx:404
+#: app/configurator/components/chart-options-selector.tsx:405
 msgid "controls.sorting.byMeasure"
 msgstr "Misura"
 
@@ -605,7 +612,7 @@ msgstr "1 → 9"
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
-#: app/configurator/components/chart-options-selector.tsx:406
+#: app/configurator/components/chart-options-selector.tsx:407
 msgid "controls.sorting.byTotalSize"
 msgstr "Grandezza totale"
 
@@ -638,7 +645,7 @@ msgstr "Seleziona una dimensione ..."
 msgid "controls.sorting.sortBy"
 msgstr "Ordina per"
 
-#: app/configurator/components/chart-type-selector.tsx:145
+#: app/configurator/components/chart-type-selector.tsx:166
 msgid "controls.switch.chart.type"
 msgstr "Passa a un altro tipo di grafico mantenendo la maggior parte delle impostazioni dei filtri"
 
@@ -650,11 +657,11 @@ msgstr "Raggruppa secondo questa colonna"
 msgid "controls.table.column.hide"
 msgstr "Nascondi la colonna"
 
-#: app/configurator/table/table-chart-configurator.tsx:107
+#: app/configurator/table/table-chart-configurator.tsx:141
 msgid "controls.table.settings"
 msgstr "Opzioni"
 
-#: app/configurator/table/table-chart-configurator.tsx:113
+#: app/configurator/table/table-chart-configurator.tsx:147
 msgid "controls.table.sorting"
 msgstr "Ordinamento"
 
@@ -678,7 +685,7 @@ msgstr "Cube checker ti aiuta a capire se un cubo ha tutti i attributi e proprie
 msgid "cube-checker.field-placeholder"
 msgstr "Cubo IRI"
 
-#: app/components/data-source-menu.tsx:113
+#: app/components/data-source-menu.tsx:119
 msgid "data.source"
 msgstr "Fonte di dati"
 
@@ -829,7 +836,7 @@ msgstr "È possibile condividere questa visualizzazione copiando l'URL o incorpo
 msgid "hint.loading.data"
 msgstr "Caricamento dei dati..."
 
-#: app/configurator/components/chart-type-selector.tsx:155
+#: app/configurator/components/chart-type-selector.tsx:179
 msgid "hint.no.visualization.with.dataset"
 msgstr "Nessuna visualizzazione può essere creata con il dataset selezionato."
 
@@ -922,7 +929,7 @@ msgstr "Ecco una visualizzazione che ho creato usando visualize.admin.ch"
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
-#: app/configurator/components/filters.tsx:516
+#: app/configurator/components/filters.tsx:560
 msgid "select.controls.filters.search"
 msgstr "Cerca"
 
@@ -934,6 +941,6 @@ msgstr "Prima di pubblicare, aggiungere un titolo e una descrizione al tuo grafi
 msgid "step.visualize"
 msgstr "Personalizza la tua visualizzazione utilizzando le opzioni di segmentazione del filtro e del colore, nelle barre laterali."
 
-#: app/configurator/components/chart-controls/drag-and-drop-tab.tsx:85
+#: app/configurator/components/chart-controls/drag-and-drop-tab.tsx:88
 msgid "table.column.no"
 msgstr "Colonna {0}"


### PR DESCRIPTION
Add empty component for when there are no groups in table chart options. Still draft, need input from @AnninaWalker.