### PR TITLE
feat: Refinements to table column styles

### DIFF
--- a/app/charts/shared/colors.tsx
+++ b/app/charts/shared/colors.tsx
@@ -1,5 +1,8 @@
 import { color, RGBColor } from "d3";
 
+import { DimensionValue } from "@/domain/data";
+import { DimensionMetadataFragment } from "@/graphql/query-hooks";
+
 export const colorToRgbArray = (_color: string, opacity?: number): number[] => {
   const { r, g, b } = color(_color) as RGBColor;
 
@@ -17,4 +20,12 @@ export const rgbArrayToHex = (rgbArray: number[]): string => {
         `You need to pass 3 or 4 arguments when converting RGB array to HEX, while ${rgbArray.length} were provided.`
       );
   }
+};
+
+export const hasDimensionColors = (
+  d?: DimensionMetadataFragment
+): d is DimensionMetadataFragment => {
+  return !!(d?.values as DimensionValue[] | undefined)?.some(
+    (d) => d.color !== undefined
+  );
 };

--- a/app/charts/table/table-state.tsx
+++ b/app/charts/table/table-state.tsx
@@ -34,7 +34,6 @@ import {
 } from "@/configurator/components/ui-helpers";
 import { Observation } from "@/domain/data";
 import { useFormatNumber, useDimensionFormatters } from "@/formatters";
-import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 import { getColorInterpolator } from "@/palettes";
 import { useTheme } from "@/themes";
 import { estimateTextWidth } from "@/utils/estimate-text-width";
