### PR TITLE
Fix maps in production

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,9 +22,7 @@ build:
   tags:
     - medium
   script:
-    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
-    - docker build --build-arg COMMIT=$CI_COMMIT_SHA --build-arg MAPTILER_STYLE_KEY=$MAPTILER_STYLE_KEY --build-arg VECTOR_TILE_URL=$VECTOR_TILE_URL -t $MAIN_IMAGE_TAG .
-    - docker push $MAIN_IMAGE_TAG
+    - DOCKER_IMAGE_TAGS="$MAIN_IMAGE_TAG" ./scripts/docker-build-push.sh
   only:
     - main
 
@@ -34,10 +32,7 @@ release:
   tags:
     - medium
   script:
-    - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
-    - docker build --build-arg COMMIT=$CI_COMMIT_SHA -t $RELEASE_IMAGE_TAG -t $CI_REGISTRY_IMAGE:$(./scripts/get-package-version.sh) .
-    - docker push $RELEASE_IMAGE_TAG
-    - docker push $CI_REGISTRY_IMAGE:$(./scripts/get-package-version.sh)
+    - DOCKER_IMAGE_TAGS="$RELEASE_IMAGE_TAG $CI_REGISTRY_IMAGE:$(./scripts/get-package-version.sh)" ./scripts/docker-build-push.sh
   only:
     - /^v\d+\.\d+\.\d+$/ # use `yarn version` to create these tags
   except:

--- a/scripts/docker-build-push.sh
+++ b/scripts/docker-build-push.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Builds and push the docker image to the registry
+# The DOCKER_IMAGE_TAGS environment variable must be set and will
+# be used to tag the image that is built.
+# Multiple tags can be used and must be separated by spaces.
+
+# Fail on error, fail if environment variable is not set, fail if pipe fails 
+set -euo pipefail
+
+# Logins to docker registry
+docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
+
+# Build docker image, passing arguments defined in the CI 
+docker build \
+    --build-arg COMMIT=$CI_COMMIT_SHA \
+    --build-arg MAPTILER_STYLE_KEY=$MAPTILER_STYLE_KEY \
+    --build-arg VECTOR_TILE_URL=$VECTOR_TILE_URL \
+    $(echo $DOCKER_IMAGE_TAGS | tr ' ' '\n' | xargs -L 1 -I {} echo "-t {}" | tr '\n' ' ' ) .
+
+# Push all the tags
+docker push $DOCKER_IMAGE_TAGS


### PR DESCRIPTION
When building the release docker image, the necessary environment variables (namely `MAPTILER_STYLE_KEY` and `VECTOR_STYLE_URL`) were not passed.
Now the build and release commands use the same command, so we will not be able to
have discrepancies between build and release.﻿
