### PR TITLE
feat: Add basic SymbolLayer color selection E2E test

### DIFF
--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -267,6 +267,7 @@ const LegendColorContent = ({
               <div
                 className={classes.legendGroup}
                 key={g.map((n) => n.label).join(" > ")}
+                data-testid="colorLegend"
               >
                 {headerLabelsArray.length > 0 ? (
                   <Typography variant="h5" display="flex" alignItems="center">

--- a/app/test/__fixtures/config/int/map-waldflasche.json
+++ b/app/test/__fixtures/config/int/map-waldflasche.json
@@ -64,14 +64,14 @@
           "show": false,
           "componentIri": "https://environment.ld.admin.ch/foen/nfi/prodreg",
           "measureIri": "https://environment.ld.admin.ch/foen/nfi/forestArea",
-          "color": {
-            "type": "single",
+          "colors": {
+            "type": "fixed",
             "value": "#1f77b4",
             "opacity": 70
           }
         }
       },
-      "baseLayer": { "show": true }
+      "baseLayer": { "show": true, "locked": false }
     }
   }
 }

--- a/cypress/fixtures/map-waldflasche-chart-config.json
+++ b/cypress/fixtures/map-waldflasche-chart-config.json
@@ -1,0 +1,74 @@
+{
+  "state": "CONFIGURING_CHART",
+  "dataSet": "https://environment.ld.admin.ch/foen/nfi/49-19-None-None-44/cube/1",
+  "dataSource": {
+    "type": "sparql",
+    "url": "https://int.lindas.admin.ch/query"
+  },
+  "meta": {
+    "title": {
+      "de": "",
+      "en": "Forest area per region",
+      "fr": "",
+      "it": ""
+    },
+    "description": {
+      "de": "",
+      "en": "",
+      "fr": "",
+      "it": ""
+    }
+  },
+  "chartConfig": {
+    "chartType": "map",
+    "filters": {
+      "https://environment.ld.admin.ch/foen/nfi/inventory": {
+        "type": "single",
+        "value": "https://environment.ld.admin.ch/foen/nfi/Inventory/150"
+      },
+      "https://environment.ld.admin.ch/foen/nfi/struk": {
+        "type": "single",
+        "value": "https://environment.ld.admin.ch/foen/nfi/ClassificationUnit/Struk/-1"
+      },
+      "https://environment.ld.admin.ch/foen/nfi/grid": {
+        "type": "single",
+        "value": "https://environment.ld.admin.ch/foen/nfi/Grid/N4"
+      },
+      "https://environment.ld.admin.ch/foen/nfi/unitOfEvaluation": {
+        "type": "single",
+        "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfEvaluation/Zgwald1234"
+      }
+    },
+    "interactiveFiltersConfig": {
+      "legend": { "active": false, "componentIri": "" },
+      "time": {
+        "active": false,
+        "componentIri": "",
+        "presets": { "type": "range", "from": "", "to": "" }
+      },
+      "dataFilters": { "active": false, "componentIris": [] }
+    },
+    "fields": {
+      "areaLayer": {
+        "show": true,
+        "componentIri": "https://environment.ld.admin.ch/foen/nfi/prodreg",
+        "measureIri": "https://environment.ld.admin.ch/foen/nfi/forestArea",
+        "colorScaleType": "continuous",
+        "colorScaleInterpolationType": "linear",
+        "palette": "oranges",
+        "nbClass": 5
+      },
+      "symbolLayer": {
+        "show": false,
+        "componentIri": "https://environment.ld.admin.ch/foen/nfi/prodreg",
+        "measureIri": "https://environment.ld.admin.ch/foen/nfi/forestArea",
+        "colors": {
+          "type": "fixed",
+          "value": "#1f77b4",
+          "opacity": 70
+        }
+      }
+    },
+    "baseLayer": { "show": true, "locked": false }
+  }
+}

--- a/cypress/integration/symbol-layer-colors.spec.ts
+++ b/cypress/integration/symbol-layer-colors.spec.ts
@@ -1,0 +1,40 @@
+import {
+  loadChartInLocalStorage,
+  waitForChartToBeLoaded,
+} from "../charts-utils";
+import mapWaldflascheChartConfigFixture from "../fixtures/map-waldflasche-chart-config.json";
+
+Cypress.on("uncaught:exception", (err) => {
+  if (err.message.includes("> ResizeObserver loop")) {
+    return false;
+  }
+});
+
+beforeEach(() => {
+  cy.viewport("macbook-15");
+});
+
+describe("Selecting SymbolLayer colors", () => {
+  it("should be possible to select nominal dimension and see a legend", () => {
+    const key = "jky5IEw6poT3";
+    const config = mapWaldflascheChartConfigFixture;
+    loadChartInLocalStorage(key, config);
+    cy.visit(`/en/create/${key}`);
+    waitForChartToBeLoaded();
+
+    cy.waitForNetworkIdle(1000);
+
+    cy.findByText("Symbols", { timeout: 15000 }).click();
+    cy.findByText("Show layer").click();
+    cy.findByText("None").click();
+
+    cy.get(
+      '[data-value="https://environment.ld.admin.ch/foen/nfi/inventory"]'
+    ).click();
+
+    cy.get('[data-testid="colorLegend"]')
+      .find("div")
+      .its("length")
+      .should("eq", 4);
+  });
+});


### PR DESCRIPTION
As mentioned in #692, this PR adds a basic E2E test for SymbolLayer colors (checks if it's possible to select a nominal dimension and if a color legend shows up afterwards).