### PR TITLE
feat: Open up color formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
   - Enable sorting of Geo dimensions
   - Maintain segment sorting type correctly when switching from / to Pie chart
   - Fix sorting by measure when undefined values are present in the data
+  - Enable CSS Color Module Level 3 color specifications in the color picker (instead of just HEX)
 - Map:
   - area & symbol layers now use the same approach as for segment field (optional select element), to be more consistent across the app
   - it's now possible to use discrete color mapping in symbol layer

--- a/app/charts/map/map-legend.tsx
+++ b/app/charts/map/map-legend.tsx
@@ -15,7 +15,7 @@ import {
 import React, { useEffect, useMemo, useRef } from "react";
 
 import { MapState } from "@/charts/map/map-state";
-import { convertRgbArrayToHex } from "@/charts/shared/colors";
+import { rgbArrayToHex } from "@/charts/shared/colors";
 import { MapLegendColor } from "@/charts/shared/legend-color";
 import { useChartState } from "@/charts/shared/use-chart-state";
 import { useChartTheme } from "@/charts/shared/use-chart-theme";
@@ -301,7 +301,7 @@ const CircleLegend = ({
   const maxRadius = radiusScale.range()[1];
 
   const color = interaction.d
-    ? convertRgbArrayToHex(getColor(interaction.d))
+    ? rgbArrayToHex(getColor(interaction.d))
     : undefined;
 
   const domainObservations = useMemo(

--- a/app/charts/map/map-state.tsx
+++ b/app/charts/map/map-state.tsx
@@ -53,7 +53,7 @@ import {
 } from "@/domain/data";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 
-import { convertHexToRgbArray } from "../shared/colors";
+import { colorToRgbArray } from "../shared/colors";
 
 import { getBBox } from "./helpers";
 
@@ -169,7 +169,7 @@ const getNumericalColorScale = ({
 };
 
 const getFixedColors = (color: FixedColorField) => {
-  const c = convertHexToRgbArray(color.value, color.opacity * 2.55);
+  const c = colorToRgbArray(color.value, color.opacity * 2.55);
   return { type: "fixed" as "fixed", getColor: (_: Observation) => c };
 };
 
@@ -183,9 +183,7 @@ const getCategoricalColors = (
   ) as DimensionMetadataFragment;
   const componentValuesByLabel = keyBy(component.values, (d) => d.label);
   const domain: string[] = component.values.map((d) => d.value) || [];
-  const rgbColorMapping = mapValues(color.colorMapping, (d) =>
-    convertHexToRgbArray(d)
-  );
+  const rgbColorMapping = mapValues(color.colorMapping, colorToRgbArray);
   const getValue = (d: Observation) =>
     d[color.componentIri] !== null ? `${d[color.componentIri]}` : "";
 

--- a/app/charts/map/map-tooltip.tsx
+++ b/app/charts/map/map-tooltip.tsx
@@ -11,7 +11,7 @@ import {
 } from "react";
 
 import { MapState } from "@/charts/map/map-state";
-import { convertRgbArrayToHex } from "@/charts/shared/colors";
+import { rgbArrayToHex } from "@/charts/shared/colors";
 import { TooltipBox } from "@/charts/shared/interaction/tooltip-box";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { useChartState } from "@/charts/shared/use-chart-state";
@@ -73,7 +73,7 @@ export const MapTooltip = () => {
 
       const value = colors.getValue(obs || {}) ?? null;
       const show = identicalLayerComponentIris || hoverObjectType === "area";
-      const color = obs ? convertRgbArrayToHex(colors.getColor(obs)) : "#fff";
+      const color = obs ? rgbArrayToHex(colors.getColor(obs)) : "#fff";
       const textColor = getTooltipTextColor(color);
       const valueFormatter = (d: number | null) =>
         formatNumberWithUnit(
@@ -109,7 +109,7 @@ export const MapTooltip = () => {
 
       const value = symbolLayer.getValue(interaction.d || {}) ?? null;
       const show = identicalLayerComponentIris || hoverObjectType === "symbol";
-      const color = obs ? convertRgbArrayToHex(colors.getColor(obs)) : "#fff";
+      const color = obs ? rgbArrayToHex(colors.getColor(obs)) : "#fff";
       const textColor = getTooltipTextColor(color);
       const valueFormatter = (d: number | null) =>
         formatNumberWithUnit(

--- a/app/charts/shared/colors.tsx
+++ b/app/charts/shared/colors.tsx
@@ -1,15 +1,12 @@
 import { color, RGBColor } from "d3";
 
-export const convertHexToRgbArray = (
-  hex: string,
-  opacity?: number
-): number[] => {
-  const { r, g, b } = color(hex) as RGBColor;
+export const colorToRgbArray = (_color: string, opacity?: number): number[] => {
+  const { r, g, b } = color(_color) as RGBColor;
 
   return opacity !== undefined ? [r, g, b, opacity] : [r, g, b];
 };
 
-export const convertRgbArrayToHex = (rgbArray: number[]): string => {
+export const rgbArrayToHex = (rgbArray: number[]): string => {
   switch (rgbArray.length) {
     case 3:
       return `rgb(${rgbArray.join(",")})`;

--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -26,7 +26,7 @@ import { dfs } from "@/utils/dfs";
 import { interlace } from "@/utils/interlace";
 import useEvent from "@/utils/use-event";
 
-import { convertRgbArrayToHex } from "./colors";
+import { rgbArrayToHex } from "./colors";
 
 type LegendSymbol = "square" | "line" | "circle";
 
@@ -247,9 +247,7 @@ export const MapLegendColor = memo(function LegendColor({
       getColor={(v) => {
         const label = getLabel(v);
         const rgb = getColor({ [component.iri]: label });
-        const hex = convertRgbArrayToHex(rgb);
-
-        return hex;
+        return rgbArrayToHex(rgb);
       }}
       getLabel={getLabel}
       symbol="circle"

--- a/app/configurator/components/chart-controls/color-picker.tsx
+++ b/app/configurator/components/chart-controls/color-picker.tsx
@@ -61,9 +61,9 @@ export const ColorPicker = ({ selectedColor, colors, onChange }: Props) => {
       setInputColorValue(_color);
       // Make sure onChange is only called with valid colors
       const c = d3Color(_color);
+
       if (c) {
-        // Type defs of d3-color are not up-to-date
-        onChange?.((c as $Unexpressable).formatHex());
+        onChange?.(_color);
       }
     },
     [onChange, setInputColorValue]
@@ -73,9 +73,9 @@ export const ColorPicker = ({ selectedColor, colors, onChange }: Props) => {
     (_color) => {
       // Make sure onChange is only called with valid colors
       const c = d3Color(_color);
+
       if (c) {
-        // Type defs of d3-color are not up-to-date
-        setInputColorValue((c as $Unexpressable).formatHex());
+        setInputColorValue(_color);
       }
     },
     [setInputColorValue]
@@ -94,7 +94,6 @@ export const ColorPicker = ({ selectedColor, colors, onChange }: Props) => {
       <Box
         display="grid"
         sx={{
-          // width: 120,
           gridTemplateColumns: "repeat(auto-fill, minmax(1.5rem, 1fr))",
           gap: 2,
           mb: 2,
@@ -120,10 +119,7 @@ export const ColorPicker = ({ selectedColor, colors, onChange }: Props) => {
             fontSize: "0.875rem",
             ":focus": { outline: "none", borderColor: "primary" },
           }}
-          inputProps={{
-            maxLength: 7,
-          }}
-          value={`#${inputColorValue.replace(/^#/, "")}`}
+          value={inputColorValue}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
             selectColor(e.currentTarget.value);
           }}
@@ -166,6 +162,7 @@ export const ColorPickerMenu = (props: Props) => {
   const borderColor = d3Color(selectedColor)?.darker().toString();
   const { isOpen, open, close } = useDisclosure();
   const buttonRef = useRef(null);
+
   return (
     <ColorPickerBox
       sx={{
@@ -192,7 +189,7 @@ export const ColorPickerMenu = (props: Props) => {
               width: "1rem",
               height: "1rem",
             }}
-          ></Box>
+          />
         </Box>
       </ColorPickerButton>
       <Popover anchorEl={buttonRef.current} open={isOpen} onClose={close}>


### PR DESCRIPTION
As we use D3's `color` function to parse color strings, we are free to use any CSS Color Module Level 3 compatible strings to specify colors.

In the test dataset provided by @Rdataflow ([test_ord_507](https://int.cube-creator.lindas.admin.ch/app/cube-projects/cube-project!!testcolor507d-znxzma1yb17/)) several different conventions are used and all of them work; however, when trying to edit the pre-defined colors in visualize, it's not possible to use the original conventions if it's not a HEX color.

This PR simplifies the color logic to remove the constraint of having to use HEX colors in the color picker.