### PR TITLE
fix: Resetting color palette for color field with pre-defined colors

### DIFF
--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -64,6 +64,7 @@ import SvgIcCheck from "@/icons/components/IcCheck";
 import SvgIcChevronRight from "@/icons/components/IcChevronRight";
 import SvgIcClose from "@/icons/components/IcClose";
 import SvgIcFormatting from "@/icons/components/IcFormatting";
+import SvgIcRefresh from "@/icons/components/IcRefresh";
 import SvgIcSearch from "@/icons/components/IcSearch";
 import { useLocale } from "@/locales/use-locale";
 import { dfs } from "@/utils/dfs";
@@ -355,9 +356,9 @@ const MultiFilterContent = ({
       dispatch({
         type: "CHART_CONFIG_UPDATE_COLOR_MAPPING",
         value: {
-        field: `${field}${
-          colorConfigPath !== undefined ? `.${colorConfigPath}` : ""
-        }`,
+          field: `${field}${
+            colorConfigPath !== undefined ? `.${colorConfigPath}` : ""
+          }`,
           dimensionIri,
           values: sortBy(colorComponent?.values, (d) =>
             usedValues.has(d.value) ? 0 : 1
@@ -376,6 +377,10 @@ const MultiFilterContent = ({
         : true)
     );
   }, [colorConfigPath, config, dimensionIri, colorComponent]);
+
+  const hasDefaultColors = useMemo(() => {
+    return colorComponent?.values?.[0].color !== undefined;
+  }, [colorComponent?.values]);
 
   return (
     <Box sx={{ position: "relative" }}>
@@ -415,21 +420,43 @@ const MultiFilterContent = ({
               Selected filters
             </Trans>
             {hasColorMapping ? (
-              <Tooltip
-                title={
-                  <Trans id="controls.filters.select.refresh-colors">
-                    Refresh colors
-                  </Trans>
-                }
-              >
-                <IconButton
-                  sx={{ ml: 1, my: -2 }}
-                  size="small"
-                  onClick={() => handleRecomputeColorMapping({ random: true })}
+              hasDefaultColors ? (
+                <Tooltip
+                  title={
+                    <Trans id="controls.filters.select.reset-colors">
+                      Reset colors
+                    </Trans>
+                  }
                 >
-                  <SvgIcFormatting fontSize="inherit" />
-                </IconButton>
-              </Tooltip>
+                  <IconButton
+                    sx={{ ml: 1, my: -2 }}
+                    size="small"
+                    onClick={() =>
+                      handleRecomputeColorMapping({ random: false })
+                    }
+                  >
+                    <SvgIcRefresh fontSize="inherit" />
+                  </IconButton>
+                </Tooltip>
+              ) : (
+                <Tooltip
+                  title={
+                    <Trans id="controls.filters.select.refresh-colors">
+                      Refresh colors
+                    </Trans>
+                  }
+                >
+                  <IconButton
+                    sx={{ ml: 1, my: -2 }}
+                    size="small"
+                    onClick={() =>
+                      handleRecomputeColorMapping({ random: true })
+                    }
+                  >
+                    <SvgIcFormatting fontSize="inherit" />
+                  </IconButton>
+                </Tooltip>
+              )
             ) : null}
           </Typography>
           <Typography variant="body2" component="span">

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -357,9 +357,6 @@ const MultiFilterContent = ({
         /** Shuffles colors to create new, randomized color mapping. */
         | "shuffle";
     }) => {
-      const computedField = `${field}${
-        colorConfigPath !== undefined ? `.${colorConfigPath}` : ""
-      }`;
       const values = colorComponent?.values || [];
 
       switch (type) {
@@ -367,7 +364,8 @@ const MultiFilterContent = ({
           return dispatch({
             type: "CHART_CONFIG_UPDATE_COLOR_MAPPING",
             value: {
-              field: computedField,
+              field,
+              colorConfigPath,
               dimensionIri,
               values,
               random: false,
@@ -378,7 +376,8 @@ const MultiFilterContent = ({
           return dispatch({
             type: "CHART_CONFIG_UPDATE_COLOR_MAPPING",
             value: {
-              field: computedField,
+              field,
+              colorConfigPath,
               dimensionIri,
               values: sortBy(values, (d) => (usedValues.has(d.value) ? 0 : 1)),
               random: true,

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -265,9 +265,11 @@ const getColorMapping = (
 };
 
 const MultiFilterContent = ({
+  field,
   colorComponent,
   tree,
 }: {
+  field: string;
   colorComponent: DimensionMetadataFragment | undefined;
   tree: HierarchyValue[];
 }) => {
@@ -353,6 +355,9 @@ const MultiFilterContent = ({
       dispatch({
         type: "CHART_CONFIG_UPDATE_COLOR_MAPPING",
         value: {
+        field: `${field}${
+          colorConfigPath !== undefined ? `.${colorConfigPath}` : ""
+        }`,
           dimensionIri,
           values: sortBy(colorComponent?.values, (d) =>
             usedValues.has(d.value) ? 0 : 1
@@ -779,6 +784,7 @@ export const DimensionValuesMultiFilter = ({
         getValueColor={getValueColor}
       >
         <MultiFilterContent
+          field={field}
           colorComponent={colorComponent}
           tree={
             hierarchyTree && hierarchyTree.length > 0

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -7,6 +7,7 @@ import {
   ChartConfig,
   ChartType,
   ColumnConfig,
+  ConfiguratorStateConfiguringChart,
   DataSource,
   MapConfig,
   TableConfig,
@@ -21,6 +22,7 @@ import {
   initChartStateFromCube,
   initChartStateFromLocalStorage,
   moveFilterField,
+  updateColorMapping,
 } from "@/configurator/configurator-state";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 import { DataCubeMetadata } from "@/graphql/types";
@@ -638,5 +640,51 @@ describe("getFiltersByMappingStatus", () => {
     expect([...mappedFiltersIris]).toEqual(
       expect.arrayContaining(["areaColorIri", "symbolColorIri"])
     );
+  });
+});
+
+describe("colorMapping", () => {
+  it("should correctly reset color mapping", () => {
+    const state = {
+      state: "CONFIGURING_CHART",
+      chartConfig: {
+        fields: {
+          areaLayer: {
+            componentIri: "areaLayerIri",
+            color: {
+              type: "categorical",
+              componentIri: "areaLayerColorIri",
+              palette: "oranges",
+              colorMapping: {
+                red: "green",
+                green: "blue",
+                blue: "red",
+              },
+            },
+          },
+        },
+      },
+    };
+
+    updateColorMapping(state as unknown as ConfiguratorStateConfiguringChart, {
+      type: "CHART_CONFIG_UPDATE_COLOR_MAPPING",
+      value: {
+        field: "areaLayer",
+        colorConfigPath: "color",
+        dimensionIri: "areaLayerColorIri",
+        values: [
+          { value: "red", label: "red", color: "red" },
+          { value: "green", label: "green", color: "green" },
+          { value: "blue", label: "blue", color: "blue" },
+        ],
+        random: false,
+      },
+    });
+
+    expect(state.chartConfig.fields.areaLayer.color.colorMapping).toEqual({
+      red: "red",
+      green: "green",
+      blue: "blue",
+    });
   });
 });

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -838,6 +838,36 @@ const handleChartFieldChanged = (
   return draft;
 };
 
+export const updateColorMapping = (
+  draft: ConfiguratorState,
+  action: Extract<
+    ConfiguratorStateAction,
+    { type: "CHART_CONFIG_UPDATE_COLOR_MAPPING" }
+  >
+) => {
+  if (draft.state === "CONFIGURING_CHART") {
+    const { field, colorConfigPath, dimensionIri, values, random } =
+      action.value;
+    const path = `fields.${field}${
+      colorConfigPath ? `.${colorConfigPath}` : ""
+    }`;
+    const fieldValue = get(draft.chartConfig, path) as
+      | (GenericField & { palette: string })
+      | undefined;
+
+    if (fieldValue?.componentIri === dimensionIri) {
+      const colorMapping = mapValueIrisToColor({
+        palette: fieldValue.palette,
+        dimensionValues: values,
+        random,
+      });
+      setWith(draft.chartConfig, `${path}.colorMapping`, colorMapping);
+    }
+  }
+
+  return draft;
+};
+
 const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
   draft,
   action
@@ -1108,27 +1138,7 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       return draft;
 
     case "CHART_CONFIG_UPDATE_COLOR_MAPPING":
-      if (draft.state === "CONFIGURING_CHART") {
-        const { field, colorConfigPath, dimensionIri, values, random } =
-          action.value;
-        const path = `fields.${field}${
-          colorConfigPath ? `.${colorConfigPath}` : ""
-        }`;
-        const fieldValue = get(draft.chartConfig, path) as
-          | (GenericField & { palette: string })
-          | undefined;
-
-        if (fieldValue?.componentIri === dimensionIri) {
-          const colorMapping = mapValueIrisToColor({
-            palette: fieldValue.palette,
-            dimensionValues: values,
-            random,
-          });
-          setWith(draft.chartConfig, `${path}.colorMapping`, colorMapping);
-        }
-      }
-
-      return draft;
+      return updateColorMapping(draft, action);
 
     case "CHART_CONFIG_FILTER_SET_MULTI":
       if (draft.state === "CONFIGURING_CHART") {

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -196,6 +196,7 @@ export type ConfiguratorStateAction =
       type: "CHART_CONFIG_UPDATE_COLOR_MAPPING";
       value: {
         field: string;
+        colorConfigPath: string | undefined;
         dimensionIri: string;
         values: DimensionValue[];
         random: boolean;
@@ -1108,8 +1109,12 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
 
     case "CHART_CONFIG_UPDATE_COLOR_MAPPING":
       if (draft.state === "CONFIGURING_CHART") {
-        const { field, dimensionIri, values, random } = action.value;
-        const fieldValue = get(draft.chartConfig, `fields.${field}`) as
+        const { field, colorConfigPath, dimensionIri, values, random } =
+          action.value;
+        const path = `fields.${field}${
+          colorConfigPath ? `.${colorConfigPath}` : ""
+        }`;
+        const fieldValue = get(draft.chartConfig, path) as
           | (GenericField & { palette: string })
           | undefined;
 
@@ -1119,11 +1124,7 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
             dimensionValues: values,
             random,
           });
-          setWith(
-            draft.chartConfig,
-            `fields.${field}.colorMapping`,
-            colorMapping
-          );
+          setWith(draft.chartConfig, `${path}.colorMapping`, colorMapping);
         }
       }
 

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -30,7 +30,7 @@ msgid "Move filter up"
 msgstr "Filter nach oben verschieben"
 
 #: app/configurator/components/dataset-browse.tsx:1027
-#: app/configurator/components/filters.tsx:681
+#: app/configurator/components/filters.tsx:714
 msgid "No results"
 msgstr "Kein Ergebnis"
 
@@ -125,16 +125,16 @@ msgid "chart.map.layers.area"
 msgstr "Flächen"
 
 #: app/configurator/components/chart-configurator.tsx:696
-#: app/configurator/components/chart-options-selector.tsx:992
+#: app/configurator/components/chart-options-selector.tsx:996
 #: app/configurator/components/ui-helpers.ts:616
 msgid "chart.map.layers.base"
 msgstr "Kartenanzeige"
 
-#: app/configurator/components/chart-options-selector.tsx:996
+#: app/configurator/components/chart-options-selector.tsx:1000
 msgid "chart.map.layers.base.show"
 msgstr "Weltkarte anzeigen"
 
-#: app/configurator/components/chart-options-selector.tsx:1005
+#: app/configurator/components/chart-options-selector.tsx:1009
 msgid "chart.map.layers.base.view.locked"
 msgstr "Gesperrte Ansicht"
 
@@ -184,7 +184,7 @@ msgstr "Fett"
 msgid "columnStyle.textStyle.regular"
 msgstr "Normal"
 
-#: app/configurator/interactive-filters/editor-time-brush.tsx:172
+#: app/configurator/interactive-filters/editor-time-brush.tsx:173
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Standardeinstellung"
 
@@ -196,39 +196,39 @@ msgstr "Horizontale Achse"
 msgid "controls.axis.vertical"
 msgstr "Vertikale Achse"
 
-#: app/configurator/components/ui-helpers.ts:692
+#: app/configurator/components/ui-helpers.ts:700
 msgid "controls.chart.type.area"
 msgstr "Flächen"
 
-#: app/configurator/components/ui-helpers.ts:684
+#: app/configurator/components/ui-helpers.ts:692
 msgid "controls.chart.type.bar"
 msgstr "Balken"
 
-#: app/configurator/components/ui-helpers.ts:680
+#: app/configurator/components/ui-helpers.ts:688
 msgid "controls.chart.type.column"
 msgstr "Säulen"
 
-#: app/configurator/components/ui-helpers.ts:688
+#: app/configurator/components/ui-helpers.ts:696
 msgid "controls.chart.type.line"
 msgstr "Linien"
 
-#: app/configurator/components/ui-helpers.ts:708
+#: app/configurator/components/ui-helpers.ts:716
 msgid "controls.chart.type.map"
 msgstr "Karte"
 
-#: app/configurator/components/ui-helpers.ts:700
+#: app/configurator/components/ui-helpers.ts:708
 msgid "controls.chart.type.pie"
 msgstr "Kreis"
 
-#: app/configurator/components/ui-helpers.ts:696
+#: app/configurator/components/ui-helpers.ts:704
 msgid "controls.chart.type.scatterplot"
 msgstr "Scatterplot"
 
-#: app/configurator/components/ui-helpers.ts:704
+#: app/configurator/components/ui-helpers.ts:712
 msgid "controls.chart.type.table"
 msgstr "Tabelle"
 
-#: app/configurator/components/chart-options-selector.tsx:714
+#: app/configurator/components/chart-options-selector.tsx:718
 #: app/configurator/components/ui-helpers.ts:602
 msgid "controls.color"
 msgstr "Farbe"
@@ -237,7 +237,7 @@ msgstr "Farbe"
 msgid "controls.color.add"
 msgstr "Hinzufügen …"
 
-#: app/configurator/components/chart-options-selector.tsx:745
+#: app/configurator/components/chart-options-selector.tsx:749
 msgid "controls.color.opacity"
 msgstr "Transparenz"
 
@@ -258,39 +258,39 @@ msgstr "Farbpalette zurücksetzen"
 msgid "controls.color.palette.sequential"
 msgstr "Sequentiell"
 
-#: app/configurator/components/chart-options-selector.tsx:836
+#: app/configurator/components/chart-options-selector.tsx:840
 msgid "controls.color.scale.discretization.jenks"
 msgstr "Jenks (Natural Breaks)"
 
-#: app/configurator/components/chart-options-selector.tsx:829
+#: app/configurator/components/chart-options-selector.tsx:833
 msgid "controls.color.scale.discretization.quantiles"
 msgstr "Quantile (gleiche Anzahl Werte)"
 
-#: app/configurator/components/chart-options-selector.tsx:822
+#: app/configurator/components/chart-options-selector.tsx:826
 msgid "controls.color.scale.discretization.quantize"
 msgstr "Quantisierung (gleiche Wertebereiche)"
 
-#: app/configurator/components/chart-options-selector.tsx:814
+#: app/configurator/components/chart-options-selector.tsx:818
 msgid "controls.color.scale.interpolation"
 msgstr "Interpolation"
 
-#: app/configurator/components/chart-options-selector.tsx:847
+#: app/configurator/components/chart-options-selector.tsx:851
 msgid "controls.color.scale.number.of.classes"
 msgstr "Anzahl Klassen"
 
-#: app/configurator/components/chart-options-selector.tsx:784
+#: app/configurator/components/chart-options-selector.tsx:788
 msgid "controls.color.scale.type.continuous"
 msgstr "Kontinuierlich"
 
-#: app/configurator/components/chart-options-selector.tsx:796
+#: app/configurator/components/chart-options-selector.tsx:800
 msgid "controls.color.scale.type.discrete"
 msgstr "Diskret"
 
-#: app/configurator/components/chart-options-selector.tsx:734
+#: app/configurator/components/chart-options-selector.tsx:738
 msgid "controls.color.select"
 msgstr "Farbe auswählen"
 
-#: app/configurator/components/chart-controls/color-picker.tsx:186
+#: app/configurator/components/chart-controls/color-picker.tsx:183
 msgid "controls.colorpicker.open"
 msgstr "Farbauswahl öffnen"
 
@@ -320,33 +320,37 @@ msgstr "Beschreibung hinzufügen"
 msgid "controls.dimensionvalue.none"
 msgstr "Kein Filter"
 
-#: app/configurator/components/filters.tsx:431
+#: app/configurator/components/filters.tsx:464
 msgid "controls.filter.nb-elements"
 msgstr "{0} von {1}"
 
-#: app/configurator/components/filters.tsx:385
-#: app/configurator/components/filters.tsx:609
+#: app/configurator/components/filters.tsx:396
+#: app/configurator/components/filters.tsx:642
 msgid "controls.filter.select.all"
 msgstr "Alle auswählen"
 
-#: app/configurator/components/filters.tsx:392
-#: app/configurator/components/filters.tsx:607
+#: app/configurator/components/filters.tsx:403
+#: app/configurator/components/filters.tsx:640
 msgid "controls.filter.select.none"
 msgstr "Alle abwählen"
 
-#: app/configurator/components/filters.tsx:402
+#: app/configurator/components/filters.tsx:413
 msgid "controls.filters.select.filters"
 msgstr "Filter"
 
-#: app/configurator/components/filters.tsx:415
+#: app/configurator/components/filters.tsx:445
 msgid "controls.filters.select.refresh-colors"
 msgstr "Farben auffrischen"
 
-#: app/configurator/components/filters.tsx:409
+#: app/configurator/components/filters.tsx:427
+msgid "controls.filters.select.reset-colors"
+msgstr "Farben zurücksetzen"
+
+#: app/configurator/components/filters.tsx:420
 msgid "controls.filters.select.selected-filters"
 msgstr "Ausgewählte Filter"
 
-#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:127
+#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:129
 msgid "controls.filters.time.range"
 msgstr "Zeitspanne"
 
@@ -370,23 +374,23 @@ msgstr "Bitte eine Designoption oder Datendimension auswählen, um diese zu bear
 msgid "controls.hint.describing.chart"
 msgstr "Bitte ein Beschreibungsfeld auswählen, um dieses zu bearbeiten."
 
-#: app/configurator/components/ui-helpers.ts:664
+#: app/configurator/components/ui-helpers.ts:672
 msgid "controls.imputation"
 msgstr "Imputationstyp"
 
-#: app/configurator/components/chart-options-selector.tsx:883
-#: app/configurator/components/ui-helpers.ts:676
+#: app/configurator/components/chart-options-selector.tsx:887
+#: app/configurator/components/ui-helpers.ts:684
 msgid "controls.imputation.type.linear"
 msgstr "Lineare Interpolation"
 
-#: app/configurator/components/chart-options-selector.tsx:876
-#: app/configurator/components/chart-options-selector.tsx:888
-#: app/configurator/components/ui-helpers.ts:668
+#: app/configurator/components/chart-options-selector.tsx:880
+#: app/configurator/components/chart-options-selector.tsx:892
+#: app/configurator/components/ui-helpers.ts:676
 msgid "controls.imputation.type.none"
 msgstr "-"
 
-#: app/configurator/components/chart-options-selector.tsx:878
-#: app/configurator/components/ui-helpers.ts:672
+#: app/configurator/components/chart-options-selector.tsx:882
+#: app/configurator/components/ui-helpers.ts:680
 msgid "controls.imputation.type.zeros"
 msgstr "Nullen"
 
@@ -410,19 +414,19 @@ msgstr "Keine Zeitdimension verfügbar!"
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Zeitfilter anzeigen"
 
-#: app/configurator/components/ui-helpers.ts:712
+#: app/configurator/components/ui-helpers.ts:720
 msgid "controls.language.english"
 msgstr "Englisch"
 
-#: app/configurator/components/ui-helpers.ts:720
+#: app/configurator/components/ui-helpers.ts:728
 msgid "controls.language.french"
 msgstr "Französisch"
 
-#: app/configurator/components/ui-helpers.ts:716
+#: app/configurator/components/ui-helpers.ts:724
 msgid "controls.language.german"
 msgstr "Deutsch"
 
-#: app/configurator/components/ui-helpers.ts:724
+#: app/configurator/components/ui-helpers.ts:732
 msgid "controls.language.italian"
 msgstr "Italienisch"
 
@@ -447,7 +451,7 @@ msgstr "Aus"
 #~ msgid "controls.option.none"
 #~ msgstr "Keine"
 
-#: app/configurator/components/chart-options-selector.tsx:777
+#: app/configurator/components/chart-options-selector.tsx:781
 msgid "controls.scale.type"
 msgstr "Skalierungstyp"
 
@@ -492,11 +496,11 @@ msgstr "Filter"
 msgid "controls.section.groups"
 msgstr "Gruppierungen"
 
-#: app/configurator/components/chart-options-selector.tsx:917
+#: app/configurator/components/chart-options-selector.tsx:921
 msgid "controls.section.imputation"
 msgstr "Fehlende Werte"
 
-#: app/configurator/components/chart-options-selector.tsx:922
+#: app/configurator/components/chart-options-selector.tsx:926
 msgid "controls.section.imputation.explanation"
 msgstr "Für diesen Diagrammtyp sollten fehlenden Werten Ersatzwerte zugewiesen werden. Entscheiden Sie sich für die Imputationslogik oder wechseln Sie zu einem anderen Diagrammtyp."
 
@@ -512,7 +516,7 @@ msgstr "Datenfilter"
 msgid "controls.section.show-standard-error"
 msgstr "Standardfehler anzeigen"
 
-#: app/configurator/components/chart-options-selector.tsx:550
+#: app/configurator/components/chart-options-selector.tsx:554
 msgid "controls.section.sorting"
 msgstr "Sortieren"
 
@@ -528,7 +532,7 @@ msgstr "Tabellensortierung"
 msgid "controls.section.tableoptions"
 msgstr "Tabellenoptionen"
 
-#: app/configurator/components/chart-configurator.tsx:542
+#: app/configurator/components/chart-configurator.tsx:541
 #: app/configurator/components/chart-type-selector.tsx:139
 #: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
@@ -575,8 +579,8 @@ msgid "controls.select.dimension"
 msgstr "Dimension auswählen"
 
 #: app/configurator/components/chart-options-selector.tsx:209
-#: app/configurator/components/chart-options-selector.tsx:640
-#: app/configurator/components/chart-options-selector.tsx:719
+#: app/configurator/components/chart-options-selector.tsx:644
+#: app/configurator/components/chart-options-selector.tsx:723
 msgid "controls.select.measure"
 msgstr "Messwert auswählen"
 
@@ -587,19 +591,19 @@ msgstr "Messwert auswählen"
 #~ msgid "controls.select.optional"
 #~ msgstr "optional"
 
-#: app/configurator/components/filters.tsx:663
+#: app/configurator/components/filters.tsx:696
 msgid "controls.set-filters"
 msgstr "Ausgewählte Filter"
 
-#: app/configurator/components/filters.tsx:670
+#: app/configurator/components/filters.tsx:703
 msgid "controls.set-filters-caption"
 msgstr "Für beste Ergebnisse wählen Sie nicht mehr als 7 Werte für die Visualisierung aus"
 
-#: app/configurator/components/filters.tsx:702
+#: app/configurator/components/filters.tsx:735
 msgid "controls.set-values-apply"
 msgstr "Filter anwenden"
 
-#: app/configurator/components/chart-options-selector.tsx:632
+#: app/configurator/components/chart-options-selector.tsx:636
 msgid "controls.size"
 msgstr "Grösse"
 
@@ -607,16 +611,22 @@ msgstr "Grösse"
 msgid "controls.sorting.addDimension"
 msgstr "Dimension hinzufügen"
 
-#: app/configurator/components/chart-options-selector.tsx:500
 #: app/configurator/components/chart-options-selector.tsx:506
+msgid "controls.sorting.byAuto"
+msgstr ""
+
+#: app/configurator/components/chart-options-selector.tsx:500
+#: app/configurator/components/chart-options-selector.tsx:510
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Name"
 
 #: app/configurator/components/ui-helpers.ts:632
+#: app/configurator/components/ui-helpers.ts:636
 msgid "controls.sorting.byDimensionLabel.ascending"
 msgstr "A → Z"
 
-#: app/configurator/components/ui-helpers.ts:636
+#: app/configurator/components/ui-helpers.ts:640
+#: app/configurator/components/ui-helpers.ts:644
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
@@ -624,11 +634,11 @@ msgstr "Z → A"
 msgid "controls.sorting.byMeasure"
 msgstr "Messwert"
 
-#: app/configurator/components/ui-helpers.ts:656
+#: app/configurator/components/ui-helpers.ts:664
 msgid "controls.sorting.byMeasure.ascending"
 msgstr "1 → 9"
 
-#: app/configurator/components/ui-helpers.ts:660
+#: app/configurator/components/ui-helpers.ts:668
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
@@ -636,19 +646,19 @@ msgstr "9 → 1"
 msgid "controls.sorting.byTotalSize"
 msgstr "Gesamtgrösse"
 
-#: app/configurator/components/ui-helpers.ts:640
+#: app/configurator/components/ui-helpers.ts:648
 msgid "controls.sorting.byTotalSize.ascending"
 msgstr "Kleinste zuerst"
 
-#: app/configurator/components/ui-helpers.ts:652
+#: app/configurator/components/ui-helpers.ts:660
 msgid "controls.sorting.byTotalSize.largestBottom"
 msgstr "Grösste unten"
 
-#: app/configurator/components/ui-helpers.ts:644
+#: app/configurator/components/ui-helpers.ts:652
 msgid "controls.sorting.byTotalSize.largestFirst"
 msgstr "Grösste zuerst"
 
-#: app/configurator/components/ui-helpers.ts:648
+#: app/configurator/components/ui-helpers.ts:656
 msgid "controls.sorting.byTotalSize.largestTop"
 msgstr "Kleinste unten"
 
@@ -824,19 +834,19 @@ msgstr "https://www.bafu.admin.ch/bafu/de/home.html"
 msgid "footer.status"
 msgstr "Status"
 
-#: app/components/hint.tsx:189
+#: app/components/hint.tsx:196
 msgid "hint.chartunexpected.message"
 msgstr ""
 
-#: app/components/hint.tsx:187
+#: app/components/hint.tsx:194
 msgid "hint.chartunexpected.title"
 msgstr ""
 
-#: app/components/hint.tsx:175
+#: app/components/hint.tsx:182
 msgid "hint.coordinatesloadingerror.message"
 msgstr "Es gab ein Problem beim Laden der Koordinaten aus den geografischen Dimensionen. Bitte später erneut versuchen."
 
-#: app/components/hint.tsx:171
+#: app/components/hint.tsx:178
 msgid "hint.coordinatesloadingerror.title"
 msgstr "Koordinaten-Ladefehler"
 
@@ -876,15 +886,15 @@ msgstr "Bitte versuchen Sie es mit einer anderen Filterkombination."
 msgid "hint.nodata.title"
 msgstr "Keine Daten für die aktuelle Filterauswahl"
 
-#: app/components/hint.tsx:211
+#: app/components/hint.tsx:218
 msgid "hint.only.negative.data.message"
 msgstr "Negative Datenwerte können mit diesem Diagrammtyp nicht dargestellt werden."
 
-#: app/components/hint.tsx:209
+#: app/components/hint.tsx:216
 msgid "hint.only.negative.data.title"
 msgstr "Negative Werte"
 
-#: app/components/hint.tsx:219
+#: app/components/hint.tsx:226
 msgid "hint.publication.success"
 msgstr "Die Visualisierung ist jetzt veröffentlicht. Sie können sie teilen oder einbetten, indem Sie die URL kopieren oder das Menü unten verwenden."
 
@@ -957,7 +967,7 @@ msgstr "Hier ist eine Visualisierung, die ich mit visualize.admin.ch erstellt ha
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
-#: app/configurator/components/filters.tsx:583
+#: app/configurator/components/filters.tsx:616
 msgid "select.controls.filters.search"
 msgstr "Suche"
 
@@ -974,7 +984,7 @@ msgid "table.column.no"
 msgstr "Spalte {0}"
 
 #: app/components/chart-footnotes.tsx:113
-#: app/components/chart-footnotes.tsx:133
+#: app/components/chart-footnotes.tsx:134
 #: app/components/chart-footnotes.tsx:145
 msgid "typography.colon"
 msgstr ": "

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -30,7 +30,7 @@ msgid "Move filter up"
 msgstr "Move filter up"
 
 #: app/configurator/components/dataset-browse.tsx:1027
-#: app/configurator/components/filters.tsx:681
+#: app/configurator/components/filters.tsx:714
 msgid "No results"
 msgstr "No results"
 
@@ -145,16 +145,16 @@ msgstr "Areas"
 #~ msgstr "Quantize (equal intervals)"
 
 #: app/configurator/components/chart-configurator.tsx:696
-#: app/configurator/components/chart-options-selector.tsx:992
+#: app/configurator/components/chart-options-selector.tsx:996
 #: app/configurator/components/ui-helpers.ts:616
 msgid "chart.map.layers.base"
 msgstr "Map Display"
 
-#: app/configurator/components/chart-options-selector.tsx:996
+#: app/configurator/components/chart-options-selector.tsx:1000
 msgid "chart.map.layers.base.show"
 msgstr "Show Worldmap"
 
-#: app/configurator/components/chart-options-selector.tsx:1005
+#: app/configurator/components/chart-options-selector.tsx:1009
 msgid "chart.map.layers.base.view.locked"
 msgstr "Locked view"
 
@@ -204,7 +204,7 @@ msgstr "Bold"
 msgid "columnStyle.textStyle.regular"
 msgstr "Regular"
 
-#: app/configurator/interactive-filters/editor-time-brush.tsx:172
+#: app/configurator/interactive-filters/editor-time-brush.tsx:173
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Default Settings"
 
@@ -216,39 +216,39 @@ msgstr "Horizontal Axis"
 msgid "controls.axis.vertical"
 msgstr "Vertical Axis"
 
-#: app/configurator/components/ui-helpers.ts:692
+#: app/configurator/components/ui-helpers.ts:700
 msgid "controls.chart.type.area"
 msgstr "Areas"
 
-#: app/configurator/components/ui-helpers.ts:684
+#: app/configurator/components/ui-helpers.ts:692
 msgid "controls.chart.type.bar"
 msgstr "Bars"
 
-#: app/configurator/components/ui-helpers.ts:680
+#: app/configurator/components/ui-helpers.ts:688
 msgid "controls.chart.type.column"
 msgstr "Columns"
 
-#: app/configurator/components/ui-helpers.ts:688
+#: app/configurator/components/ui-helpers.ts:696
 msgid "controls.chart.type.line"
 msgstr "Lines"
 
-#: app/configurator/components/ui-helpers.ts:708
+#: app/configurator/components/ui-helpers.ts:716
 msgid "controls.chart.type.map"
 msgstr "Map"
 
-#: app/configurator/components/ui-helpers.ts:700
+#: app/configurator/components/ui-helpers.ts:708
 msgid "controls.chart.type.pie"
 msgstr "Pie"
 
-#: app/configurator/components/ui-helpers.ts:696
+#: app/configurator/components/ui-helpers.ts:704
 msgid "controls.chart.type.scatterplot"
 msgstr "Scatterplot"
 
-#: app/configurator/components/ui-helpers.ts:704
+#: app/configurator/components/ui-helpers.ts:712
 msgid "controls.chart.type.table"
 msgstr "Table"
 
-#: app/configurator/components/chart-options-selector.tsx:714
+#: app/configurator/components/chart-options-selector.tsx:718
 #: app/configurator/components/ui-helpers.ts:602
 msgid "controls.color"
 msgstr "Color"
@@ -257,7 +257,7 @@ msgstr "Color"
 msgid "controls.color.add"
 msgstr "Add ..."
 
-#: app/configurator/components/chart-options-selector.tsx:745
+#: app/configurator/components/chart-options-selector.tsx:749
 msgid "controls.color.opacity"
 msgstr "Opacity"
 
@@ -278,39 +278,39 @@ msgstr "Reset color palette"
 msgid "controls.color.palette.sequential"
 msgstr "Sequential"
 
-#: app/configurator/components/chart-options-selector.tsx:836
+#: app/configurator/components/chart-options-selector.tsx:840
 msgid "controls.color.scale.discretization.jenks"
 msgstr "Jenks (natural breaks)"
 
-#: app/configurator/components/chart-options-selector.tsx:829
+#: app/configurator/components/chart-options-selector.tsx:833
 msgid "controls.color.scale.discretization.quantiles"
 msgstr "Quantiles (equal distribution of values)"
 
-#: app/configurator/components/chart-options-selector.tsx:822
+#: app/configurator/components/chart-options-selector.tsx:826
 msgid "controls.color.scale.discretization.quantize"
 msgstr "Quantize (equal intervals)"
 
-#: app/configurator/components/chart-options-selector.tsx:814
+#: app/configurator/components/chart-options-selector.tsx:818
 msgid "controls.color.scale.interpolation"
 msgstr "Interpolation"
 
-#: app/configurator/components/chart-options-selector.tsx:847
+#: app/configurator/components/chart-options-selector.tsx:851
 msgid "controls.color.scale.number.of.classes"
 msgstr "Number of classes"
 
-#: app/configurator/components/chart-options-selector.tsx:784
+#: app/configurator/components/chart-options-selector.tsx:788
 msgid "controls.color.scale.type.continuous"
 msgstr "Continuous"
 
-#: app/configurator/components/chart-options-selector.tsx:796
+#: app/configurator/components/chart-options-selector.tsx:800
 msgid "controls.color.scale.type.discrete"
 msgstr "Discrete"
 
-#: app/configurator/components/chart-options-selector.tsx:734
+#: app/configurator/components/chart-options-selector.tsx:738
 msgid "controls.color.select"
 msgstr "Select a color"
 
-#: app/configurator/components/chart-controls/color-picker.tsx:186
+#: app/configurator/components/chart-controls/color-picker.tsx:183
 msgid "controls.colorpicker.open"
 msgstr "Open Color Picker"
 
@@ -340,33 +340,37 @@ msgstr "Description"
 msgid "controls.dimensionvalue.none"
 msgstr "No Filter"
 
-#: app/configurator/components/filters.tsx:431
+#: app/configurator/components/filters.tsx:464
 msgid "controls.filter.nb-elements"
 msgstr "{0} of {1}"
 
-#: app/configurator/components/filters.tsx:385
-#: app/configurator/components/filters.tsx:609
+#: app/configurator/components/filters.tsx:396
+#: app/configurator/components/filters.tsx:642
 msgid "controls.filter.select.all"
 msgstr "Select all"
 
-#: app/configurator/components/filters.tsx:392
-#: app/configurator/components/filters.tsx:607
+#: app/configurator/components/filters.tsx:403
+#: app/configurator/components/filters.tsx:640
 msgid "controls.filter.select.none"
 msgstr "Select none"
 
-#: app/configurator/components/filters.tsx:402
+#: app/configurator/components/filters.tsx:413
 msgid "controls.filters.select.filters"
 msgstr "Filters"
 
-#: app/configurator/components/filters.tsx:415
+#: app/configurator/components/filters.tsx:445
 msgid "controls.filters.select.refresh-colors"
 msgstr "Refresh colors"
 
-#: app/configurator/components/filters.tsx:409
+#: app/configurator/components/filters.tsx:427
+msgid "controls.filters.select.reset-colors"
+msgstr "Reset colors"
+
+#: app/configurator/components/filters.tsx:420
 msgid "controls.filters.select.selected-filters"
 msgstr "Selected filters"
 
-#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:127
+#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:129
 msgid "controls.filters.time.range"
 msgstr "Time Range"
 
@@ -390,23 +394,23 @@ msgstr "Select a design element or a data dimension to modify its options."
 msgid "controls.hint.describing.chart"
 msgstr "Select an annotation field to modify its content."
 
-#: app/configurator/components/ui-helpers.ts:664
+#: app/configurator/components/ui-helpers.ts:672
 msgid "controls.imputation"
 msgstr "Imputation type"
 
-#: app/configurator/components/chart-options-selector.tsx:883
-#: app/configurator/components/ui-helpers.ts:676
+#: app/configurator/components/chart-options-selector.tsx:887
+#: app/configurator/components/ui-helpers.ts:684
 msgid "controls.imputation.type.linear"
 msgstr "Linear interpolation"
 
-#: app/configurator/components/chart-options-selector.tsx:876
-#: app/configurator/components/chart-options-selector.tsx:888
-#: app/configurator/components/ui-helpers.ts:668
+#: app/configurator/components/chart-options-selector.tsx:880
+#: app/configurator/components/chart-options-selector.tsx:892
+#: app/configurator/components/ui-helpers.ts:676
 msgid "controls.imputation.type.none"
 msgstr "-"
 
-#: app/configurator/components/chart-options-selector.tsx:878
-#: app/configurator/components/ui-helpers.ts:672
+#: app/configurator/components/chart-options-selector.tsx:882
+#: app/configurator/components/ui-helpers.ts:680
 msgid "controls.imputation.type.zeros"
 msgstr "Zeros"
 
@@ -430,19 +434,19 @@ msgstr "There is no time dimension!"
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Show time filter"
 
-#: app/configurator/components/ui-helpers.ts:712
+#: app/configurator/components/ui-helpers.ts:720
 msgid "controls.language.english"
 msgstr "English"
 
-#: app/configurator/components/ui-helpers.ts:720
+#: app/configurator/components/ui-helpers.ts:728
 msgid "controls.language.french"
 msgstr "French"
 
-#: app/configurator/components/ui-helpers.ts:716
+#: app/configurator/components/ui-helpers.ts:724
 msgid "controls.language.german"
 msgstr "German"
 
-#: app/configurator/components/ui-helpers.ts:724
+#: app/configurator/components/ui-helpers.ts:732
 msgid "controls.language.italian"
 msgstr "Italian"
 
@@ -467,7 +471,7 @@ msgstr "On"
 msgid "controls.option.isNotActive"
 msgstr "Off"
 
-#: app/configurator/components/chart-options-selector.tsx:777
+#: app/configurator/components/chart-options-selector.tsx:781
 msgid "controls.scale.type"
 msgstr "Scale type"
 
@@ -512,11 +516,11 @@ msgstr "Filter"
 msgid "controls.section.groups"
 msgstr "Groups"
 
-#: app/configurator/components/chart-options-selector.tsx:917
+#: app/configurator/components/chart-options-selector.tsx:921
 msgid "controls.section.imputation"
 msgstr "Missing values"
 
-#: app/configurator/components/chart-options-selector.tsx:922
+#: app/configurator/components/chart-options-selector.tsx:926
 msgid "controls.section.imputation.explanation"
 msgstr "For this chart type, replacement values should be assigned to missing values. Decide on the imputation logic or switch to another chart type."
 
@@ -532,7 +536,7 @@ msgstr "Data Filters"
 msgid "controls.section.show-standard-error"
 msgstr "Show standard error"
 
-#: app/configurator/components/chart-options-selector.tsx:550
+#: app/configurator/components/chart-options-selector.tsx:554
 msgid "controls.section.sorting"
 msgstr "Sort"
 
@@ -548,7 +552,7 @@ msgstr "Table Sorting"
 msgid "controls.section.tableoptions"
 msgstr "Table Options"
 
-#: app/configurator/components/chart-configurator.tsx:542
+#: app/configurator/components/chart-configurator.tsx:541
 #: app/configurator/components/chart-type-selector.tsx:139
 #: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
@@ -595,8 +599,8 @@ msgid "controls.select.dimension"
 msgstr "Select a dimension"
 
 #: app/configurator/components/chart-options-selector.tsx:209
-#: app/configurator/components/chart-options-selector.tsx:640
-#: app/configurator/components/chart-options-selector.tsx:719
+#: app/configurator/components/chart-options-selector.tsx:644
+#: app/configurator/components/chart-options-selector.tsx:723
 msgid "controls.select.measure"
 msgstr "Select a measure"
 
@@ -607,19 +611,19 @@ msgstr "Select a measure"
 #~ msgid "controls.select.optional"
 #~ msgstr "optional"
 
-#: app/configurator/components/filters.tsx:663
+#: app/configurator/components/filters.tsx:696
 msgid "controls.set-filters"
 msgstr "Set filters"
 
-#: app/configurator/components/filters.tsx:670
+#: app/configurator/components/filters.tsx:703
 msgid "controls.set-filters-caption"
 msgstr "For best results, do not select more than 7 values in the visualization."
 
-#: app/configurator/components/filters.tsx:702
+#: app/configurator/components/filters.tsx:735
 msgid "controls.set-values-apply"
 msgstr "Apply filters"
 
-#: app/configurator/components/chart-options-selector.tsx:632
+#: app/configurator/components/chart-options-selector.tsx:636
 msgid "controls.size"
 msgstr "Size"
 
@@ -627,16 +631,22 @@ msgstr "Size"
 msgid "controls.sorting.addDimension"
 msgstr "Add dimension"
 
-#: app/configurator/components/chart-options-selector.tsx:500
 #: app/configurator/components/chart-options-selector.tsx:506
+msgid "controls.sorting.byAuto"
+msgstr "Automatic"
+
+#: app/configurator/components/chart-options-selector.tsx:500
+#: app/configurator/components/chart-options-selector.tsx:510
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Name"
 
 #: app/configurator/components/ui-helpers.ts:632
+#: app/configurator/components/ui-helpers.ts:636
 msgid "controls.sorting.byDimensionLabel.ascending"
 msgstr "A → Z"
 
-#: app/configurator/components/ui-helpers.ts:636
+#: app/configurator/components/ui-helpers.ts:640
+#: app/configurator/components/ui-helpers.ts:644
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
@@ -644,11 +654,11 @@ msgstr "Z → A"
 msgid "controls.sorting.byMeasure"
 msgstr "Measure"
 
-#: app/configurator/components/ui-helpers.ts:656
+#: app/configurator/components/ui-helpers.ts:664
 msgid "controls.sorting.byMeasure.ascending"
 msgstr "1 → 9"
 
-#: app/configurator/components/ui-helpers.ts:660
+#: app/configurator/components/ui-helpers.ts:668
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
@@ -656,19 +666,19 @@ msgstr "9 → 1"
 msgid "controls.sorting.byTotalSize"
 msgstr "Total size"
 
-#: app/configurator/components/ui-helpers.ts:640
+#: app/configurator/components/ui-helpers.ts:648
 msgid "controls.sorting.byTotalSize.ascending"
 msgstr "Largest last"
 
-#: app/configurator/components/ui-helpers.ts:652
+#: app/configurator/components/ui-helpers.ts:660
 msgid "controls.sorting.byTotalSize.largestBottom"
 msgstr "Ascending"
 
-#: app/configurator/components/ui-helpers.ts:644
+#: app/configurator/components/ui-helpers.ts:652
 msgid "controls.sorting.byTotalSize.largestFirst"
 msgstr "Largest first"
 
-#: app/configurator/components/ui-helpers.ts:648
+#: app/configurator/components/ui-helpers.ts:656
 msgid "controls.sorting.byTotalSize.largestTop"
 msgstr "Descending"
 
@@ -848,19 +858,19 @@ msgstr "https://www.bafu.admin.ch/bafu/en/home.html"
 msgid "footer.status"
 msgstr "Status"
 
-#: app/components/hint.tsx:189
+#: app/components/hint.tsx:196
 msgid "hint.chartunexpected.message"
 msgstr "An unexpected error occurred while displaying this chart."
 
-#: app/components/hint.tsx:187
+#: app/components/hint.tsx:194
 msgid "hint.chartunexpected.title"
 msgstr "Unexpected error"
 
-#: app/components/hint.tsx:175
+#: app/components/hint.tsx:182
 msgid "hint.coordinatesloadingerror.message"
 msgstr "There was a problem with loading the coordinates from geographical dimensions. Please try again later."
 
-#: app/components/hint.tsx:171
+#: app/components/hint.tsx:178
 msgid "hint.coordinatesloadingerror.title"
 msgstr "Coordinates loading error"
 
@@ -900,15 +910,15 @@ msgstr "Please try with another combination of filters."
 msgid "hint.nodata.title"
 msgstr "No data available for current filter selection"
 
-#: app/components/hint.tsx:211
+#: app/components/hint.tsx:218
 msgid "hint.only.negative.data.message"
 msgstr "Negative data values cannot be displayed with this chart type."
 
-#: app/components/hint.tsx:209
+#: app/components/hint.tsx:216
 msgid "hint.only.negative.data.title"
 msgstr "Negative Values"
 
-#: app/components/hint.tsx:219
+#: app/components/hint.tsx:226
 msgid "hint.publication.success"
 msgstr "Your visualization is now published. Share it by copying the URL or use the Embed menu below."
 
@@ -981,7 +991,7 @@ msgstr "Here is a visualization I created using visualize.admin.ch"
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
-#: app/configurator/components/filters.tsx:583
+#: app/configurator/components/filters.tsx:616
 msgid "select.controls.filters.search"
 msgstr "Search"
 
@@ -998,7 +1008,7 @@ msgid "table.column.no"
 msgstr "Column {0}"
 
 #: app/components/chart-footnotes.tsx:113
-#: app/components/chart-footnotes.tsx:133
+#: app/components/chart-footnotes.tsx:134
 #: app/components/chart-footnotes.tsx:145
 msgid "typography.colon"
 msgstr ": "

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -30,7 +30,7 @@ msgid "Move filter up"
 msgstr "Déplacer le filtre vers le haut"
 
 #: app/configurator/components/dataset-browse.tsx:1027
-#: app/configurator/components/filters.tsx:681
+#: app/configurator/components/filters.tsx:714
 msgid "No results"
 msgstr "Aucun résultat"
 
@@ -145,16 +145,16 @@ msgstr "Zones"
 #~ msgstr "Intervalles égaux"
 
 #: app/configurator/components/chart-configurator.tsx:696
-#: app/configurator/components/chart-options-selector.tsx:992
+#: app/configurator/components/chart-options-selector.tsx:996
 #: app/configurator/components/ui-helpers.ts:616
 msgid "chart.map.layers.base"
 msgstr "Affichage de la carte"
 
-#: app/configurator/components/chart-options-selector.tsx:996
+#: app/configurator/components/chart-options-selector.tsx:1000
 msgid "chart.map.layers.base.show"
 msgstr "Afficher la carte du monde"
 
-#: app/configurator/components/chart-options-selector.tsx:1005
+#: app/configurator/components/chart-options-selector.tsx:1009
 msgid "chart.map.layers.base.view.locked"
 msgstr "Carte verrouillée"
 
@@ -204,7 +204,7 @@ msgstr "Gras"
 msgid "columnStyle.textStyle.regular"
 msgstr "Normal"
 
-#: app/configurator/interactive-filters/editor-time-brush.tsx:172
+#: app/configurator/interactive-filters/editor-time-brush.tsx:173
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Paramètres d'origine"
 
@@ -216,39 +216,39 @@ msgstr "Axe horizontal"
 msgid "controls.axis.vertical"
 msgstr "Axe vertical"
 
-#: app/configurator/components/ui-helpers.ts:692
+#: app/configurator/components/ui-helpers.ts:700
 msgid "controls.chart.type.area"
 msgstr "Surfaces"
 
-#: app/configurator/components/ui-helpers.ts:684
+#: app/configurator/components/ui-helpers.ts:692
 msgid "controls.chart.type.bar"
 msgstr "Barres"
 
-#: app/configurator/components/ui-helpers.ts:680
+#: app/configurator/components/ui-helpers.ts:688
 msgid "controls.chart.type.column"
 msgstr "Colonnes"
 
-#: app/configurator/components/ui-helpers.ts:688
+#: app/configurator/components/ui-helpers.ts:696
 msgid "controls.chart.type.line"
 msgstr "Lignes"
 
-#: app/configurator/components/ui-helpers.ts:708
+#: app/configurator/components/ui-helpers.ts:716
 msgid "controls.chart.type.map"
 msgstr "Carte"
 
-#: app/configurator/components/ui-helpers.ts:700
+#: app/configurator/components/ui-helpers.ts:708
 msgid "controls.chart.type.pie"
 msgstr "Secteurs"
 
-#: app/configurator/components/ui-helpers.ts:696
+#: app/configurator/components/ui-helpers.ts:704
 msgid "controls.chart.type.scatterplot"
 msgstr "Nuage de points"
 
-#: app/configurator/components/ui-helpers.ts:704
+#: app/configurator/components/ui-helpers.ts:712
 msgid "controls.chart.type.table"
 msgstr "Tableau"
 
-#: app/configurator/components/chart-options-selector.tsx:714
+#: app/configurator/components/chart-options-selector.tsx:718
 #: app/configurator/components/ui-helpers.ts:602
 msgid "controls.color"
 msgstr "Couleur"
@@ -257,7 +257,7 @@ msgstr "Couleur"
 msgid "controls.color.add"
 msgstr "Ajouter…"
 
-#: app/configurator/components/chart-options-selector.tsx:745
+#: app/configurator/components/chart-options-selector.tsx:749
 msgid "controls.color.opacity"
 msgstr "Transparence"
 
@@ -278,39 +278,39 @@ msgstr "Réinitialiser la palette de couleurs"
 msgid "controls.color.palette.sequential"
 msgstr "Séquentielle"
 
-#: app/configurator/components/chart-options-selector.tsx:836
+#: app/configurator/components/chart-options-selector.tsx:840
 msgid "controls.color.scale.discretization.jenks"
 msgstr "Jenks (intervalles naturels)"
 
-#: app/configurator/components/chart-options-selector.tsx:829
+#: app/configurator/components/chart-options-selector.tsx:833
 msgid "controls.color.scale.discretization.quantiles"
 msgstr "Quantiles (distribution homogène des valeurs)"
 
-#: app/configurator/components/chart-options-selector.tsx:822
+#: app/configurator/components/chart-options-selector.tsx:826
 msgid "controls.color.scale.discretization.quantize"
 msgstr "Intervalles égaux"
 
-#: app/configurator/components/chart-options-selector.tsx:814
+#: app/configurator/components/chart-options-selector.tsx:818
 msgid "controls.color.scale.interpolation"
 msgstr "Interpolation"
 
-#: app/configurator/components/chart-options-selector.tsx:847
+#: app/configurator/components/chart-options-selector.tsx:851
 msgid "controls.color.scale.number.of.classes"
 msgstr "Nombre de classes"
 
-#: app/configurator/components/chart-options-selector.tsx:784
+#: app/configurator/components/chart-options-selector.tsx:788
 msgid "controls.color.scale.type.continuous"
 msgstr "Continue"
 
-#: app/configurator/components/chart-options-selector.tsx:796
+#: app/configurator/components/chart-options-selector.tsx:800
 msgid "controls.color.scale.type.discrete"
 msgstr "Discrète"
 
-#: app/configurator/components/chart-options-selector.tsx:734
+#: app/configurator/components/chart-options-selector.tsx:738
 msgid "controls.color.select"
 msgstr "Sélectionner une couleur"
 
-#: app/configurator/components/chart-controls/color-picker.tsx:186
+#: app/configurator/components/chart-controls/color-picker.tsx:183
 msgid "controls.colorpicker.open"
 msgstr "Ouvrir la pipette à couleur"
 
@@ -340,33 +340,37 @@ msgstr "Description"
 msgid "controls.dimensionvalue.none"
 msgstr "Aucune filtre"
 
-#: app/configurator/components/filters.tsx:431
+#: app/configurator/components/filters.tsx:464
 msgid "controls.filter.nb-elements"
 msgstr "{0} sur {1}"
 
-#: app/configurator/components/filters.tsx:385
-#: app/configurator/components/filters.tsx:609
+#: app/configurator/components/filters.tsx:396
+#: app/configurator/components/filters.tsx:642
 msgid "controls.filter.select.all"
 msgstr "Tout sélectionner"
 
-#: app/configurator/components/filters.tsx:392
-#: app/configurator/components/filters.tsx:607
+#: app/configurator/components/filters.tsx:403
+#: app/configurator/components/filters.tsx:640
 msgid "controls.filter.select.none"
 msgstr "Tout déselectionner"
 
-#: app/configurator/components/filters.tsx:402
+#: app/configurator/components/filters.tsx:413
 msgid "controls.filters.select.filters"
 msgstr "Filtres"
 
-#: app/configurator/components/filters.tsx:415
+#: app/configurator/components/filters.tsx:445
 msgid "controls.filters.select.refresh-colors"
 msgstr "Renouveller les couleurs"
 
-#: app/configurator/components/filters.tsx:409
+#: app/configurator/components/filters.tsx:427
+msgid "controls.filters.select.reset-colors"
+msgstr "Réinitialiser les couleurs"
+
+#: app/configurator/components/filters.tsx:420
 msgid "controls.filters.select.selected-filters"
 msgstr "Filtres sélectionnés"
 
-#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:127
+#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:129
 msgid "controls.filters.time.range"
 msgstr "Intervalle de temps"
 
@@ -390,23 +394,23 @@ msgstr "Sélectionnez un élément de design ou une dimension du jeu de données
 msgid "controls.hint.describing.chart"
 msgstr "Sélectionnez une des annotations proposées pour la modifier."
 
-#: app/configurator/components/ui-helpers.ts:664
+#: app/configurator/components/ui-helpers.ts:672
 msgid "controls.imputation"
 msgstr "Type d'imputation"
 
-#: app/configurator/components/chart-options-selector.tsx:883
-#: app/configurator/components/ui-helpers.ts:676
+#: app/configurator/components/chart-options-selector.tsx:887
+#: app/configurator/components/ui-helpers.ts:684
 msgid "controls.imputation.type.linear"
 msgstr "Interpolation linéaire"
 
-#: app/configurator/components/chart-options-selector.tsx:876
-#: app/configurator/components/chart-options-selector.tsx:888
-#: app/configurator/components/ui-helpers.ts:668
+#: app/configurator/components/chart-options-selector.tsx:880
+#: app/configurator/components/chart-options-selector.tsx:892
+#: app/configurator/components/ui-helpers.ts:676
 msgid "controls.imputation.type.none"
 msgstr "-"
 
-#: app/configurator/components/chart-options-selector.tsx:878
-#: app/configurator/components/ui-helpers.ts:672
+#: app/configurator/components/chart-options-selector.tsx:882
+#: app/configurator/components/ui-helpers.ts:680
 msgid "controls.imputation.type.zeros"
 msgstr "Zéros"
 
@@ -430,19 +434,19 @@ msgstr "Il n'y a pas de dimension temporelle!"
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Afficher le filtre temporel"
 
-#: app/configurator/components/ui-helpers.ts:712
+#: app/configurator/components/ui-helpers.ts:720
 msgid "controls.language.english"
 msgstr "Anglais"
 
-#: app/configurator/components/ui-helpers.ts:720
+#: app/configurator/components/ui-helpers.ts:728
 msgid "controls.language.french"
 msgstr "Français"
 
-#: app/configurator/components/ui-helpers.ts:716
+#: app/configurator/components/ui-helpers.ts:724
 msgid "controls.language.german"
 msgstr "Allemand"
 
-#: app/configurator/components/ui-helpers.ts:724
+#: app/configurator/components/ui-helpers.ts:732
 msgid "controls.language.italian"
 msgstr "Italien"
 
@@ -467,7 +471,7 @@ msgstr "Actif"
 msgid "controls.option.isNotActive"
 msgstr "Inactif"
 
-#: app/configurator/components/chart-options-selector.tsx:777
+#: app/configurator/components/chart-options-selector.tsx:781
 msgid "controls.scale.type"
 msgstr "Type d'échelle"
 
@@ -512,11 +516,11 @@ msgstr "Filtre"
 msgid "controls.section.groups"
 msgstr "Groupes"
 
-#: app/configurator/components/chart-options-selector.tsx:917
+#: app/configurator/components/chart-options-selector.tsx:921
 msgid "controls.section.imputation"
 msgstr "Valeurs manquantes"
 
-#: app/configurator/components/chart-options-selector.tsx:922
+#: app/configurator/components/chart-options-selector.tsx:926
 msgid "controls.section.imputation.explanation"
 msgstr "En raison du type de graphique sélectionné, les valeurs manquantes doivent être remplies. Décidez de la logique d'imputation ou choisissez un autre type de graphique."
 
@@ -532,7 +536,7 @@ msgstr "Filtres de données"
 msgid "controls.section.show-standard-error"
 msgstr "Afficher l'erreur type"
 
-#: app/configurator/components/chart-options-selector.tsx:550
+#: app/configurator/components/chart-options-selector.tsx:554
 msgid "controls.section.sorting"
 msgstr "Trier"
 
@@ -548,7 +552,7 @@ msgstr "Tri du tableau"
 msgid "controls.section.tableoptions"
 msgstr "Options du tableau"
 
-#: app/configurator/components/chart-configurator.tsx:542
+#: app/configurator/components/chart-configurator.tsx:541
 #: app/configurator/components/chart-type-selector.tsx:139
 #: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
@@ -595,8 +599,8 @@ msgid "controls.select.dimension"
 msgstr "Sélectionner une dimension"
 
 #: app/configurator/components/chart-options-selector.tsx:209
-#: app/configurator/components/chart-options-selector.tsx:640
-#: app/configurator/components/chart-options-selector.tsx:719
+#: app/configurator/components/chart-options-selector.tsx:644
+#: app/configurator/components/chart-options-selector.tsx:723
 msgid "controls.select.measure"
 msgstr "Sélectionner une variable"
 
@@ -607,19 +611,19 @@ msgstr "Sélectionner une variable"
 #~ msgid "controls.select.optional"
 #~ msgstr "optionnel"
 
-#: app/configurator/components/filters.tsx:663
+#: app/configurator/components/filters.tsx:696
 msgid "controls.set-filters"
 msgstr "Appliquer les filtres"
 
-#: app/configurator/components/filters.tsx:670
+#: app/configurator/components/filters.tsx:703
 msgid "controls.set-filters-caption"
 msgstr "Pour de meilleurs résultats, ne sélectionnez pas plus de 7 valeurs dans la visualisation."
 
-#: app/configurator/components/filters.tsx:702
+#: app/configurator/components/filters.tsx:735
 msgid "controls.set-values-apply"
 msgstr "Appliquer les filtres"
 
-#: app/configurator/components/chart-options-selector.tsx:632
+#: app/configurator/components/chart-options-selector.tsx:636
 msgid "controls.size"
 msgstr "Taille"
 
@@ -627,16 +631,22 @@ msgstr "Taille"
 msgid "controls.sorting.addDimension"
 msgstr "Ajouter une dimension"
 
-#: app/configurator/components/chart-options-selector.tsx:500
 #: app/configurator/components/chart-options-selector.tsx:506
+msgid "controls.sorting.byAuto"
+msgstr ""
+
+#: app/configurator/components/chart-options-selector.tsx:500
+#: app/configurator/components/chart-options-selector.tsx:510
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Nom"
 
 #: app/configurator/components/ui-helpers.ts:632
+#: app/configurator/components/ui-helpers.ts:636
 msgid "controls.sorting.byDimensionLabel.ascending"
 msgstr "A → Z"
 
-#: app/configurator/components/ui-helpers.ts:636
+#: app/configurator/components/ui-helpers.ts:640
+#: app/configurator/components/ui-helpers.ts:644
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
@@ -644,11 +654,11 @@ msgstr "Z → A"
 msgid "controls.sorting.byMeasure"
 msgstr "Mesure"
 
-#: app/configurator/components/ui-helpers.ts:656
+#: app/configurator/components/ui-helpers.ts:664
 msgid "controls.sorting.byMeasure.ascending"
 msgstr "1 → 9"
 
-#: app/configurator/components/ui-helpers.ts:660
+#: app/configurator/components/ui-helpers.ts:668
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
@@ -656,19 +666,19 @@ msgstr "9 → 1"
 msgid "controls.sorting.byTotalSize"
 msgstr "Taille totale"
 
-#: app/configurator/components/ui-helpers.ts:640
+#: app/configurator/components/ui-helpers.ts:648
 msgid "controls.sorting.byTotalSize.ascending"
 msgstr "Croissant"
 
-#: app/configurator/components/ui-helpers.ts:652
+#: app/configurator/components/ui-helpers.ts:660
 msgid "controls.sorting.byTotalSize.largestBottom"
 msgstr "Décroissant de bas en haut"
 
-#: app/configurator/components/ui-helpers.ts:644
+#: app/configurator/components/ui-helpers.ts:652
 msgid "controls.sorting.byTotalSize.largestFirst"
 msgstr "Décroissant"
 
-#: app/configurator/components/ui-helpers.ts:648
+#: app/configurator/components/ui-helpers.ts:656
 msgid "controls.sorting.byTotalSize.largestTop"
 msgstr "Décroissant de haut en bas"
 
@@ -844,19 +854,19 @@ msgstr "https://www.bafu.admin.ch/bafu/fr/home.html"
 msgid "footer.status"
 msgstr "Statut"
 
-#: app/components/hint.tsx:189
+#: app/components/hint.tsx:196
 msgid "hint.chartunexpected.message"
 msgstr ""
 
-#: app/components/hint.tsx:187
+#: app/components/hint.tsx:194
 msgid "hint.chartunexpected.title"
 msgstr ""
 
-#: app/components/hint.tsx:175
+#: app/components/hint.tsx:182
 msgid "hint.coordinatesloadingerror.message"
 msgstr "Les données géographiques n’ont pas pu être chargées, merci de réessayer plus tard."
 
-#: app/components/hint.tsx:171
+#: app/components/hint.tsx:178
 msgid "hint.coordinatesloadingerror.title"
 msgstr "Erreur de chargement des coordonnées"
 
@@ -896,15 +906,15 @@ msgstr "Veuillez essayer avec une autre combinaison de filtres."
 msgid "hint.nodata.title"
 msgstr "Il n'y a pas de données correspondant aux filtres sélectionnés"
 
-#: app/components/hint.tsx:211
+#: app/components/hint.tsx:218
 msgid "hint.only.negative.data.message"
 msgstr "Ce type de graphique ne permet pas de représenter des données négatives."
 
-#: app/components/hint.tsx:209
+#: app/components/hint.tsx:216
 msgid "hint.only.negative.data.title"
 msgstr "Valeurs négatives"
 
-#: app/components/hint.tsx:219
+#: app/components/hint.tsx:226
 msgid "hint.publication.success"
 msgstr "Votre visualisation est à présent publiée. Partagez-là en copiant l'URL ou en utilisant les options d'intégration."
 
@@ -977,7 +987,7 @@ msgstr "Voici une visualisation que j'ai créée sur visualize.admin.ch"
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
-#: app/configurator/components/filters.tsx:583
+#: app/configurator/components/filters.tsx:616
 msgid "select.controls.filters.search"
 msgstr "Chercher"
 
@@ -994,7 +1004,7 @@ msgid "table.column.no"
 msgstr "Colonne {0}"
 
 #: app/components/chart-footnotes.tsx:113
-#: app/components/chart-footnotes.tsx:133
+#: app/components/chart-footnotes.tsx:134
 #: app/components/chart-footnotes.tsx:145
 msgid "typography.colon"
 msgstr " : "

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -30,7 +30,7 @@ msgid "Move filter up"
 msgstr "Sposta il filtro in alto"
 
 #: app/configurator/components/dataset-browse.tsx:1027
-#: app/configurator/components/filters.tsx:681
+#: app/configurator/components/filters.tsx:714
 msgid "No results"
 msgstr "Nessun risultato"
 
@@ -145,16 +145,16 @@ msgstr "Aree"
 #~ msgstr "Intervalli uguali"
 
 #: app/configurator/components/chart-configurator.tsx:696
-#: app/configurator/components/chart-options-selector.tsx:992
+#: app/configurator/components/chart-options-selector.tsx:996
 #: app/configurator/components/ui-helpers.ts:616
 msgid "chart.map.layers.base"
 msgstr "Visualizzazione della mappa"
 
-#: app/configurator/components/chart-options-selector.tsx:996
+#: app/configurator/components/chart-options-selector.tsx:1000
 msgid "chart.map.layers.base.show"
 msgstr "Mostra mappa del mondo"
 
-#: app/configurator/components/chart-options-selector.tsx:1005
+#: app/configurator/components/chart-options-selector.tsx:1009
 msgid "chart.map.layers.base.view.locked"
 msgstr "Vista bloccata"
 
@@ -204,7 +204,7 @@ msgstr "Grassetto"
 msgid "columnStyle.textStyle.regular"
 msgstr "Regular"
 
-#: app/configurator/interactive-filters/editor-time-brush.tsx:172
+#: app/configurator/interactive-filters/editor-time-brush.tsx:173
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Impostazioni predefinite"
 
@@ -216,39 +216,39 @@ msgstr "Asse orizzontale"
 msgid "controls.axis.vertical"
 msgstr "Asse verticale"
 
-#: app/configurator/components/ui-helpers.ts:692
+#: app/configurator/components/ui-helpers.ts:700
 msgid "controls.chart.type.area"
 msgstr "Aree"
 
-#: app/configurator/components/ui-helpers.ts:684
+#: app/configurator/components/ui-helpers.ts:692
 msgid "controls.chart.type.bar"
 msgstr "Barre"
 
-#: app/configurator/components/ui-helpers.ts:680
+#: app/configurator/components/ui-helpers.ts:688
 msgid "controls.chart.type.column"
 msgstr "Colonne"
 
-#: app/configurator/components/ui-helpers.ts:688
+#: app/configurator/components/ui-helpers.ts:696
 msgid "controls.chart.type.line"
 msgstr "Linee"
 
-#: app/configurator/components/ui-helpers.ts:708
+#: app/configurator/components/ui-helpers.ts:716
 msgid "controls.chart.type.map"
 msgstr "Mappa"
 
-#: app/configurator/components/ui-helpers.ts:700
+#: app/configurator/components/ui-helpers.ts:708
 msgid "controls.chart.type.pie"
 msgstr "Torta"
 
-#: app/configurator/components/ui-helpers.ts:696
+#: app/configurator/components/ui-helpers.ts:704
 msgid "controls.chart.type.scatterplot"
 msgstr "Scatterplot"
 
-#: app/configurator/components/ui-helpers.ts:704
+#: app/configurator/components/ui-helpers.ts:712
 msgid "controls.chart.type.table"
 msgstr "Tabella"
 
-#: app/configurator/components/chart-options-selector.tsx:714
+#: app/configurator/components/chart-options-selector.tsx:718
 #: app/configurator/components/ui-helpers.ts:602
 msgid "controls.color"
 msgstr "Colore"
@@ -257,7 +257,7 @@ msgstr "Colore"
 msgid "controls.color.add"
 msgstr "Aggiungi ..."
 
-#: app/configurator/components/chart-options-selector.tsx:745
+#: app/configurator/components/chart-options-selector.tsx:749
 msgid "controls.color.opacity"
 msgstr "Trasparenza"
 
@@ -278,39 +278,39 @@ msgstr "Ripristina la tavolozza dei colori"
 msgid "controls.color.palette.sequential"
 msgstr "Sequenziale"
 
-#: app/configurator/components/chart-options-selector.tsx:836
+#: app/configurator/components/chart-options-selector.tsx:840
 msgid "controls.color.scale.discretization.jenks"
 msgstr "Jenks (interruzioni naturali)"
 
-#: app/configurator/components/chart-options-selector.tsx:829
+#: app/configurator/components/chart-options-selector.tsx:833
 msgid "controls.color.scale.discretization.quantiles"
 msgstr "Quantili (distribuzione omogenea dei valori)"
 
-#: app/configurator/components/chart-options-selector.tsx:822
+#: app/configurator/components/chart-options-selector.tsx:826
 msgid "controls.color.scale.discretization.quantize"
 msgstr "Intervalli uguali"
 
-#: app/configurator/components/chart-options-selector.tsx:814
+#: app/configurator/components/chart-options-selector.tsx:818
 msgid "controls.color.scale.interpolation"
 msgstr "Interpolazione"
 
-#: app/configurator/components/chart-options-selector.tsx:847
+#: app/configurator/components/chart-options-selector.tsx:851
 msgid "controls.color.scale.number.of.classes"
 msgstr "Numero di classi"
 
-#: app/configurator/components/chart-options-selector.tsx:784
+#: app/configurator/components/chart-options-selector.tsx:788
 msgid "controls.color.scale.type.continuous"
 msgstr "Continuo"
 
-#: app/configurator/components/chart-options-selector.tsx:796
+#: app/configurator/components/chart-options-selector.tsx:800
 msgid "controls.color.scale.type.discrete"
 msgstr "Discreto"
 
-#: app/configurator/components/chart-options-selector.tsx:734
+#: app/configurator/components/chart-options-selector.tsx:738
 msgid "controls.color.select"
 msgstr "Seleziona un colore"
 
-#: app/configurator/components/chart-controls/color-picker.tsx:186
+#: app/configurator/components/chart-controls/color-picker.tsx:183
 msgid "controls.colorpicker.open"
 msgstr "Apri il selettore di colore"
 
@@ -340,33 +340,37 @@ msgstr "Descrizione"
 msgid "controls.dimensionvalue.none"
 msgstr "Nessun filtro"
 
-#: app/configurator/components/filters.tsx:431
+#: app/configurator/components/filters.tsx:464
 msgid "controls.filter.nb-elements"
 msgstr "{0} di {1}"
 
-#: app/configurator/components/filters.tsx:385
-#: app/configurator/components/filters.tsx:609
+#: app/configurator/components/filters.tsx:396
+#: app/configurator/components/filters.tsx:642
 msgid "controls.filter.select.all"
 msgstr "Seleziona tutti"
 
-#: app/configurator/components/filters.tsx:392
-#: app/configurator/components/filters.tsx:607
+#: app/configurator/components/filters.tsx:403
+#: app/configurator/components/filters.tsx:640
 msgid "controls.filter.select.none"
 msgstr "Deseleziona tutto"
 
-#: app/configurator/components/filters.tsx:402
+#: app/configurator/components/filters.tsx:413
 msgid "controls.filters.select.filters"
 msgstr "Filtri"
 
-#: app/configurator/components/filters.tsx:415
+#: app/configurator/components/filters.tsx:445
 msgid "controls.filters.select.refresh-colors"
 msgstr "Aggiorna i colori"
 
-#: app/configurator/components/filters.tsx:409
+#: app/configurator/components/filters.tsx:427
+msgid "controls.filters.select.reset-colors"
+msgstr "Reimpostare i colori"
+
+#: app/configurator/components/filters.tsx:420
 msgid "controls.filters.select.selected-filters"
 msgstr "Filtri selezionati"
 
-#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:127
+#: app/configurator/interactive-filters/editor-time-interval-brush.tsx:129
 msgid "controls.filters.time.range"
 msgstr "intervallo di tempo"
 
@@ -390,23 +394,23 @@ msgstr "Seleziona un elemento di design o una dimensione dei dati per modificarn
 msgid "controls.hint.describing.chart"
 msgstr "Seleziona una delle annotazioni proposte per modificarla."
 
-#: app/configurator/components/ui-helpers.ts:664
+#: app/configurator/components/ui-helpers.ts:672
 msgid "controls.imputation"
 msgstr "Tipo di imputazione"
 
-#: app/configurator/components/chart-options-selector.tsx:883
-#: app/configurator/components/ui-helpers.ts:676
+#: app/configurator/components/chart-options-selector.tsx:887
+#: app/configurator/components/ui-helpers.ts:684
 msgid "controls.imputation.type.linear"
 msgstr "Interpolazione lineare"
 
-#: app/configurator/components/chart-options-selector.tsx:876
-#: app/configurator/components/chart-options-selector.tsx:888
-#: app/configurator/components/ui-helpers.ts:668
+#: app/configurator/components/chart-options-selector.tsx:880
+#: app/configurator/components/chart-options-selector.tsx:892
+#: app/configurator/components/ui-helpers.ts:676
 msgid "controls.imputation.type.none"
 msgstr "-"
 
-#: app/configurator/components/chart-options-selector.tsx:878
-#: app/configurator/components/ui-helpers.ts:672
+#: app/configurator/components/chart-options-selector.tsx:882
+#: app/configurator/components/ui-helpers.ts:680
 msgid "controls.imputation.type.zeros"
 msgstr "Zeri"
 
@@ -430,19 +434,19 @@ msgstr "Nessuna dimensione temporale disponibile!"
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Mostra i filtri temporali"
 
-#: app/configurator/components/ui-helpers.ts:712
+#: app/configurator/components/ui-helpers.ts:720
 msgid "controls.language.english"
 msgstr "Inglese"
 
-#: app/configurator/components/ui-helpers.ts:720
+#: app/configurator/components/ui-helpers.ts:728
 msgid "controls.language.french"
 msgstr "Francese"
 
-#: app/configurator/components/ui-helpers.ts:716
+#: app/configurator/components/ui-helpers.ts:724
 msgid "controls.language.german"
 msgstr "Tedesco"
 
-#: app/configurator/components/ui-helpers.ts:724
+#: app/configurator/components/ui-helpers.ts:732
 msgid "controls.language.italian"
 msgstr "Italiano"
 
@@ -467,7 +471,7 @@ msgstr "Attivo"
 msgid "controls.option.isNotActive"
 msgstr "Inattivo"
 
-#: app/configurator/components/chart-options-selector.tsx:777
+#: app/configurator/components/chart-options-selector.tsx:781
 msgid "controls.scale.type"
 msgstr "Tipo di scala"
 
@@ -512,11 +516,11 @@ msgstr "Filtro"
 msgid "controls.section.groups"
 msgstr "Gruppi"
 
-#: app/configurator/components/chart-options-selector.tsx:917
+#: app/configurator/components/chart-options-selector.tsx:921
 msgid "controls.section.imputation"
 msgstr "Valori mancanti"
 
-#: app/configurator/components/chart-options-selector.tsx:922
+#: app/configurator/components/chart-options-selector.tsx:926
 msgid "controls.section.imputation.explanation"
 msgstr "Per questo tipo di grafico, i valori di sostituzione devono essere assegnati ai valori mancanti. Decidi la logica di imputazione o passa a un altro tipo di grafico."
 
@@ -532,7 +536,7 @@ msgstr "Filtri di dati"
 msgid "controls.section.show-standard-error"
 msgstr "Mostra l'errore standard"
 
-#: app/configurator/components/chart-options-selector.tsx:550
+#: app/configurator/components/chart-options-selector.tsx:554
 msgid "controls.section.sorting"
 msgstr "Ordina"
 
@@ -548,7 +552,7 @@ msgstr "Ordinamento della tabella"
 msgid "controls.section.tableoptions"
 msgstr "Opzioni della tabella"
 
-#: app/configurator/components/chart-configurator.tsx:542
+#: app/configurator/components/chart-configurator.tsx:541
 #: app/configurator/components/chart-type-selector.tsx:139
 #: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
@@ -595,8 +599,8 @@ msgid "controls.select.dimension"
 msgstr "Seleziona una dimensione"
 
 #: app/configurator/components/chart-options-selector.tsx:209
-#: app/configurator/components/chart-options-selector.tsx:640
-#: app/configurator/components/chart-options-selector.tsx:719
+#: app/configurator/components/chart-options-selector.tsx:644
+#: app/configurator/components/chart-options-selector.tsx:723
 msgid "controls.select.measure"
 msgstr "Seleziona una misura"
 
@@ -607,19 +611,19 @@ msgstr "Seleziona una misura"
 #~ msgid "controls.select.optional"
 #~ msgstr "facoltativo"
 
-#: app/configurator/components/filters.tsx:663
+#: app/configurator/components/filters.tsx:696
 msgid "controls.set-filters"
 msgstr "Filtrer"
 
-#: app/configurator/components/filters.tsx:670
+#: app/configurator/components/filters.tsx:703
 msgid "controls.set-filters-caption"
 msgstr "Pour de meilleurs résultats, ne sélectionnez pas plus de 7 valeurs dans la visualisation"
 
-#: app/configurator/components/filters.tsx:702
+#: app/configurator/components/filters.tsx:735
 msgid "controls.set-values-apply"
 msgstr "Appliquer les filtres"
 
-#: app/configurator/components/chart-options-selector.tsx:632
+#: app/configurator/components/chart-options-selector.tsx:636
 msgid "controls.size"
 msgstr "Grandezza"
 
@@ -627,16 +631,22 @@ msgstr "Grandezza"
 msgid "controls.sorting.addDimension"
 msgstr "Aggiungi una dimensione"
 
-#: app/configurator/components/chart-options-selector.tsx:500
 #: app/configurator/components/chart-options-selector.tsx:506
+msgid "controls.sorting.byAuto"
+msgstr ""
+
+#: app/configurator/components/chart-options-selector.tsx:500
+#: app/configurator/components/chart-options-selector.tsx:510
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Nome"
 
 #: app/configurator/components/ui-helpers.ts:632
+#: app/configurator/components/ui-helpers.ts:636
 msgid "controls.sorting.byDimensionLabel.ascending"
 msgstr "A → Z"
 
-#: app/configurator/components/ui-helpers.ts:636
+#: app/configurator/components/ui-helpers.ts:640
+#: app/configurator/components/ui-helpers.ts:644
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
@@ -644,11 +654,11 @@ msgstr "Z → A"
 msgid "controls.sorting.byMeasure"
 msgstr "Misura"
 
-#: app/configurator/components/ui-helpers.ts:656
+#: app/configurator/components/ui-helpers.ts:664
 msgid "controls.sorting.byMeasure.ascending"
 msgstr "1 → 9"
 
-#: app/configurator/components/ui-helpers.ts:660
+#: app/configurator/components/ui-helpers.ts:668
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
@@ -656,19 +666,19 @@ msgstr "9 → 1"
 msgid "controls.sorting.byTotalSize"
 msgstr "Grandezza totale"
 
-#: app/configurator/components/ui-helpers.ts:640
+#: app/configurator/components/ui-helpers.ts:648
 msgid "controls.sorting.byTotalSize.ascending"
 msgstr "Il più grande per ultimo"
 
-#: app/configurator/components/ui-helpers.ts:652
+#: app/configurator/components/ui-helpers.ts:660
 msgid "controls.sorting.byTotalSize.largestBottom"
 msgstr "Il più grande sotto"
 
-#: app/configurator/components/ui-helpers.ts:644
+#: app/configurator/components/ui-helpers.ts:652
 msgid "controls.sorting.byTotalSize.largestFirst"
 msgstr "Il più grande per primo"
 
-#: app/configurator/components/ui-helpers.ts:648
+#: app/configurator/components/ui-helpers.ts:656
 msgid "controls.sorting.byTotalSize.largestTop"
 msgstr "Il più grande sopra"
 
@@ -844,19 +854,19 @@ msgstr "https://www.bafu.admin.ch/bafu/it/home.html"
 msgid "footer.status"
 msgstr "Stato"
 
-#: app/components/hint.tsx:189
+#: app/components/hint.tsx:196
 msgid "hint.chartunexpected.message"
 msgstr ""
 
-#: app/components/hint.tsx:187
+#: app/components/hint.tsx:194
 msgid "hint.chartunexpected.title"
 msgstr ""
 
-#: app/components/hint.tsx:175
+#: app/components/hint.tsx:182
 msgid "hint.coordinatesloadingerror.message"
 msgstr "C'è stato un problema con il caricamento delle coordinate dalle dimensioni geografiche. Per favore riprova più tardi."
 
-#: app/components/hint.tsx:171
+#: app/components/hint.tsx:178
 msgid "hint.coordinatesloadingerror.title"
 msgstr "Errore di caricamento delle coordinate"
 
@@ -896,15 +906,15 @@ msgstr "Prova con un'altra combinazione di filtri."
 msgid "hint.nodata.title"
 msgstr "Non ci sono dati corrispondenti ai filtri selezionati"
 
-#: app/components/hint.tsx:211
+#: app/components/hint.tsx:218
 msgid "hint.only.negative.data.message"
 msgstr "Dati con valori negativi non possono essere visualizzati con questo tipo di grafico."
 
-#: app/components/hint.tsx:209
+#: app/components/hint.tsx:216
 msgid "hint.only.negative.data.title"
 msgstr "Valori negativi"
 
-#: app/components/hint.tsx:219
+#: app/components/hint.tsx:226
 msgid "hint.publication.success"
 msgstr "La tua visualizzazione è ora pubblicata. Condividila copiando l'URL o utilizzando le opzioni di incorporamento."
 
@@ -977,7 +987,7 @@ msgstr "Ecco una visualizzazione che ho creato usando visualize.admin.ch"
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
-#: app/configurator/components/filters.tsx:583
+#: app/configurator/components/filters.tsx:616
 msgid "select.controls.filters.search"
 msgstr "Cerca"
 
@@ -994,7 +1004,7 @@ msgid "table.column.no"
 msgstr "Colonna {0}"
 
 #: app/components/chart-footnotes.tsx:113
-#: app/components/chart-footnotes.tsx:133
+#: app/components/chart-footnotes.tsx:134
 #: app/components/chart-footnotes.tsx:145
 msgid "typography.colon"
 msgstr ": "


### PR DESCRIPTION
Refreshing of colors in multi filter panel wasn't working for map's area layer – this PR makes the handling of color mapping updates more generic (by using `field` + `colorPathField`).

It also introduces a distinction between reshuffling colors (default) and resetting colors (when a dimension has pre-defined colors coming from LINDAS).