### PR TITLE
feat: Add E2E test for unversioned link to dataset

### DIFF
--- a/cypress/integration/edition.spec.ts
+++ b/cypress/integration/edition.spec.ts
@@ -4,9 +4,8 @@ import {
 } from "../charts-utils";
 import offentlicheAusgabenChartConfigFixture from "../fixtures/offentliche-ausgaben-chart-config.json";
 
-const resizeObserverLoopErrRe = /> ResizeObserver loop/;
 Cypress.on("uncaught:exception", (err) => {
-  if (resizeObserverLoopErrRe.test(err.message)) {
+  if (err.message.includes("> ResizeObserver loop")) {
     return false;
   }
 });

--- a/cypress/integration/unversioned.spec.ts
+++ b/cypress/integration/unversioned.spec.ts
@@ -1,0 +1,10 @@
+describe("Unversioned dataset", () => {
+  it("should be possible to open a link to an unversioned dataset", () => {
+    cy.visit(
+      `/en/browse/dataset/https%3A%2F%2Fculture.ld.admin.ch%2Fsfa%2FStateAccounts_Function?dataSource=Int`
+    );
+
+    cy.waitForNetworkIdle(1000);
+    cy.findByText("State accounts - Function");
+  });
+});


### PR DESCRIPTION
Add a simple test to ensure that we do not have the unversioned link bug again in the future