### PR TITLE
fix: Missing dates in filters

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,31 +1,32 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-title: ''
+title: ""
 labels: bug
-assignees: ''
-
+assignees: ""
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is.
+A clear and concise description of what the bug is. If it seems connected to some data problem (missing values, wrong parsing) please first check the cube in Cube Checker ([int](https://int.visualize.admin.ch/_cube-checker), [prod](https://visualize.admin.ch/_cube-checker)) to see if everything is fine there.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
+2. Click on '...'
+3. Scroll down to '...'
 4. See error
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**Screenshots or video**
+If applicable, add screenshots or a short video to help put your problem into a context.
 
 **Environment (please complete the following information):**
- - Visualize environment and version: [e.g. INT v3.2.6]
- - Browser and version [e.g. Chrome 95]
+
+- Visualize environment and version: [e.g. INT v3.12.0]
+- Browser and version [e.g. Chrome 107]
 
 **Additional context**
 Add any other context about the problem here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 
 ## Unreleased
 
-Nothing yet.
+- Enhancements:
+  - Cube Checker:
+    - Introduced a Temporal dimensions scaleType check
+- Bug fixes:
+  - Correctly retrieve min & max values for Temporal dimensions when scaleType is not equal to Interval
 
 ## [3.12.0] - 2022-11-15
 

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -129,11 +129,14 @@ const DataFilterSelectGeneric = ({
     } else if (dimension.timeUnit === "Month") {
       return <DataFilterSelect {...sharedProps} options={values} />;
     } else {
+      const from = values[0].value;
+      const to = values[values.length - 1]?.value || from;
+
       return (
         <DataFilterSelectTime
           {...sharedProps}
-          from={values[0].value}
-          to={values[1].value}
+          from={from}
+          to={to}
           timeUnit={dimension.timeUnit}
           timeFormat={dimension.timeFormat}
         />

--- a/app/configurator/table/table-chart-options.tsx
+++ b/app/configurator/table/table-chart-options.tsx
@@ -346,7 +346,10 @@ export const TableColumnOptions = ({
                 dimensionIri={component.iri}
                 label={component.label}
                 from={component.values[0].value}
-                to={component.values[1].value}
+                to={
+                  component.values[component.values.length - 1]?.value ||
+                  component.values[0].value
+                }
                 timeUnit={component.timeUnit}
                 timeFormat={component.timeFormat}
                 disabled={false}

--- a/app/graphql/context.tsx
+++ b/app/graphql/context.tsx
@@ -20,7 +20,7 @@ import { RequestQueryMeta } from "./query-meta";
 
 const MAX_BATCH_SIZE = 500;
 
-const getRawCube = async (sourceUrl: string, iri: string) => {
+export const getRawCube = async (sourceUrl: string, iri: string) => {
   const source = createSource({ endpointUrl: sourceUrl });
   const cube = await source.cube(iri);
   return cube;

--- a/e2e/filters.spec.ts
+++ b/e2e/filters.spec.ts
@@ -18,11 +18,11 @@ describe("Filters", () => {
 
     const texts = await labels.allTextContents();
     expect(texts).toEqual([
-      "1. production region",
-      "2. stand structure",
-      "3. evaluation type",
-      "4. unit of evaluation",
-      "5. grid",
+      "1. Production region",
+      "2. Evaluation type",
+      "3. Stand structure",
+      "4. Grid",
+      "5. Inventory",
     ]);
   });
 
@@ -32,6 +32,8 @@ describe("Filters", () => {
     selectors,
     within,
   }) => {
+    test.slow();
+
     await page.goto(
       "/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/5&dataSource=Prod"
     );

--- a/e2e/filters.spec.ts
+++ b/e2e/filters.spec.ts
@@ -1,26 +1,58 @@
-import { test, expect } from "./common";
+import { describe, test, expect } from "./common";
 
-test("Filters initial state should have hierarchy dimensions first and topmost value selected", async ({
-  page,
-  selectors,
-}) => {
-  await page.goto(
-    `/en/create/new?cube=https://environment.ld.admin.ch/foen/nfi/49-19-44/cube/1&dataSource=Int`
-  );
-  await selectors.chart.loaded();
+describe("Filters", () => {
+  test("Filters initial state should have hierarchy dimensions first and topmost value selected", async ({
+    page,
+    selectors,
+  }) => {
+    await page.goto(
+      `/en/create/new?cube=https://environment.ld.admin.ch/foen/nfi/49-19-44/cube/1&dataSource=Int`
+    );
+    await selectors.chart.loaded();
 
-  const filters = selectors.edition.controlSection("Filters");
+    const filters = selectors.edition.controlSection("Filters");
 
-  await filters.locator("label").first().waitFor({ timeout: 30_000 });
+    await filters.locator("label").first().waitFor({ timeout: 30_000 });
 
-  const labels = filters.locator("label");
+    const labels = filters.locator("label");
 
-  const texts = await labels.allTextContents();
-  expect(texts).toEqual([
-    "1. production region",
-    "2. stand structure",
-    "3. evaluation type",
-    "4. unit of evaluation",
-    "5. grid",
-  ]);
+    const texts = await labels.allTextContents();
+    expect(texts).toEqual([
+      "1. production region",
+      "2. stand structure",
+      "3. evaluation type",
+      "4. unit of evaluation",
+      "5. grid",
+    ]);
+  });
+
+  test("Temporal filter should display all values", async ({
+    page,
+    actions,
+    selectors,
+    within,
+  }) => {
+    await page.goto(
+      "/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/5&dataSource=Prod"
+    );
+    await selectors.chart.loaded();
+
+    await actions.editor.changeChartType("Map");
+
+    const filters = await selectors.edition.configFilters();
+
+    await filters.locator("label").first().waitFor({ timeout: 30_000 });
+
+    const labels = filters.locator("label");
+
+    const texts = await labels.allTextContents();
+    expect(texts).toEqual(["1. Jahr der Vergütung"]);
+
+    const yearFilter = await within(filters).findByText("2014");
+    await yearFilter.click();
+
+    const options = await selectors.mui.options().allInnerTexts();
+
+    expect(options.length).toEqual(8);
+  });
 });

--- a/e2e/sorting.spec.ts
+++ b/e2e/sorting.spec.ts
@@ -85,7 +85,6 @@ test("Segment sorting with hierarchy", async ({
   selectors,
   screen,
   within,
-  page,
 }) => {
   await actions.chart.createFrom(
     "https://environment.ld.admin.ch/foen/nfi/49-19-44/cube/1",
@@ -100,7 +99,7 @@ test("Segment sorting with hierarchy", async ({
     .getByText("None")
     .click();
 
-  await actions.mui.selectOption("production region");
+  await actions.mui.selectOption("Production region");
   await selectors.chart.loaded();
 
   await selectors.edition.filtersLoaded();
@@ -109,7 +108,7 @@ test("Segment sorting with hierarchy", async ({
   await within(await selectors.chart.colorLegend()).findByText(
     "Southern Alps",
     undefined,
-    { timeout: 5000 }
+    { timeout: 10_000 }
   );
 
   const legendItems = await selectors.chart.colorLegendItems();

--- a/e2e/symbol-layer-colors.spec.ts
+++ b/e2e/symbol-layer-colors.spec.ts
@@ -21,7 +21,7 @@ test("Selecting SymbolLayer colors> should be possible to select geo dimension a
     .click();
 
   // Select production region as origin for symbols
-  await actions.mui.selectOption("production region");
+  await actions.mui.selectOption("Production region");
 
   await selectors.chart.loaded();
 
@@ -30,7 +30,7 @@ test("Selecting SymbolLayer colors> should be possible to select geo dimension a
     .click();
 
   // Selects production region for color mapping
-  await actions.mui.selectOption("production region");
+  await actions.mui.selectOption("Production region");
 
   const legendItems = await selectors.chart.colorLegendItems();
   expect(await legendItems.count()).toBe(6);


### PR DESCRIPTION
Fixes #852.

While Temporal dimensions should have Interval scale type, there is no restriction on Cube Creator side to define them in such way; that's why they can have other scale types. I think we should still enable the usage of these "incorrect" combinations.

This PR adds support for such cases & adds a cube rule check to inform the users that the mapping anyways should be changed.