### PR TITLE
Bold footnotes label

### DIFF
--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -1,4 +1,4 @@
-import { t, Trans } from "@lingui/macro";
+import { Trans } from "@lingui/macro";
 import { Box, Button, Link, Theme, Typography } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import { useEffect, useState, useMemo } from "react";
@@ -104,24 +104,16 @@ export const ChartFootnotes = ({
   if (data?.dataCubeByIri) {
     const { dataCubeByIri } = data;
 
-    const titleContent = `${dataCubeByIri.title}${
-      dataCubeByIri.dateModified
-        ? t({
-            id: "dataset.metadata.date.footnotes.updated",
-            message: `, latest update: ${formatLocale.format("%x %H:%M")(
-              new Date(dataCubeByIri.dateModified)
-            )}`,
-          })
-        : ""
-    }`;
-
     return (
       <Box sx={{ mt: 2 }}>
-        <Typography component="div" variant="caption" color="grey.600">
-          <Trans id="metadata.dataset">Dataset</Trans>:{" "}
+        <Typography component="span" variant="caption" color="grey.600">
+          <strong>
+            <Trans id="dataset.footnotes.dataset">Dataset</Trans>
+          </strong>
+          <Trans id="typography.colon">: </Trans>
           {cubeLink ? (
             <Link target="_blank" href={cubeLink} rel="noreferrer">
-              {titleContent}{" "}
+              {dataCubeByIri.title}
               <Icon
                 name="linkExternal"
                 size={12}
@@ -129,12 +121,28 @@ export const ChartFootnotes = ({
               />
             </Link>
           ) : (
-            titleContent
+            dataCubeByIri.title
           )}
         </Typography>
 
+        {dataCubeByIri.dateModified ? (
+          <Typography component="span" variant="caption" color="grey.600">
+            ,&nbsp;
+            <strong>
+              <Trans id="dataset.footnotes.updated">Latest update</Trans>
+            </strong>
+            <Trans id="typography.colon">: </Trans>
+            {formatLocale.format("%x %H:%M")(
+              new Date(dataCubeByIri.dateModified)
+            )}
+          </Typography>
+        ) : null}
+
         <Typography component="div" variant="caption" color="grey.600">
-          <Trans id="metadata.source">Source</Trans>:{" "}
+          <strong>
+            <Trans id="metadata.source">Source</Trans>
+          </strong>
+          <Trans id="typography.colon">: </Trans>
           {dataCubeByIri.publisher && (
             <Box
               component="span"

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -30,7 +30,7 @@ msgid "Move filter up"
 msgstr "Filter nach oben verschieben"
 
 #: app/configurator/components/dataset-browse.tsx:1027
-#: app/configurator/components/filters.tsx:682
+#: app/configurator/components/filters.tsx:681
 msgid "No results"
 msgstr "Kein Ergebnis"
 
@@ -120,21 +120,21 @@ msgstr "Diese Visualisierung veröffentlichen"
 msgid "button.share"
 msgstr "Teilen"
 
-#: app/configurator/components/ui-helpers.ts:614
+#: app/configurator/components/ui-helpers.ts:620
 msgid "chart.map.layers.area"
 msgstr "Flächen"
 
 #: app/configurator/components/chart-configurator.tsx:696
-#: app/configurator/components/chart-options-selector.tsx:983
-#: app/configurator/components/ui-helpers.ts:610
+#: app/configurator/components/chart-options-selector.tsx:992
+#: app/configurator/components/ui-helpers.ts:616
 msgid "chart.map.layers.base"
 msgstr "Kartenanzeige"
 
-#: app/configurator/components/chart-options-selector.tsx:987
+#: app/configurator/components/chart-options-selector.tsx:996
 msgid "chart.map.layers.base.show"
 msgstr "Weltkarte anzeigen"
 
-#: app/configurator/components/chart-options-selector.tsx:996
+#: app/configurator/components/chart-options-selector.tsx:1005
 msgid "chart.map.layers.base.view.locked"
 msgstr "Gesperrte Ansicht"
 
@@ -143,7 +143,7 @@ msgstr "Gesperrte Ansicht"
 #~ msgid "chart.map.layers.show"
 #~ msgstr "Ebene anzeigen"
 
-#: app/configurator/components/ui-helpers.ts:618
+#: app/configurator/components/ui-helpers.ts:624
 msgid "chart.map.layers.symbol"
 msgstr "Symbole"
 
@@ -188,48 +188,48 @@ msgstr "Normal"
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Standardeinstellung"
 
-#: app/configurator/components/ui-helpers.ts:584
+#: app/configurator/components/ui-helpers.ts:590
 msgid "controls.axis.horizontal"
 msgstr "Horizontale Achse"
 
-#: app/configurator/components/ui-helpers.ts:592
+#: app/configurator/components/ui-helpers.ts:598
 msgid "controls.axis.vertical"
 msgstr "Vertikale Achse"
 
-#: app/configurator/components/ui-helpers.ts:686
+#: app/configurator/components/ui-helpers.ts:692
 msgid "controls.chart.type.area"
 msgstr "Flächen"
 
-#: app/configurator/components/ui-helpers.ts:678
+#: app/configurator/components/ui-helpers.ts:684
 msgid "controls.chart.type.bar"
 msgstr "Balken"
 
-#: app/configurator/components/ui-helpers.ts:674
+#: app/configurator/components/ui-helpers.ts:680
 msgid "controls.chart.type.column"
 msgstr "Säulen"
 
-#: app/configurator/components/ui-helpers.ts:682
+#: app/configurator/components/ui-helpers.ts:688
 msgid "controls.chart.type.line"
 msgstr "Linien"
 
-#: app/configurator/components/ui-helpers.ts:702
+#: app/configurator/components/ui-helpers.ts:708
 msgid "controls.chart.type.map"
 msgstr "Karte"
 
-#: app/configurator/components/ui-helpers.ts:694
+#: app/configurator/components/ui-helpers.ts:700
 msgid "controls.chart.type.pie"
 msgstr "Kreis"
 
-#: app/configurator/components/ui-helpers.ts:690
+#: app/configurator/components/ui-helpers.ts:696
 msgid "controls.chart.type.scatterplot"
 msgstr "Scatterplot"
 
-#: app/configurator/components/ui-helpers.ts:698
+#: app/configurator/components/ui-helpers.ts:704
 msgid "controls.chart.type.table"
 msgstr "Tabelle"
 
-#: app/configurator/components/chart-options-selector.tsx:706
-#: app/configurator/components/ui-helpers.ts:596
+#: app/configurator/components/chart-options-selector.tsx:714
+#: app/configurator/components/ui-helpers.ts:602
 msgid "controls.color"
 msgstr "Farbe"
 
@@ -237,7 +237,7 @@ msgstr "Farbe"
 msgid "controls.color.add"
 msgstr "Hinzufügen …"
 
-#: app/configurator/components/chart-options-selector.tsx:737
+#: app/configurator/components/chart-options-selector.tsx:745
 msgid "controls.color.opacity"
 msgstr "Transparenz"
 
@@ -258,35 +258,35 @@ msgstr "Farbpalette zurücksetzen"
 msgid "controls.color.palette.sequential"
 msgstr "Sequentiell"
 
-#: app/configurator/components/chart-options-selector.tsx:827
+#: app/configurator/components/chart-options-selector.tsx:836
 msgid "controls.color.scale.discretization.jenks"
 msgstr "Jenks (Natural Breaks)"
 
-#: app/configurator/components/chart-options-selector.tsx:820
+#: app/configurator/components/chart-options-selector.tsx:829
 msgid "controls.color.scale.discretization.quantiles"
 msgstr "Quantile (gleiche Anzahl Werte)"
 
-#: app/configurator/components/chart-options-selector.tsx:813
+#: app/configurator/components/chart-options-selector.tsx:822
 msgid "controls.color.scale.discretization.quantize"
 msgstr "Quantisierung (gleiche Wertebereiche)"
 
-#: app/configurator/components/chart-options-selector.tsx:805
+#: app/configurator/components/chart-options-selector.tsx:814
 msgid "controls.color.scale.interpolation"
 msgstr "Interpolation"
 
-#: app/configurator/components/chart-options-selector.tsx:838
+#: app/configurator/components/chart-options-selector.tsx:847
 msgid "controls.color.scale.number.of.classes"
 msgstr "Anzahl Klassen"
 
-#: app/configurator/components/chart-options-selector.tsx:775
+#: app/configurator/components/chart-options-selector.tsx:784
 msgid "controls.color.scale.type.continuous"
 msgstr "Kontinuierlich"
 
-#: app/configurator/components/chart-options-selector.tsx:787
+#: app/configurator/components/chart-options-selector.tsx:796
 msgid "controls.color.scale.type.discrete"
 msgstr "Diskret"
 
-#: app/configurator/components/chart-options-selector.tsx:726
+#: app/configurator/components/chart-options-selector.tsx:734
 msgid "controls.color.select"
 msgstr "Farbe auswählen"
 
@@ -294,15 +294,15 @@ msgstr "Farbe auswählen"
 msgid "controls.colorpicker.open"
 msgstr "Farbauswahl öffnen"
 
-#: app/configurator/components/ui-helpers.ts:606
+#: app/configurator/components/ui-helpers.ts:612
 msgid "controls.column.grouped"
 msgstr "Gruppiert"
 
-#: app/configurator/components/ui-helpers.ts:602
+#: app/configurator/components/ui-helpers.ts:608
 msgid "controls.column.stacked"
 msgstr "Gestapelt"
 
-#: app/configurator/components/ui-helpers.ts:598
+#: app/configurator/components/ui-helpers.ts:604
 msgid "controls.description"
 msgstr "Beschreibung hinzufügen"
 
@@ -320,29 +320,29 @@ msgstr "Beschreibung hinzufügen"
 msgid "controls.dimensionvalue.none"
 msgstr "Kein Filter"
 
-#: app/configurator/components/filters.tsx:436
+#: app/configurator/components/filters.tsx:431
 msgid "controls.filter.nb-elements"
 msgstr "{0} von {1}"
 
-#: app/configurator/components/filters.tsx:390
-#: app/configurator/components/filters.tsx:610
+#: app/configurator/components/filters.tsx:385
+#: app/configurator/components/filters.tsx:609
 msgid "controls.filter.select.all"
 msgstr "Alle auswählen"
 
-#: app/configurator/components/filters.tsx:397
-#: app/configurator/components/filters.tsx:608
+#: app/configurator/components/filters.tsx:392
+#: app/configurator/components/filters.tsx:607
 msgid "controls.filter.select.none"
 msgstr "Alle abwählen"
 
-#: app/configurator/components/filters.tsx:407
+#: app/configurator/components/filters.tsx:402
 msgid "controls.filters.select.filters"
 msgstr "Filter"
 
-#: app/configurator/components/filters.tsx:420
+#: app/configurator/components/filters.tsx:415
 msgid "controls.filters.select.refresh-colors"
 msgstr "Farben auffrischen"
 
-#: app/configurator/components/filters.tsx:414
+#: app/configurator/components/filters.tsx:409
 msgid "controls.filters.select.selected-filters"
 msgstr "Ausgewählte Filter"
 
@@ -370,23 +370,23 @@ msgstr "Bitte eine Designoption oder Datendimension auswählen, um diese zu bear
 msgid "controls.hint.describing.chart"
 msgstr "Bitte ein Beschreibungsfeld auswählen, um dieses zu bearbeiten."
 
-#: app/configurator/components/ui-helpers.ts:658
+#: app/configurator/components/ui-helpers.ts:664
 msgid "controls.imputation"
 msgstr "Imputationstyp"
 
-#: app/configurator/components/chart-options-selector.tsx:874
-#: app/configurator/components/ui-helpers.ts:670
+#: app/configurator/components/chart-options-selector.tsx:883
+#: app/configurator/components/ui-helpers.ts:676
 msgid "controls.imputation.type.linear"
 msgstr "Lineare Interpolation"
 
-#: app/configurator/components/chart-options-selector.tsx:867
-#: app/configurator/components/chart-options-selector.tsx:879
-#: app/configurator/components/ui-helpers.ts:662
+#: app/configurator/components/chart-options-selector.tsx:876
+#: app/configurator/components/chart-options-selector.tsx:888
+#: app/configurator/components/ui-helpers.ts:668
 msgid "controls.imputation.type.none"
 msgstr "-"
 
-#: app/configurator/components/chart-options-selector.tsx:869
-#: app/configurator/components/ui-helpers.ts:666
+#: app/configurator/components/chart-options-selector.tsx:878
+#: app/configurator/components/ui-helpers.ts:672
 msgid "controls.imputation.type.zeros"
 msgstr "Nullen"
 
@@ -410,19 +410,19 @@ msgstr "Keine Zeitdimension verfügbar!"
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Zeitfilter anzeigen"
 
-#: app/configurator/components/ui-helpers.ts:706
+#: app/configurator/components/ui-helpers.ts:712
 msgid "controls.language.english"
 msgstr "Englisch"
 
-#: app/configurator/components/ui-helpers.ts:714
+#: app/configurator/components/ui-helpers.ts:720
 msgid "controls.language.french"
 msgstr "Französisch"
 
-#: app/configurator/components/ui-helpers.ts:710
+#: app/configurator/components/ui-helpers.ts:716
 msgid "controls.language.german"
 msgstr "Deutsch"
 
-#: app/configurator/components/ui-helpers.ts:718
+#: app/configurator/components/ui-helpers.ts:724
 msgid "controls.language.italian"
 msgstr "Italienisch"
 
@@ -431,7 +431,7 @@ msgstr "Italienisch"
 #~ msgid "controls.location"
 #~ msgstr "Standort"
 
-#: app/configurator/components/ui-helpers.ts:588
+#: app/configurator/components/ui-helpers.ts:594
 msgid "controls.measure"
 msgstr "Messwert"
 
@@ -447,7 +447,7 @@ msgstr "Aus"
 #~ msgid "controls.option.none"
 #~ msgstr "Keine"
 
-#: app/configurator/components/chart-options-selector.tsx:768
+#: app/configurator/components/chart-options-selector.tsx:777
 msgid "controls.scale.type"
 msgstr "Skalierungstyp"
 
@@ -455,7 +455,7 @@ msgstr "Skalierungstyp"
 msgid "controls.search.clear"
 msgstr "Suche zurücksetzen"
 
-#: app/configurator/components/chart-options-selector.tsx:346
+#: app/configurator/components/chart-options-selector.tsx:347
 msgid "controls.section.additional-information"
 msgstr "Zusätzliche Informationen"
 
@@ -479,8 +479,8 @@ msgstr "Filter"
 msgid "controls.section.description"
 msgstr "Titel & Beschreibung"
 
-#: app/configurator/components/chart-options-selector.tsx:400
-#: app/configurator/components/chart-options-selector.tsx:404
+#: app/configurator/components/chart-options-selector.tsx:403
+#: app/configurator/components/chart-options-selector.tsx:407
 #: app/configurator/table/table-chart-options.tsx:310
 #: app/configurator/table/table-chart-options.tsx:314
 #: app/configurator/table/table-chart-options.tsx:334
@@ -492,11 +492,11 @@ msgstr "Filter"
 msgid "controls.section.groups"
 msgstr "Gruppierungen"
 
-#: app/configurator/components/chart-options-selector.tsx:908
+#: app/configurator/components/chart-options-selector.tsx:917
 msgid "controls.section.imputation"
 msgstr "Fehlende Werte"
 
-#: app/configurator/components/chart-options-selector.tsx:913
+#: app/configurator/components/chart-options-selector.tsx:922
 msgid "controls.section.imputation.explanation"
 msgstr "Für diesen Diagrammtyp sollten fehlenden Werten Ersatzwerte zugewiesen werden. Entscheiden Sie sich für die Imputationslogik oder wechseln Sie zu einem anderen Diagrammtyp."
 
@@ -508,11 +508,11 @@ msgstr "Interaktive Filter hinzufügen"
 msgid "controls.section.interactiveFilters.dataFilters"
 msgstr "Datenfilter"
 
-#: app/configurator/components/chart-options-selector.tsx:355
+#: app/configurator/components/chart-options-selector.tsx:356
 msgid "controls.section.show-standard-error"
 msgstr "Standardfehler anzeigen"
 
-#: app/configurator/components/chart-options-selector.tsx:549
+#: app/configurator/components/chart-options-selector.tsx:550
 msgid "controls.section.sorting"
 msgstr "Sortieren"
 
@@ -534,7 +534,7 @@ msgstr "Tabellenoptionen"
 msgid "controls.select.chart.type"
 msgstr "Diagrammtyp"
 
-#: app/configurator/components/chart-options-selector.tsx:454
+#: app/configurator/components/chart-options-selector.tsx:455
 msgid "controls.select.column.layout"
 msgstr "Spaltenstil"
 
@@ -575,8 +575,8 @@ msgid "controls.select.dimension"
 msgstr "Dimension auswählen"
 
 #: app/configurator/components/chart-options-selector.tsx:209
-#: app/configurator/components/chart-options-selector.tsx:637
-#: app/configurator/components/chart-options-selector.tsx:711
+#: app/configurator/components/chart-options-selector.tsx:640
+#: app/configurator/components/chart-options-selector.tsx:719
 msgid "controls.select.measure"
 msgstr "Messwert auswählen"
 
@@ -587,19 +587,19 @@ msgstr "Messwert auswählen"
 #~ msgid "controls.select.optional"
 #~ msgstr "optional"
 
-#: app/configurator/components/filters.tsx:664
+#: app/configurator/components/filters.tsx:663
 msgid "controls.set-filters"
 msgstr "Ausgewählte Filter"
 
-#: app/configurator/components/filters.tsx:671
+#: app/configurator/components/filters.tsx:670
 msgid "controls.set-filters-caption"
 msgstr "Für beste Ergebnisse wählen Sie nicht mehr als 7 Werte für die Visualisierung aus"
 
-#: app/configurator/components/filters.tsx:703
+#: app/configurator/components/filters.tsx:702
 msgid "controls.set-values-apply"
 msgstr "Filter anwenden"
 
-#: app/configurator/components/chart-options-selector.tsx:629
+#: app/configurator/components/chart-options-selector.tsx:632
 msgid "controls.size"
 msgstr "Grösse"
 
@@ -607,48 +607,48 @@ msgstr "Grösse"
 msgid "controls.sorting.addDimension"
 msgstr "Dimension hinzufügen"
 
-#: app/configurator/components/chart-options-selector.tsx:499
-#: app/configurator/components/chart-options-selector.tsx:505
+#: app/configurator/components/chart-options-selector.tsx:500
+#: app/configurator/components/chart-options-selector.tsx:506
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Name"
 
-#: app/configurator/components/ui-helpers.ts:626
+#: app/configurator/components/ui-helpers.ts:632
 msgid "controls.sorting.byDimensionLabel.ascending"
 msgstr "A → Z"
 
-#: app/configurator/components/ui-helpers.ts:630
+#: app/configurator/components/ui-helpers.ts:636
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
-#: app/configurator/components/chart-options-selector.tsx:501
+#: app/configurator/components/chart-options-selector.tsx:502
 msgid "controls.sorting.byMeasure"
 msgstr "Messwert"
 
-#: app/configurator/components/ui-helpers.ts:650
+#: app/configurator/components/ui-helpers.ts:656
 msgid "controls.sorting.byMeasure.ascending"
 msgstr "1 → 9"
 
-#: app/configurator/components/ui-helpers.ts:654
+#: app/configurator/components/ui-helpers.ts:660
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
-#: app/configurator/components/chart-options-selector.tsx:503
+#: app/configurator/components/chart-options-selector.tsx:504
 msgid "controls.sorting.byTotalSize"
 msgstr "Gesamtgrösse"
 
-#: app/configurator/components/ui-helpers.ts:634
+#: app/configurator/components/ui-helpers.ts:640
 msgid "controls.sorting.byTotalSize.ascending"
 msgstr "Kleinste zuerst"
 
-#: app/configurator/components/ui-helpers.ts:646
+#: app/configurator/components/ui-helpers.ts:652
 msgid "controls.sorting.byTotalSize.largestBottom"
 msgstr "Grösste unten"
 
-#: app/configurator/components/ui-helpers.ts:638
+#: app/configurator/components/ui-helpers.ts:644
 msgid "controls.sorting.byTotalSize.largestFirst"
 msgstr "Grösste zuerst"
 
-#: app/configurator/components/ui-helpers.ts:642
+#: app/configurator/components/ui-helpers.ts:648
 msgid "controls.sorting.byTotalSize.largestTop"
 msgstr "Kleinste unten"
 
@@ -660,7 +660,7 @@ msgstr "Sortierung entfernen"
 msgid "controls.sorting.selectDimension"
 msgstr "Wählen Sie eine Dimension aus …"
 
-#: app/configurator/components/ui-helpers.ts:622
+#: app/configurator/components/ui-helpers.ts:628
 #: app/configurator/table/table-chart-sorting-options.tsx:319
 msgid "controls.sorting.sortBy"
 msgstr "Sortieren nach"
@@ -689,7 +689,7 @@ msgstr "Sortierung"
 msgid "controls.tableSettings.showSearch"
 msgstr "Suche anzeigen"
 
-#: app/configurator/components/ui-helpers.ts:597
+#: app/configurator/components/ui-helpers.ts:603
 msgid "controls.title"
 msgstr "Titel hinzufügen"
 
@@ -717,6 +717,14 @@ msgstr "Dieses Diagramm verwendet keine vertrauenswürdige Datenquelle."
 msgid "dataset-preview.back-to-results"
 msgstr "Zurück zu den Datensätzen"
 
+#: app/components/chart-footnotes.tsx:111
+msgid "dataset.footnotes.dataset"
+msgstr "Datensatz"
+
+#: app/components/chart-footnotes.tsx:132
+msgid "dataset.footnotes.updated"
+msgstr "Neuestes Update"
+
 #: app/components/chart-published.tsx:157
 msgid "dataset.hasImputedValues"
 msgstr "Einige Daten in diesem Datensatz fehlen und wurden interpoliert, um die Lücken zu füllen."
@@ -729,10 +737,6 @@ msgstr "Entwürfe einschließen"
 msgid "dataset.metadata.date.created"
 msgstr "Erstellungsdatum"
 
-#: app/components/chart-footnotes.tsx:109
-msgid "dataset.metadata.date.footnotes.updated"
-msgstr ", neuestes Update: {0}"
-
 #: app/configurator/components/dataset-metadata.tsx:94
 msgid "dataset.metadata.email"
 msgstr "Kontaktstellen"
@@ -741,7 +745,7 @@ msgstr "Kontaktstellen"
 msgid "dataset.metadata.furtherinformation"
 msgstr "Weitere Informationen"
 
-#: app/components/chart-footnotes.tsx:190
+#: app/components/chart-footnotes.tsx:198
 #: app/configurator/components/dataset-metadata.tsx:118
 msgid "dataset.metadata.learnmore"
 msgstr "Erfahren Sie mehr über diesen Datensatz"
@@ -898,22 +902,22 @@ msgid "logo.swiss.confederation"
 msgstr "Logo der Schweizerischen Eidgenossenschaft"
 
 #: app/components/chart-footnotes.tsx:121
-msgid "metadata.dataset"
-msgstr "Datensatz"
+#~ msgid "metadata.dataset"
+#~ msgstr "Datensatz"
 
-#: app/components/chart-footnotes.tsx:209
+#: app/components/chart-footnotes.tsx:217
 msgid "metadata.link.created.with.visualize"
 msgstr "Erstellt mit visualize.admin.ch"
 
-#: app/components/chart-footnotes.tsx:137
+#: app/components/chart-footnotes.tsx:143
 msgid "metadata.source"
 msgstr "Quelle"
 
-#: app/components/chart-footnotes.tsx:173
+#: app/components/chart-footnotes.tsx:181
 msgid "metadata.switch.chart"
 msgstr "Zur Diagrammansicht wechseln"
 
-#: app/components/chart-footnotes.tsx:175
+#: app/components/chart-footnotes.tsx:183
 msgid "metadata.switch.table"
 msgstr "Zur Tabellenansicht wechseln"
 
@@ -953,7 +957,7 @@ msgstr "Hier ist eine Visualisierung, die ich mit visualize.admin.ch erstellt ha
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
-#: app/configurator/components/filters.tsx:584
+#: app/configurator/components/filters.tsx:583
 msgid "select.controls.filters.search"
 msgstr "Suche"
 
@@ -968,3 +972,9 @@ msgstr "Passen Sie Ihre Visualisierung an, indem Sie die Filter- und Farbsegment
 #: app/configurator/components/chart-controls/drag-and-drop-tab.tsx:101
 msgid "table.column.no"
 msgstr "Spalte {0}"
+
+#: app/components/chart-footnotes.tsx:113
+#: app/components/chart-footnotes.tsx:133
+#: app/components/chart-footnotes.tsx:145
+msgid "typography.colon"
+msgstr ": "

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -30,7 +30,7 @@ msgid "Move filter up"
 msgstr "Move filter up"
 
 #: app/configurator/components/dataset-browse.tsx:1027
-#: app/configurator/components/filters.tsx:682
+#: app/configurator/components/filters.tsx:681
 msgid "No results"
 msgstr "No results"
 
@@ -120,7 +120,7 @@ msgstr "Publish this visualization"
 msgid "button.share"
 msgstr "Share"
 
-#: app/configurator/components/ui-helpers.ts:614
+#: app/configurator/components/ui-helpers.ts:620
 msgid "chart.map.layers.area"
 msgstr "Areas"
 
@@ -145,16 +145,16 @@ msgstr "Areas"
 #~ msgstr "Quantize (equal intervals)"
 
 #: app/configurator/components/chart-configurator.tsx:696
-#: app/configurator/components/chart-options-selector.tsx:983
-#: app/configurator/components/ui-helpers.ts:610
+#: app/configurator/components/chart-options-selector.tsx:992
+#: app/configurator/components/ui-helpers.ts:616
 msgid "chart.map.layers.base"
 msgstr "Map Display"
 
-#: app/configurator/components/chart-options-selector.tsx:987
+#: app/configurator/components/chart-options-selector.tsx:996
 msgid "chart.map.layers.base.show"
 msgstr "Show Worldmap"
 
-#: app/configurator/components/chart-options-selector.tsx:996
+#: app/configurator/components/chart-options-selector.tsx:1005
 msgid "chart.map.layers.base.view.locked"
 msgstr "Locked view"
 
@@ -163,7 +163,7 @@ msgstr "Locked view"
 #~ msgid "chart.map.layers.show"
 #~ msgstr "Show layer"
 
-#: app/configurator/components/ui-helpers.ts:618
+#: app/configurator/components/ui-helpers.ts:624
 msgid "chart.map.layers.symbol"
 msgstr "Symbols"
 
@@ -208,48 +208,48 @@ msgstr "Regular"
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Default Settings"
 
-#: app/configurator/components/ui-helpers.ts:584
+#: app/configurator/components/ui-helpers.ts:590
 msgid "controls.axis.horizontal"
 msgstr "Horizontal Axis"
 
-#: app/configurator/components/ui-helpers.ts:592
+#: app/configurator/components/ui-helpers.ts:598
 msgid "controls.axis.vertical"
 msgstr "Vertical Axis"
 
-#: app/configurator/components/ui-helpers.ts:686
+#: app/configurator/components/ui-helpers.ts:692
 msgid "controls.chart.type.area"
 msgstr "Areas"
 
-#: app/configurator/components/ui-helpers.ts:678
+#: app/configurator/components/ui-helpers.ts:684
 msgid "controls.chart.type.bar"
 msgstr "Bars"
 
-#: app/configurator/components/ui-helpers.ts:674
+#: app/configurator/components/ui-helpers.ts:680
 msgid "controls.chart.type.column"
 msgstr "Columns"
 
-#: app/configurator/components/ui-helpers.ts:682
+#: app/configurator/components/ui-helpers.ts:688
 msgid "controls.chart.type.line"
 msgstr "Lines"
 
-#: app/configurator/components/ui-helpers.ts:702
+#: app/configurator/components/ui-helpers.ts:708
 msgid "controls.chart.type.map"
 msgstr "Map"
 
-#: app/configurator/components/ui-helpers.ts:694
+#: app/configurator/components/ui-helpers.ts:700
 msgid "controls.chart.type.pie"
 msgstr "Pie"
 
-#: app/configurator/components/ui-helpers.ts:690
+#: app/configurator/components/ui-helpers.ts:696
 msgid "controls.chart.type.scatterplot"
 msgstr "Scatterplot"
 
-#: app/configurator/components/ui-helpers.ts:698
+#: app/configurator/components/ui-helpers.ts:704
 msgid "controls.chart.type.table"
 msgstr "Table"
 
-#: app/configurator/components/chart-options-selector.tsx:706
-#: app/configurator/components/ui-helpers.ts:596
+#: app/configurator/components/chart-options-selector.tsx:714
+#: app/configurator/components/ui-helpers.ts:602
 msgid "controls.color"
 msgstr "Color"
 
@@ -257,7 +257,7 @@ msgstr "Color"
 msgid "controls.color.add"
 msgstr "Add ..."
 
-#: app/configurator/components/chart-options-selector.tsx:737
+#: app/configurator/components/chart-options-selector.tsx:745
 msgid "controls.color.opacity"
 msgstr "Opacity"
 
@@ -278,35 +278,35 @@ msgstr "Reset color palette"
 msgid "controls.color.palette.sequential"
 msgstr "Sequential"
 
-#: app/configurator/components/chart-options-selector.tsx:827
+#: app/configurator/components/chart-options-selector.tsx:836
 msgid "controls.color.scale.discretization.jenks"
 msgstr "Jenks (natural breaks)"
 
-#: app/configurator/components/chart-options-selector.tsx:820
+#: app/configurator/components/chart-options-selector.tsx:829
 msgid "controls.color.scale.discretization.quantiles"
 msgstr "Quantiles (equal distribution of values)"
 
-#: app/configurator/components/chart-options-selector.tsx:813
+#: app/configurator/components/chart-options-selector.tsx:822
 msgid "controls.color.scale.discretization.quantize"
 msgstr "Quantize (equal intervals)"
 
-#: app/configurator/components/chart-options-selector.tsx:805
+#: app/configurator/components/chart-options-selector.tsx:814
 msgid "controls.color.scale.interpolation"
 msgstr "Interpolation"
 
-#: app/configurator/components/chart-options-selector.tsx:838
+#: app/configurator/components/chart-options-selector.tsx:847
 msgid "controls.color.scale.number.of.classes"
 msgstr "Number of classes"
 
-#: app/configurator/components/chart-options-selector.tsx:775
+#: app/configurator/components/chart-options-selector.tsx:784
 msgid "controls.color.scale.type.continuous"
 msgstr "Continuous"
 
-#: app/configurator/components/chart-options-selector.tsx:787
+#: app/configurator/components/chart-options-selector.tsx:796
 msgid "controls.color.scale.type.discrete"
 msgstr "Discrete"
 
-#: app/configurator/components/chart-options-selector.tsx:726
+#: app/configurator/components/chart-options-selector.tsx:734
 msgid "controls.color.select"
 msgstr "Select a color"
 
@@ -314,15 +314,15 @@ msgstr "Select a color"
 msgid "controls.colorpicker.open"
 msgstr "Open Color Picker"
 
-#: app/configurator/components/ui-helpers.ts:606
+#: app/configurator/components/ui-helpers.ts:612
 msgid "controls.column.grouped"
 msgstr "Grouped"
 
-#: app/configurator/components/ui-helpers.ts:602
+#: app/configurator/components/ui-helpers.ts:608
 msgid "controls.column.stacked"
 msgstr "Stacked"
 
-#: app/configurator/components/ui-helpers.ts:598
+#: app/configurator/components/ui-helpers.ts:604
 msgid "controls.description"
 msgstr "Description"
 
@@ -340,29 +340,29 @@ msgstr "Description"
 msgid "controls.dimensionvalue.none"
 msgstr "No Filter"
 
-#: app/configurator/components/filters.tsx:436
+#: app/configurator/components/filters.tsx:431
 msgid "controls.filter.nb-elements"
 msgstr "{0} of {1}"
 
-#: app/configurator/components/filters.tsx:390
-#: app/configurator/components/filters.tsx:610
+#: app/configurator/components/filters.tsx:385
+#: app/configurator/components/filters.tsx:609
 msgid "controls.filter.select.all"
 msgstr "Select all"
 
-#: app/configurator/components/filters.tsx:397
-#: app/configurator/components/filters.tsx:608
+#: app/configurator/components/filters.tsx:392
+#: app/configurator/components/filters.tsx:607
 msgid "controls.filter.select.none"
 msgstr "Select none"
 
-#: app/configurator/components/filters.tsx:407
+#: app/configurator/components/filters.tsx:402
 msgid "controls.filters.select.filters"
 msgstr "Filters"
 
-#: app/configurator/components/filters.tsx:420
+#: app/configurator/components/filters.tsx:415
 msgid "controls.filters.select.refresh-colors"
 msgstr "Refresh colors"
 
-#: app/configurator/components/filters.tsx:414
+#: app/configurator/components/filters.tsx:409
 msgid "controls.filters.select.selected-filters"
 msgstr "Selected filters"
 
@@ -390,23 +390,23 @@ msgstr "Select a design element or a data dimension to modify its options."
 msgid "controls.hint.describing.chart"
 msgstr "Select an annotation field to modify its content."
 
-#: app/configurator/components/ui-helpers.ts:658
+#: app/configurator/components/ui-helpers.ts:664
 msgid "controls.imputation"
 msgstr "Imputation type"
 
-#: app/configurator/components/chart-options-selector.tsx:874
-#: app/configurator/components/ui-helpers.ts:670
+#: app/configurator/components/chart-options-selector.tsx:883
+#: app/configurator/components/ui-helpers.ts:676
 msgid "controls.imputation.type.linear"
 msgstr "Linear interpolation"
 
-#: app/configurator/components/chart-options-selector.tsx:867
-#: app/configurator/components/chart-options-selector.tsx:879
-#: app/configurator/components/ui-helpers.ts:662
+#: app/configurator/components/chart-options-selector.tsx:876
+#: app/configurator/components/chart-options-selector.tsx:888
+#: app/configurator/components/ui-helpers.ts:668
 msgid "controls.imputation.type.none"
 msgstr "-"
 
-#: app/configurator/components/chart-options-selector.tsx:869
-#: app/configurator/components/ui-helpers.ts:666
+#: app/configurator/components/chart-options-selector.tsx:878
+#: app/configurator/components/ui-helpers.ts:672
 msgid "controls.imputation.type.zeros"
 msgstr "Zeros"
 
@@ -430,19 +430,19 @@ msgstr "There is no time dimension!"
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Show time filter"
 
-#: app/configurator/components/ui-helpers.ts:706
+#: app/configurator/components/ui-helpers.ts:712
 msgid "controls.language.english"
 msgstr "English"
 
-#: app/configurator/components/ui-helpers.ts:714
+#: app/configurator/components/ui-helpers.ts:720
 msgid "controls.language.french"
 msgstr "French"
 
-#: app/configurator/components/ui-helpers.ts:710
+#: app/configurator/components/ui-helpers.ts:716
 msgid "controls.language.german"
 msgstr "German"
 
-#: app/configurator/components/ui-helpers.ts:718
+#: app/configurator/components/ui-helpers.ts:724
 msgid "controls.language.italian"
 msgstr "Italian"
 
@@ -451,7 +451,7 @@ msgstr "Italian"
 #~ msgid "controls.location"
 #~ msgstr "Location"
 
-#: app/configurator/components/ui-helpers.ts:588
+#: app/configurator/components/ui-helpers.ts:594
 msgid "controls.measure"
 msgstr "Measure"
 
@@ -467,7 +467,7 @@ msgstr "On"
 msgid "controls.option.isNotActive"
 msgstr "Off"
 
-#: app/configurator/components/chart-options-selector.tsx:768
+#: app/configurator/components/chart-options-selector.tsx:777
 msgid "controls.scale.type"
 msgstr "Scale type"
 
@@ -475,7 +475,7 @@ msgstr "Scale type"
 msgid "controls.search.clear"
 msgstr "Clear search field"
 
-#: app/configurator/components/chart-options-selector.tsx:346
+#: app/configurator/components/chart-options-selector.tsx:347
 msgid "controls.section.additional-information"
 msgstr "Additional information"
 
@@ -499,8 +499,8 @@ msgstr "Filters"
 msgid "controls.section.description"
 msgstr "Title & Description"
 
-#: app/configurator/components/chart-options-selector.tsx:400
-#: app/configurator/components/chart-options-selector.tsx:404
+#: app/configurator/components/chart-options-selector.tsx:403
+#: app/configurator/components/chart-options-selector.tsx:407
 #: app/configurator/table/table-chart-options.tsx:310
 #: app/configurator/table/table-chart-options.tsx:314
 #: app/configurator/table/table-chart-options.tsx:334
@@ -512,11 +512,11 @@ msgstr "Filter"
 msgid "controls.section.groups"
 msgstr "Groups"
 
-#: app/configurator/components/chart-options-selector.tsx:908
+#: app/configurator/components/chart-options-selector.tsx:917
 msgid "controls.section.imputation"
 msgstr "Missing values"
 
-#: app/configurator/components/chart-options-selector.tsx:913
+#: app/configurator/components/chart-options-selector.tsx:922
 msgid "controls.section.imputation.explanation"
 msgstr "For this chart type, replacement values should be assigned to missing values. Decide on the imputation logic or switch to another chart type."
 
@@ -528,11 +528,11 @@ msgstr "Interactive Filters"
 msgid "controls.section.interactiveFilters.dataFilters"
 msgstr "Data Filters"
 
-#: app/configurator/components/chart-options-selector.tsx:355
+#: app/configurator/components/chart-options-selector.tsx:356
 msgid "controls.section.show-standard-error"
 msgstr "Show standard error"
 
-#: app/configurator/components/chart-options-selector.tsx:549
+#: app/configurator/components/chart-options-selector.tsx:550
 msgid "controls.section.sorting"
 msgstr "Sort"
 
@@ -554,7 +554,7 @@ msgstr "Table Options"
 msgid "controls.select.chart.type"
 msgstr "Chart Type"
 
-#: app/configurator/components/chart-options-selector.tsx:454
+#: app/configurator/components/chart-options-selector.tsx:455
 msgid "controls.select.column.layout"
 msgstr "Column layout"
 
@@ -595,8 +595,8 @@ msgid "controls.select.dimension"
 msgstr "Select a dimension"
 
 #: app/configurator/components/chart-options-selector.tsx:209
-#: app/configurator/components/chart-options-selector.tsx:637
-#: app/configurator/components/chart-options-selector.tsx:711
+#: app/configurator/components/chart-options-selector.tsx:640
+#: app/configurator/components/chart-options-selector.tsx:719
 msgid "controls.select.measure"
 msgstr "Select a measure"
 
@@ -607,19 +607,19 @@ msgstr "Select a measure"
 #~ msgid "controls.select.optional"
 #~ msgstr "optional"
 
-#: app/configurator/components/filters.tsx:664
+#: app/configurator/components/filters.tsx:663
 msgid "controls.set-filters"
 msgstr "Set filters"
 
-#: app/configurator/components/filters.tsx:671
+#: app/configurator/components/filters.tsx:670
 msgid "controls.set-filters-caption"
 msgstr "For best results, do not select more than 7 values in the visualization."
 
-#: app/configurator/components/filters.tsx:703
+#: app/configurator/components/filters.tsx:702
 msgid "controls.set-values-apply"
 msgstr "Apply filters"
 
-#: app/configurator/components/chart-options-selector.tsx:629
+#: app/configurator/components/chart-options-selector.tsx:632
 msgid "controls.size"
 msgstr "Size"
 
@@ -627,48 +627,48 @@ msgstr "Size"
 msgid "controls.sorting.addDimension"
 msgstr "Add dimension"
 
-#: app/configurator/components/chart-options-selector.tsx:499
-#: app/configurator/components/chart-options-selector.tsx:505
+#: app/configurator/components/chart-options-selector.tsx:500
+#: app/configurator/components/chart-options-selector.tsx:506
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Name"
 
-#: app/configurator/components/ui-helpers.ts:626
+#: app/configurator/components/ui-helpers.ts:632
 msgid "controls.sorting.byDimensionLabel.ascending"
 msgstr "A → Z"
 
-#: app/configurator/components/ui-helpers.ts:630
+#: app/configurator/components/ui-helpers.ts:636
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
-#: app/configurator/components/chart-options-selector.tsx:501
+#: app/configurator/components/chart-options-selector.tsx:502
 msgid "controls.sorting.byMeasure"
 msgstr "Measure"
 
-#: app/configurator/components/ui-helpers.ts:650
+#: app/configurator/components/ui-helpers.ts:656
 msgid "controls.sorting.byMeasure.ascending"
 msgstr "1 → 9"
 
-#: app/configurator/components/ui-helpers.ts:654
+#: app/configurator/components/ui-helpers.ts:660
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
-#: app/configurator/components/chart-options-selector.tsx:503
+#: app/configurator/components/chart-options-selector.tsx:504
 msgid "controls.sorting.byTotalSize"
 msgstr "Total size"
 
-#: app/configurator/components/ui-helpers.ts:634
+#: app/configurator/components/ui-helpers.ts:640
 msgid "controls.sorting.byTotalSize.ascending"
 msgstr "Largest last"
 
-#: app/configurator/components/ui-helpers.ts:646
+#: app/configurator/components/ui-helpers.ts:652
 msgid "controls.sorting.byTotalSize.largestBottom"
 msgstr "Ascending"
 
-#: app/configurator/components/ui-helpers.ts:638
+#: app/configurator/components/ui-helpers.ts:644
 msgid "controls.sorting.byTotalSize.largestFirst"
 msgstr "Largest first"
 
-#: app/configurator/components/ui-helpers.ts:642
+#: app/configurator/components/ui-helpers.ts:648
 msgid "controls.sorting.byTotalSize.largestTop"
 msgstr "Descending"
 
@@ -680,7 +680,7 @@ msgstr "Remove sorting dimension"
 msgid "controls.sorting.selectDimension"
 msgstr "Select a dimension …"
 
-#: app/configurator/components/ui-helpers.ts:622
+#: app/configurator/components/ui-helpers.ts:628
 #: app/configurator/table/table-chart-sorting-options.tsx:319
 msgid "controls.sorting.sortBy"
 msgstr "Sort by"
@@ -709,7 +709,7 @@ msgstr "Sorting"
 msgid "controls.tableSettings.showSearch"
 msgstr "Show search field"
 
-#: app/configurator/components/ui-helpers.ts:597
+#: app/configurator/components/ui-helpers.ts:603
 msgid "controls.title"
 msgstr "Title"
 
@@ -737,6 +737,14 @@ msgstr "This chart is not using a trusted data source."
 msgid "dataset-preview.back-to-results"
 msgstr "Back to the datasets"
 
+#: app/components/chart-footnotes.tsx:111
+msgid "dataset.footnotes.dataset"
+msgstr "Dataset"
+
+#: app/components/chart-footnotes.tsx:132
+msgid "dataset.footnotes.updated"
+msgstr "Latest update"
+
 #: app/components/chart-published.tsx:157
 msgid "dataset.hasImputedValues"
 msgstr "Some data in this dataset is missing and has been interpolated to fill the gaps."
@@ -750,8 +758,8 @@ msgid "dataset.metadata.date.created"
 msgstr "Date created"
 
 #: app/components/chart-footnotes.tsx:109
-msgid "dataset.metadata.date.footnotes.updated"
-msgstr ", latest update: {0}"
+#~ msgid "dataset.metadata.date.footnotes.updated"
+#~ msgstr ", latest update: {0}"
 
 #: app/configurator/components/dataset-metadata.tsx:94
 msgid "dataset.metadata.email"
@@ -761,7 +769,7 @@ msgstr "Contact points"
 msgid "dataset.metadata.furtherinformation"
 msgstr "Further information"
 
-#: app/components/chart-footnotes.tsx:190
+#: app/components/chart-footnotes.tsx:198
 #: app/configurator/components/dataset-metadata.tsx:118
 msgid "dataset.metadata.learnmore"
 msgstr "Learn more about the dataset"
@@ -918,22 +926,22 @@ msgid "logo.swiss.confederation"
 msgstr "Logo of the Swiss Confederation"
 
 #: app/components/chart-footnotes.tsx:121
-msgid "metadata.dataset"
-msgstr "Dataset"
+#~ msgid "metadata.dataset"
+#~ msgstr "Dataset"
 
-#: app/components/chart-footnotes.tsx:209
+#: app/components/chart-footnotes.tsx:217
 msgid "metadata.link.created.with.visualize"
 msgstr "Created with visualize.admin.ch"
 
-#: app/components/chart-footnotes.tsx:137
+#: app/components/chart-footnotes.tsx:143
 msgid "metadata.source"
 msgstr "Source"
 
-#: app/components/chart-footnotes.tsx:173
+#: app/components/chart-footnotes.tsx:181
 msgid "metadata.switch.chart"
 msgstr "Switch to chart view"
 
-#: app/components/chart-footnotes.tsx:175
+#: app/components/chart-footnotes.tsx:183
 msgid "metadata.switch.table"
 msgstr "Switch to table view"
 
@@ -973,7 +981,7 @@ msgstr "Here is a visualization I created using visualize.admin.ch"
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
-#: app/configurator/components/filters.tsx:584
+#: app/configurator/components/filters.tsx:583
 msgid "select.controls.filters.search"
 msgstr "Search"
 
@@ -988,3 +996,9 @@ msgstr "Customize your visualization by using the filter and color segmentation 
 #: app/configurator/components/chart-controls/drag-and-drop-tab.tsx:101
 msgid "table.column.no"
 msgstr "Column {0}"
+
+#: app/components/chart-footnotes.tsx:113
+#: app/components/chart-footnotes.tsx:133
+#: app/components/chart-footnotes.tsx:145
+msgid "typography.colon"
+msgstr ": "

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -30,7 +30,7 @@ msgid "Move filter up"
 msgstr "Déplacer le filtre vers le haut"
 
 #: app/configurator/components/dataset-browse.tsx:1027
-#: app/configurator/components/filters.tsx:682
+#: app/configurator/components/filters.tsx:681
 msgid "No results"
 msgstr "Aucun résultat"
 
@@ -120,7 +120,7 @@ msgstr "Publier cette visualisation"
 msgid "button.share"
 msgstr "Partager"
 
-#: app/configurator/components/ui-helpers.ts:614
+#: app/configurator/components/ui-helpers.ts:620
 msgid "chart.map.layers.area"
 msgstr "Zones"
 
@@ -145,16 +145,16 @@ msgstr "Zones"
 #~ msgstr "Intervalles égaux"
 
 #: app/configurator/components/chart-configurator.tsx:696
-#: app/configurator/components/chart-options-selector.tsx:983
-#: app/configurator/components/ui-helpers.ts:610
+#: app/configurator/components/chart-options-selector.tsx:992
+#: app/configurator/components/ui-helpers.ts:616
 msgid "chart.map.layers.base"
 msgstr "Affichage de la carte"
 
-#: app/configurator/components/chart-options-selector.tsx:987
+#: app/configurator/components/chart-options-selector.tsx:996
 msgid "chart.map.layers.base.show"
 msgstr "Afficher la carte du monde"
 
-#: app/configurator/components/chart-options-selector.tsx:996
+#: app/configurator/components/chart-options-selector.tsx:1005
 msgid "chart.map.layers.base.view.locked"
 msgstr "Carte verrouillée"
 
@@ -163,7 +163,7 @@ msgstr "Carte verrouillée"
 #~ msgid "chart.map.layers.show"
 #~ msgstr "Afficher la couche"
 
-#: app/configurator/components/ui-helpers.ts:618
+#: app/configurator/components/ui-helpers.ts:624
 msgid "chart.map.layers.symbol"
 msgstr "Symboles"
 
@@ -208,48 +208,48 @@ msgstr "Normal"
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Paramètres d'origine"
 
-#: app/configurator/components/ui-helpers.ts:584
+#: app/configurator/components/ui-helpers.ts:590
 msgid "controls.axis.horizontal"
 msgstr "Axe horizontal"
 
-#: app/configurator/components/ui-helpers.ts:592
+#: app/configurator/components/ui-helpers.ts:598
 msgid "controls.axis.vertical"
 msgstr "Axe vertical"
 
-#: app/configurator/components/ui-helpers.ts:686
+#: app/configurator/components/ui-helpers.ts:692
 msgid "controls.chart.type.area"
 msgstr "Surfaces"
 
-#: app/configurator/components/ui-helpers.ts:678
+#: app/configurator/components/ui-helpers.ts:684
 msgid "controls.chart.type.bar"
 msgstr "Barres"
 
-#: app/configurator/components/ui-helpers.ts:674
+#: app/configurator/components/ui-helpers.ts:680
 msgid "controls.chart.type.column"
 msgstr "Colonnes"
 
-#: app/configurator/components/ui-helpers.ts:682
+#: app/configurator/components/ui-helpers.ts:688
 msgid "controls.chart.type.line"
 msgstr "Lignes"
 
-#: app/configurator/components/ui-helpers.ts:702
+#: app/configurator/components/ui-helpers.ts:708
 msgid "controls.chart.type.map"
 msgstr "Carte"
 
-#: app/configurator/components/ui-helpers.ts:694
+#: app/configurator/components/ui-helpers.ts:700
 msgid "controls.chart.type.pie"
 msgstr "Secteurs"
 
-#: app/configurator/components/ui-helpers.ts:690
+#: app/configurator/components/ui-helpers.ts:696
 msgid "controls.chart.type.scatterplot"
 msgstr "Nuage de points"
 
-#: app/configurator/components/ui-helpers.ts:698
+#: app/configurator/components/ui-helpers.ts:704
 msgid "controls.chart.type.table"
 msgstr "Tableau"
 
-#: app/configurator/components/chart-options-selector.tsx:706
-#: app/configurator/components/ui-helpers.ts:596
+#: app/configurator/components/chart-options-selector.tsx:714
+#: app/configurator/components/ui-helpers.ts:602
 msgid "controls.color"
 msgstr "Couleur"
 
@@ -257,7 +257,7 @@ msgstr "Couleur"
 msgid "controls.color.add"
 msgstr "Ajouter…"
 
-#: app/configurator/components/chart-options-selector.tsx:737
+#: app/configurator/components/chart-options-selector.tsx:745
 msgid "controls.color.opacity"
 msgstr "Transparence"
 
@@ -278,35 +278,35 @@ msgstr "Réinitialiser la palette de couleurs"
 msgid "controls.color.palette.sequential"
 msgstr "Séquentielle"
 
-#: app/configurator/components/chart-options-selector.tsx:827
+#: app/configurator/components/chart-options-selector.tsx:836
 msgid "controls.color.scale.discretization.jenks"
 msgstr "Jenks (intervalles naturels)"
 
-#: app/configurator/components/chart-options-selector.tsx:820
+#: app/configurator/components/chart-options-selector.tsx:829
 msgid "controls.color.scale.discretization.quantiles"
 msgstr "Quantiles (distribution homogène des valeurs)"
 
-#: app/configurator/components/chart-options-selector.tsx:813
+#: app/configurator/components/chart-options-selector.tsx:822
 msgid "controls.color.scale.discretization.quantize"
 msgstr "Intervalles égaux"
 
-#: app/configurator/components/chart-options-selector.tsx:805
+#: app/configurator/components/chart-options-selector.tsx:814
 msgid "controls.color.scale.interpolation"
 msgstr "Interpolation"
 
-#: app/configurator/components/chart-options-selector.tsx:838
+#: app/configurator/components/chart-options-selector.tsx:847
 msgid "controls.color.scale.number.of.classes"
 msgstr "Nombre de classes"
 
-#: app/configurator/components/chart-options-selector.tsx:775
+#: app/configurator/components/chart-options-selector.tsx:784
 msgid "controls.color.scale.type.continuous"
 msgstr "Continue"
 
-#: app/configurator/components/chart-options-selector.tsx:787
+#: app/configurator/components/chart-options-selector.tsx:796
 msgid "controls.color.scale.type.discrete"
 msgstr "Discrète"
 
-#: app/configurator/components/chart-options-selector.tsx:726
+#: app/configurator/components/chart-options-selector.tsx:734
 msgid "controls.color.select"
 msgstr "Sélectionner une couleur"
 
@@ -314,15 +314,15 @@ msgstr "Sélectionner une couleur"
 msgid "controls.colorpicker.open"
 msgstr "Ouvrir la pipette à couleur"
 
-#: app/configurator/components/ui-helpers.ts:606
+#: app/configurator/components/ui-helpers.ts:612
 msgid "controls.column.grouped"
 msgstr "groupées"
 
-#: app/configurator/components/ui-helpers.ts:602
+#: app/configurator/components/ui-helpers.ts:608
 msgid "controls.column.stacked"
 msgstr "empilées"
 
-#: app/configurator/components/ui-helpers.ts:598
+#: app/configurator/components/ui-helpers.ts:604
 msgid "controls.description"
 msgstr "Description"
 
@@ -340,29 +340,29 @@ msgstr "Description"
 msgid "controls.dimensionvalue.none"
 msgstr "Aucune filtre"
 
-#: app/configurator/components/filters.tsx:436
+#: app/configurator/components/filters.tsx:431
 msgid "controls.filter.nb-elements"
 msgstr "{0} sur {1}"
 
-#: app/configurator/components/filters.tsx:390
-#: app/configurator/components/filters.tsx:610
+#: app/configurator/components/filters.tsx:385
+#: app/configurator/components/filters.tsx:609
 msgid "controls.filter.select.all"
 msgstr "Tout sélectionner"
 
-#: app/configurator/components/filters.tsx:397
-#: app/configurator/components/filters.tsx:608
+#: app/configurator/components/filters.tsx:392
+#: app/configurator/components/filters.tsx:607
 msgid "controls.filter.select.none"
 msgstr "Tout déselectionner"
 
-#: app/configurator/components/filters.tsx:407
+#: app/configurator/components/filters.tsx:402
 msgid "controls.filters.select.filters"
 msgstr "Filtres"
 
-#: app/configurator/components/filters.tsx:420
+#: app/configurator/components/filters.tsx:415
 msgid "controls.filters.select.refresh-colors"
 msgstr "Renouveller les couleurs"
 
-#: app/configurator/components/filters.tsx:414
+#: app/configurator/components/filters.tsx:409
 msgid "controls.filters.select.selected-filters"
 msgstr "Filtres sélectionnés"
 
@@ -390,23 +390,23 @@ msgstr "Sélectionnez un élément de design ou une dimension du jeu de données
 msgid "controls.hint.describing.chart"
 msgstr "Sélectionnez une des annotations proposées pour la modifier."
 
-#: app/configurator/components/ui-helpers.ts:658
+#: app/configurator/components/ui-helpers.ts:664
 msgid "controls.imputation"
 msgstr "Type d'imputation"
 
-#: app/configurator/components/chart-options-selector.tsx:874
-#: app/configurator/components/ui-helpers.ts:670
+#: app/configurator/components/chart-options-selector.tsx:883
+#: app/configurator/components/ui-helpers.ts:676
 msgid "controls.imputation.type.linear"
 msgstr "Interpolation linéaire"
 
-#: app/configurator/components/chart-options-selector.tsx:867
-#: app/configurator/components/chart-options-selector.tsx:879
-#: app/configurator/components/ui-helpers.ts:662
+#: app/configurator/components/chart-options-selector.tsx:876
+#: app/configurator/components/chart-options-selector.tsx:888
+#: app/configurator/components/ui-helpers.ts:668
 msgid "controls.imputation.type.none"
 msgstr "-"
 
-#: app/configurator/components/chart-options-selector.tsx:869
-#: app/configurator/components/ui-helpers.ts:666
+#: app/configurator/components/chart-options-selector.tsx:878
+#: app/configurator/components/ui-helpers.ts:672
 msgid "controls.imputation.type.zeros"
 msgstr "Zéros"
 
@@ -430,19 +430,19 @@ msgstr "Il n'y a pas de dimension temporelle!"
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Afficher le filtre temporel"
 
-#: app/configurator/components/ui-helpers.ts:706
+#: app/configurator/components/ui-helpers.ts:712
 msgid "controls.language.english"
 msgstr "Anglais"
 
-#: app/configurator/components/ui-helpers.ts:714
+#: app/configurator/components/ui-helpers.ts:720
 msgid "controls.language.french"
 msgstr "Français"
 
-#: app/configurator/components/ui-helpers.ts:710
+#: app/configurator/components/ui-helpers.ts:716
 msgid "controls.language.german"
 msgstr "Allemand"
 
-#: app/configurator/components/ui-helpers.ts:718
+#: app/configurator/components/ui-helpers.ts:724
 msgid "controls.language.italian"
 msgstr "Italien"
 
@@ -451,7 +451,7 @@ msgstr "Italien"
 #~ msgid "controls.location"
 #~ msgstr "Localisation"
 
-#: app/configurator/components/ui-helpers.ts:588
+#: app/configurator/components/ui-helpers.ts:594
 msgid "controls.measure"
 msgstr "Variable mesurée"
 
@@ -467,7 +467,7 @@ msgstr "Actif"
 msgid "controls.option.isNotActive"
 msgstr "Inactif"
 
-#: app/configurator/components/chart-options-selector.tsx:768
+#: app/configurator/components/chart-options-selector.tsx:777
 msgid "controls.scale.type"
 msgstr "Type d'échelle"
 
@@ -475,7 +475,7 @@ msgstr "Type d'échelle"
 msgid "controls.search.clear"
 msgstr "Effacer la recherche"
 
-#: app/configurator/components/chart-options-selector.tsx:346
+#: app/configurator/components/chart-options-selector.tsx:347
 msgid "controls.section.additional-information"
 msgstr "Informations supplémentaires"
 
@@ -499,8 +499,8 @@ msgstr "Filtres"
 msgid "controls.section.description"
 msgstr "Titre & description"
 
-#: app/configurator/components/chart-options-selector.tsx:400
-#: app/configurator/components/chart-options-selector.tsx:404
+#: app/configurator/components/chart-options-selector.tsx:403
+#: app/configurator/components/chart-options-selector.tsx:407
 #: app/configurator/table/table-chart-options.tsx:310
 #: app/configurator/table/table-chart-options.tsx:314
 #: app/configurator/table/table-chart-options.tsx:334
@@ -512,11 +512,11 @@ msgstr "Filtre"
 msgid "controls.section.groups"
 msgstr "Groupes"
 
-#: app/configurator/components/chart-options-selector.tsx:908
+#: app/configurator/components/chart-options-selector.tsx:917
 msgid "controls.section.imputation"
 msgstr "Valeurs manquantes"
 
-#: app/configurator/components/chart-options-selector.tsx:913
+#: app/configurator/components/chart-options-selector.tsx:922
 msgid "controls.section.imputation.explanation"
 msgstr "En raison du type de graphique sélectionné, les valeurs manquantes doivent être remplies. Décidez de la logique d'imputation ou choisissez un autre type de graphique."
 
@@ -528,11 +528,11 @@ msgstr "Filtres interactifs"
 msgid "controls.section.interactiveFilters.dataFilters"
 msgstr "Filtres de données"
 
-#: app/configurator/components/chart-options-selector.tsx:355
+#: app/configurator/components/chart-options-selector.tsx:356
 msgid "controls.section.show-standard-error"
 msgstr "Afficher l'erreur type"
 
-#: app/configurator/components/chart-options-selector.tsx:549
+#: app/configurator/components/chart-options-selector.tsx:550
 msgid "controls.section.sorting"
 msgstr "Trier"
 
@@ -554,7 +554,7 @@ msgstr "Options du tableau"
 msgid "controls.select.chart.type"
 msgstr "Type de graphique"
 
-#: app/configurator/components/chart-options-selector.tsx:454
+#: app/configurator/components/chart-options-selector.tsx:455
 msgid "controls.select.column.layout"
 msgstr "Mise en forme de la colonne"
 
@@ -595,8 +595,8 @@ msgid "controls.select.dimension"
 msgstr "Sélectionner une dimension"
 
 #: app/configurator/components/chart-options-selector.tsx:209
-#: app/configurator/components/chart-options-selector.tsx:637
-#: app/configurator/components/chart-options-selector.tsx:711
+#: app/configurator/components/chart-options-selector.tsx:640
+#: app/configurator/components/chart-options-selector.tsx:719
 msgid "controls.select.measure"
 msgstr "Sélectionner une variable"
 
@@ -607,19 +607,19 @@ msgstr "Sélectionner une variable"
 #~ msgid "controls.select.optional"
 #~ msgstr "optionnel"
 
-#: app/configurator/components/filters.tsx:664
+#: app/configurator/components/filters.tsx:663
 msgid "controls.set-filters"
 msgstr "Appliquer les filtres"
 
-#: app/configurator/components/filters.tsx:671
+#: app/configurator/components/filters.tsx:670
 msgid "controls.set-filters-caption"
 msgstr "Pour de meilleurs résultats, ne sélectionnez pas plus de 7 valeurs dans la visualisation."
 
-#: app/configurator/components/filters.tsx:703
+#: app/configurator/components/filters.tsx:702
 msgid "controls.set-values-apply"
 msgstr "Appliquer les filtres"
 
-#: app/configurator/components/chart-options-selector.tsx:629
+#: app/configurator/components/chart-options-selector.tsx:632
 msgid "controls.size"
 msgstr "Taille"
 
@@ -627,48 +627,48 @@ msgstr "Taille"
 msgid "controls.sorting.addDimension"
 msgstr "Ajouter une dimension"
 
-#: app/configurator/components/chart-options-selector.tsx:499
-#: app/configurator/components/chart-options-selector.tsx:505
+#: app/configurator/components/chart-options-selector.tsx:500
+#: app/configurator/components/chart-options-selector.tsx:506
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Nom"
 
-#: app/configurator/components/ui-helpers.ts:626
+#: app/configurator/components/ui-helpers.ts:632
 msgid "controls.sorting.byDimensionLabel.ascending"
 msgstr "A → Z"
 
-#: app/configurator/components/ui-helpers.ts:630
+#: app/configurator/components/ui-helpers.ts:636
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
-#: app/configurator/components/chart-options-selector.tsx:501
+#: app/configurator/components/chart-options-selector.tsx:502
 msgid "controls.sorting.byMeasure"
 msgstr "Mesure"
 
-#: app/configurator/components/ui-helpers.ts:650
+#: app/configurator/components/ui-helpers.ts:656
 msgid "controls.sorting.byMeasure.ascending"
 msgstr "1 → 9"
 
-#: app/configurator/components/ui-helpers.ts:654
+#: app/configurator/components/ui-helpers.ts:660
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
-#: app/configurator/components/chart-options-selector.tsx:503
+#: app/configurator/components/chart-options-selector.tsx:504
 msgid "controls.sorting.byTotalSize"
 msgstr "Taille totale"
 
-#: app/configurator/components/ui-helpers.ts:634
+#: app/configurator/components/ui-helpers.ts:640
 msgid "controls.sorting.byTotalSize.ascending"
 msgstr "Croissant"
 
-#: app/configurator/components/ui-helpers.ts:646
+#: app/configurator/components/ui-helpers.ts:652
 msgid "controls.sorting.byTotalSize.largestBottom"
 msgstr "Décroissant de bas en haut"
 
-#: app/configurator/components/ui-helpers.ts:638
+#: app/configurator/components/ui-helpers.ts:644
 msgid "controls.sorting.byTotalSize.largestFirst"
 msgstr "Décroissant"
 
-#: app/configurator/components/ui-helpers.ts:642
+#: app/configurator/components/ui-helpers.ts:648
 msgid "controls.sorting.byTotalSize.largestTop"
 msgstr "Décroissant de haut en bas"
 
@@ -680,7 +680,7 @@ msgstr "Supprimer la dimension de tri"
 msgid "controls.sorting.selectDimension"
 msgstr "Sélectionner une dimension…"
 
-#: app/configurator/components/ui-helpers.ts:622
+#: app/configurator/components/ui-helpers.ts:628
 #: app/configurator/table/table-chart-sorting-options.tsx:319
 msgid "controls.sorting.sortBy"
 msgstr "Trier par"
@@ -709,7 +709,7 @@ msgstr "Tri"
 msgid "controls.tableSettings.showSearch"
 msgstr "Afficher le champ de recherche"
 
-#: app/configurator/components/ui-helpers.ts:597
+#: app/configurator/components/ui-helpers.ts:603
 msgid "controls.title"
 msgstr "Titre"
 
@@ -737,6 +737,14 @@ msgstr "Ce graphique n'utilise pas une source de données fiable."
 msgid "dataset-preview.back-to-results"
 msgstr "Revenir aux jeux de données"
 
+#: app/components/chart-footnotes.tsx:111
+msgid "dataset.footnotes.dataset"
+msgstr "Jeu de données"
+
+#: app/components/chart-footnotes.tsx:132
+msgid "dataset.footnotes.updated"
+msgstr "Mise à jour"
+
 #: app/components/chart-published.tsx:157
 msgid "dataset.hasImputedValues"
 msgstr "Certaines données de cet ensemble de données sont manquantes et ont été interpolées pour combler les lacunes."
@@ -749,10 +757,6 @@ msgstr "Inclure les brouillons"
 msgid "dataset.metadata.date.created"
 msgstr "Date de création"
 
-#: app/components/chart-footnotes.tsx:109
-msgid "dataset.metadata.date.footnotes.updated"
-msgstr ", mise à jour : {0}"
-
 #: app/configurator/components/dataset-metadata.tsx:94
 msgid "dataset.metadata.email"
 msgstr "Points de contact"
@@ -761,7 +765,7 @@ msgstr "Points de contact"
 msgid "dataset.metadata.furtherinformation"
 msgstr "Informations complémentaires"
 
-#: app/components/chart-footnotes.tsx:190
+#: app/components/chart-footnotes.tsx:198
 #: app/configurator/components/dataset-metadata.tsx:118
 msgid "dataset.metadata.learnmore"
 msgstr "En savoir plus sur le jeu de données"
@@ -918,22 +922,22 @@ msgid "logo.swiss.confederation"
 msgstr "Logo de la Confédération Suisse"
 
 #: app/components/chart-footnotes.tsx:121
-msgid "metadata.dataset"
-msgstr "Jeu de données"
+#~ msgid "metadata.dataset"
+#~ msgstr "Jeu de données"
 
-#: app/components/chart-footnotes.tsx:209
+#: app/components/chart-footnotes.tsx:217
 msgid "metadata.link.created.with.visualize"
 msgstr "Créé avec visualize.admin.ch"
 
-#: app/components/chart-footnotes.tsx:137
+#: app/components/chart-footnotes.tsx:143
 msgid "metadata.source"
 msgstr "Source"
 
-#: app/components/chart-footnotes.tsx:173
+#: app/components/chart-footnotes.tsx:181
 msgid "metadata.switch.chart"
 msgstr "Passer à la vue graphique"
 
-#: app/components/chart-footnotes.tsx:175
+#: app/components/chart-footnotes.tsx:183
 msgid "metadata.switch.table"
 msgstr "Passer à la vue en tableau"
 
@@ -973,7 +977,7 @@ msgstr "Voici une visualisation que j'ai créée sur visualize.admin.ch"
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
-#: app/configurator/components/filters.tsx:584
+#: app/configurator/components/filters.tsx:583
 msgid "select.controls.filters.search"
 msgstr "Chercher"
 
@@ -988,3 +992,9 @@ msgstr "Personnalisez votre visualisation en utilisant les options de filtrage e
 #: app/configurator/components/chart-controls/drag-and-drop-tab.tsx:101
 msgid "table.column.no"
 msgstr "Colonne {0}"
+
+#: app/components/chart-footnotes.tsx:113
+#: app/components/chart-footnotes.tsx:133
+#: app/components/chart-footnotes.tsx:145
+msgid "typography.colon"
+msgstr " : "

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -30,7 +30,7 @@ msgid "Move filter up"
 msgstr "Sposta il filtro in alto"
 
 #: app/configurator/components/dataset-browse.tsx:1027
-#: app/configurator/components/filters.tsx:682
+#: app/configurator/components/filters.tsx:681
 msgid "No results"
 msgstr "Nessun risultato"
 
@@ -120,7 +120,7 @@ msgstr "Pubblica questa visualizzazione"
 msgid "button.share"
 msgstr "Condividi"
 
-#: app/configurator/components/ui-helpers.ts:614
+#: app/configurator/components/ui-helpers.ts:620
 msgid "chart.map.layers.area"
 msgstr "Aree"
 
@@ -145,16 +145,16 @@ msgstr "Aree"
 #~ msgstr "Intervalli uguali"
 
 #: app/configurator/components/chart-configurator.tsx:696
-#: app/configurator/components/chart-options-selector.tsx:983
-#: app/configurator/components/ui-helpers.ts:610
+#: app/configurator/components/chart-options-selector.tsx:992
+#: app/configurator/components/ui-helpers.ts:616
 msgid "chart.map.layers.base"
 msgstr "Visualizzazione della mappa"
 
-#: app/configurator/components/chart-options-selector.tsx:987
+#: app/configurator/components/chart-options-selector.tsx:996
 msgid "chart.map.layers.base.show"
 msgstr "Mostra mappa del mondo"
 
-#: app/configurator/components/chart-options-selector.tsx:996
+#: app/configurator/components/chart-options-selector.tsx:1005
 msgid "chart.map.layers.base.view.locked"
 msgstr "Vista bloccata"
 
@@ -163,7 +163,7 @@ msgstr "Vista bloccata"
 #~ msgid "chart.map.layers.show"
 #~ msgstr "Mostra il livello"
 
-#: app/configurator/components/ui-helpers.ts:618
+#: app/configurator/components/ui-helpers.ts:624
 msgid "chart.map.layers.symbol"
 msgstr "Simboli"
 
@@ -208,48 +208,48 @@ msgstr "Regular"
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Impostazioni predefinite"
 
-#: app/configurator/components/ui-helpers.ts:584
+#: app/configurator/components/ui-helpers.ts:590
 msgid "controls.axis.horizontal"
 msgstr "Asse orizzontale"
 
-#: app/configurator/components/ui-helpers.ts:592
+#: app/configurator/components/ui-helpers.ts:598
 msgid "controls.axis.vertical"
 msgstr "Asse verticale"
 
-#: app/configurator/components/ui-helpers.ts:686
+#: app/configurator/components/ui-helpers.ts:692
 msgid "controls.chart.type.area"
 msgstr "Aree"
 
-#: app/configurator/components/ui-helpers.ts:678
+#: app/configurator/components/ui-helpers.ts:684
 msgid "controls.chart.type.bar"
 msgstr "Barre"
 
-#: app/configurator/components/ui-helpers.ts:674
+#: app/configurator/components/ui-helpers.ts:680
 msgid "controls.chart.type.column"
 msgstr "Colonne"
 
-#: app/configurator/components/ui-helpers.ts:682
+#: app/configurator/components/ui-helpers.ts:688
 msgid "controls.chart.type.line"
 msgstr "Linee"
 
-#: app/configurator/components/ui-helpers.ts:702
+#: app/configurator/components/ui-helpers.ts:708
 msgid "controls.chart.type.map"
 msgstr "Mappa"
 
-#: app/configurator/components/ui-helpers.ts:694
+#: app/configurator/components/ui-helpers.ts:700
 msgid "controls.chart.type.pie"
 msgstr "Torta"
 
-#: app/configurator/components/ui-helpers.ts:690
+#: app/configurator/components/ui-helpers.ts:696
 msgid "controls.chart.type.scatterplot"
 msgstr "Scatterplot"
 
-#: app/configurator/components/ui-helpers.ts:698
+#: app/configurator/components/ui-helpers.ts:704
 msgid "controls.chart.type.table"
 msgstr "Tabella"
 
-#: app/configurator/components/chart-options-selector.tsx:706
-#: app/configurator/components/ui-helpers.ts:596
+#: app/configurator/components/chart-options-selector.tsx:714
+#: app/configurator/components/ui-helpers.ts:602
 msgid "controls.color"
 msgstr "Colore"
 
@@ -257,7 +257,7 @@ msgstr "Colore"
 msgid "controls.color.add"
 msgstr "Aggiungi ..."
 
-#: app/configurator/components/chart-options-selector.tsx:737
+#: app/configurator/components/chart-options-selector.tsx:745
 msgid "controls.color.opacity"
 msgstr "Trasparenza"
 
@@ -278,35 +278,35 @@ msgstr "Ripristina la tavolozza dei colori"
 msgid "controls.color.palette.sequential"
 msgstr "Sequenziale"
 
-#: app/configurator/components/chart-options-selector.tsx:827
+#: app/configurator/components/chart-options-selector.tsx:836
 msgid "controls.color.scale.discretization.jenks"
 msgstr "Jenks (interruzioni naturali)"
 
-#: app/configurator/components/chart-options-selector.tsx:820
+#: app/configurator/components/chart-options-selector.tsx:829
 msgid "controls.color.scale.discretization.quantiles"
 msgstr "Quantili (distribuzione omogenea dei valori)"
 
-#: app/configurator/components/chart-options-selector.tsx:813
+#: app/configurator/components/chart-options-selector.tsx:822
 msgid "controls.color.scale.discretization.quantize"
 msgstr "Intervalli uguali"
 
-#: app/configurator/components/chart-options-selector.tsx:805
+#: app/configurator/components/chart-options-selector.tsx:814
 msgid "controls.color.scale.interpolation"
 msgstr "Interpolazione"
 
-#: app/configurator/components/chart-options-selector.tsx:838
+#: app/configurator/components/chart-options-selector.tsx:847
 msgid "controls.color.scale.number.of.classes"
 msgstr "Numero di classi"
 
-#: app/configurator/components/chart-options-selector.tsx:775
+#: app/configurator/components/chart-options-selector.tsx:784
 msgid "controls.color.scale.type.continuous"
 msgstr "Continuo"
 
-#: app/configurator/components/chart-options-selector.tsx:787
+#: app/configurator/components/chart-options-selector.tsx:796
 msgid "controls.color.scale.type.discrete"
 msgstr "Discreto"
 
-#: app/configurator/components/chart-options-selector.tsx:726
+#: app/configurator/components/chart-options-selector.tsx:734
 msgid "controls.color.select"
 msgstr "Seleziona un colore"
 
@@ -314,15 +314,15 @@ msgstr "Seleziona un colore"
 msgid "controls.colorpicker.open"
 msgstr "Apri il selettore di colore"
 
-#: app/configurator/components/ui-helpers.ts:606
+#: app/configurator/components/ui-helpers.ts:612
 msgid "controls.column.grouped"
 msgstr "raggruppate"
 
-#: app/configurator/components/ui-helpers.ts:602
+#: app/configurator/components/ui-helpers.ts:608
 msgid "controls.column.stacked"
 msgstr "impilate"
 
-#: app/configurator/components/ui-helpers.ts:598
+#: app/configurator/components/ui-helpers.ts:604
 msgid "controls.description"
 msgstr "Descrizione"
 
@@ -340,29 +340,29 @@ msgstr "Descrizione"
 msgid "controls.dimensionvalue.none"
 msgstr "Nessun filtro"
 
-#: app/configurator/components/filters.tsx:436
+#: app/configurator/components/filters.tsx:431
 msgid "controls.filter.nb-elements"
 msgstr "{0} di {1}"
 
-#: app/configurator/components/filters.tsx:390
-#: app/configurator/components/filters.tsx:610
+#: app/configurator/components/filters.tsx:385
+#: app/configurator/components/filters.tsx:609
 msgid "controls.filter.select.all"
 msgstr "Seleziona tutti"
 
-#: app/configurator/components/filters.tsx:397
-#: app/configurator/components/filters.tsx:608
+#: app/configurator/components/filters.tsx:392
+#: app/configurator/components/filters.tsx:607
 msgid "controls.filter.select.none"
 msgstr "Deseleziona tutto"
 
-#: app/configurator/components/filters.tsx:407
+#: app/configurator/components/filters.tsx:402
 msgid "controls.filters.select.filters"
 msgstr "Filtri"
 
-#: app/configurator/components/filters.tsx:420
+#: app/configurator/components/filters.tsx:415
 msgid "controls.filters.select.refresh-colors"
 msgstr "Aggiorna i colori"
 
-#: app/configurator/components/filters.tsx:414
+#: app/configurator/components/filters.tsx:409
 msgid "controls.filters.select.selected-filters"
 msgstr "Filtri selezionati"
 
@@ -390,23 +390,23 @@ msgstr "Seleziona un elemento di design o una dimensione dei dati per modificarn
 msgid "controls.hint.describing.chart"
 msgstr "Seleziona una delle annotazioni proposte per modificarla."
 
-#: app/configurator/components/ui-helpers.ts:658
+#: app/configurator/components/ui-helpers.ts:664
 msgid "controls.imputation"
 msgstr "Tipo di imputazione"
 
-#: app/configurator/components/chart-options-selector.tsx:874
-#: app/configurator/components/ui-helpers.ts:670
+#: app/configurator/components/chart-options-selector.tsx:883
+#: app/configurator/components/ui-helpers.ts:676
 msgid "controls.imputation.type.linear"
 msgstr "Interpolazione lineare"
 
-#: app/configurator/components/chart-options-selector.tsx:867
-#: app/configurator/components/chart-options-selector.tsx:879
-#: app/configurator/components/ui-helpers.ts:662
+#: app/configurator/components/chart-options-selector.tsx:876
+#: app/configurator/components/chart-options-selector.tsx:888
+#: app/configurator/components/ui-helpers.ts:668
 msgid "controls.imputation.type.none"
 msgstr "-"
 
-#: app/configurator/components/chart-options-selector.tsx:869
-#: app/configurator/components/ui-helpers.ts:666
+#: app/configurator/components/chart-options-selector.tsx:878
+#: app/configurator/components/ui-helpers.ts:672
 msgid "controls.imputation.type.zeros"
 msgstr "Zeri"
 
@@ -430,19 +430,19 @@ msgstr "Nessuna dimensione temporale disponibile!"
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Mostra i filtri temporali"
 
-#: app/configurator/components/ui-helpers.ts:706
+#: app/configurator/components/ui-helpers.ts:712
 msgid "controls.language.english"
 msgstr "Inglese"
 
-#: app/configurator/components/ui-helpers.ts:714
+#: app/configurator/components/ui-helpers.ts:720
 msgid "controls.language.french"
 msgstr "Francese"
 
-#: app/configurator/components/ui-helpers.ts:710
+#: app/configurator/components/ui-helpers.ts:716
 msgid "controls.language.german"
 msgstr "Tedesco"
 
-#: app/configurator/components/ui-helpers.ts:718
+#: app/configurator/components/ui-helpers.ts:724
 msgid "controls.language.italian"
 msgstr "Italiano"
 
@@ -451,7 +451,7 @@ msgstr "Italiano"
 #~ msgid "controls.location"
 #~ msgstr "Posizione"
 
-#: app/configurator/components/ui-helpers.ts:588
+#: app/configurator/components/ui-helpers.ts:594
 msgid "controls.measure"
 msgstr "Misura"
 
@@ -467,7 +467,7 @@ msgstr "Attivo"
 msgid "controls.option.isNotActive"
 msgstr "Inattivo"
 
-#: app/configurator/components/chart-options-selector.tsx:768
+#: app/configurator/components/chart-options-selector.tsx:777
 msgid "controls.scale.type"
 msgstr "Tipo di scala"
 
@@ -475,7 +475,7 @@ msgstr "Tipo di scala"
 msgid "controls.search.clear"
 msgstr "Cancella la ricerca"
 
-#: app/configurator/components/chart-options-selector.tsx:346
+#: app/configurator/components/chart-options-selector.tsx:347
 msgid "controls.section.additional-information"
 msgstr "Informazioni aggiuntive"
 
@@ -499,8 +499,8 @@ msgstr "Filtri"
 msgid "controls.section.description"
 msgstr "Titolo e descrizione"
 
-#: app/configurator/components/chart-options-selector.tsx:400
-#: app/configurator/components/chart-options-selector.tsx:404
+#: app/configurator/components/chart-options-selector.tsx:403
+#: app/configurator/components/chart-options-selector.tsx:407
 #: app/configurator/table/table-chart-options.tsx:310
 #: app/configurator/table/table-chart-options.tsx:314
 #: app/configurator/table/table-chart-options.tsx:334
@@ -512,11 +512,11 @@ msgstr "Filtro"
 msgid "controls.section.groups"
 msgstr "Gruppi"
 
-#: app/configurator/components/chart-options-selector.tsx:908
+#: app/configurator/components/chart-options-selector.tsx:917
 msgid "controls.section.imputation"
 msgstr "Valori mancanti"
 
-#: app/configurator/components/chart-options-selector.tsx:913
+#: app/configurator/components/chart-options-selector.tsx:922
 msgid "controls.section.imputation.explanation"
 msgstr "Per questo tipo di grafico, i valori di sostituzione devono essere assegnati ai valori mancanti. Decidi la logica di imputazione o passa a un altro tipo di grafico."
 
@@ -528,11 +528,11 @@ msgstr "Filtri interattivi"
 msgid "controls.section.interactiveFilters.dataFilters"
 msgstr "Filtri di dati"
 
-#: app/configurator/components/chart-options-selector.tsx:355
+#: app/configurator/components/chart-options-selector.tsx:356
 msgid "controls.section.show-standard-error"
 msgstr "Mostra l'errore standard"
 
-#: app/configurator/components/chart-options-selector.tsx:549
+#: app/configurator/components/chart-options-selector.tsx:550
 msgid "controls.section.sorting"
 msgstr "Ordina"
 
@@ -554,7 +554,7 @@ msgstr "Opzioni della tabella"
 msgid "controls.select.chart.type"
 msgstr "Tipo di grafico"
 
-#: app/configurator/components/chart-options-selector.tsx:454
+#: app/configurator/components/chart-options-selector.tsx:455
 msgid "controls.select.column.layout"
 msgstr "Layout a colonne"
 
@@ -595,8 +595,8 @@ msgid "controls.select.dimension"
 msgstr "Seleziona una dimensione"
 
 #: app/configurator/components/chart-options-selector.tsx:209
-#: app/configurator/components/chart-options-selector.tsx:637
-#: app/configurator/components/chart-options-selector.tsx:711
+#: app/configurator/components/chart-options-selector.tsx:640
+#: app/configurator/components/chart-options-selector.tsx:719
 msgid "controls.select.measure"
 msgstr "Seleziona una misura"
 
@@ -607,19 +607,19 @@ msgstr "Seleziona una misura"
 #~ msgid "controls.select.optional"
 #~ msgstr "facoltativo"
 
-#: app/configurator/components/filters.tsx:664
+#: app/configurator/components/filters.tsx:663
 msgid "controls.set-filters"
 msgstr "Filtrer"
 
-#: app/configurator/components/filters.tsx:671
+#: app/configurator/components/filters.tsx:670
 msgid "controls.set-filters-caption"
 msgstr "Pour de meilleurs résultats, ne sélectionnez pas plus de 7 valeurs dans la visualisation"
 
-#: app/configurator/components/filters.tsx:703
+#: app/configurator/components/filters.tsx:702
 msgid "controls.set-values-apply"
 msgstr "Appliquer les filtres"
 
-#: app/configurator/components/chart-options-selector.tsx:629
+#: app/configurator/components/chart-options-selector.tsx:632
 msgid "controls.size"
 msgstr "Grandezza"
 
@@ -627,48 +627,48 @@ msgstr "Grandezza"
 msgid "controls.sorting.addDimension"
 msgstr "Aggiungi una dimensione"
 
-#: app/configurator/components/chart-options-selector.tsx:499
-#: app/configurator/components/chart-options-selector.tsx:505
+#: app/configurator/components/chart-options-selector.tsx:500
+#: app/configurator/components/chart-options-selector.tsx:506
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Nome"
 
-#: app/configurator/components/ui-helpers.ts:626
+#: app/configurator/components/ui-helpers.ts:632
 msgid "controls.sorting.byDimensionLabel.ascending"
 msgstr "A → Z"
 
-#: app/configurator/components/ui-helpers.ts:630
+#: app/configurator/components/ui-helpers.ts:636
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
-#: app/configurator/components/chart-options-selector.tsx:501
+#: app/configurator/components/chart-options-selector.tsx:502
 msgid "controls.sorting.byMeasure"
 msgstr "Misura"
 
-#: app/configurator/components/ui-helpers.ts:650
+#: app/configurator/components/ui-helpers.ts:656
 msgid "controls.sorting.byMeasure.ascending"
 msgstr "1 → 9"
 
-#: app/configurator/components/ui-helpers.ts:654
+#: app/configurator/components/ui-helpers.ts:660
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
-#: app/configurator/components/chart-options-selector.tsx:503
+#: app/configurator/components/chart-options-selector.tsx:504
 msgid "controls.sorting.byTotalSize"
 msgstr "Grandezza totale"
 
-#: app/configurator/components/ui-helpers.ts:634
+#: app/configurator/components/ui-helpers.ts:640
 msgid "controls.sorting.byTotalSize.ascending"
 msgstr "Il più grande per ultimo"
 
-#: app/configurator/components/ui-helpers.ts:646
+#: app/configurator/components/ui-helpers.ts:652
 msgid "controls.sorting.byTotalSize.largestBottom"
 msgstr "Il più grande sotto"
 
-#: app/configurator/components/ui-helpers.ts:638
+#: app/configurator/components/ui-helpers.ts:644
 msgid "controls.sorting.byTotalSize.largestFirst"
 msgstr "Il più grande per primo"
 
-#: app/configurator/components/ui-helpers.ts:642
+#: app/configurator/components/ui-helpers.ts:648
 msgid "controls.sorting.byTotalSize.largestTop"
 msgstr "Il più grande sopra"
 
@@ -680,7 +680,7 @@ msgstr "Rimuovi l'ordinamento"
 msgid "controls.sorting.selectDimension"
 msgstr "Seleziona una dimensione ..."
 
-#: app/configurator/components/ui-helpers.ts:622
+#: app/configurator/components/ui-helpers.ts:628
 #: app/configurator/table/table-chart-sorting-options.tsx:319
 msgid "controls.sorting.sortBy"
 msgstr "Ordina per"
@@ -709,7 +709,7 @@ msgstr "Ordinamento"
 msgid "controls.tableSettings.showSearch"
 msgstr "Mostra il campo di ricerca"
 
-#: app/configurator/components/ui-helpers.ts:597
+#: app/configurator/components/ui-helpers.ts:603
 msgid "controls.title"
 msgstr "Titolo"
 
@@ -737,6 +737,14 @@ msgstr "Questo grafico non utilizza una fonte di dati affidabile."
 msgid "dataset-preview.back-to-results"
 msgstr "Torna ai set di dati"
 
+#: app/components/chart-footnotes.tsx:111
+msgid "dataset.footnotes.dataset"
+msgstr "Set di dati"
+
+#: app/components/chart-footnotes.tsx:132
+msgid "dataset.footnotes.updated"
+msgstr "Ultimo aggiornamento"
+
 #: app/components/chart-published.tsx:157
 msgid "dataset.hasImputedValues"
 msgstr "In questo set di dati mancano alcuni dati. Questi sono stati interpolati per colmare le lacune.."
@@ -749,10 +757,6 @@ msgstr "Includere le bozze"
 msgid "dataset.metadata.date.created"
 msgstr "Data di creazione"
 
-#: app/components/chart-footnotes.tsx:109
-msgid "dataset.metadata.date.footnotes.updated"
-msgstr ", ultimo aggiornamento: {0}"
-
 #: app/configurator/components/dataset-metadata.tsx:94
 msgid "dataset.metadata.email"
 msgstr "Punti di contatto"
@@ -761,7 +765,7 @@ msgstr "Punti di contatto"
 msgid "dataset.metadata.furtherinformation"
 msgstr "Addizionali informazioni"
 
-#: app/components/chart-footnotes.tsx:190
+#: app/components/chart-footnotes.tsx:198
 #: app/configurator/components/dataset-metadata.tsx:118
 msgid "dataset.metadata.learnmore"
 msgstr "Ulteriori informazioni sul set di dati"
@@ -918,22 +922,22 @@ msgid "logo.swiss.confederation"
 msgstr "Logo della Confederazione svizzera"
 
 #: app/components/chart-footnotes.tsx:121
-msgid "metadata.dataset"
-msgstr "Dataset"
+#~ msgid "metadata.dataset"
+#~ msgstr "Dataset"
 
-#: app/components/chart-footnotes.tsx:209
+#: app/components/chart-footnotes.tsx:217
 msgid "metadata.link.created.with.visualize"
 msgstr "Creato con visualize.admin.ch"
 
-#: app/components/chart-footnotes.tsx:137
+#: app/components/chart-footnotes.tsx:143
 msgid "metadata.source"
 msgstr "Fonte"
 
-#: app/components/chart-footnotes.tsx:173
+#: app/components/chart-footnotes.tsx:181
 msgid "metadata.switch.chart"
 msgstr "Passare alla visualizzazione del grafico"
 
-#: app/components/chart-footnotes.tsx:175
+#: app/components/chart-footnotes.tsx:183
 msgid "metadata.switch.table"
 msgstr "Passare alla vista tabella"
 
@@ -973,7 +977,7 @@ msgstr "Ecco una visualizzazione che ho creato usando visualize.admin.ch"
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
-#: app/configurator/components/filters.tsx:584
+#: app/configurator/components/filters.tsx:583
 msgid "select.controls.filters.search"
 msgstr "Cerca"
 
@@ -988,3 +992,9 @@ msgstr "Personalizza la tua visualizzazione utilizzando le opzioni di segmentazi
 #: app/configurator/components/chart-controls/drag-and-drop-tab.tsx:101
 msgid "table.column.no"
 msgstr "Colonna {0}"
+
+#: app/components/chart-footnotes.tsx:113
+#: app/components/chart-footnotes.tsx:133
+#: app/components/chart-footnotes.tsx:145
+msgid "typography.colon"
+msgstr ": "


### PR DESCRIPTION
- feat: Use bold for footnotes labels, and use swiss date format

I used a translation string for the colon since in French, there is a space before the colon.

Fixes https://github.com/orgs/visualize-admin/projects/1/views/18