### PR TITLE
feat: Apply hierarchical dimension first in filters & select top most…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,11 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 - Added migrations of chart configs (breaking changes to schema will not break existing charts)
 - Tech
   - Diminish size of Javascript that is shipped to the client. Should improve page load performance
-- Better formatting of numbers inside chart tooltips (for example for currencies)
-
+- Charts
+  - Better formatting of numbers inside chart tooltips (for example for currencies)
+- Filters
+  - Initially, left filters are ordered so that dimension with hierarchy are at the top. Additionally, the topmost hierarchical value with a value is selected.
+- 
 ## [3.7.11] - 2022-09-09
 
 - 🚀 Maps

--- a/app/components/chart-filters-list.tsx
+++ b/app/components/chart-filters-list.tsx
@@ -69,6 +69,7 @@ export const ChartFiltersList = ({
             component="div"
             variant="body2"
             sx={{ color: "grey.800" }}
+            data-testid="chart-filters-list"
           >
             {namedFilters.map(({ dimension, value }, i) => (
               <Fragment key={dimension.iri}>

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -567,7 +567,10 @@ export const ChartConfigurator = ({
             ) : null}
           </SectionTitle>
 
-          <ControlSectionContent aria-labelledby="controls-data">
+          <ControlSectionContent
+            aria-labelledby="controls-data"
+            data-testid="configurator-filters"
+          >
             <DragDropContext onDragEnd={handleDragEnd}>
               <Droppable droppableId="filters">
                 {(provided) => (

--- a/app/configurator/components/chart-controls/color-ramp.tsx
+++ b/app/configurator/components/chart-controls/color-ramp.tsx
@@ -112,14 +112,15 @@ export const ColorRampField = ({
 
   return (
     <Box pb={2} sx={{ pointerEvents: disabled ? "none" : "auto" }}>
-      <Label smaller sx={{ mb: 1 }}>
+      <Label smaller sx={{ mb: 1 }} htmlFor="color-palette">
         <Trans id="controls.color.palette">Color palette</Trans>
       </Label>
       <Select
         value={currentPalette}
         disabled={disabled}
         sx={{
-          "& .MuiSelect-select": { height: "44px !important" },
+          width: "100%",
+          "& .MuiSelect-select": { height: "44px", width: "100%" },
         }}
         onChange={onSelectedItemChange}
         renderValue={(value) => {
@@ -129,6 +130,7 @@ export const ColorRampField = ({
                 colorInterpolator={value.interpolator}
                 nbClass={nbClass}
                 disabled={disabled}
+                width={220}
               />
             </Box>
           );
@@ -143,7 +145,11 @@ export const ColorRampField = ({
             key={`sequential-${i}`}
             value={d.value}
           >
-            <ColorRamp colorInterpolator={d.interpolator} nbClass={nbClass} />
+            <ColorRamp
+              colorInterpolator={d.interpolator}
+              nbClass={nbClass}
+              width={220}
+            />
           </MenuItem>
         ))}
         <ListSubheader>
@@ -155,7 +161,11 @@ export const ColorRampField = ({
             key={`diverging-${i}`}
             value={d.value}
           >
-            <ColorRamp colorInterpolator={d.interpolator} nbClass={nbClass} />
+            <ColorRamp
+              colorInterpolator={d.interpolator}
+              nbClass={nbClass}
+              width={220}
+            />
           </MenuItem>
         ))}
       </Select>

--- a/app/configurator/components/chart-controls/section.tsx
+++ b/app/configurator/components/chart-controls/section.tsx
@@ -60,6 +60,7 @@ export const ControlSectionContent = ({
   gap = "default",
   px,
   sx,
+  ...props
 }: {
   component?: ElementType;
   role?: string;
@@ -71,12 +72,13 @@ export const ControlSectionContent = ({
   gap?: "large" | "default" | "none";
   px?: "small" | "default";
   sx?: BoxProps["sx"];
-}) => {
+} & BoxProps) => {
   return (
     <Box
       component={component}
       role={role}
       aria-labelledby={ariaLabelledBy}
+      {...props}
       sx={{
         display: "flex",
         flexDirection: "column",

--- a/app/configurator/map/map-chart-options.tsx
+++ b/app/configurator/map/map-chart-options.tsx
@@ -243,6 +243,7 @@ export const AreaLayerSettings = memo(
             />
             <div>
               <FieldSetLegend
+                sx={{ mb: 1 }}
                 legendTitle={t({
                   id: "controls.scale.type",
                   message: "Scale type",

--- a/app/configurator/map/map-chart-options.tsx
+++ b/app/configurator/map/map-chart-options.tsx
@@ -497,7 +497,11 @@ export const SymbolLayerSettings = memo(
                 />
               ) : null
             ) : (
-              <ColorRampField field={activeField} path="colors.palette" />
+              <ColorRampField
+                field={activeField}
+                path="colors.palette"
+                disabled={!symbolLayer.show}
+              />
             )}
           </ControlSectionContent>
         </ControlSection>

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -49,6 +49,7 @@ fragment dimensionMetadata on Dimension {
     iri
     type
   }
+  ...hierarchyMetadata
   ... on TemporalDimension {
     timeUnit
     timeFormat

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -452,17 +452,35 @@ export type DataCubesQueryVariables = Exact<{
 
 export type DataCubesQuery = { __typename: 'Query', dataCubes: Array<{ __typename: 'DataCubeResult', highlightedTitle?: Maybe<string>, highlightedDescription?: Maybe<string>, dataCube: { __typename: 'DataCube', iri: string, title: string, workExamples?: Maybe<Array<Maybe<string>>>, description?: Maybe<string>, publicationStatus: DataCubePublicationStatus, datePublished?: Maybe<string>, creator?: Maybe<{ __typename: 'DataCubeOrganization', iri: string, label?: Maybe<string> }>, themes: Array<{ __typename: 'DataCubeTheme', iri: string, label?: Maybe<string> }> } }> };
 
-type DimensionMetadata_GeoCoordinatesDimension_Fragment = { __typename: 'GeoCoordinatesDimension', iri: string, label: string, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetadata_GeoCoordinatesDimension_Fragment = (
+  { __typename: 'GeoCoordinatesDimension', iri: string, label: string, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  & HierarchyMetadata_GeoCoordinatesDimension_Fragment
+);
 
-type DimensionMetadata_GeoShapesDimension_Fragment = { __typename: 'GeoShapesDimension', iri: string, label: string, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetadata_GeoShapesDimension_Fragment = (
+  { __typename: 'GeoShapesDimension', iri: string, label: string, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  & HierarchyMetadata_GeoShapesDimension_Fragment
+);
 
-type DimensionMetadata_Measure_Fragment = { __typename: 'Measure', isCurrency?: Maybe<boolean>, currencyExponent?: Maybe<number>, resolution?: Maybe<number>, iri: string, label: string, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetadata_Measure_Fragment = (
+  { __typename: 'Measure', isCurrency?: Maybe<boolean>, currencyExponent?: Maybe<number>, resolution?: Maybe<number>, iri: string, label: string, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  & HierarchyMetadata_Measure_Fragment
+);
 
-type DimensionMetadata_NominalDimension_Fragment = { __typename: 'NominalDimension', iri: string, label: string, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetadata_NominalDimension_Fragment = (
+  { __typename: 'NominalDimension', iri: string, label: string, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  & HierarchyMetadata_NominalDimension_Fragment
+);
 
-type DimensionMetadata_OrdinalDimension_Fragment = { __typename: 'OrdinalDimension', iri: string, label: string, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetadata_OrdinalDimension_Fragment = (
+  { __typename: 'OrdinalDimension', iri: string, label: string, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  & HierarchyMetadata_OrdinalDimension_Fragment
+);
 
-type DimensionMetadata_TemporalDimension_Fragment = { __typename: 'TemporalDimension', timeUnit: TimeUnit, timeFormat: string, iri: string, label: string, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetadata_TemporalDimension_Fragment = (
+  { __typename: 'TemporalDimension', timeUnit: TimeUnit, timeFormat: string, iri: string, label: string, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  & HierarchyMetadata_TemporalDimension_Fragment
+);
 
 export type DimensionMetadataFragment = DimensionMetadata_GeoCoordinatesDimension_Fragment | DimensionMetadata_GeoShapesDimension_Fragment | DimensionMetadata_Measure_Fragment | DimensionMetadata_NominalDimension_Fragment | DimensionMetadata_OrdinalDimension_Fragment | DimensionMetadata_TemporalDimension_Fragment;
 
@@ -835,30 +853,6 @@ export type DatasetCountQueryVariables = Exact<{
 
 export type DatasetCountQuery = { __typename: 'Query', datasetcount?: Maybe<Array<{ __typename: 'DatasetCount', count: number, iri: string }>> };
 
-export const DimensionMetadataFragmentDoc = gql`
-    fragment dimensionMetadata on Dimension {
-  iri
-  label
-  isNumerical
-  isKeyDimension
-  order
-  values(sourceType: $sourceType, sourceUrl: $sourceUrl, filters: $filters)
-  unit
-  related {
-    iri
-    type
-  }
-  ... on TemporalDimension {
-    timeUnit
-    timeFormat
-  }
-  ... on Measure {
-    isCurrency
-    currencyExponent
-    resolution
-  }
-}
-    `;
 export const HierarchyValueFieldsFragmentDoc = gql`
     fragment hierarchyValueFields on HierarchyValue {
   value
@@ -884,6 +878,31 @@ export const HierarchyMetadataFragmentDoc = gql`
   }
 }
     ${HierarchyValueFieldsFragmentDoc}`;
+export const DimensionMetadataFragmentDoc = gql`
+    fragment dimensionMetadata on Dimension {
+  iri
+  label
+  isNumerical
+  isKeyDimension
+  order
+  values(sourceType: $sourceType, sourceUrl: $sourceUrl, filters: $filters)
+  unit
+  related {
+    iri
+    type
+  }
+  ...hierarchyMetadata
+  ... on TemporalDimension {
+    timeUnit
+    timeFormat
+  }
+  ... on Measure {
+    isCurrency
+    currencyExponent
+    resolution
+  }
+}
+    ${HierarchyMetadataFragmentDoc}`;
 export const DataCubesDocument = gql`
     query DataCubes($sourceType: String!, $sourceUrl: String!, $locale: String!, $query: String, $order: DataCubeResultOrder, $includeDrafts: Boolean, $filters: [DataCubeSearchFilter!]) {
   dataCubes(

--- a/app/package.json
+++ b/app/package.json
@@ -55,7 +55,6 @@
     "d3-time-format": "3.0.0",
     "dataloader": "^2.0.0",
     "date-fns": "^2.28.0",
-    "downshift": "^6.0.6",
     "exceljs": "^4.3.0",
     "file-saver": "^2.0.2",
     "flexsearch": "^0.6.32",

--- a/app/rdf/tree-utils.ts
+++ b/app/rdf/tree-utils.ts
@@ -90,18 +90,44 @@ export const getCheckboxStates = (
   return res;
 };
 
+/**
+ * Visits a hierarchy with depth first search
+ */
 export const visitHierarchy = (
   tree: HierarchyValue[],
-  cb: (node: HierarchyValue) => void
+  /** Will be run over all children. Return false to abort early */
+  visitor: (node: HierarchyValue) => void | false
 ) => {
   let q = [...tree];
   while (q.length > 0) {
     const node = q.pop()!;
-    cb(node);
+    const ret = visitor(node);
+    if (ret === false) {
+      break;
+    }
     for (let c of node.children || []) {
       q.push(c);
     }
   }
+};
+
+/**
+ * Visits a hierarchy with depth first search
+ */
+export const findInHierarchy = (
+  tree: HierarchyValue[],
+  /** Will be run over all children. Return false to abort early */
+  finder: (node: HierarchyValue) => boolean
+) => {
+  let res = undefined as HierarchyValue | undefined;
+  visitHierarchy(tree, (node) => {
+    const found = finder(node);
+    if (found) {
+      res = node;
+      return false;
+    }
+  });
+  return res;
 };
 
 export const makeTreeFromValues = (

--- a/app/themes/federal.tsx
+++ b/app/themes/federal.tsx
@@ -682,6 +682,8 @@ theme.components = {
         lineHeight: 1.5,
         borderBottom: "1px solid",
         borderBottomColor: theme.palette.grey[500],
+        paddingTop: theme.spacing(1),
+        paddingBottom: theme.spacing(1),
       },
     },
   },

--- a/cypress/integration/chart-snapshots.spec.ts
+++ b/cypress/integration/chart-snapshots.spec.ts
@@ -18,7 +18,7 @@ describe("Chart Snapshots", () => {
         });
         cy.viewport(...viewportArgs);
         cy.visit(`/en/__test/${env}/${slug}`);
-        cy.get(`[data-chart-loaded="true"]`, { timeout: 40000 });
+        cy.get(`[data-chart-loaded="true"]`, { timeout: 90000 });
         cy.wait(100);
 
         if (slug.includes("map")) {

--- a/cypress/integration/filters.spec.ts
+++ b/cypress/integration/filters.spec.ts
@@ -1,0 +1,33 @@
+import { waitForChartToBeLoaded } from "../charts-utils";
+
+import selectors from "./selectors";
+
+Cypress.on("uncaught:exception", (err) => {
+  if (err.message.includes("> ResizeObserver loop")) {
+    return false;
+  }
+});
+
+describe("Filters", () => {
+  it("Initial state should have hierarchy dimensions first and topmost value selected", () => {
+    cy.visit(
+      `/en/create/new?cube=https://environment.ld.admin.ch/foen/nfi/49-19-None-None-44/cube/1&dataSource=Int`
+    );
+    waitForChartToBeLoaded();
+
+    selectors.edition.findConfiguratorFilters(cy).within(() => {
+      cy.findByText("1. production region");
+      cy.findByText("2. stand structure");
+      cy.findByText("3. evaluation type");
+      cy.findByText("4. Inventory");
+      cy.findByText("5. unit of evaluation");
+    });
+
+    selectors.edition
+      .findChartFiltersList(cy)
+      .should(
+        "contain.text",
+        "production region: Switzerland, stand structure: total, evaluation type: Zustand, Inventory: NFI1, unit of evaluation: accessible forest without shrub forest NFI1/NFI2/NFI3/NFI4"
+      );
+  });
+});

--- a/cypress/integration/home.spec.ts
+++ b/cypress/integration/home.spec.ts
@@ -1,5 +1,11 @@
 import { ignoreUncaughtExceptions } from "./utils";
 
+Cypress.on("uncaught:exception", (err) => {
+  if (err.message.includes("> ResizeObserver loop")) {
+    return false;
+  }
+});
+
 describe("The Home Page", () => {
   it("default language (de) should render on /", () => {
     cy.request({

--- a/cypress/integration/selectors.ts
+++ b/cypress/integration/selectors.ts
@@ -6,6 +6,8 @@ const selectors = {
     findIncludeDraftsCheckbox: (cy: Cy) => cy.get("#dataset-include-drafts"),
   },
   edition: {
+    findLeftPanel: (cy: Cy) => cy.get('[data-name="panel-left"]'),
+    findRightPanel: (cy: Cy) => cy.get('[data-name="panel-right"]'),
     findConfiguratorFilters: (cy: Cy) =>
       cy.findByTestId("configurator-filters"),
     findChartFiltersList: (cy: Cy) => cy.findByTestId("chart-filters-list"),

--- a/cypress/integration/selectors.ts
+++ b/cypress/integration/selectors.ts
@@ -1,0 +1,15 @@
+type Cy = Cypress.Chainable;
+
+const selectors = {
+  search: {
+    findSearchInput: (cy: Cy) => cy.get("#datasetSearch"),
+    findIncludeDraftsCheckbox: (cy: Cy) => cy.get("#dataset-include-drafts"),
+  },
+  edition: {
+    findConfiguratorFilters: (cy: Cy) =>
+      cy.findByTestId("configurator-filters"),
+    findChartFiltersList: (cy: Cy) => cy.findByTestId("chart-filters-list"),
+  },
+};
+
+export default selectors;

--- a/cypress/integration/symbol-layer-colors.spec.ts
+++ b/cypress/integration/symbol-layer-colors.spec.ts
@@ -4,6 +4,8 @@ import {
 } from "../charts-utils";
 import mapWaldflascheChartConfigFixture from "../fixtures/map-waldflasche-chart-config.json";
 
+import selectors from "./selectors";
+
 Cypress.on("uncaught:exception", (err) => {
   if (err.message.includes("> ResizeObserver loop")) {
     return false;
@@ -20,11 +22,17 @@ describe("Selecting SymbolLayer colors", () => {
     const config = mapWaldflascheChartConfigFixture;
     loadChartInLocalStorage(key, config);
     cy.visit(`/en/create/${key}`);
+
     waitForChartToBeLoaded();
 
     cy.waitForNetworkIdle(1000);
 
     cy.findByText("Symbols", { timeout: 15000 }).click();
+    selectors.edition
+      .findRightPanel(cy)
+      .get(".MuiSelect-select")
+      .should("have.class", "Mui-disabled");
+
     cy.findByText("Show layer").click();
     cy.findByText("None").click();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6671,11 +6671,6 @@ compress-commons@^4.1.0:
     normalize-path "^3.0.0"
     readable-stream "^3.6.0"
 
-compute-scroll-into-view@^1.0.17:
-  version "1.0.17"
-  resolved "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz"
-  integrity sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg==
-
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
@@ -7800,16 +7795,6 @@ dotenv@^8.2.0:
   version "8.6.0"
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz"
   integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
-
-downshift@^6.0.6:
-  version "6.1.3"
-  resolved "https://registry.npmjs.org/downshift/-/downshift-6.1.3.tgz"
-  integrity sha512-RA1MuaNcTbt0j+sVLhSs8R2oZbBXYAtdQP/V+uHhT3DoDteZzJPjlC+LQVm9T07Wpvo84QXaZtUCePLDTDwGXg==
-  dependencies:
-    "@babel/runtime" "^7.13.10"
-    compute-scroll-into-view "^1.0.17"
-    prop-types "^15.7.2"
-    react-is "^17.0.2"
 
 draco3d@1.4.1:
   version "1.4.1"


### PR DESCRIPTION
Apply hierarchical dimension first in filters & select top most value.

- For NFI datasets, Switzerland should be selected first in the left filters : https://visualization-tool-git-feat-topmost-map-layer-ixt1.vercel.app/en/create/new?cube=https://environment.ld.admin.ch/foen/nfi/49-19-None-None-44/cube/1
- For Public accounts datasets, Total should be selected first in the left filters : https://visualization-tool-git-feat-topmost-map-layer-ixt1.vercel.app/en/create/new?cube=https://environment.ld.admin.ch/foen/fab_Offentliche_Ausgaben_test3/8

Smaller fixes on color palette to make it coherent with other fields (checked with @AnninaWalker)

- feat: Use Select from MUI to implement ColorRampField
- fix: Missing gutter
- feat: Add name of palette
- feat: Better spacing for ListSubheader
- feat: Make color palette field width 100%
- feat: Remove downshift

Fix #711 
