### PR TITLE
Make chart choice more visible

### DIFF
--- a/app/components/chart-panel.tsx
+++ b/app/components/chart-panel.tsx
@@ -24,7 +24,10 @@ export const ChartPanelConfigurator = (props: ChartPanelProps) => {
 
   return (
     <>
-      <ChartSelectionTabs editable chartType={state.chartConfig.chartType} />
+      <ChartSelectionTabs
+        editable={false}
+        chartType={state.chartConfig.chartType}
+      />
       <ChartPanelInner showTabs {...props} />
     </>
   );

--- a/app/components/chart-selection-tabs.tsx
+++ b/app/components/chart-selection-tabs.tsx
@@ -161,9 +161,11 @@ const TabContent = ({
         px: 3,
         borderRadius: 3,
         transition: "0.125s ease background-color",
-        "&:hover": {
-          backgroundColor: "grey.200",
-        },
+        "&:hover": editable
+          ? {
+              backgroundColor: "grey.200",
+            }
+          : undefined,
       }}
     >
       <Icon name={iconName} />

--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -235,7 +235,7 @@ export const Select = ({
       >
         {sortedOptions.map((opt) => {
           return opt.type === "group" ? (
-            <ListSubheader>{opt.label}</ListSubheader>
+            <ListSubheader key={opt.label}>{opt.label}</ListSubheader>
           ) : (
             <MenuItem
               key={opt.value}

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   Button,
   CircularProgress,
+  Divider,
   IconButton,
   Menu,
   MenuItem,
@@ -72,6 +73,7 @@ import { Icon } from "@/icons";
 import useEvent from "@/lib/use-event";
 import { useLocale } from "@/locales/use-locale";
 
+import { ChartTypeSelector } from "./chart-type-selector";
 import useHierarchyParents from "./use-hierarchy-parents";
 
 const asGroup = (
@@ -541,6 +543,13 @@ export const ChartConfigurator = ({
   return (
     <>
       <ControlSection>
+        <SectionTitle titleId="controls-design">
+          <Trans id="controls.select.chart.type">Chart Type</Trans>
+        </SectionTitle>
+        <ControlSectionContent side="left">
+          <ChartTypeSelector showHelp={false} state={state} sx={{ mt: 2 }} />
+        </ControlSectionContent>
+        <Divider />
         <SectionTitle titleId="controls-design">
           <Trans id="controls.section.chart.options">Chart Options</Trans>
         </SectionTitle>

--- a/app/configurator/components/chart-controls/control-tab.tsx
+++ b/app/configurator/components/chart-controls/control-tab.tsx
@@ -189,7 +189,7 @@ export const ControlTabButton = ({
     id={`tab-${value}`}
     onClick={() => onClick(value)}
     sx={{
-      backgroundColor: checked ? "muted.dark" : "grey.100",
+      backgroundColor: checked ? "action.hover" : "grey.100",
       color: "grey.700",
       borderColor: "primary",
       borderRadius: 1.5,
@@ -203,10 +203,10 @@ export const ControlTabButton = ({
       transition: "background-color .2s",
       cursor: "pointer",
       ":hover": {
-        backgroundColor: "muted.dark",
+        backgroundColor: "action.hover",
       },
       ":active": {
-        backgroundColor: "muted.dark",
+        backgroundColor: "action.hover",
       },
       ":disabled": {
         cursor: "initial",

--- a/app/configurator/components/chart-type-selector.tsx
+++ b/app/configurator/components/chart-type-selector.tsx
@@ -7,11 +7,7 @@ import React, { SyntheticEvent } from "react";
 import { enabledChartTypes, getPossibleChartType } from "@/charts";
 import Flex from "@/components/flex";
 import { Hint } from "@/components/hint";
-import {
-  ControlSection,
-  ControlSectionContent,
-  ControlSectionSkeleton,
-} from "@/configurator/components/chart-controls/section";
+import { ControlSectionSkeleton } from "@/configurator/components/chart-controls/section";
 import {
   getFieldLabel,
   getIconName,
@@ -135,11 +131,15 @@ const ChartTypeSelectorField = ({
 
 export const ChartTypeSelector = ({
   state,
+  showHelp,
+  sx,
 }: {
   state:
     | ConfiguratorStateConfiguringChart
     | ConfiguratorStateDescribingChart
     | ConfiguratorStatePublishing;
+  showHelp?: boolean;
+  sx?: BoxProps["sx"];
 }) => {
   const locale = useLocale();
   const [{ data }] = useDataCubeMetadataWithComponentValuesQuery({
@@ -156,20 +156,24 @@ export const ChartTypeSelector = ({
     const possibleChartTypes = getPossibleChartType({ meta: metaData });
 
     return (
-      <ControlSection sx={{ position: "relative", width: "320px" }}>
+      <Box sx={sx}>
         <legend style={{ display: "none" }}>
           <Trans id="controls.select.chart.type">Chart Type</Trans>
         </legend>
-        <Box sx={{ m: 4, textAlign: "center" }}>
-          <Typography variant="body2">
-            <Trans id="controls.switch.chart.type">
-              Switch to another chart type while maintaining most filter
-              settings.
-            </Trans>
-          </Typography>
-        </Box>
+        {showHelp !== false ? (
+          <Box sx={{ m: 4, textAlign: "center" }}>
+            <Typography variant="body2">
+              <Trans id="controls.switch.chart.type">
+                Switch to another chart type while maintaining most filter
+                settings.
+              </Trans>
+            </Typography>
+          </Box>
+        ) : (
+          false
+        )}
 
-        <ControlSectionContent side="left">
+        <div>
           {!possibleChartTypes ? (
             <Hint>
               <Trans id="hint.no.visualization.with.dataset">
@@ -183,7 +187,7 @@ export const ChartTypeSelector = ({
                 sx={{
                   gridTemplateColumns: ["1fr 1fr", "1fr 1fr", "1fr 1fr 1fr"],
                   gridGap: "0.75rem",
-                  mx: 4,
+                  mx: 2,
                 }}
               >
                 {enabledChartTypes.map((d) => (
@@ -204,8 +208,8 @@ export const ChartTypeSelector = ({
               </Button> */}
             </Flex>
           )}
-        </ControlSectionContent>
-      </ControlSection>
+        </div>
+      </Box>
     );
   } else {
     return <ControlSectionSkeleton />;

--- a/app/configurator/components/chart-type-selector.tsx
+++ b/app/configurator/components/chart-type-selector.tsx
@@ -1,5 +1,7 @@
 import { Trans } from "@lingui/macro";
-import { Box, ButtonBase, Typography } from "@mui/material";
+import { Box, BoxProps, ButtonBase, Theme, Typography } from "@mui/material";
+import { makeStyles } from "@mui/styles";
+import clsx from "clsx";
 import React, { SyntheticEvent } from "react";
 
 import { enabledChartTypes, getPossibleChartType } from "@/charts";
@@ -29,6 +31,44 @@ import {
   ConfiguratorStatePublishing,
 } from "../config-types";
 
+const useSelectionButtonStyles = makeStyles((theme: Theme) => ({
+  root: {
+    width: "86px",
+    height: "64px",
+    borderRadius: 4,
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    alignItems: "center",
+
+    transition: "all .2s",
+    cursor: "pointer",
+
+    "&:hover": {
+      backgroundColor: theme.palette.action.hover,
+    },
+    "& svg": {
+      color: theme.palette.primary.main,
+    },
+  },
+  checked: {
+    color: "white",
+    backgroundColor: theme.palette.primary.main,
+    "&:hover": {
+      backgroundColor: theme.palette.primary.main,
+    },
+    "& svg": {
+      color: "white",
+    },
+  },
+  disabled: {
+    cursor: "initial",
+    "& svg": {
+      color: theme.palette.grey[500],
+    },
+  },
+}));
+
 export const ChartTypeSelectionButton = ({
   label,
   value,
@@ -40,45 +80,25 @@ export const ChartTypeSelectionButton = ({
   disabled?: boolean;
   onClick: (e: SyntheticEvent<HTMLButtonElement>) => void;
 } & FieldProps) => {
+  const classes = useSelectionButtonStyles();
   return (
     <ButtonBase
       tabIndex={0}
       value={value}
       onClick={onClick}
       disabled={disabled}
-      sx={{
-        width: "86px",
-        height: "64px",
-        borderRadius: 4,
-
-        backgroundColor: checked ? "muted.dark" : "grey.100",
-        color: checked ? "primary.main" : disabled ? "grey.500" : "grey.700",
-
-        display: "flex",
-        flexDirection: "column",
-        justifyContent: "center",
-        alignItems: "center",
-
-        cursor: disabled ? "initial" : "pointer",
-        pointerEvents: disabled ? "none" : "initial",
-
-        transition: "all .2s",
-
-        ":hover": {
-          backgroundColor: disabled
-            ? "muted.colored"
-            : checked
-            ? "primary"
-            : "muted.dark",
-        },
-      }}
+      className={clsx(
+        classes.root,
+        disabled ? classes.disabled : null,
+        checked ? classes.checked : null
+      )}
     >
       <Icon size={24} name={getIconName(label)} />
       <Typography
-        variant="body2"
+        variant="caption"
         sx={{
-          color: disabled ? "grey.600" : "grey.700",
-          fontSize: ["0.75rem", "0.75rem", "0.75rem"],
+          color: disabled ? "text.primary" : "inherit",
+          mt: 1,
         }}
       >
         {getFieldLabel(label)}

--- a/app/configurator/table/table-chart-configurator.tsx
+++ b/app/configurator/table/table-chart-configurator.tsx
@@ -1,4 +1,5 @@
 import { Trans } from "@lingui/macro";
+import { Divider } from "@mui/material";
 import { useCallback, useState } from "react";
 import {
   DragDropContext,
@@ -21,6 +22,8 @@ import { useConfiguratorState } from "@/configurator/configurator-state";
 import { moveFields } from "@/configurator/table/table-config-state";
 import { useDataCubeMetadataWithComponentValuesQuery } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
+
+import { ChartTypeSelector } from "../components/chart-type-selector";
 
 export const ChartConfiguratorTable = ({
   state,
@@ -92,6 +95,13 @@ export const ChartConfiguratorTable = ({
     return (
       <>
         <ControlSection>
+          <SectionTitle titleId="controls-design">
+            <Trans id="controls.select.chart.type">Chart Type</Trans>
+          </SectionTitle>
+          <ControlSectionContent side="left">
+            <ChartTypeSelector showHelp={false} state={state} sx={{ mt: 2 }} />
+          </ControlSectionContent>
+          <Divider />
           <SectionTitle>
             <Trans id="controls.section.tableoptions">Table Options</Trans>
           </SectionTitle>

--- a/app/themes/federal.tsx
+++ b/app/themes/federal.tsx
@@ -41,7 +41,7 @@ export const theme = createTheme({
     },
     divider: "#CCCCCC",
     action: {
-      hover: "#d8e8ef",
+      hover: "#F2F7F9",
     },
     secondary: {
       main: "#757575",


### PR DESCRIPTION
Previously, we had extracted the chart type choice inside the tabs. Here we revert this choice and put it back in the left panel.