### PR TITLE
Refactor selector and actions

### DIFF
--- a/e2e/actions.ts
+++ b/e2e/actions.ts
@@ -1,0 +1,21 @@
+import selectors from "./selectors";
+import { TestContext } from "./types";
+
+export const loadDatasetPreview = async (
+  ctx: TestContext,
+  iri: string,
+  dataSource: "Int" | "Prod"
+) => {
+  const { page } = ctx;
+  await page.goto(
+    `en/browse/dataset/${encodeURIComponent(iri)}?dataSource=${dataSource}`
+  );
+
+  await selectors.datasetPreview.loaded(ctx);
+};
+
+const actions = {
+  loadDatasetPreview,
+};
+
+export default actions;

--- a/e2e/actions.ts
+++ b/e2e/actions.ts
@@ -1,5 +1,5 @@
 import selectors from "./selectors";
-import { TestContext } from "./types";
+import { makeActions, TestContext } from "./types";
 
 export const loadDatasetPreview = async (
   ctx: TestContext,
@@ -14,8 +14,10 @@ export const loadDatasetPreview = async (
   await selectors.datasetPreview.loaded(ctx);
 };
 
-const actions = {
-  loadDatasetPreview,
-};
+const actions = makeActions({
+  datasetPreview: {
+    load: loadDatasetPreview,
+  },
+});
 
 export default actions;

--- a/e2e/chart-snapshots.spec.ts
+++ b/e2e/chart-snapshots.spec.ts
@@ -1,6 +1,7 @@
 import intConfigs from "../app/test/__fixtures/config/int/configs";
 
 import { test, sleep } from "./common";
+import selectors from "./selectors";
 
 // Right now the CI app server runs connected to int.lindas.admin.ch
 const configs = intConfigs.map((x) => ({ env: "int", ...x }));
@@ -18,17 +19,19 @@ const viewports = {
 
 for (let [viewportName, viewportSize] of Object.entries(viewports)) {
   for (let { slug, env } of configs) {
-    test(`Chart Snapshots ${slug} ${env} ${viewportName}`, async ({ page }) => {
+    test(`Chart Snapshots ${slug} ${env} ${viewportName}`, async ({
+      page,
+      screen,
+    }) => {
+      const ctx = { page, screen };
+
       test.setTimeout(1 * 60 * 1000);
       await page.setViewportSize(viewportSize);
       await page.goto(`/en/__test/${env}/${slug}?dataSource=Int`);
-      await page
-        .locator(`[data-chart-loaded="true"]`)
-        .waitFor({ timeout: 90000 });
+      await selectors.chart.loaded(ctx);
       await sleep(100);
 
       if (slug.includes("map")) {
-        // @ts-ignore
         await sleep(1000);
       }
       await page.screenshot({

--- a/e2e/edition.spec.ts
+++ b/e2e/edition.spec.ts
@@ -8,11 +8,12 @@ test("should be possible to edit filters of a hierarchy", async ({
   screen,
   within,
 }) => {
+  const ctx = { page, screen };
   const key = "WtHYbmsehQKo";
   const config = offentlicheAusgabenChartConfigFixture;
   await loadChartInLocalStorage(page, key, config);
   await page.goto(`/en/create/${key}`);
-  await selectors.chart.loaded(screen, page);
+  await selectors.chart.loaded(ctx);
 
   const selectNone = await screen.findByText("Select none", undefined, {
     timeout: 10 * 1000,
@@ -26,14 +27,14 @@ test("should be possible to edit filters of a hierarchy", async ({
     })
   ).click();
 
-  const filters = await selectors.edition.filterDrawer(screen);
+  const filters = await selectors.edition.filterDrawer(ctx);
 
   await (await within(filters).findByText("Economic affairs")).click();
   await (await within(filters).findByText("Social protection")).click();
   await (await within(filters).findByText("Health")).click();
   await (await within(filters).findByText("Apply filters")).click();
-  await selectors.chart.loaded(screen, page);
-  const middlePanel = await selectors.panels.middle(screen);
+  await selectors.chart.loaded(ctx);
+  const middlePanel = await selectors.panels.middle(ctx);
   await middlePanel.evaluate((panel) => {
     panel.scrollTo(0, 200);
   });

--- a/e2e/filters.spec.ts
+++ b/e2e/filters.spec.ts
@@ -2,16 +2,18 @@ import { test } from "./common";
 import selectors from "./selectors";
 
 test("Filters initial state should have hierarchy dimensions first and topmost value selected", async ({
-  screen,
   page,
+  screen,
   within,
 }) => {
-  page.goto(
+  const ctx = { page, screen };
+
+  await page.goto(
     `/en/create/new?cube=https://environment.ld.admin.ch/foen/nfi/49-19-44/cube/1&dataSource=Int`
   );
-  await selectors.chart.loaded(screen, page);
+  await selectors.chart.loaded(ctx);
 
-  const filters = await selectors.edition.configFilters(screen);
+  const filters = await selectors.edition.configFilters(ctx);
 
   await within(filters).findByText("1. production region", undefined, {
     timeout: 30 * 1000,

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,9 +1,9 @@
 import { URL } from "url";
 
-import { describe, it, expect } from "./common";
+import { describe, test, expect } from "./common";
 
 describe("The Home Page", () => {
-  it("default language (de) should render on /", async ({ page, screen }) => {
+  test("default language (de) should render on /", async ({ page, screen }) => {
     await page.setExtraHTTPHeaders({
       "Accept-Language": "de",
     });
@@ -13,7 +13,7 @@ describe("The Home Page", () => {
     expect(await page.locator("html").getAttribute("lang")).toEqual("de");
   });
 
-  it("Accept-Language header for alternative language (fr) should display French", async ({
+  test("Accept-Language header for alternative language (fr) should display French", async ({
     page,
     screen,
   }) => {
@@ -28,7 +28,7 @@ describe("The Home Page", () => {
     expect(await page.locator("html").getAttribute("lang")).toEqual("fr");
   });
 
-  it("language switch should work", async ({ page, screen }) => {
+  test("language switch should work", async ({ page, screen }) => {
     await page.goto("/");
     await page.locator('a[hreflang="fr"]').click();
     await screen.findByText(

--- a/e2e/ordinal-measures.spec.ts
+++ b/e2e/ordinal-measures.spec.ts
@@ -8,15 +8,16 @@ describe("viewing a dataset with only ordinal measures", () => {
   const config = testOrd507;
 
   test("should retrieve dimension values properly", async ({
-    screen,
     page,
+    screen,
   }) => {
-    page.goto(
+    const ctx = { page, screen };
+    ctx.page.goto(
       `en/browse/dataset/${encodeURIComponent(config.dataSet)}?dataSource=Int`
     );
 
-    await selectors.datasetPreview.loaded(screen, page);
-    const cells = await selectors.datasetPreview.cells(screen, page);
+    await selectors.datasetPreview.loaded(ctx);
+    const cells = await selectors.datasetPreview.cells(ctx);
     const texts = await cells.allInnerTexts();
     expect(texts).not.toContain("NaN");
   });
@@ -25,13 +26,14 @@ describe("viewing a dataset with only ordinal measures", () => {
     page,
     screen,
   }) => {
+    const ctx = { page, screen };
     await loadChartInLocalStorage(page, key, config);
     page.goto(`/en/create/${key}`);
 
-    await selectors.chart.loaded(screen, page);
+    await selectors.chart.loaded(ctx);
 
     const enabledButtons = await (
-      await selectors.edition.chartTypeSelector(screen)
+      await selectors.edition.chartTypeSelector(ctx)
     ).locator("button:not(.Mui-disabled)");
 
     expect(await enabledButtons.count()).toEqual(1);

--- a/e2e/ordinal-measures.spec.ts
+++ b/e2e/ordinal-measures.spec.ts
@@ -14,7 +14,7 @@ describe("viewing a dataset with only ordinal measures", () => {
   }) => {
     const ctx = { page, screen };
 
-    await actions.loadDatasetPreview(ctx, config.dataSet, "Int");
+    await actions.datasetPreview.load(ctx, config.dataSet, "Int");
     const cells = await selectors.datasetPreview.cells(ctx);
     const texts = await cells.allInnerTexts();
     expect(texts).not.toContain("NaN");

--- a/e2e/ordinal-measures.spec.ts
+++ b/e2e/ordinal-measures.spec.ts
@@ -1,3 +1,4 @@
+import actions from "./actions";
 import { loadChartInLocalStorage } from "./charts-utils";
 import { test, expect, describe } from "./common";
 import testOrd507 from "./fixtures/test-ord-507-chart-config.json";
@@ -12,11 +13,8 @@ describe("viewing a dataset with only ordinal measures", () => {
     screen,
   }) => {
     const ctx = { page, screen };
-    ctx.page.goto(
-      `en/browse/dataset/${encodeURIComponent(config.dataSet)}?dataSource=Int`
-    );
 
-    await selectors.datasetPreview.loaded(ctx);
+    await actions.loadDatasetPreview(ctx, config.dataSet, "Int");
     const cells = await selectors.datasetPreview.cells(ctx);
     const texts = await cells.allInnerTexts();
     expect(texts).not.toContain("NaN");

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -4,25 +4,29 @@ import { test, expect } from "./common";
 import selectors from "./selectors";
 
 test("should be possible to open a search URL, and search state should be recovered", async ({
-  screen,
   page,
+  screen,
 }) => {
+  const ctx = { page, screen };
+
   test.slow();
 
   page.goto(
     `/en/browse?includeDrafts=true&order=SCORE&search=category&dataSource=Int`
   );
 
-  expect(
-    await selectors.search.searchInput(screen, page).getAttribute("value")
-  ).toEqual("category");
+  expect(await selectors.search.searchInput(ctx).getAttribute("value")).toEqual(
+    "category"
+  );
 
   expect(
-    await selectors.search.draftsCheckbox(screen, page).getAttribute("checked")
+    await selectors.search.draftsCheckbox(ctx).getAttribute("checked")
   ).toBe("");
 });
 
-test("search results count coherence", async ({ screen, page }) => {
+test("search results count coherence", async ({ page, screen }) => {
+  const ctx = { page, screen };
+
   test.slow();
 
   const categories = [
@@ -40,7 +44,7 @@ test("search results count coherence", async ({ screen, page }) => {
 
   for (let t of [...categories, ...themes]) {
     await page.goto("/en/browse?dataSource=Int");
-    await selectors.search.resultsCount(screen);
+    await selectors.search.resultsCount(ctx);
 
     const panelLeft = await screen.findByTestId("panel-left");
     await within(panelLeft).findByText(t, undefined, { timeout: 5000 });

--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -1,46 +1,54 @@
 import { LocatorFixtures } from "@playwright-testing-library/test/fixture";
-import { Page } from "@playwright/test";
+
+import { TestContext } from "./types";
 
 type Screen = LocatorFixtures["screen"];
 
 const selectors = {
   search: {
-    searchInput: (_sc: Screen, page: Page) => page.locator("#datasetSearch"),
-    draftsCheckbox: (_sc: Screen, page: Page) =>
-      page.locator("#dataset-include-drafts"),
-    navItem: (sc: Screen) => sc.findByTestId("navItem"),
-    navChip: (sc: Screen) => sc.findByTestId("navChip"),
-    resultsCount: (sc: Screen) =>
-      sc.findByTestId("search-results-count", undefined, { timeout: 5000 }),
+    searchInput: (ctx: TestContext) => ctx.page.locator("#datasetSearch"),
+    draftsCheckbox: (ctx: TestContext) =>
+      ctx.page.locator("#dataset-include-drafts"),
+    navItem: (ctx: TestContext) => ctx.screen.findByTestId("navItem"),
+    navChip: (ctx: TestContext) => ctx.screen.findByTestId("navChip"),
+    resultsCount: (ctx: TestContext) =>
+      ctx.screen.findByTestId("search-results-count", undefined, {
+        timeout: 5000,
+      }),
   },
   datasetPreview: {
-    loaded: (sc: Screen, page: Page) =>
-      page
+    loaded: (ctx: TestContext) =>
+      ctx.page
         .locator("table td")
         .first()
         .waitFor({ timeout: 20 * 1000 }),
-    cells: (sc: Screen, page: Page) => page.locator("table td"),
+    cells: (ctx: TestContext) => ctx.page.locator("table td"),
   },
   panels: {
-    left: (sc: Screen) => sc.findByTestId("panel-left"),
-    right: (sc: Screen) => sc.findByTestId("panel-right"),
-    middle: (sc: Screen) => sc.findByTestId("panel-middle"),
+    left: (ctx: TestContext) => ctx.screen.findByTestId("panel-left"),
+    right: (ctx: TestContext) => ctx.screen.findByTestId("panel-right"),
+    middle: (ctx: TestContext) => ctx.screen.findByTestId("panel-middle"),
   },
   edition: {
-    configFilters: (sc: Screen) =>
-      sc.findByTestId("configurator-filters", undefined, {
+    configFilters: (ctx: TestContext) =>
+      ctx.screen.findByTestId("configurator-filters", undefined, {
         timeout: 20 * 1000,
       }),
-    chartFilters: (sc: Screen) => sc.findByTestId("chart-filters-list"),
-    filterDrawer: (sc: Screen) => sc.findByTestId("edition-filters-drawer"),
-    filterCheckbox: (_sc: Screen, page: Page, value: string) =>
-      page.locator(`[data-value="${value}"]`),
-    chartTypeSelector: (sc: Screen) => sc.findByTestId("chart-type-selector"),
+    chartFilters: (ctx: TestContext) =>
+      ctx.screen.findByTestId("chart-filters-list"),
+    filterDrawer: (ctx: TestContext) =>
+      ctx.screen.findByTestId("edition-filters-drawer"),
+    filterCheckbox: (ctx, value: string) =>
+      ctx.page.locator(`[data-value="${value}"]`),
+    chartTypeSelector: (ctx: TestContext) =>
+      ctx.screen.findByTestId("chart-type-selector"),
   },
   chart: {
-    colorLegend: (sc: Screen) => sc.findByTestId("colorLegend"),
-    loaded: (_sc: Screen, page: Page) =>
-      page.locator(`[data-chart-loaded="true"]`).waitFor({ timeout: 20000 }),
+    colorLegend: (ctx: TestContext) => ctx.screen.findByTestId("colorLegend"),
+    loaded: (ctx: TestContext) =>
+      ctx.page
+        .locator(`[data-chart-loaded="true"]`)
+        .waitFor({ timeout: 40 * 1000 }),
   },
 };
 

--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -1,55 +1,72 @@
-import { LocatorFixtures } from "@playwright-testing-library/test/fixture";
+import { Locator } from "@playwright/test";
 
-import { TestContext } from "./types";
+import { TestContext as Ctx } from "./types";
 
-type Screen = LocatorFixtures["screen"];
+type SelectorFunction = (
+  ctx: Ctx,
+  arg1?: any,
+  arg2?: any
+) => Promise<Locator> | Locator | Promise<void>;
 
-const selectors = {
+type CheckSelector<T> = T extends Record<
+  string,
+  Record<string, SelectorFunction>
+>
+  ? T
+  : never;
+
+/**
+ * Constrains what we can put in selectors.
+ *
+ * We use this so that we cannot put anything we want inside the selectors.
+ * At the same time, T is returned so that downstream has the correct types.
+ */
+const makeSelectors = <T>(selectors: CheckSelector<T>): T => selectors;
+
+const selectors = makeSelectors({
   search: {
-    searchInput: (ctx: TestContext) => ctx.page.locator("#datasetSearch"),
-    draftsCheckbox: (ctx: TestContext) =>
-      ctx.page.locator("#dataset-include-drafts"),
-    navItem: (ctx: TestContext) => ctx.screen.findByTestId("navItem"),
-    navChip: (ctx: TestContext) => ctx.screen.findByTestId("navChip"),
-    resultsCount: (ctx: TestContext) =>
+    searchInput: (ctx: Ctx) => ctx.page.locator("#datasetSearch"),
+    draftsCheckbox: (ctx: Ctx) => ctx.page.locator("#dataset-include-drafts"),
+    navItem: (ctx: Ctx) => ctx.screen.findByTestId("navItem"),
+    navChip: (ctx: Ctx) => ctx.screen.findByTestId("navChip"),
+    resultsCount: (ctx: Ctx) =>
       ctx.screen.findByTestId("search-results-count", undefined, {
         timeout: 5000,
       }),
   },
   datasetPreview: {
-    loaded: (ctx: TestContext) =>
+    loaded: (ctx: Ctx) =>
       ctx.page
         .locator("table td")
         .first()
         .waitFor({ timeout: 20 * 1000 }),
-    cells: (ctx: TestContext) => ctx.page.locator("table td"),
+    cells: (ctx: Ctx) => ctx.page.locator("table td"),
   },
   panels: {
-    left: (ctx: TestContext) => ctx.screen.findByTestId("panel-left"),
-    right: (ctx: TestContext) => ctx.screen.findByTestId("panel-right"),
-    middle: (ctx: TestContext) => ctx.screen.findByTestId("panel-middle"),
+    left: (ctx: Ctx) => ctx.screen.findByTestId("panel-left"),
+    right: (ctx: Ctx) => ctx.screen.findByTestId("panel-right"),
+    middle: (ctx: Ctx) => ctx.screen.findByTestId("panel-middle"),
   },
   edition: {
-    configFilters: (ctx: TestContext) =>
+    configFilters: (ctx: Ctx) =>
       ctx.screen.findByTestId("configurator-filters", undefined, {
         timeout: 20 * 1000,
       }),
-    chartFilters: (ctx: TestContext) =>
-      ctx.screen.findByTestId("chart-filters-list"),
-    filterDrawer: (ctx: TestContext) =>
+    chartFilters: (ctx: Ctx) => ctx.screen.findByTestId("chart-filters-list"),
+    filterDrawer: (ctx: Ctx) =>
       ctx.screen.findByTestId("edition-filters-drawer"),
-    filterCheckbox: (ctx, value: string) =>
+    filterCheckbox: (ctx: Ctx, value: string) =>
       ctx.page.locator(`[data-value="${value}"]`),
-    chartTypeSelector: (ctx: TestContext) =>
+    chartTypeSelector: (ctx: Ctx) =>
       ctx.screen.findByTestId("chart-type-selector"),
   },
   chart: {
-    colorLegend: (ctx: TestContext) => ctx.screen.findByTestId("colorLegend"),
-    loaded: (ctx: TestContext) =>
+    colorLegend: (ctx: Ctx) => ctx.screen.findByTestId("colorLegend"),
+    loaded: (ctx: Ctx) =>
       ctx.page
         .locator(`[data-chart-loaded="true"]`)
         .waitFor({ timeout: 40 * 1000 }),
   },
-};
+});
 
 export default selectors;

--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -1,27 +1,4 @@
-import { Locator } from "@playwright/test";
-
-import { TestContext as Ctx } from "./types";
-
-type SelectorFunction = (
-  ctx: Ctx,
-  arg1?: any,
-  arg2?: any
-) => Promise<Locator> | Locator | Promise<void>;
-
-type CheckSelector<T> = T extends Record<
-  string,
-  Record<string, SelectorFunction>
->
-  ? T
-  : never;
-
-/**
- * Constrains what we can put in selectors.
- *
- * We use this so that we cannot put anything we want inside the selectors.
- * At the same time, T is returned so that downstream has the correct types.
- */
-const makeSelectors = <T>(selectors: CheckSelector<T>): T => selectors;
+import { makeSelectors, TestContext as Ctx } from "./types";
 
 const selectors = makeSelectors({
   search: {

--- a/e2e/symbol-layer-colors.spec.ts
+++ b/e2e/symbol-layer-colors.spec.ts
@@ -7,19 +7,21 @@ test("Selecting SymbolLayer colors> should be possible to select nominal dimensi
   page,
   screen,
 }) => {
+  const ctx = { page, screen };
+
   const key = "jky5IEw6poT3";
   const config = mapWaldflascheChartConfigFixture;
   await loadChartInLocalStorage(page, key, config);
   await page.goto(`/en/create/${key}`);
 
-  await selectors.chart.loaded(screen, page);
+  await selectors.chart.loaded(ctx);
 
   await (
     await screen.findByText("Symbols", undefined, { timeout: 15000 })
   ).click();
 
   const selects = await (
-    await selectors.panels.right(screen)
+    await selectors.panels.right(ctx)
   ).locator(".MuiSelect-select");
 
   const count = await selects.count();
@@ -32,14 +34,10 @@ test("Selecting SymbolLayer colors> should be possible to select nominal dimensi
   await (await screen.findByText("None")).click();
 
   await selectors.edition
-    .filterCheckbox(
-      screen,
-      page,
-      "https://environment.ld.admin.ch/foen/nfi/inventory"
-    )
+    .filterCheckbox(ctx, "https://environment.ld.admin.ch/foen/nfi/inventory")
     .click();
 
   expect(
-    await (await selectors.chart.colorLegend(screen)).locator("div").count()
+    await (await selectors.chart.colorLegend(ctx)).locator("div").count()
   ).toBe(4);
 });

--- a/e2e/types.ts
+++ b/e2e/types.ts
@@ -1,0 +1,9 @@
+import { LocatorFixtures } from "@playwright-testing-library/test/fixture";
+import { Page } from "@playwright/test";
+
+type Screen = LocatorFixtures["screen"];
+
+export type TestContext = {
+  screen: Screen;
+  page: Page;
+};

--- a/e2e/types.ts
+++ b/e2e/types.ts
@@ -1,5 +1,5 @@
 import { LocatorFixtures } from "@playwright-testing-library/test/fixture";
-import { Page } from "@playwright/test";
+import { Locator, Page } from "@playwright/test";
 
 type Screen = LocatorFixtures["screen"];
 
@@ -7,3 +7,26 @@ export type TestContext = {
   screen: Screen;
   page: Page;
 };
+
+type SelectorOrActionFunction = (
+  ctx: TestContext,
+  arg1?: any,
+  arg2?: any
+) => Promise<Locator> | Locator | Promise<void>;
+
+export type SelectorOrActionGuard<T> = T extends Record<
+  string,
+  Record<string, SelectorOrActionFunction>
+>
+  ? T
+  : never;
+
+/**
+ * Constrains what we can put in selectors / actions
+ *
+ * We use this so that we cannot put anything we want inside the selectors.
+ * At the same time, T is returned so that downstream has the correct types.
+ */
+export const makeSelectors = <T>(selectors: SelectorOrActionGuard<T>): T =>
+  selectors;
+export const makeActions = <T>(actions: SelectorOrActionGuard<T>): T => actions;


### PR DESCRIPTION
- test: Use a context object for selectors, simplifies calling selectors & actions
- refactor: Add actions pattern to open a dataset preview
- refactor: Add constraints on what we can put into selectors
- feat: Implement guard on actions
