### PR TITLE
Better formatting for map legend items

### DIFF
--- a/app/components/chart-filters-list.tsx
+++ b/app/components/chart-filters-list.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography } from "@mui/material";
+import { Box, Typography, Tooltip } from "@mui/material";
 import { Fragment } from "react";
 
 import { useQueryFilters } from "@/charts/shared/chart-helpers";
@@ -73,14 +73,21 @@ export const ChartFiltersList = ({
           >
             {namedFilters.map(({ dimension, value }, i) => (
               <Fragment key={dimension.iri}>
-                <Box component="span">
-                  {dimension.label}
+                <Box component="span" fontWeight="bold">
+                  {dimension.description ? (
+                    <Tooltip arrow title={dimension.description}>
+                      <span style={{ textDecoration: "underline" }}>
+                        {dimension.label}
+                      </span>
+                    </Tooltip>
+                  ) : (
+                    dimension.label
+                  )}
+
                   {": "}
                 </Box>
 
-                <Box component="span" sx={{ fontWeight: "bold" }}>
-                  {value && value.label}
-                </Box>
+                <Box component="span">{value && value.label}</Box>
                 {i < namedFilters.length - 1 && ", "}
               </Fragment>
             ))}

--- a/app/docs/components.tsx
+++ b/app/docs/components.tsx
@@ -1,7 +1,7 @@
 import { markdown } from "catalog";
 
 const Doc = () => markdown`
-> The components used in the User Interface are built upon [rebass](https://rebassjs.org/), a library of React primitive UI components.
+> The components used in the User Interface are built upon [rebass](https://mui.com/), a library of React UI components.
 
 > All styles are defined in a \`theme\` file [that can be customized to a specific brand](/theming).
 

--- a/app/docs/tooltips.docs.tsx
+++ b/app/docs/tooltips.docs.tsx
@@ -1,0 +1,18 @@
+import { Tooltip, Typography } from "@mui/material";
+import { markdown, ReactSpecimen } from "catalog";
+
+const Doc = () => markdown`
+Tooltips are used to provide more information.
+
+${(
+  <ReactSpecimen span={2}>
+    <Tooltip title="I have a tooltip" arrow open>
+      <Typography display="inline" variant="body2">
+        Content with tooltip
+      </Typography>
+    </Tooltip>
+  </ReactSpecimen>
+)}
+`;
+
+export default Doc;

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -40,6 +40,7 @@ query DataCubes(
 fragment dimensionMetadata on Dimension {
   iri
   label
+  description
   isNumerical
   isKeyDimension
   order

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -116,6 +116,7 @@ export type DatasetCount = {
 export type Dimension = {
   iri: Scalars['String'];
   label: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
   scaleType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
@@ -154,6 +155,7 @@ export type GeoCoordinatesDimension = Dimension & {
   __typename: 'GeoCoordinatesDimension';
   iri: Scalars['String'];
   label: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
   scaleType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
@@ -183,6 +185,7 @@ export type GeoShapesDimension = Dimension & {
   __typename: 'GeoShapesDimension';
   iri: Scalars['String'];
   label: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
   scaleType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
@@ -221,6 +224,7 @@ export type Measure = Dimension & {
   __typename: 'Measure';
   iri: Scalars['String'];
   label: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
   scaleType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
@@ -251,6 +255,7 @@ export type NominalDimension = Dimension & {
   __typename: 'NominalDimension';
   iri: Scalars['String'];
   label: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
   scaleType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
@@ -298,6 +303,7 @@ export type OrdinalDimension = Dimension & {
   __typename: 'OrdinalDimension';
   iri: Scalars['String'];
   label: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
   scaleType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
@@ -404,6 +410,7 @@ export type TemporalDimension = Dimension & {
   __typename: 'TemporalDimension';
   iri: Scalars['String'];
   label: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
   timeUnit: TimeUnit;
   timeFormat: Scalars['String'];
   unit?: Maybe<Scalars['String']>;
@@ -453,32 +460,32 @@ export type DataCubesQueryVariables = Exact<{
 export type DataCubesQuery = { __typename: 'Query', dataCubes: Array<{ __typename: 'DataCubeResult', highlightedTitle?: Maybe<string>, highlightedDescription?: Maybe<string>, dataCube: { __typename: 'DataCube', iri: string, title: string, workExamples?: Maybe<Array<Maybe<string>>>, description?: Maybe<string>, publicationStatus: DataCubePublicationStatus, datePublished?: Maybe<string>, creator?: Maybe<{ __typename: 'DataCubeOrganization', iri: string, label?: Maybe<string> }>, themes: Array<{ __typename: 'DataCubeTheme', iri: string, label?: Maybe<string> }> } }> };
 
 type DimensionMetadata_GeoCoordinatesDimension_Fragment = (
-  { __typename: 'GeoCoordinatesDimension', iri: string, label: string, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'GeoCoordinatesDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_GeoCoordinatesDimension_Fragment
 );
 
 type DimensionMetadata_GeoShapesDimension_Fragment = (
-  { __typename: 'GeoShapesDimension', iri: string, label: string, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'GeoShapesDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_GeoShapesDimension_Fragment
 );
 
 type DimensionMetadata_Measure_Fragment = (
-  { __typename: 'Measure', isCurrency?: Maybe<boolean>, currencyExponent?: Maybe<number>, resolution?: Maybe<number>, iri: string, label: string, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'Measure', isCurrency?: Maybe<boolean>, currencyExponent?: Maybe<number>, resolution?: Maybe<number>, iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_Measure_Fragment
 );
 
 type DimensionMetadata_NominalDimension_Fragment = (
-  { __typename: 'NominalDimension', iri: string, label: string, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'NominalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_NominalDimension_Fragment
 );
 
 type DimensionMetadata_OrdinalDimension_Fragment = (
-  { __typename: 'OrdinalDimension', iri: string, label: string, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'OrdinalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_OrdinalDimension_Fragment
 );
 
 type DimensionMetadata_TemporalDimension_Fragment = (
-  { __typename: 'TemporalDimension', timeUnit: TimeUnit, timeFormat: string, iri: string, label: string, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'TemporalDimension', timeUnit: TimeUnit, timeFormat: string, iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_TemporalDimension_Fragment
 );
 
@@ -882,6 +889,7 @@ export const DimensionMetadataFragmentDoc = gql`
     fragment dimensionMetadata on Dimension {
   iri
   label
+  description
   isNumerical
   isKeyDimension
   order

--- a/app/graphql/resolver-types.ts
+++ b/app/graphql/resolver-types.ts
@@ -122,6 +122,7 @@ export type DatasetCount = {
 export type Dimension = {
   iri: Scalars['String'];
   label: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
   scaleType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
@@ -160,6 +161,7 @@ export type GeoCoordinatesDimension = Dimension & {
   __typename?: 'GeoCoordinatesDimension';
   iri: Scalars['String'];
   label: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
   scaleType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
@@ -189,6 +191,7 @@ export type GeoShapesDimension = Dimension & {
   __typename?: 'GeoShapesDimension';
   iri: Scalars['String'];
   label: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
   scaleType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
@@ -227,6 +230,7 @@ export type Measure = Dimension & {
   __typename?: 'Measure';
   iri: Scalars['String'];
   label: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
   scaleType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
@@ -257,6 +261,7 @@ export type NominalDimension = Dimension & {
   __typename?: 'NominalDimension';
   iri: Scalars['String'];
   label: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
   scaleType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
@@ -304,6 +309,7 @@ export type OrdinalDimension = Dimension & {
   __typename?: 'OrdinalDimension';
   iri: Scalars['String'];
   label: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
   scaleType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
@@ -410,6 +416,7 @@ export type TemporalDimension = Dimension & {
   __typename?: 'TemporalDimension';
   iri: Scalars['String'];
   label: Scalars['String'];
+  description?: Maybe<Scalars['String']>;
   timeUnit: TimeUnit;
   timeFormat: Scalars['String'];
   unit?: Maybe<Scalars['String']>;
@@ -631,6 +638,7 @@ export type DimensionResolvers<ContextType = GraphQLContext, ParentType extends 
   __resolveType: TypeResolveFn<'GeoCoordinatesDimension' | 'GeoShapesDimension' | 'Measure' | 'NominalDimension' | 'OrdinalDimension' | 'TemporalDimension', ParentType, ContextType>;
   iri?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   unit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   scaleType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -664,6 +672,7 @@ export type GeoCoordinatesResolvers<ContextType = GraphQLContext, ParentType ext
 export type GeoCoordinatesDimensionResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['GeoCoordinatesDimension'] = ResolversParentTypes['GeoCoordinatesDimension']> = ResolversObject<{
   iri?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   unit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   scaleType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -683,6 +692,7 @@ export interface GeoShapesScalarConfig extends GraphQLScalarTypeConfig<Resolvers
 export type GeoShapesDimensionResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['GeoShapesDimension'] = ResolversParentTypes['GeoShapesDimension']> = ResolversObject<{
   iri?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   unit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   scaleType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -708,6 +718,7 @@ export type HierarchyValueResolvers<ContextType = GraphQLContext, ParentType ext
 export type MeasureResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['Measure'] = ResolversParentTypes['Measure']> = ResolversObject<{
   iri?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   unit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   scaleType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -725,6 +736,7 @@ export type MeasureResolvers<ContextType = GraphQLContext, ParentType extends Re
 export type NominalDimensionResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['NominalDimension'] = ResolversParentTypes['NominalDimension']> = ResolversObject<{
   iri?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   unit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   scaleType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -758,6 +770,7 @@ export type ObservationsQueryResolvers<ContextType = GraphQLContext, ParentType 
 export type OrdinalDimensionResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['OrdinalDimension'] = ResolversParentTypes['OrdinalDimension']> = ResolversObject<{
   iri?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   unit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   scaleType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
@@ -792,6 +805,7 @@ export type RelatedDimensionResolvers<ContextType = GraphQLContext, ParentType e
 export type TemporalDimensionResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['TemporalDimension'] = ResolversParentTypes['TemporalDimension']> = ResolversObject<{
   iri?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   timeUnit?: Resolver<ResolversTypes['TimeUnit'], ParentType, ContextType>;
   timeFormat?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   unit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/app/graphql/resolvers/index.ts
+++ b/app/graphql/resolvers/index.ts
@@ -105,6 +105,7 @@ const mkDimensionResolvers = (_: string): Resolvers["Dimension"] => ({
   },
   iri: ({ data: { iri } }) => iri,
   label: ({ data: { name } }) => name,
+  description: ({ data: { description } }) => description || null,
   related: ({ data: { related } }) => related,
   order: ({ data: { order } }) => (order !== undefined ? order : null),
   isNumerical: ({ data: { isNumerical } }) => isNumerical,

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -70,6 +70,7 @@ type HierarchyValue {
 interface Dimension {
   iri: String!
   label: String!
+  description: String
   unit: String
   scaleType: String
   order: Int
@@ -94,6 +95,7 @@ type GeoCoordinates {
 type GeoCoordinatesDimension implements Dimension {
   iri: String!
   label: String!
+  description: String
   unit: String
   scaleType: String
   order: Int
@@ -118,6 +120,7 @@ type ObservationFilter {
 type GeoShapesDimension implements Dimension {
   iri: String!
   label: String!
+  description: String
   unit: String
   scaleType: String
   order: Int
@@ -136,6 +139,7 @@ type GeoShapesDimension implements Dimension {
 type NominalDimension implements Dimension {
   iri: String!
   label: String!
+  description: String
   unit: String
   scaleType: String
   order: Int
@@ -153,6 +157,7 @@ type NominalDimension implements Dimension {
 type OrdinalDimension implements Dimension {
   iri: String!
   label: String!
+  description: String
   unit: String
   scaleType: String
   order: Int
@@ -180,6 +185,7 @@ enum TimeUnit {
 type TemporalDimension implements Dimension {
   iri: String!
   label: String!
+  description: String
   timeUnit: TimeUnit!
   timeFormat: String!
   unit: String
@@ -199,6 +205,7 @@ type TemporalDimension implements Dimension {
 type Measure implements Dimension {
   iri: String!
   label: String!
+  description: String
   unit: String
   scaleType: String
   order: Int

--- a/app/graphql/shared-types.ts
+++ b/app/graphql/shared-types.ts
@@ -57,6 +57,7 @@ export type ResolvedDimension = {
     dataType?: string;
     order?: number;
     name: string;
+    description?: string;
     dataKind?: "Time" | "GeoCoordinates" | "GeoShape";
     related: Omit<RelatedDimension, "__typename">[];
     timeUnit?: TimeUnit;

--- a/app/pages/docs/index.tsx
+++ b/app/pages/docs/index.tsx
@@ -198,6 +198,11 @@ const pages: ConfigPageOrGroup[] = [
         content: require("@/docs/tags.docs"),
       },
       {
+        path: "/components/tooltips",
+        title: "Tooltips",
+        content: require("@/docs/tooltips.docs"),
+      },
+      {
         path: "/components/typography",
         title: "Typography",
         content: require("@/docs/text.docs"),

--- a/app/rdf/parse.ts
+++ b/app/rdf/parse.ts
@@ -238,6 +238,7 @@ export const parseCubeDimension = ({
   const order = rawOrder !== undefined ? parseInt(rawOrder, 10) : undefined;
 
   const name = dim.out(ns.schema.name, outOpts).value ?? dim.path?.value!;
+  const description = dim.out(ns.schema.description, outOpts).value;
   const resolution =
     dataType?.equals(ns.xsd.int) || dataType?.equals(ns.xsd.integer)
       ? 0
@@ -250,6 +251,8 @@ export const parseCubeDimension = ({
 
     data: {
       iri: dim.path?.value!,
+      name,
+      description,
       related,
       isLiteral,
       isNumerical,
@@ -263,8 +266,7 @@ export const parseCubeDimension = ({
       currencyExponent: dimensionUnit?.currencyExponent?.value
         ? parseInt(dimensionUnit?.currencyExponent?.value)
         : undefined,
-      name,
-      order: order,
+      order,
       dataKind: dataKindTerm?.equals(ns.time.GeneralDateTimeDescription)
         ? "Time"
         : dataKindTerm?.equals(ns.schema.GeoCoordinates)

--- a/app/themes/federal.tsx
+++ b/app/themes/federal.tsx
@@ -548,6 +548,22 @@ theme.components = {
       },
     },
   },
+  MuiTooltip: {
+    styleOverrides: {
+      tooltip: {
+        backgroundColor: theme.palette.background.paper,
+        color: theme.palette.text.primary,
+        fontSize: theme.typography.body2.fontSize,
+        boxShadow: theme.shadows[18],
+        zIndex: 1,
+        position: "relative",
+        padding: theme.spacing(4),
+      },
+      arrow: {
+        color: theme.palette.background.paper,
+      },
+    },
+  },
   MuiNativeSelect: {
     styleOverrides: {
       root: {


### PR DESCRIPTION
Dimension related formatting was not applied to continuous color and circle legend of map legend.

<img width="582" alt="image" src="https://user-images.githubusercontent.com/465582/190588098-b2bf135c-b6ba-4700-9ed9-8411ad872a94.png">

fix #712

To test with the einmalverguetung_fuer_photovoltaikanlagen dataset.

/en/browse/dataset/https%3A%2F%2Fenergy.ld.admin.ch%2Fsfoe%2Fbfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen%2F13?previous=%7B%22includeDrafts%22%3Afalse%2C%22order%22%3A%22SCORE%22%2C%22search%22%3A%22photovoltaik%22%7D&dataSource=Int