@@ -281,9 +280,7 @@ const useTableState = ({
           return common as TextColumnMeta;
         } else if (columnStyleType === "category") {
           const { colorMapping } = columnStyle as ColumnStyleCategory;
-          const dimension = dimensions.find(
-            (d) => d.iri === iri
-          ) as DimensionMetadataFragment;
+          const dimension = allColumnsByIri[iri];
 
           // Color scale (always from colorMappings)
           const colorScale = scaleOrdinal<string>();

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -33,6 +33,7 @@ import React, {
   useState,
 } from "react";
 
+import { hasDimensionColors } from "@/charts/shared/colors";
 import Flex from "@/components/flex";
 import { Loading } from "@/components/hint";
 import {
@@ -396,9 +397,9 @@ const MultiFilterContent = ({
     );
   }, [colorConfigPath, config, dimensionIri, colorComponent]);
 
-  const hasDefaultColors = useMemo(() => {
-    return colorComponent?.values?.[0]?.color !== undefined;
-  }, [colorComponent?.values]);
+  const hasColors = useMemo(() => {
+    return hasDimensionColors(colorComponent);
+  }, [colorComponent]);
 
   return (
     <Box sx={{ position: "relative" }}>
@@ -438,7 +439,7 @@ const MultiFilterContent = ({
               Selected filters
             </Trans>
             {hasColorMapping ? (
-              hasDefaultColors ? (
+              hasColors ? (
                 <Tooltip
                   title={
                     <Trans id="controls.filters.select.reset-colors">

--- a/app/configurator/components/ui-helpers.ts
+++ b/app/configurator/components/ui-helpers.ts
@@ -211,7 +211,9 @@ export const mapValueIrisToColor = ({
 
   const paletteValues = getPalette(palette);
   const colors = dimensionValues.map(
-    (d, i) => d.color || paletteValues[i % paletteValues.length]
+    (d, i) =>
+      (palette === "dimension" && d.color) ||
+      paletteValues[i % paletteValues.length]
   );
   const colorScale = scaleOrdinal<string, string>()
     .domain(dimensionValues.map((d) => `${d.value}`))

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -655,7 +655,7 @@ describe("colorMapping", () => {
             color: {
               type: "categorical",
               componentIri: "areaLayerColorIri",
-              palette: "oranges",
+              palette: "dimension",
               colorMapping: {
                 red: "green",
                 green: "blue",
@@ -719,7 +719,7 @@ describe("handleChartOptionChanged", () => {
             color: {
               type: "categorical",
               componentIri: "areaLayerColorIri",
-              palette: "oranges",
+              palette: "dimension",
               colorMapping: {
                 red: "green",
                 green: "blue",

--- a/app/configurator/table/table-chart-options.tsx
+++ b/app/configurator/table/table-chart-options.tsx
@@ -43,6 +43,7 @@ import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 import { DataCubeMetadata } from "@/graphql/types";
 import {
   getDefaultCategoricalPalette,
+  getDefaultCategoricalPaletteName,
   getDefaultDivergingSteppedPalette,
 } from "@/palettes";
 
@@ -256,12 +257,14 @@ export const TableColumnOptions = ({
                       columnColor: "#fff",
                     };
                   case "category":
+                    const palette = getDefaultCategoricalPaletteName(component);
+
                     return {
                       type: "category",
                       textStyle: "regular",
-                      palette: getDefaultCategoricalPalette().value,
+                      palette,
                       colorMapping: mapValueIrisToColor({
-                        palette: getDefaultCategoricalPalette().value,
+                        palette,
                         dimensionValues: (
                           component as DimensionMetadataFragment
                         )?.values,
@@ -416,7 +419,7 @@ const ColumnStyleSubOptions = ({
         <>
           <ColorPalette
             field={activeField}
-            colorConfigPath={"columnStyle"}
+            colorConfigPath="columnStyle"
             component={component}
           />
         </>
@@ -424,7 +427,7 @@ const ColumnStyleSubOptions = ({
         <>
           <ColorPalette
             field={activeField}
-            colorConfigPath={"columnStyle"}
+            colorConfigPath="columnStyle"
             component={component}
           />
         </>

--- a/app/configurator/table/table-chart-options.tsx
+++ b/app/configurator/table/table-chart-options.tsx
@@ -38,7 +38,7 @@ import {
   updateIsGroup,
   updateIsHidden,
 } from "@/configurator/table/table-config-state";
-import { canDimensionBeMultiFiltered } from "@/domain/data";
+import { canDimensionBeMultiFiltered, isNumericalMeasure } from "@/domain/data";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 import { DataCubeMetadata } from "@/graphql/types";
 import {
@@ -170,34 +170,31 @@ export const TableColumnOptions = ({
 
   const { isGroup, isHidden } = chartConfig.fields[activeField];
 
-  const columnStyleOptions =
-    component.__typename === "NominalDimension" ||
-    component.__typename === "OrdinalDimension" ||
-    component.__typename === "TemporalDimension"
-      ? [
-          {
-            value: "text",
-            label: t({ id: "columnStyle.text", message: `Text` }),
-          },
-          {
-            value: "category",
-            label: t({ id: "columnStyle.categories", message: `Categories` }),
-          },
-        ]
-      : [
-          {
-            value: "text",
-            label: t({ id: "columnStyle.text", message: `Text` }),
-          },
-          {
-            value: "heatmap",
-            label: t({ id: "columnStyle.heatmap", message: `Heat Map` }),
-          },
-          {
-            value: "bar",
-            label: t({ id: "columnStyle.bar", message: `Bar Chart` }),
-          },
-        ];
+  const columnStyleOptions = isNumericalMeasure(component)
+    ? [
+        {
+          value: "text",
+          label: t({ id: "columnStyle.text", message: `Text` }),
+        },
+        {
+          value: "heatmap",
+          label: t({ id: "columnStyle.heatmap", message: `Heat Map` }),
+        },
+        {
+          value: "bar",
+          label: t({ id: "columnStyle.bar", message: `Bar Chart` }),
+        },
+      ]
+    : [
+        {
+          value: "text",
+          label: t({ id: "columnStyle.text", message: `Text` }),
+        },
+        {
+          value: "category",
+          label: t({ id: "columnStyle.categories", message: `Categories` }),
+        },
+      ];
   return (
     <div
       key={`control-panel-table-column-${activeField}`}

--- a/app/configurator/table/table-chart-sorting-options.tsx
+++ b/app/configurator/table/table-chart-sorting-options.tsx
@@ -7,6 +7,7 @@ import {
   Typography,
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
+import { ascending } from "d3";
 import React, { ChangeEvent, useCallback } from "react";
 import {
   DragDropContext,
@@ -215,34 +216,38 @@ const AddTableSortingOption = ({
       }),
       disabled: true,
     },
-    ...columns.flatMap((c) => {
-      if (
-        chartConfig.sorting.some(
-          ({ componentIri }) => componentIri === c.componentIri
-        )
-      ) {
-        return [];
-      }
+    ...columns
+      .flatMap((c) => {
+        if (
+          chartConfig.sorting.some(
+            ({ componentIri }) => componentIri === c.componentIri
+          )
+        ) {
+          return [];
+        }
 
-      const component =
-        metaData.dimensions.find(({ iri }) => iri === c.componentIri) ??
-        metaData.measures.find(({ iri }) => iri === c.componentIri);
+        const component =
+          metaData.dimensions.find(({ iri }) => iri === c.componentIri) ??
+          metaData.measures.find(({ iri }) => iri === c.componentIri);
 
-      return component
-        ? [
-            {
-              value: component.iri,
-              label: component.label,
-            },
-          ]
-        : [];
-    }),
+        return component
+          ? [
+              {
+                value: component.iri,
+                label: component.label,
+              },
+            ]
+          : [];
+      })
+      .sort((a, b) => ascending(a.label, b.label)),
   ];
+
   return (
     <Select
       id="add-tablesorting"
       value="-"
       options={options}
+      sortOptions={false}
       label={t({
         id: "controls.sorting.addDimension",
         message: `Add dimension`,

--- a/app/palettes.ts
+++ b/app/palettes.ts
@@ -33,15 +33,43 @@ import {
   schemeTableau10,
 } from "d3";
 
+import { hasDimensionColors } from "./charts/shared/colors";
 import {
   DivergingPaletteType,
   SequentialPaletteType,
 } from "./configurator/config-types";
+import { DimensionMetadataFragment } from "./graphql/query-hooks";
 
 // Colors
 
-export const getPalette = (palette?: string): ReadonlyArray<string> => {
+export const getDefaultCategoricalPaletteName = (
+  d: DimensionMetadataFragment
+): string => {
+  const hasColors = hasDimensionColors(d);
+  return hasColors ? "dimension" : DEFAULT_CATEGORICAL_PALETTE_NAME;
+};
+
+export const getDefaultCategoricalPalette = (
+  colors?: string[]
+): CategoricalPalette => {
+  if (colors) {
+    return {
+      label: "default",
+      value: "dimension",
+      colors: colors.slice(0, 10),
+    };
+  } else {
+    return categoricalPalettes[0];
+  }
+};
+
+export const getPalette = (
+  palette?: string,
+  colors?: string[]
+): ReadonlyArray<string> => {
   switch (palette) {
+    case "dimension":
+      return getDefaultCategoricalPalette(colors).colors;
     case "accent":
       return schemeAccent;
     case "category10":
@@ -67,6 +95,30 @@ export const getPalette = (palette?: string): ReadonlyArray<string> => {
       return schemeCategory10;
   }
 };
+
+type CategoricalPalette = {
+  label: string;
+  value: string;
+  colors: ReadonlyArray<string>;
+};
+
+export const categoricalPalettes: Array<CategoricalPalette> = [
+  {
+    label: "category10",
+    value: "category10",
+    colors: getPalette("category10"),
+  },
+  { label: "accent", value: "accent", colors: getPalette("accent") },
+  { label: "dark2", value: "dark2", colors: getPalette("dark2") },
+  { label: "paired", value: "paired", colors: getPalette("paired") },
+  { label: "pastel1", value: "pastel1", colors: getPalette("pastel1") },
+  { label: "pastel2", value: "pastel2", colors: getPalette("pastel2") },
+  { label: "set1", value: "set1", colors: getPalette("set1") },
+  { label: "set2", value: "set2", colors: getPalette("set2") },
+  { label: "set3", value: "set3", colors: getPalette("set3") },
+];
+
+export const DEFAULT_CATEGORICAL_PALETTE_NAME = categoricalPalettes[0].value;
 
 export const getSingleHueSequentialPalette = ({
   nbClass = 5,
@@ -101,28 +153,6 @@ export const getSingleHueSequentialPalette = ({
       return schemeOranges[nbClass];
   }
 };
-
-export const categoricalPalettes: Array<{
-  label: string;
-  value: string;
-  colors: ReadonlyArray<string>;
-}> = [
-  {
-    label: "category10",
-    value: "category10",
-    colors: getPalette("category10"),
-  },
-  { label: "accent", value: "accent", colors: getPalette("accent") },
-  { label: "dark2", value: "dark2", colors: getPalette("dark2") },
-  { label: "paired", value: "paired", colors: getPalette("paired") },
-  { label: "pastel1", value: "pastel1", colors: getPalette("pastel1") },
-  { label: "pastel2", value: "pastel2", colors: getPalette("pastel2") },
-  { label: "set1", value: "set1", colors: getPalette("set1") },
-  { label: "set2", value: "set2", colors: getPalette("set2") },
-  { label: "set3", value: "set3", colors: getPalette("set3") },
-];
-
-export const getDefaultCategoricalPalette = () => categoricalPalettes[0];
 
 export type Palette<T> = {
   label: string;


### PR DESCRIPTION
Closes #808.

Previously we incorrectly enabled bar and heat map column style options for some dimension types; this PR improves that by enabling them only for numerical measures and allowing to use categories for other dimension types. It also moves a placeholder text "Select a dimension" to top, instead of being the last option.

Additionally, there is now a "dimension" color palette, which exists when there are pre-defined colors attached to dimension values; we are then able to select such palette from ColorPalette picker.

### How to test
1. Go to `/en/browse/dataset/https%3A%2F%2Fenvironment.ld.admin.ch%2Ffoen%2Ftest_ordinal_507%2F7?dataSource=Int`
2. Select `ord1` dimension in Columns section.
3. Change column style to `Categories`.
4. See that the values are colored according to custom dimension colors.
5. See that it's possible to change the default color palette to different palettes.