### PR TITLE
Show contents of urql panel in PROD

### DIFF
--- a/app/gql-flamegraph/devtool.tsx
+++ b/app/gql-flamegraph/devtool.tsx
@@ -407,23 +407,13 @@ export const urqlEE = mitt<{
 }>();
 
 export const gqlFlamegraphExchange: Exchange = ({ forward }) => {
-  if (process.env.NODE_ENV === "production") {
-    return (ops$) => forward(ops$);
-  } else {
-    return (ops$) =>
-      pipe(
-        ops$,
-        tap((operation) =>
-          // eslint-disable-next-line no-console
-          urqlEE.emit("urql-received-operation", operation)
-        ),
-        forward,
-        tap((result) =>
-          // eslint-disable-next-line no-console
-          urqlEE.emit("urql-received-result", result)
-        )
-      );
-  }
+  return (ops$) =>
+    pipe(
+      ops$,
+      tap((operation) => urqlEE.emit("urql-received-operation", operation)),
+      forward,
+      tap((result) => urqlEE.emit("urql-received-result", result))
+    );
 };
 
 export default GqlDebug;

--- a/app/graphql/client.tsx
+++ b/app/graphql/client.tsx
@@ -6,8 +6,5 @@ import { devtoolsExchanges } from "@/graphql/devtools";
 
 export const client = createClient({
   url: GRAPHQL_ENDPOINT,
-  exchanges:
-    process.env.NODE_ENV === "development"
-      ? [...devtoolsExchanges, ...defaultExchanges]
-      : [...defaultExchanges],
+  exchanges: [...devtoolsExchanges, ...defaultExchanges],
 });

--- a/app/graphql/devtools.prod.ts
+++ b/app/graphql/devtools.prod.ts
@@ -1,1 +1,3 @@
-export const devtoolsExchanges = [];
+import { gqlFlamegraphExchange } from "@/gql-flamegraph/devtool";
+
+export const devtoolsExchanges = [gqlFlamegraphExchange];


### PR DESCRIPTION
- [x] Edit: this doesn't seem to do the trick, needs further investigation
- [x] gql flamegraph exchange is activated on production
- [x] The urql devtool was guarded on process.env.NODE_ENV === 'development' at two places, via the .dev / .prod technique and inside the the client creation. Now it's only done via the .dev / .prod technique. We prefer the .dev / .prod technique so that in production the urql devtools are not bundled.