### PR TITLE
fix: Use proper label for undefined namedNodes when fetching observations

### DIFF
--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -704,11 +704,15 @@ function parseObservation(
     return Object.fromEntries(
       cubeDimensions.map((d) => {
         const label = obs[labelDimensionIri(d.data.iri)]?.value;
+        const termType = obs[d.data.iri]?.termType;
 
         const value =
-          obs[d.data.iri]?.termType === "Literal" &&
+          termType === "Literal" &&
           ns.cube.Undefined.equals((obs[d.data.iri] as Literal)?.datatype)
             ? null
+            : termType === "NamedNode" &&
+              ns.cube.Undefined.equals(obs[d.data.iri])
+            ? "–"
             : obs[d.data.iri]?.value;
 
         const rawValue = parseObservationValue({ value: obs[d.data.iri] });


### PR DESCRIPTION
When we fetch dimension values, we treat undefined values as

`{ value: "https://cube.link/Undefined", label: "–" }`,

while when we fetch observations, we do

`{ value: "https://cube.link/Undefined", label: "https://cube.link/Undefined" }`,

which can lead to some unexpected bugs. This PR fixes that by using a proper label for such cases (-).