### PR TITLE
Use a cube loader

### DIFF
--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -7,6 +7,7 @@ import {
   Menu,
   MenuItem,
   Theme,
+  Typography,
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import { ascending } from "d3";
@@ -229,6 +230,7 @@ const useEnsurePossibleFilters = ({
         .toPromise();
       if (error || !data) {
         setError(error);
+        setFetching(false);
         console.warn("Could not fetch possible filters", error);
         return;
       }
@@ -516,9 +518,10 @@ export const ChartConfigurator = ({
   } = useFilterReorder({
     onAddDimensionFilter: () => closeFilterMenu(),
   });
-  const { fetching: possibleFiltersFetching } = useEnsurePossibleFilters({
-    state,
-  });
+  const { fetching: possibleFiltersFetching, error: possibleFiltersError } =
+    useEnsurePossibleFilters({
+      state,
+    });
   const fetching = possibleFiltersFetching || dataFetching;
 
   const filterMenuButtonRef = useRef(null);
@@ -577,6 +580,11 @@ export const ChartConfigurator = ({
             aria-labelledby="controls-data"
             data-testid="configurator-filters"
           >
+            {possibleFiltersError ? (
+              <Typography variant="body2" color="error">
+                {possibleFiltersError.message}
+              </Typography>
+            ) : null}
             <DragDropContext onDragEnd={handleDragEnd}>
               <Droppable droppableId="filters">
                 {(provided) => (

--- a/app/graphql/resolvers/rdf.ts
+++ b/app/graphql/resolvers/rdf.ts
@@ -278,15 +278,13 @@ const getDimensionValuesLoader = (
 };
 
 export const hierarchy: NonNullable<DimensionResolvers["hierarchy"]> = async (
-  { data: { iri } },
-  _unused,
+  { cube, data: { iri } },
+  _args,
   { setup },
   info
 ) => {
   const { locale } = info.variableValues;
-  const cubeIri = info.variableValues.iri || info.variableValues.cubeIri;
-  const { sparqlClient, sparqlClientStream, loaders } = await setup(info);
-  const cube = await loaders.cube.load(cubeIri);
+  const { sparqlClient, sparqlClientStream } = await setup(info);
 
   if (!cube) {
     throw new Error("Could not find cube");

--- a/app/graphql/resolvers/rdf.ts
+++ b/app/graphql/resolvers/rdf.ts
@@ -279,18 +279,26 @@ const getDimensionValuesLoader = (
 
 export const hierarchy: NonNullable<DimensionResolvers["hierarchy"]> = async (
   { data: { iri } },
-  { sourceUrl },
+  _unused,
   { setup },
   info
 ) => {
-  const { sparqlClient, sparqlClientStream } = await setup(info);
-  return queryHierarchy(
+  const { locale } = info.variableValues;
+  const cubeIri = info.variableValues.iri || info.variableValues.cubeIri;
+  const { sparqlClient, sparqlClientStream, loaders } = await setup(info);
+  const cube = await loaders.cube.load(cubeIri);
+
+  if (!cube) {
+    throw new Error("Could not find cube");
+  }
+  const res = await queryHierarchy(
+    cube,
     iri,
-    sourceUrl,
-    info.variableValues.locale,
+    locale,
     sparqlClient,
     sparqlClientStream
   );
+  return res;
 };
 
 export const dimensionValues: NonNullable<

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -126,24 +126,15 @@ export const getCubes = async ({
   return cubes.map((cube) => parseCube({ cube, locale }));
 };
 
-export const getCube = async ({
-  iri,
-  sourceUrl,
+export const getResolvedCube = async ({
+  cube,
   locale,
   latest = true,
 }: {
-  iri: string;
-  sourceUrl: string;
+  cube: Cube;
   locale: string;
   latest?: boolean;
 }): Promise<ResolvedDataCube | null> => {
-  const source = createSource({ endpointUrl: sourceUrl });
-  const cube = await source.cube(iri);
-
-  if (!cube) {
-    return null;
-  }
-
   const latestCube = latest === false ? cube : await getLatestCube(cube);
   return parseCube({ cube: latestCube, locale });
 };

--- a/app/rdf/query-literals.ts
+++ b/app/rdf/query-literals.ts
@@ -1,4 +1,5 @@
 import { SELECT, sparql } from "@tpluscode/sparql-builder";
+import uniqBy from "lodash/uniqBy";
 import { NamedNode, Literal } from "rdf-js";
 import ParsingClient from "sparql-http-client/ParsingClient";
 
@@ -20,10 +21,11 @@ const buildResourceLiteralQuery = ({
   values: NamedNode<string>[];
   predicates: PredicateOption;
 }) => {
+  const uniqueValues = uniqBy(values, (x) => x.value);
   const q = SELECT.DISTINCT`?iri ${Object.keys(predicates).map((x) => `?${x}`)}`
     .WHERE`
       values ?iri {
-        ${values}
+        ${uniqueValues}
       }
 
       ${Object.entries(predicates)

--- a/app/rdf/query-unit-labels.ts
+++ b/app/rdf/query-unit-labels.ts
@@ -1,4 +1,5 @@
 import { SELECT } from "@tpluscode/sparql-builder";
+import uniqBy from "lodash/uniqBy";
 import { Term } from "rdf-js";
 import ParsingClient from "sparql-http-client/ParsingClient";
 
@@ -12,10 +13,11 @@ interface ResourceLabel {
 }
 
 const buildUnitsQuery = (values: Term[], locale: string) => {
+  const uniqueValues = uniqBy(values, (v) => v.value);
   return SELECT.DISTINCT`?iri ?label ?isCurrency ?currencyExponent ?isCurrency`
     .WHERE`
         values ?iri {
-          ${values}
+          ${uniqueValues}
         }
 
         OPTIONAL { ?iri ${ns.rdfs.label} ?rdfsLabel }

--- a/app/typings/rdf.d.ts
+++ b/app/typings/rdf.d.ts
@@ -110,6 +110,7 @@ declare module "rdf-cube-view-query" {
       }
     );
     async cube(term: Term | string): Promise<Cube | null>;
+    endpoint: string;
     async cubes(options?: {
       noShape?: boolean;
       filters: $FixMe;

--- a/app/utils/cached-with-ttl.ts
+++ b/app/utils/cached-with-ttl.ts
@@ -16,7 +16,7 @@ const cachedWithTTL = <T extends (...args: any[]) => any>(
     if (cache[key]) {
       res = cache[key].result;
     } else {
-      const cached = await fn(...args);
+      const cached = fn(...args);
       cache[key] = { date: Date.now(), result: cached };
       res = cache[key].result;
     }

--- a/app/utils/timed.ts
+++ b/app/utils/timed.ts
@@ -3,9 +3,11 @@ export type Timing = {
   end: number;
 };
 
+export type TimingCallback = ({ start, end }: Timing, ...args: any[]) => void;
+
 export const timed = <T extends (...args: any) => any>(
   fn: T,
-  cb: ({ start, end }: Timing, ...args: Parameters<T>) => void
+  cb: TimingCallback
 ) => {
   const wrapped = async function (...args: Parameters<T>) {
     const start = Date.now();


### PR DESCRIPTION
While investigating queries, I noticed that we were loading the cubes a lot,
since the dataCubeByIri resolver is high and needs to load the cube shape.
Since the cube can be shared across resolvers, I used a loader.
Since the cube does not change a lot, I added also an application level
cache through the cachedWithTTL helper. This means that even across requests,
within a 60s timespan, the cube will be resolved through a cache.

## How to test

Every interaction with cubes in the cube configurator should be faster.

