### PR TITLE
feat: Run SPARQL query enhancements

### DIFF
--- a/app/.env.development
+++ b/app/.env.development
@@ -1,6 +1,5 @@
 DATABASE_URL=postgres://postgres:password@localhost:5432/visualization_tool
 ENDPOINT=sparql+https://lindas.admin.ch/query
 SPARQL_GEO_ENDPOINT=https://geo.ld.admin.ch/query
-SPARQL_EDITOR=https://int.lindas.admin.ch/sparql/
 GRAPHQL_ENDPOINT=/api/graphql
 WHITELISTED_DATA_SOURCES=["Prod", "Int", "Test"]

--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -17,33 +17,35 @@ import { makeOpenDataLink } from "@/utils/opendata";
 
 import { useQueryFilters } from "../charts/shared/chart-helpers";
 
-const useStyles = makeStyles((theme: Theme) => ({
-  actions: {
-    marginTop: theme.spacing(2),
-    "--column-gap": "16px",
-    columnGap: "var(--column-gap)",
-    rowGap: 1,
-    display: "flex",
-    flexDirection: "row",
-    alignItems: "center",
-    flexWrap: "wrap",
-    overflow: "hidden",
+export const useFootnotesStyles = makeStyles<Theme, { useMarginTop: boolean }>(
+  (theme) => ({
+    actions: {
+      marginTop: ({ useMarginTop }) => (useMarginTop ? theme.spacing(2) : 0),
+      "--column-gap": "16px",
+      columnGap: "var(--column-gap)",
+      rowGap: 1,
+      display: "flex",
+      flexDirection: "row",
+      alignItems: "center",
+      flexWrap: "wrap",
+      overflow: "hidden",
 
-    // Separator between flex elements, the trick to have them not displayed
-    // for each line leftmost element is to have them negatively positioned
-    // cut by the overflow hidden
-    "& > *:before": {
-      content: '" "',
-      display: "block",
-      height: "3px",
-      width: "3px ",
-      borderRadius: "3px",
-      position: "relative",
-      left: "calc(-1 * var(--column-gap) / 2)",
-      backgroundColor: theme.palette.grey[600],
+      // Separator between flex elements, the trick to have them not displayed
+      // for each line leftmost element is to have them negatively positioned
+      // cut by the overflow hidden
+      "& > *:before": {
+        content: '" "',
+        display: "block",
+        height: "3px",
+        width: "3px ",
+        borderRadius: "3px",
+        position: "relative",
+        left: "calc(-1 * var(--column-gap) / 2)",
+        backgroundColor: theme.palette.grey[600],
+      },
     },
-  },
-}));
+  })
+);
 
 export const ChartFootnotes = ({
   dataSetIri,
@@ -58,7 +60,7 @@ export const ChartFootnotes = ({
   configKey?: string;
   onToggleTableView: () => void;
 }) => {
-  const classes = useStyles();
+  const classes = useFootnotesStyles({ useMarginTop: true });
   const locale = useLocale();
   const [shareUrl, setShareUrl] = useState("");
   const { state: isTablePreview, setStateRaw: setIsTablePreview } =

--- a/app/components/debug-panel/DebugPanel.tsx
+++ b/app/components/debug-panel/DebugPanel.tsx
@@ -11,7 +11,7 @@ import { Inspector } from "react-inspector";
 
 import { useInteractiveFilters } from "@/charts/shared/use-interactive-filters";
 import { DataSource, useConfiguratorState } from "@/configurator";
-import { SPARQL_EDITOR } from "@/domain/env";
+import { dataSourceToSparqlEditorUrl } from "@/domain/datasource";
 import { useDataCubeMetadataWithComponentValuesQuery } from "@/graphql/query-hooks";
 import { Icon } from "@/icons";
 import { useLocale } from "@/src";
@@ -80,6 +80,9 @@ const CubeMetadata = ({
 
 const DebugConfigurator = () => {
   const [configuratorState] = useConfiguratorState();
+  const sparqlEditorUrl = dataSourceToSparqlEditorUrl(
+    configuratorState.dataSource
+  );
 
   return (
     <>
@@ -107,13 +110,13 @@ const DebugConfigurator = () => {
         ) : (
           <Typography variant="body1">Please select a dataset first</Typography>
         )}
-        {SPARQL_EDITOR && (
+        {
           <Button
             component="a"
             color="primary"
             variant="text"
             size="small"
-            href={`${SPARQL_EDITOR}#query=${encodeURIComponent(
+            href={`${sparqlEditorUrl}#query=${encodeURIComponent(
               `#pragma describe.strategy cbd
               #pragma join.hash off
               
@@ -125,7 +128,7 @@ DESCRIBE <${configuratorState.dataSet ?? ""}>`
           >
             <Typography variant="body2">Cube Metadata Query</Typography>
           </Button>
-        )}
+        }
         {configuratorState.dataSet ? (
           <CubeMetadata
             datasetIri={configuratorState.dataSet}

--- a/app/configurator/components/dataset-preview.tsx
+++ b/app/configurator/components/dataset-preview.tsx
@@ -4,6 +4,7 @@ import Head from "next/head";
 import Link from "next/link";
 import * as React from "react";
 
+import { useFootnotesStyles } from "@/components/chart-footnotes";
 import { DataDownloadMenu, RunSparqlQuery } from "@/components/data-download";
 import DebugPanel from "@/components/debug-panel";
 import Flex from "@/components/flex";
@@ -26,6 +27,7 @@ export const DataSetPreview = ({
   dataSetIri: string;
   dataSource: DataSource;
 }) => {
+  const classes = useFootnotesStyles({ useMarginTop: false });
   const locale = useLocale();
   const [{ data: metadata, fetching, error }] = useDataCubePreviewQuery({
     variables: {
@@ -114,16 +116,18 @@ export const DataSetPreview = ({
             />
           </Box>
           <Flex sx={{ mt: 4, justifyContent: "space-between" }}>
-            <DataDownloadMenu
-              dataSetIri={dataSetIri}
-              dataSource={dataSource}
-              title={dataCubeByIri.title}
-            />
+            <Flex className={classes.actions}>
+              <DataDownloadMenu
+                dataSetIri={dataSetIri}
+                dataSource={dataSource}
+                title={dataCubeByIri.title}
+              />
               {dataCubeByIri.observations.sparqlEditorUrl && (
                 <RunSparqlQuery
                   url={dataCubeByIri.observations.sparqlEditorUrl}
                 />
               )}
+            </Flex>
             <Typography
               variant="body2"
               sx={{ color: "grey.600", fontWeight: "light" }}

--- a/app/configurator/components/dataset-preview.tsx
+++ b/app/configurator/components/dataset-preview.tsx
@@ -27,7 +27,7 @@ export const DataSetPreview = ({
   dataSource: DataSource;
 }) => {
   const locale = useLocale();
-  const [{ data: metaData, fetching, error }] = useDataCubePreviewQuery({
+  const [{ data: metadata, fetching, error }] = useDataCubePreviewQuery({
     variables: {
       iri: dataSetIri,
       sourceType: dataSource.type,
@@ -36,8 +36,9 @@ export const DataSetPreview = ({
     },
   });
 
-  if (metaData && metaData.dataCubeByIri) {
-    const { dataCubeByIri } = metaData;
+  if (metadata?.dataCubeByIri) {
+    const { dataCubeByIri } = metadata;
+
     return (
       <Flex
         sx={{
@@ -46,7 +47,7 @@ export const DataSetPreview = ({
           justifyContent: "space-between",
         }}
       >
-        {metaData.dataCubeByIri.publicationStatus ===
+        {dataCubeByIri.publicationStatus ===
           DataCubePublicationStatus.Draft && (
           <Box sx={{ mb: 4 }}>
             <HintRed iconName="datasetError" iconSize={64}>
@@ -107,10 +108,9 @@ export const DataSetPreview = ({
           >
             <DataSetPreviewTable
               title={dataCubeByIri.title}
-              dataSetIri={dataCubeByIri.iri}
-              dataSource={dataSource}
               dimensions={dataCubeByIri.dimensions}
               measures={dataCubeByIri.measures}
+              observations={dataCubeByIri.observations.data}
             />
           </Box>
           <Flex sx={{ mt: 4, justifyContent: "space-between" }}>

--- a/app/configurator/components/dataset-preview.tsx
+++ b/app/configurator/components/dataset-preview.tsx
@@ -4,7 +4,7 @@ import Head from "next/head";
 import Link from "next/link";
 import * as React from "react";
 
-import { DataDownloadMenu } from "@/components/data-download";
+import { DataDownloadMenu, RunSparqlQuery } from "@/components/data-download";
 import DebugPanel from "@/components/debug-panel";
 import Flex from "@/components/flex";
 import { HintRed, Loading, LoadingDataError } from "@/components/hint";
@@ -119,6 +119,11 @@ export const DataSetPreview = ({
               dataSource={dataSource}
               title={dataCubeByIri.title}
             />
+              {dataCubeByIri.observations.sparqlEditorUrl && (
+                <RunSparqlQuery
+                  url={dataCubeByIri.observations.sparqlEditorUrl}
+                />
+              )}
             <Typography
               variant="body2"
               sx={{ color: "grey.600", fontWeight: "light" }}

--- a/app/configurator/components/dataset-preview.tsx
+++ b/app/configurator/components/dataset-preview.tsx
@@ -1,5 +1,6 @@
 import { Trans } from "@lingui/macro";
-import { Box, Button, Paper, Typography } from "@mui/material";
+import { Box, Button, Paper, Theme, Typography } from "@mui/material";
+import { makeStyles } from "@mui/styles";
 import Head from "next/head";
 import Link from "next/link";
 import * as React from "react";
@@ -15,6 +16,61 @@ import { useDataCubePreviewQuery } from "@/graphql/query-hooks";
 import { DataCubePublicationStatus } from "@/graphql/resolver-types";
 import { useLocale } from "@/locales/use-locale";
 
+const useStyles = makeStyles<Theme, { descriptionPresent: boolean }>(
+  (theme) => ({
+    root: {
+      flexGrow: 1,
+      flexDirection: "column",
+      justifyContent: "space-between",
+    },
+    header: {
+      alignItems: "center",
+      justifyContent: "space-between",
+      marginBottom: theme.spacing(6),
+    },
+    title: {
+      color: theme.palette.grey[800],
+    },
+    createChartButton: {
+      marginLeft: theme.spacing(6),
+      whiteSpace: "nowrap",
+      flexShrink: 0,
+    },
+    paper: {
+      borderRadius: theme.spacing(4),
+      paddingLeft: theme.spacing(5),
+      paddingTop: theme.spacing(6),
+      paddingRight: theme.spacing(5),
+      paddingBottom: theme.spacing(6),
+    },
+    description: {
+      marginBottom: theme.spacing(4),
+      color: theme.palette.grey[600],
+    },
+    tableWrapper: {
+      flexGrow: 1,
+      width: "100%",
+      position: "relative",
+      overflowX: "auto",
+      marginTop: ({ descriptionPresent }) =>
+        descriptionPresent ? theme.spacing(6) : 0,
+    },
+    footnotesWrapper: {
+      marginTop: theme.spacing(4),
+      justifyContent: "space-between",
+    },
+    numberOfRows: {
+      color: theme.palette.grey[600],
+    },
+    loadingWrapper: {
+      flexDirection: "column",
+      justifyContent: "space-between",
+      flexGrow: 1,
+      padding: theme.spacing(5),
+    },
+  })
+);
+
 export interface Preview {
   iri: string;
   label: string;
@@ -27,7 +83,7 @@ export const DataSetPreview = ({
   dataSetIri: string;
   dataSource: DataSource;
 }) => {
-  const classes = useFootnotesStyles({ useMarginTop: false });
+  const footnotesClasses = useFootnotesStyles({ useMarginTop: false });
   const locale = useLocale();
   const [{ data: metadata, fetching, error }] = useDataCubePreviewQuery({
     variables: {
@@ -37,18 +93,15 @@ export const DataSetPreview = ({
       locale,
     },
   });
+  const classes = useStyles({
+    descriptionPresent: !!metadata?.dataCubeByIri?.description,
+  });
 
   if (metadata?.dataCubeByIri) {
     const { dataCubeByIri } = metadata;
 
     return (
-      <Flex
-        sx={{
-          flexGrow: 1,
-          flexDirection: "column",
-          justifyContent: "space-between",
-        }}
-      >
+      <Flex className={classes.root}>
         {dataCubeByIri.publicationStatus ===
           DataCubePublicationStatus.Draft && (
           <Box sx={{ mb: 4 }}>
@@ -61,53 +114,35 @@ export const DataSetPreview = ({
             </HintRed>
           </Box>
         )}
-        <Flex
-          sx={{ alignItems: "center", justifyContent: "space-between", mb: 6 }}
-        >
+        <Flex className={classes.header}>
           <Head>
             <title key="title">
               {dataCubeByIri.title} - visualize.admin.ch
             </title>
           </Head>
-          <Typography component="div" variant="h1" sx={{ color: "grey.800" }}>
+          <Typography className={classes.title} component="div" variant="h1">
             {dataCubeByIri.title}
           </Typography>
           <Link passHref href={`/create/new?cube=${dataCubeByIri.iri}`}>
-            <Button
-              component="a"
-              sx={{ ml: 6, whiteSpace: "nowrap", flexShrink: 0 }}
-            >
+            <Button className={classes.createChartButton} component="a">
               <Trans id="browse.dataset.create-visualization">
                 Create visualization from dataset
               </Trans>
             </Button>
           </Link>
         </Flex>
-        <Paper
-          elevation={5}
-          sx={{
-            borderRadius: 8,
-            py: 6,
-            px: 5,
-          }}
-        >
-          <Typography
-            component="div"
-            variant="body2"
-            sx={{ mb: 4, color: "grey.600" }}
-          >
-            {dataCubeByIri.description}
-          </Typography>
+        <Paper className={classes.paper} elevation={5}>
+          {dataCubeByIri.description && (
+            <Typography
+              className={classes.description}
+              component="div"
+              variant="body2"
+            >
+              {dataCubeByIri.description}
+            </Typography>
+          )}
 
-          <Box
-            sx={{
-              flexGrow: 1,
-              width: "100%",
-              position: "relative",
-              overflowX: "auto",
-              mt: 6,
-            }}
-          >
+          <Box className={classes.tableWrapper}>
             <DataSetPreviewTable
               title={dataCubeByIri.title}
               dimensions={dataCubeByIri.dimensions}
@@ -115,8 +150,8 @@ export const DataSetPreview = ({
               observations={dataCubeByIri.observations.data}
             />
           </Box>
-          <Flex sx={{ mt: 4, justifyContent: "space-between" }}>
-            <Flex className={classes.actions}>
+          <Flex className={classes.footnotesWrapper}>
+            <Flex className={footnotesClasses.actions}>
               <DataDownloadMenu
                 dataSetIri={dataSetIri}
                 dataSource={dataSource}
@@ -129,8 +164,9 @@ export const DataSetPreview = ({
               )}
             </Flex>
             <Typography
+              className={classes.numberOfRows}
               variant="body2"
-              sx={{ color: "grey.600", fontWeight: "light" }}
+              sx={{ fontWeight: "light" }}
             >
               <Trans id="datatable.showing.first.rows">
                 Showing first 10 rows
@@ -143,27 +179,13 @@ export const DataSetPreview = ({
     );
   } else if (fetching) {
     return (
-      <Flex
-        sx={{
-          flexDirection: "column",
-          justifyContent: "space-between",
-          flexGrow: 1,
-          p: 5,
-        }}
-      >
+      <Flex className={classes.loadingWrapper}>
         <Loading />
       </Flex>
     );
   } else {
     return (
-      <Flex
-        sx={{
-          flexDirection: "column",
-          justifyContent: "space-between",
-          flexGrow: 1,
-          p: 5,
-        }}
-      >
+      <Flex className={classes.loadingWrapper}>
         <LoadingDataError message={error?.message} />
       </Flex>
     );

--- a/app/configurator/components/datatable.tsx
+++ b/app/configurator/components/datatable.tsx
@@ -22,7 +22,6 @@ import { useDimensionFormatters } from "@/formatters";
 import {
   DimensionMetadataFragment,
   useDataCubeObservationsQuery,
-  useDataCubePreviewObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
@@ -172,38 +171,25 @@ const BackgroundRow = ({ nCells }: { nCells: number }) => {
 
 export const DataSetPreviewTable = ({
   title,
-  dataSetIri,
-  dataSource,
   dimensions,
   measures,
+  observations,
 }: {
   title: string;
-  dataSetIri: string;
-  dataSource: DataSource;
   dimensions: DimensionMetadataFragment[];
   measures: DimensionMetadataFragment[];
+  observations: Observation[];
 }) => {
-  const locale = useLocale();
-  const [{ data, fetching }] = useDataCubePreviewObservationsQuery({
-    variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-      dimensions: null,
-    },
-  });
-
   const headers = useMemo(() => {
     return getSortedHeaders(dimensions, measures);
   }, [dimensions, measures]);
 
-  if (!fetching && data?.dataCubeByIri) {
+  if (observations) {
     return (
       <PreviewTable
         title={title}
         headers={headers}
-        observations={data.dataCubeByIri.observations.data}
+        observations={observations}
       />
     );
   } else {

--- a/app/domain/datasource/index.ts
+++ b/app/domain/datasource/index.ts
@@ -92,3 +92,13 @@ export const isDataSourceChangeable = (pathname: string) => {
     return false;
   }
 };
+
+export const dataSourceToSparqlEditorUrl = (dataSource: DataSource): string => {
+  switch (dataSource.type) {
+    case "sparql":
+      const url = new URL(dataSource.url);
+      return `${url.origin}/sparql`;
+    case "sql":
+      throw new Error("Not implemented yet.");
+  }
+};

--- a/app/domain/env.ts
+++ b/app/domain/env.ts
@@ -36,9 +36,6 @@ export const SPARQL_GEO_ENDPOINT =
   process.env.SPARQL_GEO_ENDPOINT ??
   "https://geo.ld.admin.ch/query";
 
-export const SPARQL_EDITOR =
-  clientEnv?.SPARQL_EDITOR ?? process.env.SPARQL_EDITOR;
-
 export const SQL_ENDPOINT =
   clientEnv?.SQL_ENDPOINT ?? process.env.SQL_ENDPOINT ?? "";
 

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -87,32 +87,10 @@ query DataCubePreview(
     measures(sourceType: $sourceType, sourceUrl: $sourceUrl) {
       ...dimensionMetadata
     }
-  }
-}
-
-query DataCubePreviewObservations(
-  $iri: String!
-  $sourceType: String!
-  $sourceUrl: String!
-  $locale: String!
-  $dimensions: [String!]
-  $latest: Boolean
-) {
-  dataCubeByIri(
-    iri: $iri
-    sourceType: $sourceType
-    sourceUrl: $sourceUrl
-    locale: $locale
-    latest: $latest
-  ) {
-    observations(
-      sourceType: $sourceType
-      sourceUrl: $sourceUrl
-      dimensions: $dimensions
-      limit: 10
-    ) {
+    observations(sourceType: $sourceType, sourceUrl: $sourceUrl, limit: 10) {
       data
       sparql
+      sparqlEditorUrl
     }
   }
 }

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -565,19 +565,7 @@ export type DataCubePreviewQuery = { __typename: 'Query', dataCubeByIri?: Maybe<
     ) | (
       { __typename: 'OrdinalMeasure' }
       & DimensionMetadata_OrdinalMeasure_Fragment
-    )> }> };
-
-export type DataCubePreviewObservationsQueryVariables = Exact<{
-  iri: Scalars['String'];
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  locale: Scalars['String'];
-  dimensions?: Maybe<Array<Scalars['String']> | Scalars['String']>;
-  latest?: Maybe<Scalars['Boolean']>;
-}>;
-
-
-export type DataCubePreviewObservationsQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', observations: { __typename: 'ObservationsQuery', data: Array<any>, sparql: string } }> };
+    )>, observations: { __typename: 'ObservationsQuery', data: Array<any>, sparql: string, sparqlEditorUrl?: Maybe<string> } }> };
 
 export type DataCubeMetadataQueryVariables = Exact<{
   iri: Scalars['String'];
@@ -1043,37 +1031,17 @@ export const DataCubePreviewDocument = gql`
     measures(sourceType: $sourceType, sourceUrl: $sourceUrl) {
       ...dimensionMetadata
     }
+    observations(sourceType: $sourceType, sourceUrl: $sourceUrl, limit: 10) {
+      data
+      sparql
+      sparqlEditorUrl
+    }
   }
 }
     ${DimensionMetadataFragmentDoc}`;
 
 export function useDataCubePreviewQuery(options: Omit<Urql.UseQueryArgs<DataCubePreviewQueryVariables>, 'query'> = {}) {
   return Urql.useQuery<DataCubePreviewQuery>({ query: DataCubePreviewDocument, ...options });
-};
-export const DataCubePreviewObservationsDocument = gql`
-    query DataCubePreviewObservations($iri: String!, $sourceType: String!, $sourceUrl: String!, $locale: String!, $dimensions: [String!], $latest: Boolean) {
-  dataCubeByIri(
-    iri: $iri
-    sourceType: $sourceType
-    sourceUrl: $sourceUrl
-    locale: $locale
-    latest: $latest
-  ) {
-    observations(
-      sourceType: $sourceType
-      sourceUrl: $sourceUrl
-      dimensions: $dimensions
-      limit: 10
-    ) {
-      data
-      sparql
-    }
-  }
-}
-    `;
-
-export function useDataCubePreviewObservationsQuery(options: Omit<Urql.UseQueryArgs<DataCubePreviewObservationsQueryVariables>, 'query'> = {}) {
-  return Urql.useQuery<DataCubePreviewObservationsQuery>({ query: DataCubePreviewObservationsDocument, ...options });
 };
 export const DataCubeMetadataDocument = gql`
     query DataCubeMetadata($iri: String!, $sourceType: String!, $sourceUrl: String!, $locale: String!, $latest: Boolean) {

--- a/app/graphql/resolvers/index.ts
+++ b/app/graphql/resolvers/index.ts
@@ -15,8 +15,8 @@ import {
 } from "@/graphql/resolver-types";
 import * as RDF from "@/graphql/resolvers/rdf";
 import * as SQL from "@/graphql/resolvers/sql";
-import { getSparqlEditorUrl } from "@/rdf/queries";
 import { RawGeoShape } from "@/rdf/query-geo-shapes";
+import { getSparqlEditorUrl } from "@/rdf/sparql-utils";
 
 const getSource = (dataSourceType: string) => {
   return dataSourceType === "sparql" ? RDF : SQL;
@@ -160,8 +160,20 @@ export const resolvers: Resolvers = {
     rawData: async ({ data: { observationsRaw } }) => observationsRaw,
     sparql: async ({ data: { query } }) =>
       query.replace(/\n+/g, " ").replace(/"/g, "'"),
-    sparqlEditorUrl: async ({ data: { query } }) =>
-      getSparqlEditorUrl({ query }),
+    sparqlEditorUrl: async (
+      { data: { query } },
+      {},
+      {},
+      { variableValues }
+    ) => {
+      return getSparqlEditorUrl({
+        query,
+        dataSource: {
+          type: variableValues.sourceType,
+          url: variableValues.sourceUrl,
+        },
+      });
+    },
   },
   Dimension: {
     __resolveType({ data: { dataKind, scaleType } }) {

--- a/app/pages/api/client-env.ts
+++ b/app/pages/api/client-env.ts
@@ -14,7 +14,6 @@ export default async function clientEnvApi(
       try {
         const result = `window.__clientEnv__=${JSON.stringify({
           GA_TRACKING_ID: process.env.GA_TRACKING_ID,
-          SPARQL_EDITOR: process.env.SPARQL_EDITOR,
           ENDPOINT: process.env.ENDPOINT,
           WHITELISTED_DATA_SOURCES:
             process.env.WHITELISTED_DATA_SOURCES !== undefined

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -23,7 +23,6 @@ import {
   parseObservationValue,
   shouldValuesBeLoadedForResolvedDimension,
 } from "../domain/data";
-import { SPARQL_EDITOR } from "../domain/env";
 import { DataCubeSearchFilter } from "../graphql/query-hooks";
 import { ResolvedDataCube, ResolvedDimension } from "../graphql/shared-types";
 
@@ -637,16 +636,6 @@ const buildFilters = ({
   });
 
   return filterEntries;
-};
-
-export const getSparqlEditorUrl = ({
-  query,
-}: {
-  query: string;
-}): string | null => {
-  return SPARQL_EDITOR
-    ? `${SPARQL_EDITOR}#query=${encodeURIComponent(query)}&requestMethod=POST`
-    : null;
 };
 
 async function fetchViewObservations({

--- a/app/rdf/sparql-utils.spec.ts
+++ b/app/rdf/sparql-utils.spec.ts
@@ -1,0 +1,30 @@
+import { DataSource } from "@/configurator/config-types";
+
+import { getSparqlEditorUrl } from "./sparql-utils";
+
+describe("getSparqlEditorUrl", () => {
+  const testData: { dataSource: DataSource; urlPrefix: string }[] = [
+    "",
+    "int.",
+    "test.",
+  ].map((d) => ({
+    dataSource: {
+      type: "sparql",
+      url: `https://${d}lindas.admin.ch/query`,
+    },
+    urlPrefix: d,
+  }));
+
+  it("should correctly create url based on data source", () => {
+    testData.forEach(({ dataSource, urlPrefix }) => {
+      const stringUrl = getSparqlEditorUrl({
+        query: "SELECT * FROM TABLE",
+        dataSource,
+      });
+      const url = new URL(stringUrl);
+      expect(url.origin + url.pathname).toEqual(
+        `https://${urlPrefix}lindas.admin.ch/sparql`
+      );
+    });
+  });
+});

--- a/app/rdf/sparql-utils.ts
+++ b/app/rdf/sparql-utils.ts
@@ -1,0 +1,13 @@
+import { DataSource } from "@/configurator/config-types";
+import { dataSourceToSparqlEditorUrl } from "@/domain/datasource";
+
+export const getSparqlEditorUrl = ({
+  query,
+  dataSource,
+}: {
+  query: string;
+  dataSource: DataSource;
+}): string => {
+  const editorUrl = dataSourceToSparqlEditorUrl(dataSource);
+  return `${editorUrl}#query=${encodeURIComponent(query)}&requestMethod=POST`;
+};

--- a/app/scripts/cube.ts
+++ b/app/scripts/cube.ts
@@ -15,9 +15,9 @@ import {
   DataCubeMetadataWithComponentValuesDocument,
   DataCubeMetadataWithComponentValuesQuery,
   DataCubeMetadataWithComponentValuesQueryVariables,
-  DataCubePreviewObservationsDocument,
-  DataCubePreviewObservationsQuery,
-  DataCubePreviewObservationsQueryVariables,
+  DataCubePreviewDocument,
+  DataCubePreviewQuery,
+  DataCubePreviewQueryVariables,
 } from "../graphql/query-hooks";
 
 config();
@@ -130,16 +130,16 @@ const previewCube = async ({
   }
 
   const res = await client
-    .query<
-      DataCubePreviewObservationsQuery,
-      DataCubePreviewObservationsQueryVariables
-    >(DataCubePreviewObservationsDocument, {
-      iri,
-      sourceType,
-      sourceUrl,
-      locale,
-      latest,
-    })
+    .query<DataCubePreviewQuery, DataCubePreviewQueryVariables>(
+      DataCubePreviewDocument,
+      {
+        iri,
+        sourceType,
+        sourceUrl,
+        locale,
+        latest,
+      }
+    )
     .toPromise();
 
   if (res.error) {


### PR DESCRIPTION
Closes #563.
Fixes #779.

- Add a "Run SPARQL query" button to dataset preview
- Fix "Run SPARQL query" urls pointing to wrong LINDAS environments (now it's based on current DataSource)
- Consolidate fetching of data cube preview + preview observations (so we have access to editor url in the right place)

### How to test
1. Go to any dataset preview and see that there is a Run SPARQL query button below table.
2. Choose other datasets from different data source environments (Prod, Int, Test) on the same Visualize environment (TEST) and see that the button works correctly with every data environment.