### PR TITLE
fix: Use dimension colors for segments

### DIFF
--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -52,7 +52,13 @@ jest.mock("@/graphql/client", () => {
                 {
                   __typename: "GeoShapesDimension",
                   iri: "newAreaLayerColorIri",
-                  values: [{ value: "orange", label: "orange" }],
+                  values: [
+                    {
+                      value: "orange",
+                      label: "orange",
+                      color: "rgb(255, 153, 0)",
+                    },
+                  ],
                 },
                 {
                   __typename: "GeoCoordinatesDimension",
@@ -720,6 +726,41 @@ describe("colorMapping", () => {
       red: "red",
       green: "green",
       blue: "blue",
+    });
+  });
+
+  it("should use dimension colors if present", () => {
+    const state = {
+      state: "CONFIGURING_CHART",
+      dataSource: {
+        type: "sparql",
+        url: "fakeUrl",
+      },
+      chartConfig: {
+        chartType: "column",
+        fields: {},
+        filters: {},
+      },
+    } as ConfiguratorStateConfiguringChart;
+
+    handleChartFieldChanged(
+      state as unknown as ConfiguratorStateConfiguringChart,
+      {
+        type: "CHART_FIELD_CHANGED",
+        value: {
+          locale: "en",
+          field: "segment",
+          componentIri: "newAreaLayerColorIri",
+        },
+      }
+    );
+
+    const chartConfig = state.chartConfig as ColumnConfig;
+
+    expect(chartConfig.fields.segment?.componentIri === "newAreaLayerColorIri");
+    expect(chartConfig.fields.segment?.palette === "dimension");
+    expect(chartConfig.fields.segment?.colorMapping).toEqual({
+      orange: "rgb(255, 153, 0)",
     });
   });
 });

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -29,7 +29,6 @@ import {
   getPossibleChartType,
 } from "@/charts";
 import { DEFAULT_FIXED_COLOR_FIELD } from "@/charts/map/constants";
-import { hasDimensionColors } from "@/charts/shared/colors";
 import { mapValueIrisToColor } from "@/configurator/components/ui-helpers";
 import {
   ConfiguratorStateConfiguringChart,
@@ -81,7 +80,7 @@ import {
 import { DataCubeMetadata } from "@/graphql/types";
 import { Locale } from "@/locales/locales";
 import { useLocale } from "@/locales/use-locale";
-import { DEFAULT_CATEGORICAL_PALETTE_NAME } from "@/palettes";
+import { getDefaultCategoricalPaletteName } from "@/palettes";
 import { findInHierarchy } from "@/rdf/tree-utils";
 import {
   getDataSourceFromLocalStorage,
@@ -803,8 +802,9 @@ export const handleChartFieldChanged = (
       // FIXME: This should be more chart specific
       // (no "stacked" for scatterplots for instance)
       if (isSegmentInConfig(draft.chartConfig)) {
+        const palette = getDefaultCategoricalPaletteName(component);
         const colorMapping = mapValueIrisToColor({
-          palette: DEFAULT_CATEGORICAL_PALETTE_NAME,
+          palette,
           dimensionValues: component?.values || [],
         });
         draft.chartConfig.filters[componentIri] = {
@@ -815,7 +815,7 @@ export const handleChartFieldChanged = (
         };
         draft.chartConfig.fields.segment = {
           componentIri,
-          palette: DEFAULT_CATEGORICAL_PALETTE_NAME,
+          palette,
           // Type exists only within column charts.
           ...(isColumnConfig(draft.chartConfig) && { type: "stacked" }),
           sorting: DEFAULT_SORTING,
@@ -847,10 +847,12 @@ export const handleChartFieldChanged = (
       draft.chartConfig.fields.segment &&
       "palette" in draft.chartConfig.fields.segment
     ) {
+      const palette = getDefaultCategoricalPaletteName(
+        component,
+        draft.chartConfig.fields.segment.palette
+      );
       const colorMapping = mapValueIrisToColor({
-        palette:
-          draft.chartConfig.fields.segment.palette ||
-          DEFAULT_CATEGORICAL_PALETTE_NAME,
+        palette,
         dimensionValues: component?.values || [],
       });
 
@@ -971,10 +973,10 @@ export const handleChartOptionChanged = (
             canDimensionBeMultiFiltered(component) ||
             isOrdinalMeasure(component)
           ) {
-            const hasColors = hasDimensionColors(component);
-            const palette = hasColors
-              ? "dimension"
-              : previousPalette || DEFAULT_CATEGORICAL_PALETTE_NAME;
+            const palette = getDefaultCategoricalPaletteName(
+              component,
+              previousPalette
+            );
             setWith(
               draft,
               `chartConfig.fields.${action.value.field}.color`,

--- a/app/palettes.ts
+++ b/app/palettes.ts
@@ -41,12 +41,14 @@ import {
 import { DimensionMetadataFragment } from "./graphql/query-hooks";
 
 // Colors
-
 export const getDefaultCategoricalPaletteName = (
-  d: DimensionMetadataFragment
+  d?: DimensionMetadataFragment,
+  previousPaletteName?: string
 ): string => {
   const hasColors = hasDimensionColors(d);
-  return hasColors ? "dimension" : DEFAULT_CATEGORICAL_PALETTE_NAME;
+  return hasColors
+    ? "dimension"
+    : previousPaletteName || DEFAULT_CATEGORICAL_PALETTE_NAME;
 };
 
 export const getDefaultCategoricalPalette = (


### PR DESCRIPTION
Recently we enabled fetching of default colors attached to dimensions, but it turned out they weren't enabled for segment fields – this PR fixes that. It also corrects display of reset / refresh based on whether a palette is `dimension` or not (and not as previously, where we just checked if dimension has custom colors).