### PR TITLE
Sort legend items in case of hierarchy

### DIFF
--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -1,6 +1,7 @@
 import { Theme, Typography } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import clsx from "clsx";
+import { ascending } from "d3";
 import React, { memo, useMemo } from "react";
 
 import {
@@ -231,8 +232,18 @@ const useLegendGroups = ({
     }
 
     const groups = Array.from(groupsMap.entries());
+    if (segmentField && "sorting" in segmentField) {
+      // Re-sort hierarchy groups against the label order that we have received
+      const labelOrder = Object.fromEntries(
+        labels.map((x, i) => [x, i] as const)
+      );
+      groups.forEach(([_groupName, entries]) => {
+        entries.sort((a, b) => ascending(labelOrder[a], labelOrder[b]));
+      });
+    }
+
     return groups;
-  }, [hierarchy, labels, title]);
+  }, [hierarchy, labels, segmentField, title]);
 
   return groups;
 };

--- a/app/graphql/resolvers/rdf.ts
+++ b/app/graphql/resolvers/rdf.ts
@@ -200,7 +200,12 @@ export const dataCubeDimensionByIri: NonNullable<
 > = async ({ cube, locale }, { iri }, { setup }, info) => {
   const { sparqlClient } = await setup(info);
   const dimension = (
-    await getCubeDimensions({ cube, locale, sparqlClient })
+    await getCubeDimensions({
+      cube,
+      locale,
+      sparqlClient,
+      dimensionIris: [iri],
+    })
   ).find((d) => iri === d.data.iri);
   return dimension ?? null;
 };

--- a/app/pages/_document.tsx
+++ b/app/pages/_document.tsx
@@ -7,6 +7,7 @@ class MyDocument extends Document {
     return (
       <Html data-app-version={`${process.env.NEXT_PUBLIC_VERSION}`}>
         <Head>
+          {/* eslint-disable-next-line @next/next/no-sync-scripts */}
           <script src="/api/client-env"></script>
           {GA_TRACKING_ID && (
             <>
@@ -24,7 +25,7 @@ class MyDocument extends Document {
         </Head>
         <body>
           <Main />
-          <script noModule src="/static/ie-check.js"></script>
+          <script noModule src="/static/ie-check.js" defer></script>
           <NextScript />
         </body>
       </Html>

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -158,13 +158,19 @@ export const getCubeDimensions = async ({
   cube,
   locale,
   sparqlClient,
+  dimensionIris,
 }: {
   cube: Cube;
   locale: string;
   sparqlClient: ParsingClient;
+  dimensionIris?: string[];
 }): Promise<ResolvedDimension[]> => {
   try {
-    const dimensions = cube.dimensions.filter(isObservationDimension);
+    const dimensions = cube.dimensions
+      .filter(isObservationDimension)
+      .filter((x) =>
+        dimensionIris ? dimensionIris.includes(x.path.value) : true
+      );
     const dimensionUnits = dimensions.flatMap(getDimensionUnits);
 
     const dimensionUnitIndex = index(

--- a/e2e/actions.ts
+++ b/e2e/actions.ts
@@ -38,9 +38,7 @@ export const createActions = ({
       chartLoadedOptions?: Parameters<typeof selectors.chart.loaded>[0]
     ) => {
       await page.goto(
-        `en/browse/create/new?cube=${encodeURIComponent(
-          iri
-        )}&dataSource=${dataSource}`
+        `en/create/new?cube=${encodeURIComponent(iri)}&dataSource=${dataSource}`
       );
 
       await selectors.chart.loaded(chartLoadedOptions);

--- a/e2e/sorting.spec.ts
+++ b/e2e/sorting.spec.ts
@@ -77,3 +77,55 @@ test("Segment sorting", async ({
     await actions.mui.selectOption("Automatic");
   }
 });
+
+test("Segment sorting with hierarchy", async ({
+  actions,
+  selectors,
+  screen,
+  within,
+  page,
+}) => {
+  await actions.chart.createFrom(
+    "https://environment.ld.admin.ch/foen/nfi/49-19-44/cube/1",
+    "Int"
+  );
+  await actions.editor.selectActiveField("Color");
+
+  // Wait for color section to be ready
+  await selectors.edition.controlSection("Color").waitFor();
+
+  await within(selectors.edition.controlSection("Color"))
+    .getByText("None")
+    .click();
+
+  await actions.mui.selectOption("production region");
+  await selectors.chart.loaded();
+
+  await selectors.edition.filtersLoaded();
+  await selectors.chart.colorLegend(undefined, { setTimeout: 5_000 });
+
+  await within(await selectors.chart.colorLegend()).findByText(
+    "Southern Alps",
+    undefined,
+    { timeout: 5000 }
+  );
+
+  const legendItems = await selectors.chart.colorLegendItems();
+
+  expect(await legendItems.allInnerTexts()).toEqual([
+    "Jura",
+    "Plateau",
+    "Pre-Alps",
+    "Alps",
+    "Southern Alps",
+  ]);
+
+  await screen.getByText("Z → A").click();
+  expect(await legendItems.allInnerTexts()).toEqual([
+    "Southern Alps",
+    "Alps",
+    "Pre-Alps",
+    "Plateau",
+    "Jura",
+  ]);
+});


### PR DESCRIPTION
In case of hierarchy, we would not sort legend items and instead rely
on hierarchy order, which is not what we want.

Fixes : https://github.com/visualize-admin/visualization-tool/issues/806

### How to test

- Use the NFI dataset `/en/create/new?cube=https://environment.ld.admin.ch/foen/nfi/49-19-44/cube/1`
- Color by production region
- Verify that legend items are sorted automatically and can sorted in reverse, and by name