### PR TITLE
feat: Tooltips show numbers that are formatted according to their dimension formatter

### DIFF
--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -48,11 +48,10 @@ import {
 } from "@/configurator/components/ui-helpers";
 import { Observation } from "@/domain/data";
 import { useLocale } from "@/locales/use-locale";
+import useChartFormatters from "@/shared/use-chart-formatters";
 import { sortByIndex } from "@/utils/array";
 import { estimateTextWidth } from "@/utils/estimate-text-width";
 import { makeOrdinalDimensionSorter } from "@/utils/sorting-values";
-
-import useChartFormatters from "../shared/use-chart-formatters";
 
 export interface AreasState {
   chartType: "area";

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -52,10 +52,9 @@ import {
 } from "@/configurator/components/ui-helpers";
 import { Observation } from "@/domain/data";
 import { useLocale } from "@/locales/use-locale";
+import useChartFormatters from "@/shared/use-chart-formatters";
 import { sortByIndex } from "@/utils/array";
 import { makeOrdinalDimensionSorter } from "@/utils/sorting-values";
-
-import useChartFormatters from "../shared/use-chart-formatters";
 
 export interface GroupedColumnsState {
   chartType: "column";

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -54,10 +54,9 @@ import {
 } from "@/configurator/components/ui-helpers";
 import { Observation } from "@/domain/data";
 import { useLocale } from "@/locales/use-locale";
+import useChartFormatters from "@/shared/use-chart-formatters";
 import { sortByIndex } from "@/utils/array";
 import { makeOrdinalDimensionSorter } from "@/utils/sorting-values";
-
-import useChartFormatters from "../shared/use-chart-formatters";
 
 export interface StackedColumnsState {
   chartType: "column";

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -50,9 +50,8 @@ import {
 } from "@/configurator/components/ui-helpers";
 import { Observation } from "@/domain/data";
 import { TimeUnit } from "@/graphql/query-hooks";
+import useChartFormatters from "@/shared/use-chart-formatters";
 import { makeOrdinalDimensionSorter } from "@/utils/sorting-values";
-
-import useChartFormatters from "../shared/use-chart-formatters";
 
 export interface ColumnsState {
   chartType: "column";

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -39,12 +39,11 @@ import {
   useTimeFormatUnit,
 } from "@/configurator/components/ui-helpers";
 import { Observation } from "@/domain/data";
+import useChartFormatters from "@/shared/use-chart-formatters";
 import { useTheme } from "@/themes";
 import { sortByIndex } from "@/utils/array";
 import { estimateTextWidth } from "@/utils/estimate-text-width";
 import { makeOrdinalDimensionSorter } from "@/utils/sorting-values";
-
-import useChartFormatters from "../shared/use-chart-formatters";
 
 export interface LinesState {
   chartType: "line";

--- a/app/charts/map/map-state.tsx
+++ b/app/charts/map/map-state.tsx
@@ -446,14 +446,8 @@ const useMapState = (
   const identicalLayerComponentIris =
     areaLayer.componentIri === symbolLayer.componentIri;
 
-  const areaMeasureLabel = useMemo(
-    () => measures.find((m) => m.iri === areaLayer.measureIri)?.label || "",
-    [areaLayer.measureIri, measures]
-  );
-  const symbolMeasureLabel = useMemo(
-    () => measures.find((m) => m.iri === symbolLayer.measureIri)?.label || "",
-    [symbolLayer.measureIri, measures]
-  );
+  const areaMeasureLabel = areaMeasureDimension?.label || "";
+  const symbolMeasureLabel = symbolMeasureDimension?.label || "";
 
   const areaDataDomain = (extent(areaData, (d) => getAreaValue(d)) || [
     0, 100,
@@ -603,18 +597,16 @@ export const MapChart = ({
   return (
     <Observer>
       <InteractionProvider>
-        <MapTooltipProvider>
-          <MapChartProvider
-            data={data}
-            features={features}
-            fields={fields}
-            measures={measures}
-            dimensions={dimensions}
-            baseLayer={baseLayer}
-          >
-            {children}
-          </MapChartProvider>
-        </MapTooltipProvider>
+        <MapChartProvider
+          data={data}
+          features={features}
+          fields={fields}
+          measures={measures}
+          dimensions={dimensions}
+          baseLayer={baseLayer}
+        >
+          <MapTooltipProvider>{children}</MapTooltipProvider>
+        </MapChartProvider>
       </InteractionProvider>
     </Observer>
   );

--- a/app/charts/map/map-tooltip.tsx
+++ b/app/charts/map/map-tooltip.tsx
@@ -19,6 +19,9 @@ import {
   formatNumberWithUnit,
   useFormatNumber,
 } from "@/configurator/components/ui-helpers";
+import { truthy } from "@/domain/types";
+
+import useChartFormatters from "../shared/use-chart-formatters";
 
 export type HoverObjectType = "area" | "symbol";
 
@@ -82,6 +85,30 @@ export const MapTooltip = () => {
       textColor,
     };
   }, [areaValue, areaLayer]);
+
+  const formatters = useChartFormatters({
+    dimensions: [],
+    measures: [areaLayer.measureDimension, symbolLayer.measureDimension].filter(
+      truthy
+    ),
+  });
+  const areaValueFormatter = (value: number | null) =>
+    formatNumberWithUnit(
+      value,
+      areaLayer.measureDimension?.iri
+        ? formatters[areaLayer.measureDimension?.iri] || formatNumber
+        : formatNumber,
+      areaLayer.measureDimension?.unit
+    );
+  const symbolValueFormatter = (value: number | null) =>
+    formatNumberWithUnit(
+      value,
+      symbolLayer.measureDimension?.iri
+        ? formatters[symbolLayer.measureDimension?.iri] || formatNumber
+        : formatNumber,
+      symbolLayer.measureDimension?.unit
+    );
+
   const symbolColorProps = useMemo(() => {
     const obs = interaction.d;
     const colors = symbolLayer.colors;
@@ -167,11 +194,7 @@ export const MapTooltip = () => {
                       title={areaLayer.measureLabel}
                       background={areaColorProps.color}
                       color={areaColorProps.textColor}
-                      value={formatNumberWithUnit(
-                        areaValue,
-                        formatNumber,
-                        areaLayer?.measureDimension?.unit
-                      )}
+                      value={areaValueFormatter(areaValue)}
                       error={
                         formatAreaError
                           ? ` ± ${formatAreaError(interaction.d)}`
@@ -200,11 +223,7 @@ export const MapTooltip = () => {
                               ? symbolColorProps.textColor
                               : "#000"
                           }
-                          value={formatNumberWithUnit(
-                            symbolValue,
-                            formatNumber,
-                            symbolLayer?.measureDimension?.unit
-                          )}
+                          value={symbolValueFormatter(symbolValue)}
                           error={
                             formatSymbolError
                               ? ` ± ${formatSymbolError(interaction.d)}`

--- a/app/charts/map/map-tooltip.tsx
+++ b/app/charts/map/map-tooltip.tsx
@@ -20,8 +20,7 @@ import {
   useFormatNumber,
 } from "@/configurator/components/ui-helpers";
 import { truthy } from "@/domain/types";
-
-import useChartFormatters from "../shared/use-chart-formatters";
+import useChartFormatters from "@/shared/use-chart-formatters";
 
 export type HoverObjectType = "area" | "symbol";
 

--- a/app/charts/pie/pie-state.tsx
+++ b/app/charts/pie/pie-state.tsx
@@ -29,8 +29,7 @@ import {
   useFormatNumber,
 } from "@/configurator/components/ui-helpers";
 import { Observation } from "@/domain/data";
-
-import useChartFormatters from "../shared/use-chart-formatters";
+import useChartFormatters from "@/shared/use-chart-formatters";
 
 const sortData = ({
   data,

--- a/app/charts/shared/use-chart-formatters.ts
+++ b/app/charts/shared/use-chart-formatters.ts
@@ -1,0 +1,19 @@
+import { useMemo } from "react";
+
+import { useDimensionFormatters } from "@/configurator/components/ui-helpers";
+
+import { ChartProps } from "./use-chart-state";
+
+const useChartFormatters = (
+  chartProps: Pick<ChartProps, "measures" | "dimensions">
+) => {
+  const { measures, dimensions } = chartProps;
+  const allDimensions = useMemo(
+    () => [...measures, ...dimensions],
+    [measures, dimensions]
+  );
+  const formatters = useDimensionFormatters(allDimensions);
+  return formatters;
+};
+
+export default useChartFormatters;

--- a/app/components/common-chart.tsx
+++ b/app/components/common-chart.tsx
@@ -1,13 +1,56 @@
-import { ChartAreasVisualization } from "@/charts/area/chart-area";
-import { ChartBarsVisualization } from "@/charts/bar/chart-bar";
-import { ChartColumnsVisualization } from "@/charts/column/chart-column";
-import { ChartLinesVisualization } from "@/charts/line/chart-lines";
-import { ChartMapVisualization } from "@/charts/map/chart-map";
-import { ChartPieVisualization } from "@/charts/pie/chart-pie";
-import { ChartScatterplotVisualization } from "@/charts/scatterplot/chart-scatterplot";
+import dynamic from "next/dynamic";
+
 import { useQueryFilters } from "@/charts/shared/chart-helpers";
-import { ChartTableVisualization } from "@/charts/table/chart-table";
 import { ChartConfig, DataSource } from "@/configurator";
+
+const ChartAreasVisualization = dynamic(
+  import("@/charts/area/chart-area").then(
+    (mod) => mod.ChartAreasVisualization,
+    () => null as never
+  )
+);
+const ChartBarsVisualization = dynamic(
+  import("@/charts/bar/chart-bar").then(
+    (mod) => mod.ChartBarsVisualization,
+    () => null as never
+  )
+);
+const ChartColumnsVisualization = dynamic(
+  import("@/charts/column/chart-column").then(
+    (mod) => mod.ChartColumnsVisualization,
+    () => null as never
+  )
+);
+const ChartLinesVisualization = dynamic(
+  import("@/charts/line/chart-lines").then(
+    (mod) => mod.ChartLinesVisualization,
+    () => null as never
+  )
+);
+const ChartMapVisualization = dynamic(
+  import("@/charts/map/chart-map").then(
+    (mod) => mod.ChartMapVisualization,
+    () => null as never
+  )
+);
+const ChartPieVisualization = dynamic(
+  import("@/charts/pie/chart-pie").then(
+    (mod) => mod.ChartPieVisualization,
+    () => null as never
+  )
+);
+const ChartScatterplotVisualization = dynamic(
+  import("@/charts/scatterplot/chart-scatterplot").then(
+    (mod) => mod.ChartScatterplotVisualization,
+    () => null as never
+  )
+);
+const ChartTableVisualization = dynamic(
+  import("@/charts/table/chart-table").then(
+    (mod) => mod.ChartTableVisualization,
+    () => null as never
+  )
+);
 
 const GenericChart = ({
   dataSet,


### PR DESCRIPTION
We have rules for formatting numbers according to what their dimension specifies.
Previously those rules applied only to the table.
Now they apply to the tooltips of the charts.



