### PR TITLE
fix: Crashing of charts when selecting component "too fast"

### DIFF
--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -1,4 +1,6 @@
 import { t } from "@lingui/macro";
+import { CircularProgress, Theme } from "@mui/material";
+import { makeStyles } from "@mui/styles";
 import { extent, timeFormat, TimeLocaleObject, timeParse } from "d3";
 import get from "lodash/get";
 import { ChangeEvent, ReactNode, useCallback, useMemo, useState } from "react";
@@ -52,6 +54,15 @@ import { DimensionMetadataFragment, TimeUnit } from "@/graphql/query-hooks";
 import { IconName } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
 import { getPalette } from "@/palettes";
+
+const useStyles = makeStyles<Theme>((theme) => ({
+  loadingIndicator: {
+    color: theme.palette.grey[700],
+    display: "inline-block",
+    marginTop: theme.spacing(1),
+    marginLeft: theme.spacing(2),
+  },
+}));
 
 export const ControlTabField = ({
   component,
@@ -625,7 +636,8 @@ export const ChartFieldField = ({
   optional?: boolean;
   disabled?: boolean;
 }) => {
-  const fieldProps = useChartFieldField({ field });
+  const classes = useStyles();
+  const { fetching, ...fieldProps } = useChartFieldField({ field });
 
   const noneLabel = t({
     id: "controls.dimension.none",
@@ -641,8 +653,21 @@ export const ChartFieldField = ({
     <Select
       key={`select-${field}-dimension`}
       id={field}
-      label={optional ? `${label} (${optionalLabel})` : label}
-      disabled={disabled}
+      label={
+        <>
+          {optional ? (
+            <span>
+              {label} ({optionalLabel})
+            </span>
+          ) : (
+            <span>{label}</span>
+          )}
+          {fetching ? (
+            <CircularProgress size={12} className={classes.loadingIndicator} />
+          ) : null}
+        </>
+      }
+      disabled={disabled || fetching}
       options={
         optional
           ? [

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -41,6 +41,39 @@ jest.mock("@/utils/chart-config/exchange", () => ({
   fetchChartConfig: jest.fn(),
 }));
 
+jest.mock("@/graphql/client", () => {
+  return {
+    client: {
+      readQuery: () => {
+        return {
+          data: {
+            dataCubeByIri: {
+              dimensions: [
+                {
+                  __typename: "GeoShapesDimension",
+                  iri: "newAreaLayerColorIri",
+                  values: [{ value: "orange", label: "orange" }],
+                },
+                {
+                  __typename: "GeoCoordinatesDimension",
+                  iri: "symbolLayerIri",
+                  values: [{ value: "x", label: "y" }],
+                },
+              ],
+              measures: [
+                {
+                  __typename: "NumericalMeasure",
+                  iri: "measure",
+                },
+              ],
+            },
+          },
+        };
+      },
+    },
+  };
+});
+
 afterEach(() => {
   jest.restoreAllMocks();
 });
@@ -692,23 +725,6 @@ describe("colorMapping", () => {
 });
 
 describe("handleChartFieldChanged", () => {
-  jest.mock("@/graphql/client", () => ({
-    readQuery: () => {
-      return {
-        dimensions: [
-          {
-            iri: "newAreaLayerColorIri",
-            values: [{ value: "orange", label: "orange" }],
-          },
-          {
-            iri: "symbolLayerIri",
-            values: [{ value: "x", label: "y" }],
-          },
-        ],
-      };
-    },
-  }));
-
   it("should not reset symbol layer when it's being updated", () => {
     const state = {
       state: "CONFIGURING_CHART",
@@ -755,23 +771,6 @@ describe("handleChartFieldChanged", () => {
 });
 
 describe("handleChartOptionChanged", () => {
-  jest.mock("@/graphql/client", () => ({
-    readQuery: () => {
-      return {
-        dimensions: [
-          {
-            iri: "newAreaLayerColorIri",
-            values: [{ value: "orange", label: "orange" }],
-          },
-          {
-            iri: "symbolLayerIri",
-            values: [{ value: "x", label: "y" }],
-          },
-        ],
-      };
-    },
-  }));
-
   it("should reset previous color filters", () => {
     const state = {
       state: "CONFIGURING_CHART",

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -727,16 +727,13 @@ const handleChartFieldChanged = (
     // optionalFields = ['segment', 'areaLayer', 'symbolLayer'],
     // should be reflected in chart encodings
     if (field === "segment") {
-      const colorMapping =
-        component?.values &&
-        mapValueIrisToColor({
-          palette: DEFAULT_PALETTE,
-          dimensionValues: component?.values,
-        });
-
       // FIXME: This should be more chart specific
       // (no "stacked" for scatterplots for instance)
       if (isSegmentInConfig(draft.chartConfig)) {
+        const colorMapping = mapValueIrisToColor({
+          palette: DEFAULT_PALETTE,
+          dimensionValues: component?.values || [],
+        });
         draft.chartConfig.filters[componentIri] = {
           type: "multi",
           values: Object.fromEntries(
@@ -744,12 +741,12 @@ const handleChartFieldChanged = (
           ),
         };
         draft.chartConfig.fields.segment = {
-          componentIri: componentIri,
+          componentIri,
           palette: DEFAULT_PALETTE,
           // Type exists only within column charts.
           ...(isColumnConfig(draft.chartConfig) && { type: "stacked" }),
           sorting: DEFAULT_SORTING,
-          colorMapping: colorMapping,
+          colorMapping,
         };
       }
 
@@ -785,12 +782,10 @@ const handleChartFieldChanged = (
       draft.chartConfig.fields.segment &&
       "palette" in draft.chartConfig.fields.segment
     ) {
-      const colorMapping =
-        component &&
-        mapValueIrisToColor({
-          palette: draft.chartConfig.fields.segment.palette || DEFAULT_PALETTE,
-          dimensionValues: component?.values,
-        });
+      const colorMapping = mapValueIrisToColor({
+        palette: draft.chartConfig.fields.segment.palette || DEFAULT_PALETTE,
+        dimensionValues: component?.values || [],
+      });
 
       draft.chartConfig.fields.segment.componentIri = componentIri;
       draft.chartConfig.fields.segment.colorMapping = colorMapping;
@@ -803,7 +798,7 @@ const handleChartFieldChanged = (
     } else {
       // Reset other field options
       (draft.chartConfig.fields as GenericFields)[field] = {
-        componentIri: componentIri,
+        componentIri,
       };
       // if x !== time, also deactivate interactive time filter
       if (


### PR DESCRIPTION
Fixes #788.

In some rare scenarios, user could re-select (or select another dimension) of a field that was still being computed.

In such cases, we would trigger an "update" of a field, which by default cleared all the contents of a field, keeping only `componentIri`, which led to errors with the map charts, as in other places we were expecting `(area | symbol)Layer.color` to be defined.

This PR fixes this issue by populating the color field for map charts while the field is updated.

I am not 100% happy with this solution, as ideally we should set the select value immediately and fetch the hierarchies afterwards (as the part that makes the selection slow is [this part](https://github.com/visualize-admin/visualization-tool/blob/main/app/configurator/config-form.tsx#L79-L95), which fetches the hierarchy before sending update event). I tried to make it work by first sending an `CHART_FIELD_CHANGED` event with `selectedValues: []`, then querying hierarchies with subsequent event sent after they are fetched, but there were also some problems with this approach and I still think it should be done better 😅 

Let me know if you have better ideas on how to handle this – maybe it needs a bigger refactor?

Edit: I've additionally disabled select element when hierarchies are being fetched.