### PR TITLE
fix: Color field filters not cleared when switching dimensions

### DIFF
--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -397,7 +397,7 @@ const MultiFilterContent = ({
   }, [colorConfigPath, config, dimensionIri, colorComponent]);
 
   const hasDefaultColors = useMemo(() => {
-    return colorComponent?.values?.[0].color !== undefined;
+    return colorComponent?.values?.[0]?.color !== undefined;
   }, [colorComponent?.values]);
 
   return (

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -18,6 +18,7 @@ import {
   deriveFiltersFromFields,
   getFiltersByMappingStatus,
   getLocalStorageKey,
+  handleChartOptionChanged,
   initChartStateFromChart,
   initChartStateFromCube,
   initChartStateFromLocalStorage,
@@ -686,5 +687,74 @@ describe("colorMapping", () => {
       green: "green",
       blue: "blue",
     });
+  });
+});
+
+describe("handleChartOptionChanged", () => {
+  jest.mock("@/graphql/client", () => ({
+    readQuery: () => {
+      return {
+        dimensions: [
+          {
+            iri: "newAreaLayerColorIri",
+            values: [{ value: "orange", label: "orange" }],
+          },
+        ],
+      };
+    },
+  }));
+
+  it("should reset previous color filters", () => {
+    const state = {
+      state: "CONFIGURING_CHART",
+      dataSet: "mapDataset",
+      dataSource: {
+        type: "sparql",
+        url: "fakeUrl",
+      },
+      chartConfig: {
+        fields: {
+          areaLayer: {
+            componentIri: "areaLayerIri",
+            color: {
+              type: "categorical",
+              componentIri: "areaLayerColorIri",
+              palette: "oranges",
+              colorMapping: {
+                red: "green",
+                green: "blue",
+                blue: "red",
+              },
+            },
+          },
+        },
+        filters: {
+          areaLayerColorIri: {
+            type: "multi",
+            values: {
+              red: true,
+              green: true,
+            },
+          },
+        },
+      },
+    };
+
+    handleChartOptionChanged(
+      state as unknown as ConfiguratorStateConfiguringChart,
+      {
+        type: "CHART_OPTION_CHANGED",
+        value: {
+          locale: "en",
+          field: "areaLayer",
+          path: "color.componentIri",
+          value: "newAreaLayerColorIri",
+        },
+      }
+    );
+
+    expect(Object.keys(state.chartConfig.filters)).not.toContain(
+      "areaLayerColorIri"
+    );
   });
 });

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -949,6 +949,15 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
               setWith(draft, nbClassPath, 3, Object);
             }
           } else if (action.value.path === "color.componentIri") {
+            const fieldIri = get(
+              draft,
+              `chartConfig.fields.${action.value.field}.componentIri`
+            );
+            const previousComponentIri = get(
+              draft,
+              `chartConfig.fields.${action.value.field}.color.componentIri`
+            ) as string;
+
             const allComponents = [
               ...action.value.dataSetMetadata.dimensions,
               ...action.value.dataSetMetadata.measures,
@@ -956,6 +965,11 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
             const component = allComponents.find(
               (d) => d.iri === action.value.value
             );
+
+            // Clear old filters when switching to a new component.
+            if (previousComponentIri !== fieldIri) {
+              unset(draft, `chartConfig.filters["${previousComponentIri}"]`);
+            }
 
             if (!component) {
               setWith(
@@ -965,20 +979,12 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
                 Object
               );
             } else {
-              const previousComponentIri = get(
-                draft,
-                `chartConfig.fields.${action.value.field}.color.componentIri`
-              );
               const previousComponent = allComponents.find(
                 (d) => d.iri === previousComponentIri
               );
               const previousPalette = get(
                 draft,
                 `chartConfig.fields.${action.value.field}.color.palette`
-              );
-              const fieldIri = get(
-                draft,
-                `chartConfig.fields.${action.value.field}.componentIri`
               );
 
               if (
@@ -1000,10 +1006,6 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
                   },
                   Object
                 );
-
-                if (fieldIri === component.iri) {
-                  unset(draft, `chartConfig.filters["${component.iri}"]`);
-                }
               } else if (isNumericalMeasure(component)) {
                 if (
                   (previousComponent &&


### PR DESCRIPTION
Fixes #803.

The filters created by a new color field weren't cleared when switching to a new color dimension. This PR fixes that.

Additionally, it fixes another bug that appeared when no dimension values were selected (undefined color assessor) + it adds fetching of un-filtered dimensions and measures to be used as `dataSetMetadata` (as in general, we need unfiltered values in configurator state).