### PR TITLE
fix: Use a proper time unit to format brush extent dates

### DIFF
--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -823,8 +823,10 @@ export const TimeFilter = ({
 
     return (
       <Box>
-        {timeFormatUnit(timeRange[0], timeUnit)} –{" "}
-        {timeFormatUnit(timeRange[1], timeUnit)}
+        <Typography variant="body2">
+          {timeFormatUnit(timeRange[0], timeUnit)} –{" "}
+          {timeFormatUnit(timeRange[1], timeUnit)}
+        </Typography>
         <EditorIntervalBrush
           timeExtent={[from, to]}
           timeRange={timeRange}

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -829,6 +829,7 @@ export const TimeFilter = ({
           timeExtent={[from, to]}
           timeRange={timeRange}
           timeInterval={timeInterval}
+          timeUnit={timeUnit}
           onChange={([from, to]) =>
             setFilterRange([formatDateValue(from), formatDateValue(to)])
           }

--- a/app/configurator/interactive-filters/editor-time-interval-brush.tsx
+++ b/app/configurator/interactive-filters/editor-time-interval-brush.tsx
@@ -12,9 +12,11 @@ import React, { useCallback, useEffect, useRef } from "react";
 
 import Flex from "@/components/flex";
 import { Label } from "@/components/form";
-import { useFormatFullDateAuto } from "@/configurator/components/ui-helpers";
+import { TimeUnit } from "@/graphql/query-hooks";
 import { useResizeObserver } from "@/lib/use-resize-observer";
 import { useTheme } from "@/themes";
+
+import { useTimeFormatUnit } from "../components/ui-helpers";
 
 const HANDLE_SIZE = 20;
 const HANDLE_OFFSET = HANDLE_SIZE / 8;
@@ -25,19 +27,21 @@ export const EditorIntervalBrush = ({
   timeExtent,
   timeRange,
   timeInterval,
+  timeUnit,
   onChange,
   disabled = false,
 }: {
   timeExtent: Date[];
   timeRange: Date[];
   timeInterval: CountableTimeInterval;
+  timeUnit: TimeUnit;
   onChange: (extent: Date[]) => void;
   disabled?: boolean;
 }) => {
   const [resizeRef, width] = useResizeObserver<HTMLDivElement>();
   const brushRef = useRef<SVGGElement>(null);
   const theme = useTheme();
-  const formatDateAuto = useFormatFullDateAuto();
+  const timeFormatUnit = useTimeFormatUnit();
 
   const brushWidth = width - (MARGIN + HANDLE_OFFSET) * 2;
   const timeScale = scaleTime().domain(timeExtent).range([0, brushWidth]);
@@ -140,10 +144,10 @@ export const EditorIntervalBrush = ({
         }}
       >
         <Typography component="div" variant="caption">
-          {formatDateAuto(timeExtent[0])}
+          {timeFormatUnit(timeExtent[0], timeUnit)}
         </Typography>
         <Typography component="div" variant="caption">
-          {formatDateAuto(timeExtent[1])}
+          {timeFormatUnit(timeExtent[1], timeUnit)}
         </Typography>
       </Flex>
     </Box>


### PR DESCRIPTION
Closes #571.

I think it makes more sense to use the same date format as visible above the time slider, see picture below. I don't think we should use formatDateAuto when we have an easy access to a timeUnit of given TemporalDimension.

<img width="316" alt="Screenshot 2022-08-18 at 12 54 27" src="https://user-images.githubusercontent.com/52032047/185379372-72d37b8d-3576-46f9-9732-1561d4fc973f.png">

