### PR TITLE
feat: Fetch colors for nominal dimensions

### DIFF
--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -327,7 +327,7 @@ const getCubeDimensionValuesWithLabels = async ({
             predicate: schema.position,
           })
         : [],
-      scaleType === "Ordinal"
+      scaleType === "Nominal" || scaleType === "Ordinal"
         ? loadResourceLiterals({
             ids: namedNodes,
             sparqlClient,


### PR DESCRIPTION
As dimensions of nominal scale type can also be used as color mappings, we should also fetch `schema:color` for them to potentially populate default colors.