### PR TITLE
fix: Initialize ColorMapping with all values

### DIFF
--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -339,22 +339,25 @@ const MultiFilterContent = ({
 
   // Recomputes color palette making sure that used values
   // are sorted first, so they have different colors
-  const handleRecomputeColorMapping = useEvent(() => {
-    const usedValues = new Set(values.map((v) => v.value));
-    dispatch({
-      type: "CHART_CONFIG_UPDATE_COLOR_MAPPING",
-      value: {
-        dimensionIri,
-        values: sortBy(allValues, (v) => (usedValues.has(v) ? 0 : 1)),
-      },
-    });
-  });
+  const handleRecomputeColorMapping = useEvent(
+    ({ random }: { random: boolean } = { random: false }) => {
+      const usedValues = new Set(values.map((v) => v.value));
+      dispatch({
+        type: "CHART_CONFIG_UPDATE_COLOR_MAPPING",
+        value: {
+          dimensionIri,
+          values: sortBy(allValues, (v) => (usedValues.has(v) ? 0 : 1)),
+          random,
+        },
+      });
+    }
+  );
 
   const hasColorMapping = useMemo(() => {
     return !!getColorMapping(config, colorConfigPath);
   }, [colorConfigPath, config]);
 
-  // Initialize color mapping with all values.
+  // Initialize color mapping with all values, not randomizing the order.
   useEffect(() => {
     if (hasColorMapping) {
       handleRecomputeColorMapping();
@@ -409,7 +412,7 @@ const MultiFilterContent = ({
                 <IconButton
                   sx={{ ml: 1, my: -2 }}
                   size="small"
-                  onClick={handleRecomputeColorMapping}
+                  onClick={() => handleRecomputeColorMapping({ random: true })}
                 >
                   <SvgIcFormatting fontSize="inherit" />
                 </IconButton>

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -25,6 +25,7 @@ import React, {
   MouseEventHandler,
   MutableRefObject,
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -352,6 +353,13 @@ const MultiFilterContent = ({
   const hasColorMapping = useMemo(() => {
     return !!getColorMapping(config, colorConfigPath);
   }, [colorConfigPath, config]);
+
+  // Initialize color mapping with all values.
+  useEffect(() => {
+    if (hasColorMapping) {
+      handleRecomputeColorMapping();
+    }
+  }, [hasColorMapping]);
 
   return (
     <Box sx={{ position: "relative" }}>

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -170,7 +170,7 @@ export type ConfiguratorStateAction =
     }
   | {
       type: "CHART_CONFIG_UPDATE_COLOR_MAPPING";
-      value: { dimensionIri: string; values: string[] };
+      value: { dimensionIri: string; values: string[]; random: boolean };
     }
   | {
       type: "CHART_CONFIG_FILTER_ADD_MULTI";
@@ -942,7 +942,7 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
 
     case "CHART_CONFIG_UPDATE_COLOR_MAPPING":
       if (draft.state === "CONFIGURING_CHART") {
-        const { dimensionIri, values } = action.value;
+        const { dimensionIri, values, random } = action.value;
         if (
           isSegmentColorMappingInConfig(draft.chartConfig) &&
           draft.chartConfig.fields.segment &&
@@ -951,7 +951,7 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
           const colorMapping = mapValueIrisToColor({
             palette: draft.chartConfig.fields.segment.palette,
             dimensionValues: values.map((value) => ({ value })),
-            random: true,
+            random,
           });
           draft.chartConfig.fields.segment.colorMapping = colorMapping;
         }


### PR DESCRIPTION
Fixes #675.

In some cases, the dimension used to create ColorMapping is filtered; in such situations users can't set color values for new values which appeared on chart during filtering. This PR fixes that by firing `handleRecomputeColorMapping` on first load of color mapping to assure it will use all dimension's values.