### PR TITLE
feat: Sorting improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 
 ## Unreleased
 
-Nothing yet.
+- Charts:
+  - Enable sorting of Geo dimensions
+  - Maintain segment sorting type correctly when switching from / to Pie chart
+  - Fix sorting by measure when undefined values are present in the data
 
 ## [3.9.5] - 2022-10-04
 

--- a/app/charts/chart-config-ui-options.ts
+++ b/app/charts/chart-config-ui-options.ts
@@ -77,6 +77,19 @@ const SEGMENT_DIMENSION_TYPES: DimensionType[] = [
   "GeoShapesDimension",
 ];
 
+export const AREA_SEGMENT_SORTING: EncodingSortingOption[] = [
+  { sortingType: "byDimensionLabel", sortingOrder: ["asc", "desc"] },
+  { sortingType: "byTotalSize", sortingOrder: ["asc", "desc"] },
+];
+
+export const COLUMN_SEGMENT_SORTING: EncodingSortingOption[] =
+  AREA_SEGMENT_SORTING;
+
+export const PIE_SEGMENT_SORTING: EncodingSortingOption[] = [
+  { sortingType: "byMeasure", sortingOrder: ["asc", "desc"] },
+  { sortingType: "byDimensionLabel", sortingOrder: ["asc", "desc"] },
+];
+
 export const chartConfigOptionsUISpec: ChartSpecs = {
   column: {
     chartType: "column",
@@ -109,10 +122,7 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
         optional: true,
         values: SEGMENT_DIMENSION_TYPES,
         filters: true,
-        sorting: [
-          { sortingType: "byDimensionLabel", sortingOrder: ["asc", "desc"] },
-          { sortingType: "byTotalSize", sortingOrder: ["asc", "desc"] },
-        ],
+        sorting: COLUMN_SEGMENT_SORTING,
         options: [
           { field: "chartSubType", values: ["stacked", "grouped"] },
           { field: "color", values: ["palette"] },
@@ -204,10 +214,7 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
         optional: true,
         values: SEGMENT_DIMENSION_TYPES,
         filters: true,
-        sorting: [
-          { sortingType: "byDimensionLabel", sortingOrder: ["asc", "desc"] },
-          { sortingType: "byTotalSize", sortingOrder: ["asc", "desc"] },
-        ],
+        sorting: AREA_SEGMENT_SORTING,
         options: [
           { field: "color", values: ["palette"] },
           { field: "imputationType", values: imputationTypes },
@@ -255,10 +262,7 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
         optional: false,
         values: SEGMENT_DIMENSION_TYPES,
         filters: true,
-        sorting: [
-          { sortingType: "byMeasure", sortingOrder: ["asc", "desc"] },
-          { sortingType: "byDimensionLabel", sortingOrder: ["asc", "desc"] },
-        ],
+        sorting: PIE_SEGMENT_SORTING,
         options: [{ field: "color", values: ["palette"] }],
       },
     ],

--- a/app/charts/chart-config-ui-options.ts
+++ b/app/charts/chart-config-ui-options.ts
@@ -45,7 +45,7 @@ export interface EncodingSpec {
   optional: boolean;
   values: DimensionType[];
   filters: boolean;
-  sorting?: EncodingSortingOption[]; // { field: string; values: string | string[] }[];
+  sorting?: EncodingSortingOption[];
   options?: EncodingOptions;
 }
 export interface ChartSpec {
@@ -69,6 +69,13 @@ interface ChartSpecs {
  * @todo
  * - Differentiate sorting within chart vs. sorting legend/tooltip only
  */
+
+const SEGMENT_DIMENSION_TYPES: DimensionType[] = [
+  "NominalDimension",
+  "OrdinalDimension",
+  "GeoCoordinatesDimension",
+  "GeoShapesDimension",
+];
 
 export const chartConfigOptionsUISpec: ChartSpecs = {
   column: {
@@ -100,12 +107,7 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
       {
         field: "segment",
         optional: true,
-        values: [
-          "NominalDimension",
-          "OrdinalDimension",
-          "GeoCoordinatesDimension",
-          "GeoShapesDimension",
-        ],
+        values: SEGMENT_DIMENSION_TYPES,
         filters: true,
         sorting: [
           { sortingType: "byDimensionLabel", sortingOrder: ["asc", "desc"] },
@@ -143,12 +145,7 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
       {
         field: "segment",
         optional: true,
-        values: [
-          "NominalDimension",
-          "OrdinalDimension",
-          "GeoCoordinatesDimension",
-          "GeoShapesDimension",
-        ],
+        values: SEGMENT_DIMENSION_TYPES,
         filters: true,
         sorting: [
           { sortingType: "byDimensionLabel", sortingOrder: ["asc", "desc"] },
@@ -180,23 +177,13 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
       {
         field: "segment",
         optional: true,
-        values: [
-          "NominalDimension",
-          "OrdinalDimension",
-          "GeoCoordinatesDimension",
-          "GeoShapesDimension",
-        ],
+        values: SEGMENT_DIMENSION_TYPES,
         filters: true,
-        // sorting: [
-        //   { sortingType: "byTotalSize", sortingOrder: ["asc", "desc"] },
-        //   { sortingType: "byDimensionLabel", sortingOrder: ["asc", "desc"] },
-        // ],
         options: [{ field: "color", values: ["palette"] }],
       },
     ],
     interactiveFilters: ["legend", "time"],
   },
-
   area: {
     chartType: "area",
     encodings: [
@@ -215,12 +202,7 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
       {
         field: "segment",
         optional: true,
-        values: [
-          "NominalDimension",
-          "OrdinalDimension",
-          "GeoCoordinatesDimension",
-          "GeoShapesDimension",
-        ],
+        values: SEGMENT_DIMENSION_TYPES,
         filters: true,
         sorting: [
           { sortingType: "byDimensionLabel", sortingOrder: ["asc", "desc"] },
@@ -252,12 +234,7 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
       {
         field: "segment",
         optional: true,
-        values: [
-          "NominalDimension",
-          "OrdinalDimension",
-          "GeoCoordinatesDimension",
-          "GeoShapesDimension",
-        ],
+        values: SEGMENT_DIMENSION_TYPES,
         filters: true,
         options: [{ field: "color", values: ["palette"] }],
       },
@@ -276,12 +253,7 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
       {
         field: "segment",
         optional: false,
-        values: [
-          "NominalDimension",
-          "OrdinalDimension",
-          "GeoCoordinatesDimension",
-          "GeoShapesDimension",
-        ],
+        values: SEGMENT_DIMENSION_TYPES,
         filters: true,
         sorting: [
           { sortingType: "byMeasure", sortingOrder: ["asc", "desc"] },

--- a/app/charts/chart-config-ui-options.ts
+++ b/app/charts/chart-config-ui-options.ts
@@ -1,5 +1,5 @@
 import { ChartType, SortingOrder } from "../configurator";
-import { imputationTypes } from "../configurator/config-types";
+import { imputationTypes, SortingType } from "../configurator/config-types";
 
 /**
  * This module controls chart controls displayed in the UI.
@@ -36,7 +36,7 @@ export type EncodingOptions =
         | { field: string; values?: string | string[] }[];
     }[];
 export type EncodingSortingOption = {
-  sortingType: "byDimensionLabel" | "byTotalSize" | "byMeasure";
+  sortingType: SortingType;
   sortingOrder: SortingOrder[];
 };
 type InteractiveFilterType = "legend" | "time";

--- a/app/charts/column/columns-simple.tsx
+++ b/app/charts/column/columns-simple.tsx
@@ -60,9 +60,7 @@ export const Columns = () => {
             y={yScale(Math.max(y, 0))}
             height={Math.abs(yScale(y) - yScale(0))}
             color={
-              (getY(d) ?? NaN) <= 0
-                ? theme.palette.secondary.main
-                : theme.palette.primary.main
+              y <= 0 ? theme.palette.secondary.main : theme.palette.primary.main
             }
           />
         );

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -434,9 +434,9 @@ const sortData = ({
   } else if (sortingOrder === "asc" && sortingType === "byDimensionLabel") {
     return [...data].sort((a, b) => ascending(getX(a), getX(b)));
   } else if (sortingOrder === "desc" && sortingType === "byMeasure") {
-    return [...data].sort((a, b) => descending(getY(a) ?? NaN, getY(b) ?? NaN));
+    return [...data].sort((a, b) => descending(getY(a) ?? -1, getY(b) ?? -1));
   } else if (sortingOrder === "asc" && sortingType === "byMeasure") {
-    return [...data].sort((a, b) => ascending(getY(a) ?? NaN, getY(b) ?? NaN));
+    return [...data].sort((a, b) => ascending(getY(a) ?? -1, getY(b) ?? -1));
   } else {
     // default to ascending alphabetical
     return [...data].sort((a, b) => ascending(getX(a), getX(b)));

--- a/app/charts/pie/pie-state.tsx
+++ b/app/charts/pie/pie-state.tsx
@@ -49,9 +49,9 @@ const sortData = ({
   } else if (sortingOrder === "asc" && sortingType === "byDimensionLabel") {
     return [...data].sort((a, b) => ascending(getX(a), getX(b)));
   } else if (sortingOrder === "desc" && sortingType === "byMeasure") {
-    return [...data].sort((a, b) => descending(getY(a) ?? NaN, getY(b) ?? NaN));
+    return [...data].sort((a, b) => descending(getY(a) ?? -1, getY(b) ?? -1));
   } else if (sortingOrder === "asc" && sortingType === "byMeasure") {
-    return [...data].sort((a, b) => ascending(getY(a) ?? NaN, getY(b) ?? NaN));
+    return [...data].sort((a, b) => ascending(getY(a) ?? -1, getY(b) ?? -1));
   } else {
     // default to ascending byDimensionLabel
     return [...data].sort((a, b) => ascending(getX(a), getX(b)));
@@ -204,9 +204,9 @@ const usePieState = (
       } else if (sortingOrder === "asc" && sortingType === "byDimensionLabel") {
         return ascending(getX(a), getX(b));
       } else if (sortingOrder === "desc" && sortingType === "byMeasure") {
-        return descending(getY(a) ?? NaN, getY(b) ?? NaN);
+        return descending(getY(a) ?? -1, getY(b) ?? -1);
       } else if (sortingOrder === "asc" && sortingType === "byMeasure") {
-        return ascending(getY(a) ?? NaN, getY(b) ?? NaN);
+        return ascending(getY(a) ?? -1, getY(b) ?? -1);
       } else {
         // default to ascending byDimensionLabel
         return ascending(getX(a), getX(b));

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -50,6 +50,7 @@ import { MapColumnOptions } from "@/configurator/map/map-chart-options";
 import { TableColumnOptions } from "@/configurator/table/table-chart-options";
 import {
   getDimensionsByDimensionType,
+  isDimensionSortable,
   isStandardErrorDimension,
 } from "@/domain/data";
 import {
@@ -278,15 +279,11 @@ const EncodingOptionsPanel = ({
           )}
         </ControlSectionContent>
       </ControlSection>
-      {/* Only nominal dimensions are sortable!
-          Temporal and Ordinal dimensions already have a defined order. */}
-      {encoding.sorting && component?.__typename === "NominalDimension" && (
+      {encoding.sorting && isDimensionSortable(component) && (
         <ChartFieldSorting
           state={state}
-          disabled={!component}
           field={encoding.field}
           encodingSortingOptions={encoding.sorting}
-          // chartType={chartType}
         />
       )}
       {optionsByField["showStandardError"] && hasStandardError && (

--- a/app/configurator/config-types.ts
+++ b/app/configurator/config-types.ts
@@ -533,21 +533,13 @@ export type ChartFields =
   | TableFields
   | MapFields;
 
-// interface IriBrand {
-//   readonly IRI: unique symbol;
-// }
-// const Iri = t.brand(
-//   t.string,
-//   (s): s is t.Branded<string, IriBrand> => true,
-//   "IRI"
-// );
+export type ChartSegmentField =
+  | AreaSegmentField
+  | ColumnSegmentField
+  | LineSegmentField
+  | PieSegmentField
+  | ScatterPlotSegmentField;
 
-// const ChartConfig = t.intersection([
-//   t.union([AreaConfig, BarConfig, ColumnConfig, LineConfig, ScatterPlotConfig]),
-//   t.type({
-//     fields: GenericFields
-//   })
-// ]);
 const ChartConfig = t.union([
   AreaConfig,
   BarConfig,

--- a/app/domain/data.ts
+++ b/app/domain/data.ts
@@ -147,6 +147,16 @@ export const canDimensionBeMultiFiltered = (d: DimensionMetadataFragment) => {
   );
 };
 
+export const isDimensionSortable = (
+  d?: DimensionMetadataFragment
+): d is NominalDimension | GeoCoordinatesDimension | GeoShapesDimension => {
+  return (
+    isNominalDimension(d) ||
+    isGeoCoordinatesDimension(d) ||
+    isGeoShapesDimension(d)
+  );
+};
+
 /**
  * @fixme use metadata to filter categorical dimension!
  */

--- a/app/domain/data.ts
+++ b/app/domain/data.ts
@@ -182,13 +182,13 @@ export const getDimensionsByDimensionType = ({
 
 export const isNominalDimension = (
   dimension?: DimensionMetadataFragment
-): dimension is GeoCoordinatesDimension => {
+): dimension is NominalDimension => {
   return dimension?.__typename === "NominalDimension";
 };
 
 export const isOrdinalDimension = (
   dimension?: DimensionMetadataFragment
-): dimension is GeoCoordinatesDimension => {
+): dimension is OrdinalDimension => {
   return dimension?.__typename === "OrdinalDimension";
 };
 


### PR DESCRIPTION
When I was starting to implement Ordinal Measures in maps, I noticed that we do not allow to sort Geo dimensions (by name or measure).

I think we should enable this, as essentially they are just Nominal dimensions with coordinates attached – this PR adds support for sorting Geo dimensions.

Additionally, I've noticed that sorting doesn't work properly when there are undefined values, see screenshots down below – it was related to treating undefined values as NaNs instead of -1s. Also, the switch between Pie chart and Column / Area chart (and vice versa) was resulting in blank sorting by value in the segment field (it's also fixed now).

<img width="1122" alt="Screenshot 2022-10-06 at 12 16 29" src="https://user-images.githubusercontent.com/52032047/194288389-694b0bb0-b216-4d7d-ad42-476cbda77e9d.png">

<img width="1120" alt="Screenshot 2022-10-06 at 12 16 37" src="https://user-images.githubusercontent.com/52032047/194288408-cc25d839-70e3-4afb-a39a-49c7a1410d8b.png">

### How to test
- [ ] Go to `/en/browse/dataset/https%3A%2F%2Fenvironment.ld.admin.ch%2Ffoen%2Fubd0104prod%2F5?&dataSource=Int`
  - create a new column chart
  - add segmentation by Parameter
  - set sorting by total size
  -  switch to pie chart
  - go to segmentation
  - see that it's correctly set to measure
  - repeat the same process on TEST env to see that it's blank here
- [ ] Go to `/en/browse/dataset/https%3A%2F%2Fenergy.ld.admin.ch%2Fsfoe%2Fbfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen%2F13?dataSource=Int`
  - create new column chart
  - set X axis to Standort der Anlage
  - see that it's possible to sort by this Geo dimension (and that the sorting is correct)
  - repeat the same process on TEST env to see that it's not possible to sort this axis there