### PR TITLE
Retain filters when switching to map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 
 Nothing yet.
 
+## [3.9.3] - 2022-09-27
+
+- Map: Retain filters when switching from another chart type to map
+
 ## [3.9.2] - 2022-09-20
 
 - Map: fix a layer offset problem on Windows Edge.

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -798,8 +798,14 @@ const chartConfigsAdjusters: ChartConfigsAdjusters = {
   map: {
     filters: ({ oldValue, newChartConfig }) => {
       return produce(newChartConfig, (draft) => {
-        if (!oldValue) {
-          draft.filters = oldValue;
+        // Filters have been reset by the initial config of the map.
+        // We need to set them back to their old value, taking care not
+        // to override the filters that have been set by the initial config
+        // of the map.
+        for (const [iri, value] of Object.entries(oldValue)) {
+          if (draft.filters[iri] === undefined) {
+            draft.filters[iri] = value;
+          }
         }
       });
     },

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -2,6 +2,7 @@ import { ascending, group } from "d3";
 import produce from "immer";
 import get from "lodash/get";
 import groupBy from "lodash/groupBy";
+import sortBy from "lodash/sortBy";
 
 import { DEFAULT_SYMBOL_LAYER_COLORS } from "@/charts/map/constants";
 import {
@@ -34,6 +35,8 @@ import {
   getCategoricalDimensions,
   getGeoDimensions,
   getTimeDimensions,
+  isGeoCoordinatesDimension,
+  isGeoShapesDimension,
 } from "../domain/data";
 import { DimensionMetadataFragment } from "../graphql/query-hooks";
 import { DataCubeMetadata } from "../graphql/types";
@@ -166,7 +169,9 @@ export const getInitialConfig = ({
         fields: {
           x: {
             componentIri: findPreferredDimension(
-              dimensions,
+              sortBy(dimensions, (x) =>
+                isGeoCoordinatesDimension(x) || isGeoShapesDimension(x) ? 1 : -1
+              ),
               "TemporalDimension"
             ).iri,
             sorting: DEFAULT_SORTING,

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -457,6 +457,17 @@ describe("retainChartConfigWhenSwitchingChartType", () => {
             newFieldGetterPath: "fields.areaLayer.componentIri",
             equal: false,
           },
+          {
+            oldFieldGetterPath: [
+              "filters",
+              "https://environment.ld.admin.ch/foen/COVID19VaccPersons_v2/type",
+            ],
+            newFieldGetterPath: [
+              "filters",
+              "https://environment.ld.admin.ch/foen/COVID19VaccPersons_v2/type",
+            ],
+            equal: true,
+          },
         ],
       },
     },

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -3,6 +3,7 @@ import get from "lodash/get";
 import mapValues from "lodash/mapValues";
 import pickBy from "lodash/pickBy";
 import setWith from "lodash/setWith";
+import sortBy from "lodash/sortBy";
 import { useRouter } from "next/router";
 import {
   createContext,
@@ -352,8 +353,8 @@ export const deriveFiltersFromFields = produce(
       const isField = (iri: string) => fieldDimensionIris.has(iri);
 
       // Apply hierarchical dimensions first
-      const sortedDimensions = [...dimensions].sort(
-        (a, b) => (a.hierarchy ? -1 : 1) - (b.hierarchy ? -1 : 1)
+      const sortedDimensions = sortBy(dimensions, (d) =>
+        d.hierarchy ? -1 : 1
       );
       sortedDimensions.forEach((dimension) =>
         applyNonTableDimensionToFilters({

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -855,8 +855,9 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
         // setWith(draft, action.value.path, action.value.value, Object);
         const { chartType, dataSetMetadata } = action.value;
 
+        const previousConfig = current(draft.chartConfig);
         draft.chartConfig = getChartConfigAdjustedToChartType({
-          chartConfig: current(draft.chartConfig),
+          chartConfig: previousConfig,
           newChartType: chartType,
           dimensions: dataSetMetadata.dimensions,
           measures: dataSetMetadata.measures,

--- a/cypress/integration/filters.spec.ts
+++ b/cypress/integration/filters.spec.ts
@@ -19,15 +19,7 @@ describe("Filters", () => {
       cy.findByText("1. production region");
       cy.findByText("2. stand structure");
       cy.findByText("3. evaluation type");
-      cy.findByText("4. Inventory");
-      cy.findByText("5. unit of evaluation");
+      cy.findByText("4. unit of evaluation");
     });
-
-    selectors.edition
-      .findChartFiltersList(cy)
-      .should(
-        "contain.text",
-        "production region: Switzerland, stand structure: total, evaluation type: Zustand, Inventory: NFI1, unit of evaluation: accessible forest without shrub forest NFI1/NFI2/NFI3/NFI4"
-      );
   });
 });


### PR DESCRIPTION
Fix #708

Since filters for the map have been improved to initially contain the downmost areas, they did not retain the previous filters.

Here, we put back the filters from the previous config inside the new config.
