### PR TITLE
Format currencies improvements

### DIFF
--- a/app/components/debug-search.tsx
+++ b/app/components/debug-search.tsx
@@ -54,13 +54,13 @@ const Search = ({
 
   useEffect(() => {
     startTimeRef.current = Date.now();
-  }, [query, locale]);
+  }, [query, locale, includeDrafts]);
 
   const [cubes] = useDataCubesQuery({
     variables: {
       locale: locale,
       query: query,
-      filters: filters.map(({ name, type, value }) => ({ type, value })),
+      filters: filters.map(({ type, value }) => ({ type, value })),
       includeDrafts,
       sourceUrl,
       sourceType: "sparql",
@@ -69,7 +69,6 @@ const Search = ({
 
   useEffect(() => {
     if (cubes.data) {
-      console.log("seting end time", query);
       setEndTime(Date.now());
     }
   }, [cubes.data]);

--- a/app/configurator/components/ui-helpers.spec.ts
+++ b/app/configurator/components/ui-helpers.spec.ts
@@ -56,6 +56,14 @@ describe("useDimensionFormatters", () => {
           isNumerical: true,
           isKeyDimension: false,
         } as DimensionMetaDataFragment,
+        {
+          iri: "iri-currency",
+          isNumerical: true,
+          isKeyDimension: false,
+          isCurrency: true,
+          currencyExponent: 1,
+          __typename: "Measure",
+        } as DimensionMetaDataFragment,
       ])
     );
     return { formatters };
@@ -74,6 +82,11 @@ describe("useDimensionFormatters", () => {
   it("should work with numbers", () => {
     const { formatters } = setup();
     expect(formatters["iri-number"]("2.33333")).toEqual("2,33");
+  });
+
+  it("should work with currencies", () => {
+    const { formatters } = setup();
+    expect(formatters["iri-currency"]("20002.3333")).toEqual("20'002,3");
   });
 });
 

--- a/app/configurator/components/ui-helpers.ts
+++ b/app/configurator/components/ui-helpers.ts
@@ -161,16 +161,24 @@ export const useDimensionFormatters = (
   return useMemo(() => {
     return Object.fromEntries(
       dimensions.map((d) => {
-        return [
-          d.iri,
-          d.__typename === "Measure" || d.isNumerical
-            ? formatNumber
-            : d.__typename === "TemporalDimension"
-            ? dateFormatterFromDimension(d, dateFormatters, formatDateAuto)
-            : isNamedNodeDimension(d)
-            ? namedNodeFormatter(d)
-            : formatIdentity,
-        ];
+        let formatter: (s: any) => string;
+        if (d.__typename === "Measure") {
+          formatter = formatNumber;
+        } else if (d.__typename === "TemporalDimension") {
+          formatter = dateFormatterFromDimension(
+            d,
+            dateFormatters,
+            formatDateAuto
+          );
+        } else if (isNamedNodeDimension(d)) {
+          formatter = namedNodeFormatter(d);
+        } else if (d.isNumerical) {
+          formatter = formatNumber;
+        } else {
+          formatter = formatIdentity;
+        }
+
+        return [d.iri, formatter];
       })
     );
   }, [dimensions, formatNumber, dateFormatters, formatDateAuto]);

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -53,6 +53,10 @@ fragment dimensionMetaData on Dimension {
     timeUnit
     timeFormat
   }
+  ... on Measure {
+    isCurrency
+    currencyExponent
+  }
 }
 
 query DataCubePreview(

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -226,6 +226,8 @@ export type Measure = Dimension & {
   order?: Maybe<Scalars['Int']>;
   isNumerical: Scalars['Boolean'];
   isKeyDimension: Scalars['Boolean'];
+  isCurrency?: Maybe<Scalars['Boolean']>;
+  currencyExponent?: Maybe<Scalars['Int']>;
   values: Array<Scalars['DimensionValue']>;
   related?: Maybe<Array<RelatedDimension>>;
   hierarchy?: Maybe<Array<HierarchyValue>>;
@@ -453,7 +455,7 @@ type DimensionMetaData_GeoCoordinatesDimension_Fragment = { __typename: 'GeoCoor
 
 type DimensionMetaData_GeoShapesDimension_Fragment = { __typename: 'GeoShapesDimension', iri: string, label: string, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
 
-type DimensionMetaData_Measure_Fragment = { __typename: 'Measure', iri: string, label: string, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetaData_Measure_Fragment = { __typename: 'Measure', isCurrency?: Maybe<boolean>, currencyExponent?: Maybe<number>, iri: string, label: string, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
 
 type DimensionMetaData_NominalDimension_Fragment = { __typename: 'NominalDimension', iri: string, label: string, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
 
@@ -809,6 +811,10 @@ export const DimensionMetaDataFragmentDoc = gql`
   ... on TemporalDimension {
     timeUnit
     timeFormat
+  }
+  ... on Measure {
+    isCurrency
+    currencyExponent
   }
 }
     `;

--- a/app/graphql/resolver-types.ts
+++ b/app/graphql/resolver-types.ts
@@ -232,6 +232,8 @@ export type Measure = Dimension & {
   order?: Maybe<Scalars['Int']>;
   isNumerical: Scalars['Boolean'];
   isKeyDimension: Scalars['Boolean'];
+  isCurrency?: Maybe<Scalars['Boolean']>;
+  currencyExponent?: Maybe<Scalars['Int']>;
   values: Array<Scalars['DimensionValue']>;
   related?: Maybe<Array<RelatedDimension>>;
   hierarchy?: Maybe<Array<HierarchyValue>>;
@@ -710,6 +712,8 @@ export type MeasureResolvers<ContextType = GraphQLContext, ParentType extends Re
   order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   isNumerical?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   isKeyDimension?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  isCurrency?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
+  currencyExponent?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   values?: Resolver<Array<ResolversTypes['DimensionValue']>, ParentType, ContextType, RequireFields<MeasureValuesArgs, 'sourceType' | 'sourceUrl'>>;
   related?: Resolver<Maybe<Array<ResolversTypes['RelatedDimension']>>, ParentType, ContextType>;
   hierarchy?: Resolver<Maybe<Array<ResolversTypes['HierarchyValue']>>, ParentType, ContextType, RequireFields<MeasureHierarchyArgs, 'sourceType' | 'sourceUrl'>>;

--- a/app/graphql/resolvers/index.ts
+++ b/app/graphql/resolvers/index.ts
@@ -233,5 +233,11 @@ export const resolvers: Resolvers = {
   },
   Measure: {
     ...mkDimensionResolvers("Measure"),
+    isCurrency: ({ data: { isCurrency } }) => {
+      return isCurrency;
+    },
+    currencyExponent: ({ data: { currencyExponent } }) => {
+      return currencyExponent || 0;
+    },
   },
 };

--- a/app/graphql/resolvers/index.ts
+++ b/app/graphql/resolvers/index.ts
@@ -87,7 +87,7 @@ const DataCube: DataCubeResolvers = {
   },
 };
 
-const mkDimensionResolvers = (debugName: string): Resolvers["Dimension"] => ({
+const mkDimensionResolvers = (type: string): Resolvers["Dimension"] => ({
   // TODO: how to pass dataSource here? If it's possible, then we also could have
   // different resolvers for RDF and SQL.
   __resolveType({ data: { dataKind, scaleType } }) {
@@ -160,7 +160,10 @@ export const resolvers: Resolvers = {
       getSparqlEditorUrl({ query }),
   },
   Dimension: {
-    __resolveType({ data: { dataKind, scaleType } }) {
+    __resolveType({ data: { dataKind, scaleType, isMeasureDimension } }) {
+      if (isMeasureDimension) {
+        return "Measure";
+      }
       if (dataKind === "Time") {
         return "TemporalDimension";
       } else if (dataKind === "GeoCoordinates") {
@@ -175,25 +178,25 @@ export const resolvers: Resolvers = {
     },
   },
   NominalDimension: {
-    ...mkDimensionResolvers("nominal"),
+    ...mkDimensionResolvers("NominalDimension"),
   },
   OrdinalDimension: {
-    ...mkDimensionResolvers("ordinal"),
+    ...mkDimensionResolvers("OrdinalDimension"),
   },
   TemporalDimension: {
-    ...mkDimensionResolvers("temporal"),
+    ...mkDimensionResolvers("TemporalDimension"),
     timeUnit: ({ data: { timeUnit } }) => timeUnit!,
     timeFormat: ({ data: { timeFormat } }) => timeFormat!,
   },
   GeoCoordinatesDimension: {
-    ...mkDimensionResolvers("geocoordinates"),
+    ...mkDimensionResolvers("GeoCoordinatesDimension"),
     geoCoordinates: async (parent, args, { setup }, info) => {
       const { loaders } = await setup(info);
       return await loaders.geoCoordinates.load(parent);
     },
   },
   GeoShapesDimension: {
-    ...mkDimensionResolvers("geoshapes"),
+    ...mkDimensionResolvers("GeoShapesDimension"),
     geoShapes: async (parent, args, { setup }, info) => {
       const { loaders } = await setup(info);
       const dimValues = (await loaders.dimensionValues.load(
@@ -229,6 +232,6 @@ export const resolvers: Resolvers = {
     },
   },
   Measure: {
-    ...mkDimensionResolvers("measure"),
+    ...mkDimensionResolvers("Measure"),
   },
 };

--- a/app/graphql/resolvers/sql.ts
+++ b/app/graphql/resolvers/sql.ts
@@ -89,6 +89,10 @@ const parseSQLDimension = (
       iri,
       name,
       isLiteral: true,
+
+      // FIXME: Handle currencies in SQL resolvers
+      isCurrency: false,
+      currencyExponent: 0,
       // FIXME: not only measures can be numerical
       isNumerical: isMeasure,
       isKeyDimension: true,

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -204,6 +204,8 @@ type Measure implements Dimension {
   order: Int
   isNumerical: Boolean!
   isKeyDimension: Boolean!
+  isCurrency: Boolean
+  currencyExponent: Int
   values(
     sourceType: String!
     sourceUrl: String!

--- a/app/graphql/shared-types.ts
+++ b/app/graphql/shared-types.ts
@@ -49,6 +49,8 @@ export type ResolvedDimension = {
     isNumerical: boolean;
     isKeyDimension: boolean;
     isMeasureDimension: boolean;
+    isCurrency: boolean;
+    currencyExponent?: number;
     hasUndefinedValues: boolean;
     unit?: string;
     dataType?: string;

--- a/app/rdf/parse.ts
+++ b/app/rdf/parse.ts
@@ -195,7 +195,10 @@ export const parseCubeDimension = ({
   dim: CubeDimension;
   cube: Cube;
   locale: string;
-  units?: Map<string, { iri: Term; label?: Term }>;
+  units?: Map<
+    string,
+    { iri: Term; label?: Term; isCurrency?: Term; currencyExponent?: Term }
+  >;
 }): ResolvedDimension => {
   const outOpts = { language: getQueryLocales(locale) };
 
@@ -227,9 +230,8 @@ export const parseCubeDimension = ({
     .terms.some((t) => t.equals(ns.cube.MeasureDimension));
 
   const unitTerm = dim.out(ns.qudt.unit).term;
-  const dimensionUnit = unitTerm
-    ? units?.get(unitTerm.value)?.label?.value
-    : undefined;
+  const dimensionUnit = unitTerm ? units?.get(unitTerm.value) : undefined;
+  const dimensionUnitLabel = dimensionUnit?.label?.value;
 
   const rawOrder = dim.out(ns.sh.order).value;
   const order = rawOrder !== undefined ? parseInt(rawOrder, 10) : undefined;
@@ -247,8 +249,12 @@ export const parseCubeDimension = ({
       isKeyDimension,
       isMeasureDimension,
       hasUndefinedValues,
-      unit: dimensionUnit,
+      unit: dimensionUnitLabel,
       dataType: dataType?.value,
+      isCurrency: !!dimensionUnit?.isCurrency?.value,
+      currencyExponent: dimensionUnit?.currencyExponent?.value
+        ? parseInt(dimensionUnit?.currencyExponent?.value)
+        : undefined,
       name: dim.out(ns.schema.name, outOpts).value ?? dim.path?.value!,
       order: order,
       dataKind: dataKindTerm?.equals(ns.time.GeneralDateTimeDescription)

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -39,7 +39,7 @@ import { loadDimensionValues } from "./query-dimension-values";
 import { loadResourceLabels } from "./query-labels";
 import { loadResourcePositions } from "./query-positions";
 import { loadUnversionedResources } from "./query-sameas";
-import { loadUnitLabels } from "./query-unit-labels";
+import { loadUnits } from "./query-unit-labels";
 
 const DIMENSION_VALUE_UNDEFINED = ns.cube.Undefined.value;
 
@@ -173,8 +173,8 @@ export const getCubeDimensions = async ({
       return t ? [t] : [];
     });
 
-    const dimensionUnitLabels = index(
-      await loadUnitLabels({
+    const dimensionUnitIndex = index(
+      await loadUnits({
         ids: dimensionUnits,
         locale: "en", // No other locales exist yet
         sparqlClient,
@@ -187,7 +187,7 @@ export const getCubeDimensions = async ({
         dim,
         cube,
         locale,
-        units: dimensionUnitLabels,
+        units: dimensionUnitIndex,
       });
     });
   } catch (e) {

--- a/app/rdf/query-unit-labels.ts
+++ b/app/rdf/query-unit-labels.ts
@@ -10,8 +10,9 @@ interface ResourceLabel {
   label?: Term;
 }
 
-const buildUnitLabelsQuery = (values: Term[], locale: string) => {
-  return SELECT.DISTINCT`?iri ?label`.WHERE`
+const buildUnitsQuery = (values: Term[], locale: string) => {
+  return SELECT.DISTINCT`?iri ?label ?isCurrency ?currencyExponent ?isCurrency`
+    .WHERE`
         values ?iri {
           ${values}
         }
@@ -20,6 +21,9 @@ const buildUnitLabelsQuery = (values: Term[], locale: string) => {
         OPTIONAL { ?iri  ${ns.qudt.symbol}  ?symbol }
         OPTIONAL { ?iri  ${ns.qudt.ucumCode}  ?ucumCode }
         OPTIONAL { ?iri  ${ns.qudt.expression}  ?expression }
+
+        OPTIONAL { ?iri ?isCurrency ${ns.qudt.CurrencyUnit} }
+        OPTIONAL { ?iri ${ns.qudt.currencyExponent} ?currencyExponent }
 
         BIND(str(coalesce(str(?symbol), str(?ucumCode), str(?expression), str(?rdfsLabel), "?")) AS ?label)
         
@@ -30,7 +34,7 @@ const buildUnitLabelsQuery = (values: Term[], locale: string) => {
 /**
  * Load labels for a list of unit IDs
  */
-export async function loadUnitLabels({
+export async function loadUnits({
   ids,
   locale = "en",
   sparqlClient,
@@ -42,6 +46,6 @@ export async function loadUnitLabels({
   return batchLoad({
     ids,
     sparqlClient,
-    buildQuery: (values: Term[]) => buildUnitLabelsQuery(values, locale),
+    buildQuery: (values: Term[]) => buildUnitsQuery(values, locale),
   });
 }


### PR DESCRIPTION
When we detect a currency in the data (from the unit in qudt.unit), we format the data with currencyExponent digits.

In this issue, the usecase of data where the floating precision is more than currencyExponent (for example for currency exchange datasets) is not tackled. It would be possible to tackle this when the dimension metadata informs us on the precision necessary.

Fixes https://github.com/orgs/visualize-admin/projects/1/views/18

This can be tested with the "State accounts - Office" dataset where amounts should have a precision of 2 digits after comma since the currency is CHF, and the currency exponent of CHF is 2. 

<img width="168" alt="image" src="https://user-images.githubusercontent.com/465582/186159296-cf87bbd6-0bb1-477c-833b-352beb38f19b.png">
