### PR TITLE
Support partial search terms

### DIFF
--- a/app/components/debug-search.tsx
+++ b/app/components/debug-search.tsx
@@ -182,6 +182,13 @@ const DebugSearch = () => {
       <Search
         sourceUrl={sourceUrl}
         includeDrafts={includeDrafts}
+        query="bath"
+        filters={[territoryTheme]}
+        locale="en"
+      />
+      <Search
+        sourceUrl={sourceUrl}
+        includeDrafts={includeDrafts}
         query="Ausgaben"
         filters={[]}
         locale="de"

--- a/app/rdf/query-search.ts
+++ b/app/rdf/query-search.ts
@@ -54,8 +54,19 @@ const makeVisualizeFilter = (includeDrafts: boolean) => {
   `;
 };
 
+const enhanceQuery = (rawQuery: string) => {
+  return (
+    rawQuery
+      .toLowerCase()
+      .split(" ")
+      // Wildcard Searches on each term
+      .map((t) => `${t}*`)
+      .join(" ")
+  );
+};
+
 export const searchCubes = async ({
-  query,
+  query: rawQuery,
   locale,
   filters,
   includeDrafts,
@@ -69,6 +80,8 @@ export const searchCubes = async ({
   sparqlClient: ParsingClient;
   sparqlClientStream: StreamClient;
 }) => {
+  const query = rawQuery ? enhanceQuery(rawQuery) : undefined;
+
   // Search cubeIris along with their score
   const themeValues =
     filters?.filter((x) => x.type === "DataCubeTheme").map((v) => v.value) ||


### PR DESCRIPTION
Add wildcards to the Lucene query used in the search to support
partial terms.

- [x] "bath" should return the "bathing water quality" dataset
- [x] "tari" should return the electricity tariff datasets
﻿
