### PR TITLE
Fix link unversioned dataset

### DIFF
--- a/app/configurator/components/select-dataset-step.tsx
+++ b/app/configurator/components/select-dataset-step.tsx
@@ -5,8 +5,7 @@ import { AnimatePresence } from "framer-motion";
 import Head from "next/head";
 import NextLink from "next/link";
 import { Router, useRouter } from "next/router";
-import React, { useEffect, useMemo } from "react";
-import ParsingClient from "sparql-http-client/ParsingClient";
+import React, { useMemo } from "react";
 import { useDebounce } from "use-debounce";
 
 import { Footer } from "@/components/footer";
@@ -32,9 +31,9 @@ import {
 } from "@/configurator/components/presence";
 import { useDataCubesQuery } from "@/graphql/query-hooks";
 import { Icon } from "@/icons";
-import { queryLatestPublishedCubeFromUnversionedIri } from "@/rdf/query-cube-metadata";
 import { useConfiguratorState, useLocale } from "@/src";
-import { getErrorQueryParams } from "@/utils/flashes";
+
+import { useRedirectToVersionedCube } from "./use-redirect-to-versioned-cube";
 
 const softJSONParse = (v: string) => {
   try {
@@ -81,14 +80,6 @@ export const formatBackLink = (
   return buildURLFromBrowseState(backParameters);
 };
 
-/**
- * Heuristic to check if a dataset IRI is versioned.
- * Versioned iris look like https://blabla/<number/
- */
-const isDatasetIriVersioned = (iri: string) => {
-  return iri.match(/\/\d+\/?$/) !== null;
-};
-
 const SelectDatasetStepContent = () => {
   const locale = useLocale();
   const [configState] = useConfiguratorState();
@@ -121,41 +112,10 @@ const SelectDatasetStepContent = () => {
     },
   });
 
-  useEffect(() => {
-    const run = async () => {
-      if (
-        dataset !== null &&
-        !Array.isArray(dataset) &&
-        !isDatasetIriVersioned(dataset)
-      ) {
-        const sparqlClient = new ParsingClient({
-          endpointUrl: configState.dataSource.url,
-        });
-        const resp = await queryLatestPublishedCubeFromUnversionedIri(
-          sparqlClient,
-          dataset
-        );
-
-        if (!resp) {
-          router.replace({
-            pathname: `/?${getErrorQueryParams("CANNOT_FIND_CUBE", {
-              iri: dataset,
-            })}`,
-          });
-        } else {
-          router.replace({
-            pathname: `/${locale}/browse/dataset/${encodeURIComponent(
-              resp.iri
-            )}`,
-          });
-        }
-      }
-    };
-
-    if (router.isReady) {
-      run();
-    }
-  }, [configState.dataSource.url, dataset, router, locale]);
+  useRedirectToVersionedCube({
+    dataSource: configState.dataSource,
+    datasetIri: dataset,
+  });
 
   if (configState.state !== "SELECTING_DATASET") {
     return null;

--- a/app/configurator/components/select-dataset-step.tsx
+++ b/app/configurator/components/select-dataset-step.tsx
@@ -142,12 +142,20 @@ const SelectDatasetStepContent = () => {
               iri: dataset,
             })}`,
           });
+        } else {
+          router.replace({
+            pathname: `/${locale}/browse/dataset/${encodeURIComponent(
+              resp.iri
+            )}`,
+          });
         }
       }
     };
 
-    run();
-  });
+    if (router.isReady) {
+      run();
+    }
+  }, [configState.dataSource.url, dataset, router, locale]);
 
   if (configState.state !== "SELECTING_DATASET") {
     return null;

--- a/app/configurator/components/select-dataset-step.tsx
+++ b/app/configurator/components/select-dataset-step.tsx
@@ -34,7 +34,7 @@ import { useDataCubesQuery } from "@/graphql/query-hooks";
 import { Icon } from "@/icons";
 import { queryLatestPublishedCubeFromUnversionedIri } from "@/rdf/query-cube-metadata";
 import { useConfiguratorState, useLocale } from "@/src";
-import { getQueryParams } from "@/utils/flashes";
+import { getErrorQueryParams } from "@/utils/flashes";
 
 const softJSONParse = (v: string) => {
   try {
@@ -138,7 +138,7 @@ const SelectDatasetStepContent = () => {
 
         if (!resp) {
           router.replace({
-            pathname: `/?${getQueryParams("CANNOT_FIND_CUBE", {
+            pathname: `/?${getErrorQueryParams("CANNOT_FIND_CUBE", {
               iri: dataset,
             })}`,
           });

--- a/app/configurator/components/use-redirect-to-versioned-cube.spec.tsx
+++ b/app/configurator/components/use-redirect-to-versioned-cube.spec.tsx
@@ -1,0 +1,103 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { NextRouter, useRouter } from "next/router";
+
+import { useLocale } from "@/locales/use-locale";
+import { queryLatestPublishedCubeFromUnversionedIri } from "@/rdf/query-cube-metadata";
+
+import { useRedirectToVersionedCube } from "./use-redirect-to-versioned-cube";
+jest.mock("@/rdf/query-cube-metadata", () => ({
+  queryLatestPublishedCubeFromUnversionedIri: jest.fn(),
+}));
+
+jest.mock("next/router", () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock("@/locales/use-locale", () => ({
+  useLocale: jest.fn(),
+}));
+
+const sleep = (duration: number) =>
+  new Promise((resolve) => setTimeout(resolve, duration));
+
+describe("use redirect to versioned cube", () => {
+  const setup = async ({
+    versionedCube,
+    datasetIri,
+  }: {
+    datasetIri: string;
+    versionedCube: undefined | { iri: string };
+  }) => {
+    const router = {
+      route: "",
+      pathname: "",
+      query: {},
+      asPath: "",
+      basePath: "",
+      isLocaleDomain: true,
+      isReady: true,
+      replace: jest.fn(async () => true),
+    } as unknown as NextRouter;
+    (useRouter as jest.MockedFunction<typeof useRouter>).mockReturnValue(
+      router
+    );
+
+    (useLocale as jest.MockedFunction<typeof useLocale>).mockReturnValue("de");
+
+    (
+      queryLatestPublishedCubeFromUnversionedIri as jest.MockedFunction<
+        typeof queryLatestPublishedCubeFromUnversionedIri
+      >
+    ).mockImplementation(async () => {
+      return versionedCube;
+    });
+
+    renderHook(() =>
+      useRedirectToVersionedCube({
+        datasetIri,
+        dataSource: {
+          type: "sparql",
+          url: "https://int.lindas.admin.ch/query",
+        },
+      })
+    );
+
+    // Wait for effects to have finished
+    await sleep(1);
+
+    return {
+      router,
+    };
+  };
+
+  it("should not do anything if initial cube IRI seems to be versioned", async () => {
+    const { router } = await setup({
+      datasetIri:
+        "https://environment.ld.admin.ch/foen/nfi/49-19-None-None-44/cube/1",
+      versionedCube: { iri: "https://versioned-cube" },
+    });
+
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+
+  it("should redirect to versioned IRI if initial cube IRI does not seem to be versioned", async () => {
+    const { router } = await setup({
+      datasetIri:
+        "https://environment.ld.admin.ch/foen/nfi/49-19-None-None-44/cube",
+      versionedCube: { iri: "https://versioned-cube" },
+    });
+    expect(router.replace).toHaveBeenCalledWith({
+      pathname: "/de/browse/dataset/https%3A%2F%2Fversioned-cube",
+    });
+  });
+
+  it("should redirect to versioned IRI if initial cube IRI does not seem to be versioned 2", async () => {
+    const { router } = await setup({
+      datasetIri: "https://environment.ld.admin.ch/foen/ubd000501",
+      versionedCube: { iri: "https://versioned-cube2" },
+    });
+    expect(router.replace).toHaveBeenCalledWith({
+      pathname: "/de/browse/dataset/https%3A%2F%2Fversioned-cube2",
+    });
+  });
+});

--- a/app/configurator/components/use-redirect-to-versioned-cube.tsx
+++ b/app/configurator/components/use-redirect-to-versioned-cube.tsx
@@ -1,0 +1,75 @@
+import { useRouter } from "next/router";
+import { useEffect, useRef } from "react";
+import ParsingClient from "sparql-http-client/ParsingClient";
+
+import { useLocale } from "@/locales/use-locale";
+import { queryLatestPublishedCubeFromUnversionedIri } from "@/rdf/query-cube-metadata";
+import { getErrorQueryParams } from "@/utils/flashes";
+
+import { ConfiguratorState } from "../config-types";
+
+/**
+ * Heuristic to check if a dataset IRI is versioned.
+ * Versioned iris look like https://blabla/<number/
+ */
+const isDatasetIriVersioned = (iri: string) => {
+  return iri.match(/\/\d+\/?$/) !== null;
+};
+export const useRedirectToVersionedCube = ({
+  datasetIri,
+  dataSource,
+}: {
+  datasetIri: string | undefined;
+  dataSource: ConfiguratorState["dataSource"];
+}) => {
+  const locale = useLocale();
+  const router = useRouter();
+  const hasRun = useRef(false);
+
+  useEffect(() => {
+    if (dataSource.type !== "sparql") {
+      console.error(
+        `Cannot redirect to unversioned IRI if dataSource.type !== "sparql", here it\'s ${dataSource.type}`
+      );
+      return;
+    }
+    const { url: dataSourceURL } = dataSource;
+    const run = async () => {
+      if (hasRun.current) {
+        return;
+      }
+      if (
+        datasetIri &&
+        !Array.isArray(datasetIri) &&
+        !isDatasetIriVersioned(datasetIri)
+      ) {
+        const sparqlClient = new ParsingClient({
+          endpointUrl: dataSourceURL,
+        });
+        const resp = await queryLatestPublishedCubeFromUnversionedIri(
+          sparqlClient,
+          datasetIri
+        );
+
+        if (!resp) {
+          router.replace({
+            pathname: `/?${getErrorQueryParams("CANNOT_FIND_CUBE", {
+              iri: datasetIri,
+            })}`,
+          });
+        } else {
+          router.replace({
+            pathname: `/${locale}/browse/dataset/${encodeURIComponent(
+              resp.iri
+            )}`,
+          });
+        }
+        hasRun.current = true;
+      }
+    };
+
+    if (router.isReady) {
+      run();
+    }
+  }, [router, locale, dataSource, datasetIri]);
+};

--- a/app/stores/data-source.ts
+++ b/app/stores/data-source.ts
@@ -8,7 +8,7 @@ import {
   sourceToLabel,
 } from "@/domain/datasource";
 import { isRunningInBrowser } from "@/utils/is-running-in-browser";
-import { getURLParam } from "@/utils/router/helpers";
+import { getURLParam, setURLParam } from "@/utils/router/helpers";
 
 export type DataSourceStore = {
   dataSource: DataSource;
@@ -33,18 +33,12 @@ const shouldKeepSourceInURL = (pathname: string) => {
   return !pathname.includes("__test");
 };
 
-const updateRouterDataSourceParam = (
-  router: SingletonRouter,
-  dataSource: DataSource
-) => {
+const saveToURL = (dataSource: DataSource) => {
   const urlDataSourceLabel = getURLParam(PARAM_KEY);
   const dataSourceLabel = sourceToLabel(dataSource);
 
   if (urlDataSourceLabel !== dataSourceLabel) {
-    router.replace({
-      pathname: router.pathname,
-      query: { ...router.query, [PARAM_KEY]: dataSourceLabel },
-    });
+    setURLParam(PARAM_KEY, dataSourceLabel);
   }
 };
 
@@ -68,7 +62,7 @@ export const dataSourceStoreMiddleware =
 
         if (isRunningInBrowser()) {
           saveToLocalStorage(payload.dataSource);
-          updateRouterDataSourceParam(router, payload.dataSource);
+          saveToURL(payload.dataSource);
         }
       },
       get,
@@ -99,11 +93,10 @@ export const dataSourceStoreMiddleware =
     }
 
     const callback = () => {
-      // Theoretically get().dataSource shouldn't fail, but when testing it does.
       const newSource = get()?.dataSource;
 
       if (newSource && shouldKeepSourceInURL(router.pathname)) {
-        updateRouterDataSourceParam(router, newSource);
+        saveToURL(newSource);
       }
     };
 

--- a/app/utils/flashes.tsx
+++ b/app/utils/flashes.tsx
@@ -10,7 +10,10 @@ export const flashes = {
   CANNOT_FIND_CUBE: "CANNOT_FIND_CUBE",
 } as const;
 
-export const getQueryParams = (errorId: keyof typeof flashes, options: any) => {
+export const getErrorQueryParams = (
+  errorId: keyof typeof flashes,
+  options: any
+) => {
   return `errorId=${errorId}&errorOptions=${encodeURIComponent(
     JSON.stringify(options)
   )}`;

--- a/app/utils/router/helpers.ts
+++ b/app/utils/router/helpers.ts
@@ -18,3 +18,16 @@ export const updateRouterQuery = (
     shallow: true,
   });
 };
+
+export const setURLParam = (param: string, value: string) => {
+  const qs = new URL(window.location.href).searchParams;
+  qs.delete(param);
+  qs.append(param, value);
+  const newUrl =
+    window.location.protocol +
+    "//" +
+    window.location.host +
+    window.location.pathname +
+    `?${qs.toString()}`;
+  window.history.replaceState({ path: newUrl }, "", newUrl);
+};

--- a/app/utils/router/helpers.ts
+++ b/app/utils/router/helpers.ts
@@ -20,14 +20,10 @@ export const updateRouterQuery = (
 };
 
 export const setURLParam = (param: string, value: string) => {
-  const qs = new URL(window.location.href).searchParams;
+  const { protocol, host, pathname, href } = window.location;
+  const qs = new URL(href).searchParams;
   qs.delete(param);
   qs.append(param, value);
-  const newUrl =
-    window.location.protocol +
-    "//" +
-    window.location.host +
-    window.location.pathname +
-    `?${qs.toString()}`;
+  const newUrl = `${protocol}//${host}${pathname}?${qs}`;
   window.history.replaceState({ path: newUrl }, "", newUrl);
 };


### PR DESCRIPTION
After the implementation of the datasource functionality, we moved the redirect to the front-end as we needed to access the localStorage. It seems that when we did that we missed one of the redirect.

I also experimented an issue with the router.replace function (an error while access /browser/dataset/iri, see the description of the commit), so I simplified the saving of the dataSource param in the URL, and used directly history.pushState.

Fixes https://github.com/visualize-admin/visualization-tool/issues/288

### How to test

Going to the following URLs should correctly redirect to the versioned IRI and the cube preview should be displayed.

- `/en/browse/dataset/https%3A%2F%2Fculture.ld.admin.ch%2Fsfa%2FStateAccounts_Function?dataSource=Int`
- `/en/browse/dataset/https%3A%2F%2Fenvironment.ld.admin.ch%2Ffoen%2Fubd000501?dataSource=Int` 
