### PR TITLE
feat: Add chartConfig versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 
 ## Unreleased
 
-Nothing yet.
+- Added migrations of chart configs (breaking changes to schema will not break existing charts)
 
 ## [3.7.10] - 2022-08-26
 
@@ -22,7 +22,7 @@ Nothing yet.
   - For the table chart columns
 - Default state for area chart uses the hierarchy and selects
   bottommost children
-- Add cube checker to docs 
+- Add cube checker to docs
 - Font alignments with design
 - Table config uses data column order to order columns
 - Search handles wildcards ("bath" returns "bathing site" results)

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -26,6 +26,7 @@ import {
 import { DEFAULT_PALETTE } from "@/configurator/configurator-state";
 import { HierarchyValue } from "@/graphql/resolver-types";
 import { visitHierarchy } from "@/rdf/tree-utils";
+import { CHART_CONFIG_VERSION } from "@/utils/chart-config/versioning";
 
 import { mapValueIrisToColor } from "../configurator/components/ui-helpers";
 import {
@@ -140,6 +141,7 @@ export const getInitialConfig = ({
   switch (chartType) {
     case "bar":
       return {
+        version: CHART_CONFIG_VERSION,
         chartType,
         filters: {},
         interactiveFiltersConfig: INITIAL_INTERACTIVE_FILTERS_CONFIG,
@@ -156,6 +158,7 @@ export const getInitialConfig = ({
       };
     case "column":
       return {
+        version: CHART_CONFIG_VERSION,
         chartType,
         filters: {},
         interactiveFiltersConfig: INITIAL_INTERACTIVE_FILTERS_CONFIG,
@@ -172,6 +175,7 @@ export const getInitialConfig = ({
       };
     case "line":
       return {
+        version: CHART_CONFIG_VERSION,
         chartType,
         filters: {},
         interactiveFiltersConfig: INITIAL_INTERACTIVE_FILTERS_CONFIG,
@@ -182,6 +186,7 @@ export const getInitialConfig = ({
       };
     case "area":
       return {
+        version: CHART_CONFIG_VERSION,
         chartType,
         filters: {},
         interactiveFiltersConfig: INITIAL_INTERACTIVE_FILTERS_CONFIG,
@@ -192,6 +197,7 @@ export const getInitialConfig = ({
       };
     case "scatterplot":
       return {
+        version: CHART_CONFIG_VERSION,
         chartType: "scatterplot",
         filters: {},
         interactiveFiltersConfig: INITIAL_INTERACTIVE_FILTERS_CONFIG,
@@ -213,6 +219,7 @@ export const getInitialConfig = ({
       };
     case "pie":
       return {
+        version: CHART_CONFIG_VERSION,
         chartType,
         filters: {},
         interactiveFiltersConfig: INITIAL_INTERACTIVE_FILTERS_CONFIG,
@@ -234,6 +241,7 @@ export const getInitialConfig = ({
         ascending(a.order ?? Infinity, b.order ?? Infinity)
       );
       return {
+        version: CHART_CONFIG_VERSION,
         chartType,
         filters: {},
         interactiveFiltersConfig: undefined,
@@ -269,6 +277,7 @@ export const getInitialConfig = ({
 
       const areaDimension = geoShapes[0];
       return {
+        version: CHART_CONFIG_VERSION,
         chartType,
         filters: makeInitialFiltersForArea(areaDimension),
         interactiveFiltersConfig: INITIAL_INTERACTIVE_FILTERS_CONFIG,

--- a/app/configurator/config-types.ts
+++ b/app/configurator/config-types.ts
@@ -186,6 +186,7 @@ const BarFields = t.intersection([
 ]);
 const BarConfig = t.type(
   {
+    version: t.string,
     chartType: t.literal("bar"),
     filters: Filters,
     interactiveFiltersConfig: InteractiveFiltersConfig,
@@ -212,6 +213,7 @@ const ColumnFields = t.intersection([
 ]);
 const ColumnConfig = t.type(
   {
+    version: t.string,
     chartType: t.literal("column"),
     filters: Filters,
     interactiveFiltersConfig: InteractiveFiltersConfig,
@@ -236,6 +238,7 @@ const LineFields = t.intersection([
 ]);
 const LineConfig = t.type(
   {
+    version: t.string,
     chartType: t.literal("line"),
     filters: Filters,
     interactiveFiltersConfig: InteractiveFiltersConfig,
@@ -272,6 +275,7 @@ const AreaFields = t.intersection([
 ]);
 const AreaConfig = t.type(
   {
+    version: t.string,
     chartType: t.literal("area"),
     filters: Filters,
     interactiveFiltersConfig: InteractiveFiltersConfig,
@@ -296,6 +300,7 @@ const ScatterPlotFields = t.intersection([
 ]);
 const ScatterPlotConfig = t.type(
   {
+    version: t.string,
     chartType: t.literal("scatterplot"),
     filters: Filters,
     interactiveFiltersConfig: InteractiveFiltersConfig,
@@ -316,6 +321,7 @@ const PieFields = t.type({
 });
 const PieConfig = t.type(
   {
+    version: t.string,
     chartType: t.literal("pie"),
     interactiveFiltersConfig: InteractiveFiltersConfig,
     filters: Filters,
@@ -427,6 +433,7 @@ export type TableSortingOption = t.TypeOf<typeof TableSortingOption>;
 
 const TableConfig = t.type(
   {
+    version: t.string,
     chartType: t.literal("table"),
     fields: TableFields,
     filters: Filters,
@@ -504,6 +511,7 @@ const MapFields = t.type({
 
 const MapConfig = t.type(
   {
+    version: t.string,
     chartType: t.literal("map"),
     interactiveFiltersConfig: InteractiveFiltersConfig,
     filters: Filters,

--- a/app/configurator/config-types.ts
+++ b/app/configurator/config-types.ts
@@ -561,6 +561,21 @@ const ChartConfig = t.union([
 // t.record(t.string, t.any)
 export type ChartConfig = t.TypeOf<typeof ChartConfig>;
 
+export const decodeChartConfig = (
+  chartConfig: unknown
+): ChartConfig | undefined => {
+  return pipe(
+    ChartConfig.decode(chartConfig),
+    fold(
+      (err) => {
+        console.error("Error while decoding chart config", err);
+        return undefined;
+      },
+      (d) => d
+    )
+  );
+};
+
 export type ChartType = ChartConfig["chartType"];
 
 export const isAreaConfig = (

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -2,7 +2,6 @@ import { Client } from "@urql/core";
 import { createDraft, current } from "immer";
 import { get } from "lodash";
 
-import * as api from "@/api";
 import { getChartConfigAdjustedToChartType } from "@/charts";
 import {
   ChartConfig,
@@ -28,6 +27,7 @@ import covid19TableChartConfig from "@/test/__fixtures/config/dev/chartConfig-ta
 import { data as fakeVizFixture } from "@/test/__fixtures/config/prod/line-1.json";
 import bathingWaterMetadata from "@/test/__fixtures/data/DataCubeMetadataWithComponentValues-bathingWater.json";
 import covid19Metadata from "@/test/__fixtures/data/DataCubeMetadataWithComponentValues-covid19.json";
+import * as api from "@/utils/chart-config/exchange";
 
 const mockedApi = api as jest.Mocked<typeof api>;
 

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -31,7 +31,7 @@ import * as api from "@/utils/chart-config/exchange";
 
 const mockedApi = api as jest.Mocked<typeof api>;
 
-jest.mock("../api", () => ({
+jest.mock("@/utils/chart-config/exchange", () => ({
   fetchChartConfig: jest.fn(),
 }));
 

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -13,7 +13,6 @@ import {
 import { Client, useClient } from "urql";
 import { Reducer, useImmerReducer } from "use-immer";
 
-import { fetchChartConfig, saveChartConfig } from "@/api";
 import {
   getChartConfigAdjustedToChartType,
   getFieldComponentIris,
@@ -62,6 +61,10 @@ import {
   getDataSourceFromLocalStorage,
   useDataSourceStore,
 } from "@/stores/data-source";
+import {
+  fetchChartConfig,
+  saveChartConfig,
+} from "@/utils/chart-config/exchange";
 import { createChartId } from "@/utils/create-chart-id";
 import { unreachableError } from "@/utils/unreachable";
 

--- a/app/docs/fixtures.ts
+++ b/app/docs/fixtures.ts
@@ -30,6 +30,7 @@ export const states: ConfiguratorState[] = [
     dataSet: "foo",
     dataSource: DEFAULT_DATA_SOURCE,
     chartConfig: {
+      version: "1.0.2",
       chartType: "column",
       fields: {
         x: {
@@ -822,6 +823,7 @@ export const tableDimensions = [
   },
 ];
 export const tableConfig: TableConfig = {
+  version: "1.0.2",
   chartType: "table",
   filters: {},
   interactiveFiltersConfig: undefined,

--- a/app/homepage/examples.tsx
+++ b/app/homepage/examples.tsx
@@ -52,6 +52,7 @@ export const Examples = ({
             },
           }}
           chartConfig={{
+            version: "1.0.2",
             fields: {
               x: {
                 sorting: {
@@ -150,6 +151,7 @@ export const Examples = ({
             },
           }}
           chartConfig={{
+            version: "1.0.2",
             fields: {
               x: {
                 componentIri: "http://www.w3.org/2006/time#Year",

--- a/app/pages/v/[chartId].tsx
+++ b/app/pages/v/[chartId].tsx
@@ -15,6 +15,7 @@ import { PublishActions } from "@/components/publish-actions";
 import { Config } from "@/configurator";
 import { getConfig } from "@/db/config";
 import { useLocale } from "@/locales/use-locale";
+import { migrateChartConfig } from "@/utils/chart-config/versioning";
 
 type PageProps =
   | {
@@ -36,7 +37,18 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
 
   if (config && config.data) {
     // TODO validate configuration
-    return { props: { status: "found", config } };
+    return {
+      props: {
+        status: "found",
+        config: {
+          ...config,
+          data: {
+            ...config.data,
+            chartConfig: migrateChartConfig(config.data.chartConfig),
+          },
+        },
+      },
+    };
   }
 
   res.statusCode = 404;

--- a/app/test/__fixtures/config/dev/4YL1p4QTFQS4.json
+++ b/app/test/__fixtures/config/dev/4YL1p4QTFQS4.json
@@ -7,6 +7,7 @@
     },
     "dataSet": "http://environment.ld.admin.ch/foen/px/0703010000_103/dataset",
     "chartConfig": {
+      "version": "1.0.2",
       "fields": {
         "x": {
           "sorting": {

--- a/app/test/__fixtures/config/dev/QGYSf81ILfWG.json
+++ b/app/test/__fixtures/config/dev/QGYSf81ILfWG.json
@@ -7,6 +7,7 @@
     },
     "dataSet": "http://environment.ld.admin.ch/foen/rl_trial/dataset",
     "chartConfig": {
+      "version": "1.0.2",
       "fields": {
         "x": {
           "sorting": {

--- a/app/test/__fixtures/config/dev/QzgH15yNMeuZ.json
+++ b/app/test/__fixtures/config/dev/QzgH15yNMeuZ.json
@@ -7,6 +7,7 @@
     },
     "dataSet": "http://environment.ld.admin.ch/foen/px/0703010000_103/dataset",
     "chartConfig": {
+      "version": "1.0.2",
       "fields": {
         "x": {
           "sorting": {

--- a/app/test/__fixtures/config/dev/UElM_bRD-FNL.json
+++ b/app/test/__fixtures/config/dev/UElM_bRD-FNL.json
@@ -7,6 +7,7 @@
     },
     "dataSet": "http://environment.ld.admin.ch/foen/px/0703010000_106/dataset",
     "chartConfig": {
+      "version": "1.0.2",
       "fields": {
         "x": {
           "componentIri": "http://environment.ld.admin.ch/foen/px/0703010000_106/dimension/0"

--- a/app/test/__fixtures/config/dev/V66Osn7TPFKs.json
+++ b/app/test/__fixtures/config/dev/V66Osn7TPFKs.json
@@ -7,6 +7,7 @@
     },
     "dataSet": "http://environment.ld.admin.ch/foen/px/0703030000_134/dataset",
     "chartConfig": {
+      "version": "1.0.2",
       "fields": {
         "x": {
           "sorting": {

--- a/app/test/__fixtures/config/dev/ZiLzQXCUhY5h.json
+++ b/app/test/__fixtures/config/dev/ZiLzQXCUhY5h.json
@@ -7,6 +7,7 @@
     },
     "dataSet": "http://environment.ld.admin.ch/foen/px/0703010000_103/dataset",
     "chartConfig": {
+      "version": "1.0.2",
       "fields": {
         "x": {
           "sorting": {

--- a/app/test/__fixtures/config/dev/cFd4UuIwNd8E.json
+++ b/app/test/__fixtures/config/dev/cFd4UuIwNd8E.json
@@ -7,6 +7,7 @@
     },
     "dataSet": "http://environment.ld.admin.ch/foen/px/0703030000_134/dataset",
     "chartConfig": {
+      "version": "1.0.2",
       "fields": {
         "x": {
           "sorting": {

--- a/app/test/__fixtures/config/dev/cYUA63lm2Avv.json
+++ b/app/test/__fixtures/config/dev/cYUA63lm2Avv.json
@@ -7,6 +7,7 @@
     },
     "dataSet": "http://environment.ld.admin.ch/foen/px/0703030000_112/dataset",
     "chartConfig": {
+      "version": "1.0.2",
       "fields": {
         "x": {
           "componentIri": "http://environment.ld.admin.ch/foen/px/0703030000_112/dimension/2"

--- a/app/test/__fixtures/config/dev/chartConfig-column-covid19.json
+++ b/app/test/__fixtures/config/dev/chartConfig-column-covid19.json
@@ -1,4 +1,5 @@
 {
+  "version": "1.0.2",
   "chartType": "column",
   "filters": {
     "https://environment.ld.admin.ch/foen/COVID19VaccPersons_v2/georegion": {

--- a/app/test/__fixtures/config/dev/chartConfig-table-covid19.json
+++ b/app/test/__fixtures/config/dev/chartConfig-table-covid19.json
@@ -1,4 +1,5 @@
 {
+  "version": "1.0.2",
   "chartType": "table",
   "filters": {},
   "settings": {

--- a/app/test/__fixtures/config/dev/u7SwBlMbyT2v.json
+++ b/app/test/__fixtures/config/dev/u7SwBlMbyT2v.json
@@ -7,6 +7,7 @@
     },
     "dataSet": "http://environment.ld.admin.ch/foen/px/0703030000_112/dataset",
     "chartConfig": {
+      "version": "1.0.2",
       "fields": {
         "x": {
           "sorting": {

--- a/app/test/__fixtures/config/dev/u8lguct-hWGI.json
+++ b/app/test/__fixtures/config/dev/u8lguct-hWGI.json
@@ -7,6 +7,7 @@
     },
     "dataSet": "http://environment.ld.admin.ch/foen/px/0703010000_103/dataset",
     "chartConfig": {
+      "version": "1.0.2",
       "fields": {
         "x": {
           "sorting": {

--- a/app/test/__fixtures/config/int/column-heavy-metals.json
+++ b/app/test/__fixtures/config/int/column-heavy-metals.json
@@ -21,6 +21,7 @@
       "url": "https://int.lindas.admin.ch/query"
     },
     "chartConfig": {
+      "version": "1.0.2",
       "fields": {
         "x": {
           "sorting": {

--- a/app/test/__fixtures/config/int/column-red-list.json
+++ b/app/test/__fixtures/config/int/column-red-list.json
@@ -21,6 +21,7 @@
       "url": "https://int.lindas.admin.ch/query"
     },
     "chartConfig": {
+      "version": "1.0.2",
       "fields": {
         "x": {
           "sorting": {

--- a/app/test/__fixtures/config/int/column-waldflasche.json
+++ b/app/test/__fixtures/config/int/column-waldflasche.json
@@ -12,6 +12,7 @@
       "description": { "de": "", "fr": "", "it": "", "en": "" }
     },
     "chartConfig": {
+      "version": "1.0.2",
       "chartType": "column",
       "filters": {
         "https://environment.ld.admin.ch/foen/nfi/inventory": {

--- a/app/test/__fixtures/config/int/line-state-accounts.json
+++ b/app/test/__fixtures/config/int/line-state-accounts.json
@@ -17,6 +17,7 @@
       "description": { "de": "", "fr": "", "it": "", "en": "" }
     },
     "chartConfig": {
+      "version": "1.0.2",
       "chartType": "line",
       "filters": {
         "https://culture.ld.admin.ch/sfa/StateAccounts_Office/office": {

--- a/app/test/__fixtures/config/int/map-waldflasche.json
+++ b/app/test/__fixtures/config/int/map-waldflasche.json
@@ -22,6 +22,7 @@
       }
     },
     "chartConfig": {
+      "version": "1.0.2",
       "chartType": "map",
       "filters": {
         "https://environment.ld.admin.ch/foen/nfi/inventory": {

--- a/app/test/__fixtures/config/int/pie-red-list.json
+++ b/app/test/__fixtures/config/int/pie-red-list.json
@@ -16,6 +16,7 @@
       "description": { "de": "", "fr": "", "it": "", "en": "" }
     },
     "chartConfig": {
+      "version": "1.0.2",
       "chartType": "pie",
       "filters": {
         "https://environment.ld.admin.ch/foen/UBD003002/artengruppe": {

--- a/app/test/__fixtures/config/int/scatterplot-palmer-penguins.json
+++ b/app/test/__fixtures/config/int/scatterplot-palmer-penguins.json
@@ -17,6 +17,7 @@
       "description": { "de": "", "fr": "", "it": "", "en": "" }
     },
     "chartConfig": {
+      "version": "1.0.2",
       "chartType": "scatterplot",
       "filters": {
         "https://environment.ld.admin.ch/foen/palmer-penguins/species": {

--- a/app/test/__fixtures/config/prod/column-1.json
+++ b/app/test/__fixtures/config/prod/column-1.json
@@ -11,6 +11,7 @@
       "url": "https://lindas.admin.ch/query"
     },
     "chartConfig": {
+      "version": "1.0.2",
       "fields": {
         "x": {
           "componentIri": "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2"

--- a/app/test/__fixtures/config/prod/column-2.json
+++ b/app/test/__fixtures/config/prod/column-2.json
@@ -11,6 +11,7 @@
       "url": "https://lindas.admin.ch/query"
     },
     "chartConfig": {
+      "version": "1.0.2",
       "fields": {
         "x": {
           "sorting": {

--- a/app/test/__fixtures/config/prod/column-3.json
+++ b/app/test/__fixtures/config/prod/column-3.json
@@ -11,6 +11,7 @@
       "url": "https://lindas.admin.ch/query"
     },
     "chartConfig": {
+      "version": "1.0.2",
       "fields": {
         "x": {
           "sorting": { "sortingType": "byMeasure", "sortingOrder": "asc" },

--- a/app/test/__fixtures/config/prod/column-4.json
+++ b/app/test/__fixtures/config/prod/column-4.json
@@ -11,6 +11,7 @@
       "url": "https://lindas.admin.ch/query"
     },
     "chartConfig": {
+      "version": "1.0.2",
       "fields": {
         "x": {
           "sorting": {

--- a/app/test/__fixtures/config/prod/column-5.json
+++ b/app/test/__fixtures/config/prod/column-5.json
@@ -11,6 +11,7 @@
       "url": "https://lindas.admin.ch/query"
     },
     "chartConfig": {
+      "version": "1.0.2",
       "fields": {
         "x": {
           "sorting": {

--- a/app/test/__fixtures/config/prod/column-6.json
+++ b/app/test/__fixtures/config/prod/column-6.json
@@ -16,6 +16,7 @@
       "url": "https://lindas.admin.ch/query"
     },
     "chartConfig": {
+      "version": "1.0.2",
       "fields": {
         "x": {
           "componentIri": "http://environment.ld.admin.ch/foen/px/0703010000_106/dimension/2"

--- a/app/test/__fixtures/config/prod/column-7.json
+++ b/app/test/__fixtures/config/prod/column-7.json
@@ -11,6 +11,7 @@
       "url": "https://lindas.admin.ch/query"
     },
     "chartConfig": {
+      "version": "1.0.2",
       "fields": {
         "x": {
           "sorting": {

--- a/app/test/__fixtures/config/prod/column-traffic-pollution.json
+++ b/app/test/__fixtures/config/prod/column-traffic-pollution.json
@@ -21,6 +21,7 @@
       "url": "https://lindas.admin.ch/query"
     },
     "chartConfig": {
+      "version": "1.0.2",
       "fields": {
         "x": {
           "sorting": {

--- a/app/test/__fixtures/config/prod/line-1.json
+++ b/app/test/__fixtures/config/prod/line-1.json
@@ -11,6 +11,7 @@
       "url": "https://lindas.admin.ch/query"
     },
     "chartConfig": {
+      "version": "1.0.2",
       "fields": {
         "x": {
           "componentIri": "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/0"

--- a/app/test/__fixtures/config/prod/line-2.json
+++ b/app/test/__fixtures/config/prod/line-2.json
@@ -16,6 +16,7 @@
       "url": "https://lindas.admin.ch/query"
     },
     "chartConfig": {
+      "version": "1.0.2",
       "fields": {
         "x": {
           "componentIri": "http://environment.ld.admin.ch/foen/px/0703030000_112/dimension/0"

--- a/app/test/__fixtures/config/prod/pie-1.json
+++ b/app/test/__fixtures/config/prod/pie-1.json
@@ -11,6 +11,7 @@
       "url": "https://lindas.admin.ch/query"
     },
     "chartConfig": {
+      "version": "1.0.2",
       "fields": {
         "y": {
           "componentIri": "http://environment.ld.admin.ch/foen/px/0703010000_106/measure/0"

--- a/app/utils/chart-config/__snapshots__/versioning.spec.ts.snap
+++ b/app/utils/chart-config/__snapshots__/versioning.spec.ts.snap
@@ -1,0 +1,54 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`config migrations should migrate to newest config 1`] = `
+Object {
+  "baseLayer": Object {
+    "bbox": undefined,
+    "locked": false,
+    "show": true,
+  },
+  "chartType": "map",
+  "fields": Object {
+    "areaLayer": Object {
+      "colorScaleInterpolationType": "linear",
+      "colorScaleType": "continuous",
+      "componentIri": "GeoShapesDimensionIri",
+      "measureIri": "MeasureIri",
+      "nbClass": 5,
+      "palette": "oranges",
+      "show": true,
+    },
+    "symbolLayer": Object {
+      "colors": Object {
+        "opacity": 80,
+        "type": "fixed",
+        "value": "blue",
+      },
+      "componentIri": "GeoCoordinatesDimensionIri",
+      "measureIri": "MeasureIri",
+      "show": true,
+    },
+  },
+  "filters": Object {},
+  "interactiveFiltersConfig": Object {
+    "dataFilters": Object {
+      "active": false,
+      "componentIris": Array [],
+    },
+    "legend": Object {
+      "active": false,
+      "componentIri": "",
+    },
+    "time": Object {
+      "active": false,
+      "componentIri": "",
+      "presets": Object {
+        "from": "",
+        "to": "",
+        "type": "range",
+      },
+    },
+  },
+  "version": "1.0.2",
+}
+`;

--- a/app/utils/chart-config/exchange.ts
+++ b/app/utils/chart-config/exchange.ts
@@ -1,4 +1,4 @@
-import { ConfiguratorStatePublishing } from "./configurator/config-types";
+import { ConfiguratorStatePublishing } from "../../configurator/config-types";
 
 export const fetchChartConfig = async (chartId: string) => {
   return await fetch(`/api/config/${chartId}`).then((result) => result.json());

--- a/app/utils/chart-config/versioning.spec.ts
+++ b/app/utils/chart-config/versioning.spec.ts
@@ -1,0 +1,66 @@
+import { decodeChartConfig } from "@/configurator/config-types";
+
+import { migrateChartConfig } from "./versioning";
+
+describe("config migrations", () => {
+  const oldConfig = {
+    version: "1.0.0",
+    chartType: "map",
+    interactiveFiltersConfig: {
+      legend: {
+        active: false,
+        componentIri: "",
+      },
+      time: {
+        active: false,
+        componentIri: "",
+        presets: {
+          type: "range",
+          from: "",
+          to: "",
+        },
+      },
+      dataFilters: {
+        active: false,
+        componentIris: [],
+      },
+    },
+    filters: {},
+    fields: {
+      areaLayer: {
+        show: true,
+        componentIri: "GeoShapesDimensionIri",
+        measureIri: "MeasureIri",
+        colorScaleType: "continuous",
+        colorScaleInterpolationType: "linear",
+        palette: "oranges",
+        nbClass: 5,
+      },
+      symbolLayer: {
+        show: true,
+        componentIri: "GeoCoordinatesDimensionIri",
+        measureIri: "MeasureIri",
+        color: "blue",
+      },
+    },
+    baseLayer: {
+      show: true,
+    },
+  };
+
+  it("should migrate to newest config", () => {
+    const migratedConfig = migrateChartConfig(oldConfig);
+    const decodedConfig = decodeChartConfig(migratedConfig);
+
+    expect(decodedConfig).toMatchSnapshot();
+  });
+
+  it("should migrate to initial config from migrated config", () => {
+    const migratedConfig = migrateChartConfig(oldConfig);
+    const migratedOldConfig = migrateChartConfig(migratedConfig, {
+      toVersion: "1.0.0",
+    });
+
+    expect(migratedOldConfig).toEqual(oldConfig);
+  });
+});

--- a/app/utils/chart-config/versioning.ts
+++ b/app/utils/chart-config/versioning.ts
@@ -1,0 +1,154 @@
+import produce from "immer";
+
+export const CHART_CONFIG_VERSION = "1.0.2";
+
+type Migration = {
+  description: string;
+  from: string;
+  to: string;
+  up: (config: any) => any;
+  down: (config: any) => any;
+};
+
+const migrations: Migration[] = [
+  {
+    description: `MAP
+    baseLayer {
+      + locked
+      + bbox
+    }`,
+    from: "1.0.0",
+    to: "1.0.1",
+    up: (config: any) => {
+      let newConfig = { ...config, version: "1.0.1" };
+
+      if (newConfig.chartType === "map") {
+        const { baseLayer } = newConfig;
+        newConfig = produce(newConfig, (draft: any) => {
+          draft.baseLayer = {
+            show: baseLayer.show,
+            locked: false,
+          };
+        });
+      }
+
+      return newConfig;
+    },
+    down: (config: any) => {
+      let newConfig = { ...config, version: "1.0.0" };
+
+      if (newConfig.chartType === "map") {
+        const { baseLayer } = newConfig;
+        newConfig = produce(newConfig, (draft: any) => {
+          draft.baseLayer = {
+            show: baseLayer.show,
+          };
+        });
+      }
+
+      return newConfig;
+    },
+  },
+  {
+    description: `MAP
+    symbolLayer {
+      + colors {
+        + type
+        + value
+        + opacity
+      }
+      - color
+    }`,
+    from: "1.0.1",
+    to: "1.0.2",
+    up: (config: any) => {
+      let newConfig = { ...config, version: "1.0.2" };
+
+      if (newConfig.chartType === "map") {
+        const { fields } = newConfig;
+        const { symbolLayer } = fields;
+        const { show, componentIri, measureIri, color } = symbolLayer;
+        newConfig = produce(newConfig, (draft: any) => {
+          draft.fields.symbolLayer = {
+            show,
+            componentIri,
+            measureIri,
+            colors: {
+              type: "fixed",
+              value: color,
+              opacity: 80,
+            },
+          };
+        });
+      }
+
+      return newConfig;
+    },
+    down: (config: any) => {
+      let newConfig = { ...config, version: "1.0.1" };
+
+      if (newConfig.chartType === "map") {
+        const { fields } = newConfig;
+        const { symbolLayer } = fields;
+        const { show, componentIri, measureIri, colors } = symbolLayer;
+        newConfig = produce(newConfig, (draft: any) => {
+          draft.fields.symbolLayer = {
+            show,
+            componentIri,
+            measureIri,
+            color: colors.value,
+          };
+        });
+      }
+
+      return newConfig;
+    },
+  },
+];
+
+export const migrateChartConfig = (
+  config: any,
+  {
+    fromVersion,
+    toVersion = CHART_CONFIG_VERSION,
+  }: { fromVersion?: string; toVersion?: string } = {}
+): any => {
+  const fromVersionFinal = fromVersion || config.version || "1.0.0";
+  const direction = upOrDown(fromVersionFinal, toVersion);
+
+  if (direction === "same") {
+    return config;
+  }
+
+  const currentMigration = migrations.find(
+    (migration) =>
+      migration[direction === "up" ? "from" : "to"] === fromVersionFinal
+  );
+
+  if (currentMigration) {
+    const newConfig = currentMigration[direction](config);
+    return migrateChartConfig(newConfig, { fromVersion, toVersion });
+  }
+
+  return config;
+};
+
+const upOrDown = (
+  fromVersion: string,
+  toVersion: string
+): "up" | "down" | "same" => {
+  const fromNumbers = fromVersion.split(".").map((d) => +d);
+  const toNumbers = toVersion.split(".").map((d) => +d);
+
+  for (let i = 0; i < fromNumbers.length; i++) {
+    if (fromNumbers[i] < toNumbers[i]) {
+      return "up";
+    }
+
+    if (fromNumbers[i] > toNumbers[i]) {
+      return "down";
+    }
+  }
+
+  return "same";
+};

--- a/cypress/fixtures/offentliche-ausgaben-chart-config.json
+++ b/cypress/fixtures/offentliche-ausgaben-chart-config.json
@@ -27,6 +27,7 @@
       "dataFilters": { "active": false, "componentIris": [] }
     },
     "fields": {
+      "version": "1.0.2",
       "x": {
         "componentIri": "https://environment.ld.admin.ch/foen/fab_Offentliche_Ausgaben_test3/jahr",
         "sorting": { "sortingType": "byDimensionLabel", "sortingOrder": "asc" }


### PR DESCRIPTION
As there can be breaking changes to the chartConfig schema (as was the case for SymbolLayer colors recently), we should have a mechanism of migrating old chartConfig to new ones, so the charts created with older visualize versions would still work in the current version.

This PR is a proposal to handle such situations.

### To clarify
Should we save migrated chartConfigs of published charts in the database?

### TODO
- [x] add tests