### PR TITLE
feat: Split words of query and send 1 query per word

### DIFF
--- a/app/components/debug-search.tsx
+++ b/app/components/debug-search.tsx
@@ -177,7 +177,7 @@ const Search = ({
 };
 
 const DebugSearch = () => {
-  const [includeDrafts, setIncludeDrafts] = useState(false);
+  const [includeDrafts, setIncludeDrafts] = useState(true);
   const [sourceUrl, setSourceUrl] = useState(
     "https://int.lindas.admin.ch/query"
   );

--- a/app/rdf/query-search.ts
+++ b/app/rdf/query-search.ts
@@ -86,6 +86,7 @@ const enhanceQuery = (rawQuery: string) => {
     rawQuery
       .toLowerCase()
       .split(" ")
+      .filter((x) => x.toUpperCase() === x || x.length > 2)
       // Wildcard Searches on each term
       .map((t) => `${t}*`)
       .join(" ")


### PR DESCRIPTION
This PR tries to improve the search times when there are several words.
Instead of considering the full query, we send several query for each word, ignoring very small words that are not capitalized.

- feat: Split words of query and send 1 query per word
- feat: Default debug search uses drafts
- fix: Ignore search terms that are not capitalized and under 2 letters of length

This is related to https://github.com/visualize-admin/visualization-tool/issues/683
