### PR TITLE
fix: Top level hierarchy values in color legend

### DIFF
--- a/app/charts/shared/legend-color-helpers.ts
+++ b/app/charts/shared/legend-color-helpers.ts
@@ -1,0 +1,46 @@
+import { ascending } from "d3";
+
+import { HierarchyValue } from "@/graphql/resolver-types";
+import { dfs } from "@/utils/dfs";
+
+export const getLegendGroups = ({
+  title,
+  labels,
+  hierarchy,
+  sort,
+}: {
+  title?: string;
+  labels: string[];
+  hierarchy?: HierarchyValue[] | null;
+  sort: boolean;
+}) => {
+  const groupsMap = new Map<HierarchyValue[], string[]>();
+
+  if (!hierarchy) {
+    groupsMap.set(title ? [{ label: title } as HierarchyValue] : [], labels);
+  } else {
+    const labelSet = new Set(labels);
+    const emptyParents: HierarchyValue[] = [];
+
+    dfs(hierarchy, (node, { parents: _parents }) => {
+      if (!labelSet.has(node.label)) {
+        return;
+      }
+
+      const parents = _parents.length === 0 ? emptyParents : _parents;
+      groupsMap.set(parents, groupsMap.get(parents) || []);
+      groupsMap.get(parents)?.push(node.label);
+    });
+  }
+
+  const groups = Array.from(groupsMap.entries());
+  if (sort) {
+    // Re-sort hierarchy groups against the label order that we have received
+    const labelOrder = Object.fromEntries(labels.map((x, i) => [x, i]));
+    groups.forEach(([_, entries]) => {
+      entries.sort((a, b) => ascending(labelOrder[a], labelOrder[b]));
+    });
+  }
+
+  return groups;
+};

--- a/app/charts/shared/legend-color.spec.ts
+++ b/app/charts/shared/legend-color.spec.ts
@@ -1,0 +1,23 @@
+import { HierarchyValue } from "@/graphql/resolver-types";
+
+import { getLegendGroups } from "./legend-color-helpers";
+
+describe("getLegendGroups", () => {
+  const hierarchy: HierarchyValue[] = [
+    { dimensionIri: "numbers", depth: 0, value: "1", label: "one" },
+    { dimensionIri: "numbers", depth: 0, value: "2", label: "two" },
+    { dimensionIri: "numbers", depth: 0, value: "3", label: "three" },
+  ];
+
+  it("should properly create groups when encountering top-level values", () => {
+    const groups = getLegendGroups({
+      title: "",
+      labels: hierarchy.map((d) => d.label),
+      hierarchy,
+      sort: true,
+    });
+
+    expect(groups.length).toEqual(1);
+    expect(groups[0][1]).toEqual(["one", "two", "three"]);
+  });
+});


### PR DESCRIPTION
Fixes #858.

The `useLegendGroups` function was appending empty arrays for top-level values (without parents) – this PR fixes that by creating an empty array outside of the `dfs` function to use the same object as parent for such values.