### PR TITLE
fix: Copying of chart with empty data source

### DIFF
--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -1101,7 +1101,12 @@ export const initChartStateFromChart = async (
 ): Promise<ConfiguratorState | undefined> => {
   const config = await fetchChartConfig(from);
   if (config && config.data) {
-    const { dataSet, dataSource, meta, chartConfig } = config.data;
+    const {
+      dataSet,
+      dataSource = DEFAULT_DATA_SOURCE,
+      meta,
+      chartConfig,
+    } = config.data;
     return {
       state: "CONFIGURING_CHART",
       dataSet,


### PR DESCRIPTION
Fixes #622.

For old charts there is no dataSource prop defined. This PR makes sure that a chart uses a default data source for a given Visualize env if it's not defined in its config.