### PR TITLE
feat: Provide query timings in debug search page

### DIFF
--- a/app/components/debug-search.tsx
+++ b/app/components/debug-search.tsx
@@ -1,4 +1,7 @@
 import { FormControlLabel, Stack } from "@mui/material";
+import Accordion from "@mui/material/Accordion";
+import AccordionDetails from "@mui/material/AccordionDetails";
+import AccordionSummary from "@mui/material/AccordionSummary";
 import Box from "@mui/material/Box";
 import Chip from "@mui/material/Chip";
 import CircularProgress from "@mui/material/CircularProgress";
@@ -80,6 +83,8 @@ const Search = ({
       ? endTime - startTimeRef.current
       : undefined;
 
+  const queries = cubes?.extensions?.queries as RequestQueryMeta[] | undefined;
+
   return (
     <Box>
       <Typography variant="h5">
@@ -112,6 +117,7 @@ const Search = ({
       {cubes.error ? (
         <Typography color="error">{cubes.error.message}</Typography>
       ) : null}
+
       <Stack spacing={4}>
         {cubes.data?.dataCubes.map((c) => {
           return (
@@ -132,6 +138,40 @@ const Search = ({
           );
         })}
       </Stack>
+      <Accordion sx={{ mt: 2, borderTop: 0 }}>
+        <AccordionSummary sx={{ typography: "h4" }}>queries</AccordionSummary>
+        <AccordionDetails>
+          <Stack spacing={2}>
+            {queries
+              ? queries.map((q, i) => {
+                  return (
+                    <div key={i}>
+                      <Typography variant="h5">{q.label}</Typography>
+                      <Stack direction="row" spacing={4}>
+                        <div>
+                          <Typography variant="overline">Duration</Typography>
+                          <Typography variant="body2">
+                            {q.endTime - q.startTime}ms
+                          </Typography>
+                        </div>
+                      </Stack>
+                      <Accordion sx={{ mt: 2 }}>
+                        <AccordionSummary sx={{ typography: "overline" }}>
+                          Query
+                        </AccordionSummary>
+                        <AccordionDetails>
+                          <Box component="pre" sx={{ fontSize: "small" }}>
+                            {q.text}
+                          </Box>
+                        </AccordionDetails>
+                      </Accordion>
+                    </div>
+                  );
+                })
+              : null}
+          </Stack>
+        </AccordionDetails>
+      </Accordion>
     </Box>
   );
 };

--- a/app/graphql/context.tsx
+++ b/app/graphql/context.tsx
@@ -90,7 +90,10 @@ const createContextContent = async ({
 export const createContext = () => {
   let setupping: ReturnType<typeof createContextContent>;
 
-  return {
+  const ctx = {
+    // Stores meta information on queries that have been made during the request
+    queries: [] as RequestQueryMeta[],
+
     setup: async ({
       variableValues: { locale, sourceUrl },
     }: GraphQLResolveInfo) => {
@@ -98,6 +101,8 @@ export const createContext = () => {
       return await setupping;
     },
   };
+
+  return ctx;
 };
 
 export type GraphQLContext = ReturnType<typeof createContext>;

--- a/app/graphql/context.tsx
+++ b/app/graphql/context.tsx
@@ -8,7 +8,7 @@ import { createClient, defaultExchanges, Provider } from "urql";
 import { GRAPHQL_ENDPOINT } from "@/domain/env";
 import { Awaited } from "@/domain/types";
 // @ts-ignore - dynamic package import based on NODE_ENV
-import { devtoolsExchange } from "@/graphql/devtools";
+import { devtoolsExchanges } from "@/graphql/devtools";
 
 import { createCubeDimensionValuesLoader } from "../rdf/queries";
 import {
@@ -22,7 +22,7 @@ const client = createClient({
   url: GRAPHQL_ENDPOINT,
   exchanges:
     process.env.NODE_ENV === "development"
-      ? [devtoolsExchange, ...defaultExchanges]
+      ? [...devtoolsExchanges, ...defaultExchanges]
       : [...defaultExchanges],
 });
 

--- a/app/graphql/devtools.dev.ts
+++ b/app/graphql/devtools.dev.ts
@@ -1,3 +1,3 @@
 import { devtoolsExchange } from "@urql/devtools";
 
-export { devtoolsExchange };
+export const devtoolsExchanges = [devtoolsExchange];

--- a/app/graphql/devtools.prod.ts
+++ b/app/graphql/devtools.prod.ts
@@ -1,3 +1,1 @@
-const devtoolsExchange = undefined;
-
-export { devtoolsExchange };
+export const devtoolsExchanges = [];

--- a/app/graphql/query-meta.ts
+++ b/app/graphql/query-meta.ts
@@ -1,0 +1,6 @@
+type RequestQueryMeta = {
+  text: string;
+  startTime: number;
+  endTime: number;
+  label?: string;
+};

--- a/app/graphql/resolvers/rdf.ts
+++ b/app/graphql/resolvers/rdf.ts
@@ -38,7 +38,7 @@ import { searchCubes } from "@/rdf/query-search";
 export const dataCubes: NonNullable<QueryResolvers["dataCubes"]> = async (
   _,
   { locale, query, order, includeDrafts, filters },
-  { setup },
+  { setup, queries },
   info
 ) => {
   const { sparqlClient, sparqlClientStream } = await setup(info);
@@ -57,7 +57,7 @@ export const dataCubes: NonNullable<QueryResolvers["dataCubes"]> = async (
     }
   };
 
-  const candidates = await searchCubes({
+  const { candidates, meta } = await searchCubes({
     locale,
     includeDrafts,
     filters,
@@ -65,6 +65,11 @@ export const dataCubes: NonNullable<QueryResolvers["dataCubes"]> = async (
     query,
     sparqlClientStream,
   });
+
+  for (let query of meta.queries) {
+    queries.push(query);
+  }
+
   sortResults(candidates, (x) => x.dataCube.data);
   return candidates;
 };

--- a/app/pages/api/graphql.ts
+++ b/app/pages/api/graphql.ts
@@ -3,7 +3,7 @@ import "global-agent/bootstrap";
 import configureCors from "cors";
 import { NextApiRequest, NextApiResponse } from "next";
 
-import { createContext } from "../../graphql/context";
+import { createContext, GraphQLContext } from "../../graphql/context";
 import { resolvers } from "../../graphql/resolvers";
 import typeDefs from "../../graphql/schema.graphql";
 import { runMiddleware } from "../../utils/run-middleware";
@@ -16,6 +16,12 @@ const server = new ApolloServer({
   formatError: (err) => {
     console.error(err, err?.extensions?.exception?.stacktrace);
     return err;
+  },
+  formatResponse: (response, reqCtx) => {
+    response.extensions = {
+      queries: (reqCtx.context as GraphQLContext).queries,
+    };
+    return response;
   },
   context: createContext,
   // Enable playground in production


### PR DESCRIPTION
To provide the debug search page with the actual graphql queries that were sent to the sparql server, I use the extensions part of the graphql response.

I use the context to store the particular query times (at each query I push the meta information in context.queries)
Then I use the formatResponse callback from apollo-server to add to the extensions part of the response the queries that were stored in the context while the response is processed.