### PR TITLE
Use trees in selects when hierarchy is present

### DIFF
--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -306,7 +306,7 @@ const DataFilterHierarchyDimension = ({
       opts = dimensionValues;
     }
     if (!isKeyDimension) {
-      opts.push({
+      opts.unshift({
         value: FIELD_VALUE_NONE,
         label: noneLabel,
         isNoneValue: true,

--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -11,6 +11,7 @@ import {
   Input as MUIInput,
   Radio as MUIRadio,
   Select as MUISelect,
+  Skeleton,
   Slider as MUISlider,
   Switch as MUISwitch,
   SelectProps,
@@ -20,7 +21,6 @@ import {
   MenuItem,
   TypographyProps,
   Stack,
-  CircularProgress,
   styled,
   PaperProps,
 } from "@mui/material";
@@ -285,23 +285,17 @@ const LoadingMenuPaper = forwardRef<HTMLDivElement>(
     const loading = useContext(LoadingMenuPaperContext);
     return (
       <MenuPaper {...props} ref={ref}>
-        {props.children}
         {loading ? (
-          <Box
-            px={4}
-            py={2}
-            sx={{
-              position: "sticky",
-              bottom: 0,
-              backgroundColor: "warning.light",
-            }}
-          >
-            <Typography variant="body2">
+          <Box px={4} py={5}>
+            <Typography variant="body2" sx={{ mb: 2 }} color="text.secondary">
               <Trans id="hint.loading.data" />
-              <CircularProgress size={12} color="inherit" />
             </Typography>
+            <Skeleton sx={{ bgcolor: "grey.300" }} />
+            <Skeleton sx={{ bgcolor: "grey.300" }} />
           </Box>
-        ) : null}
+        ) : (
+          props.children
+        )}
       </MenuPaper>
     );
   }

--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -318,6 +318,8 @@ export const Select = ({
   controls,
   optionGroups,
   tooltipText,
+  open,
+  onClose,
   onOpen,
   loading,
 }: {
@@ -367,7 +369,9 @@ export const Select = ({
           onChange={onChange}
           value={value}
           disabled={disabled}
+          open={open}
           onOpen={onOpen}
+          onClose={onClose}
           MenuProps={{
             PaperProps: {
               // @ts-ignore - It works

--- a/app/components/select-tree.tsx
+++ b/app/components/select-tree.tsx
@@ -13,6 +13,7 @@ import {
   useEventCallback,
   OutlinedInput,
   Typography,
+  Collapse,
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import useId from "@mui/utils/useId";
@@ -274,6 +275,7 @@ function SelectTree({
   const classes = useStyles({ disabled, open });
 
   const parentsRef = React.useRef({} as Record<NodeId, NodeId>);
+
   const labelsByValue = useMemo(() => {
     parentsRef.current = {} as Record<NodeId, NodeId>;
     const res: Record<string, string> = {};
@@ -309,6 +311,17 @@ function SelectTree({
   });
 
   const treeItemClasses = useTreeItemStyles();
+  const treeItemTransitionProps = useMemo(
+    () => ({
+      onEntered: () => {
+        menuRef.current?.updatePosition();
+      },
+      onExited: () => {
+        menuRef.current?.updatePosition();
+      },
+    }),
+    []
+  );
   const renderTreeContent = useCallback(
     (nodesData: Tree) => {
       return (
@@ -324,6 +337,8 @@ function SelectTree({
                   children && children.length > 0 ? <ChevronRightIcon /> : null
                 }
                 classes={treeItemClasses}
+                TransitionComponent={Collapse}
+                TransitionProps={treeItemTransitionProps}
                 ContentProps={{
                   // @ts-expect-error - TS says we cannot put a data attribute
                   // on the HTML element, but we know we can.
@@ -338,21 +353,10 @@ function SelectTree({
         </>
       );
     },
-    [defaultExpanded, treeItemClasses]
+    [defaultExpanded, treeItemClasses, treeItemTransitionProps]
   );
 
   const menuRef = React.useRef<PopoverActions>(null);
-  const handleNodeToggle = () => {
-    setTimeout(() => {
-      menuRef.current?.updatePosition();
-    }, 500);
-    setTimeout(() => {
-      menuRef.current?.updatePosition();
-    }, 1000);
-    setTimeout(() => {
-      menuRef.current?.updatePosition();
-    }, 2000);
-  };
 
   const paperProps = useMemo(() => {
     return {
@@ -362,8 +366,8 @@ function SelectTree({
     };
   }, [minMenuWidth]);
 
-  const transitionProps = useMemo(() => {
-    return {
+  const menuTransitionProps = useMemo(
+    () => ({
       /**
        * Adds transition for top, as we need to reposition the paper when a node is toggled.
        * This needs to be done like this since the Grow transition component imperatively
@@ -374,8 +378,9 @@ function SelectTree({
           node.style.transition = `${node.style.transition}, top 158ms cubic-bezier(0.4, 0, 0.2, 1)`;
         }
       },
-    };
-  }, []);
+    }),
+    []
+  );
 
   const id = useId();
 
@@ -406,13 +411,12 @@ function SelectTree({
         onClose={handleClose}
         action={menuRef}
         PaperProps={paperProps}
-        TransitionProps={transitionProps}
+        TransitionProps={menuTransitionProps}
       >
         <TreeView
           defaultSelected={value}
           defaultExpanded={defaultExpanded}
           onNodeSelect={handleNodeSelect}
-          onNodeToggle={handleNodeToggle}
           defaultCollapseIcon={<ExpandMoreIcon />}
           defaultExpandIcon={<ChevronRightIcon />}
           sx={{ flexGrow: 1, overflowY: "auto", pb: 2, "user-select": "none" }}

--- a/app/components/select-tree.tsx
+++ b/app/components/select-tree.tsx
@@ -20,6 +20,7 @@ import useId from "@mui/utils/useId";
 import clsx from "clsx";
 import { useCallback, useMemo, useState } from "react";
 import * as React from "react";
+import { useEffect } from "react";
 
 import { Label } from "@/components/form";
 import { Icon } from "@/icons";
@@ -253,6 +254,9 @@ export type SelectTreeProps = {
   disabled?: boolean;
   tooltipText?: string;
   label?: string;
+  onOpen?: () => void;
+  onClose?: () => void;
+  open?: boolean;
 };
 
 function SelectTree({
@@ -263,6 +267,9 @@ function SelectTree({
   tooltipText,
   disabled,
   controls,
+  onOpen,
+  onClose,
+  open,
 }: SelectTreeProps) {
   const [anchorEl, setAnchorEl] = useState<HTMLElement>();
   const [minMenuWidth, setMinMenuWidth] = useState<number>();
@@ -270,11 +277,13 @@ function SelectTree({
   const handleClick = useEventCallback((ev: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(ev.currentTarget);
     setMinMenuWidth(ev.currentTarget.clientWidth);
+    onOpen?.();
   });
+
   const handleClose = useEventCallback(() => {
     setAnchorEl(undefined);
+    onClose?.();
   });
-  const open = !!anchorEl;
   const classes = useStyles({ disabled, open });
 
   const parentsRef = React.useRef({} as Record<NodeId, NodeId>);
@@ -390,6 +399,14 @@ function SelectTree({
   );
 
   const id = useId();
+  const inputRef = React.useRef<HTMLDivElement>();
+
+  useEffect(() => {
+    const inputNode = inputRef.current;
+    if (inputNode) {
+      setMinMenuWidth(inputNode.clientWidth);
+    }
+  }, [open]);
 
   return (
     <div>
@@ -403,6 +420,7 @@ function SelectTree({
         readOnly
         value={value ? labelsByValue[value] : undefined}
         disabled={disabled}
+        ref={inputRef}
         size="small"
         className={classes.input}
         onClick={disabled ? undefined : handleClick}
@@ -414,7 +432,7 @@ function SelectTree({
           horizontal: "left",
         }}
         anchorEl={anchorEl}
-        open={open}
+        open={open !== undefined ? open : !!anchorEl}
         onClose={handleClose}
         action={menuRef}
         PaperProps={paperProps}

--- a/app/components/select-tree.tsx
+++ b/app/components/select-tree.tsx
@@ -302,8 +302,16 @@ function SelectTree({
       res.push(parents[cur]);
       cur = parents[cur];
     }
+    if (res.length === 0) {
+      const children = options[0].children;
+      if (children) {
+        res.push(options[0].value);
+      }
+    }
+
+    console.log("expanded", res);
     return res;
-  }, [value]);
+  }, [value, options]);
 
   const handleNodeSelect = useEventCallback((_ev, value: NodeId) => {
     onChange({ target: { value: value } });

--- a/app/components/select-tree.tsx
+++ b/app/components/select-tree.tsx
@@ -61,19 +61,36 @@ const useTreeItemStyles = makeStyles<Theme>((theme) => ({
       },
     },
   },
+  // Necessary to use $content below
+  content: {},
   root: {
     "&:hover > div > $iconContainer": {
       opacity: 1,
+    },
+    "--depth": 1,
+    "& &": {
+      "--depth": 2,
+    },
+    "& & &": {
+      "--depth": 3,
+    },
+    "& & & &": {
+      "--depth": 4,
+    },
+    "& & & & &": {
+      "--depth": 5,
+    },
+    "& $content": {
+      paddingLeft: "calc(var(--depth) * 10px)",
     },
   },
   iconContainer: {
     opacity: 0.5,
   },
   group: {
+    // The padding is done on the content inside the row for the hover
+    // effect to extend until the edge of the popover
     marginLeft: 0,
-  },
-  content: {
-    paddingLeft: theme.spacing(2),
   },
 }));
 

--- a/app/components/select-tree.tsx
+++ b/app/components/select-tree.tsx
@@ -1,0 +1,351 @@
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import MUITreeItem, {
+  TreeItemContentClassKey,
+  TreeItemProps,
+  useTreeItem,
+} from "@mui/lab/TreeItem";
+import TreeView from "@mui/lab/TreeView";
+import {
+  Theme,
+  Menu,
+  PopoverActions,
+  useEventCallback,
+  OutlinedInput,
+} from "@mui/material";
+import { makeStyles } from "@mui/styles";
+import useId from "@mui/utils/useId";
+import clsx from "clsx";
+import { useCallback, useMemo, useState } from "react";
+import * as React from "react";
+
+import { Label } from "@/components/form";
+import { Icon } from "@/icons";
+import useEvent from "@/utils/use-event";
+
+const useStyles = makeStyles<Theme, { disabled?: boolean; open?: boolean }>(
+  (theme) => ({
+    input: {
+      width: "100%",
+      cursor: "pointer",
+      borderRadius: 4,
+      fontSize: theme.typography.body2.fontSize,
+      minHeight: 40,
+
+      "& input": {
+        cursor: "pointer",
+      },
+    },
+    icon: {
+      flexShrink: 0,
+      marginRight: -6,
+      width: 20,
+      height: 20,
+      color: ({ disabled }) =>
+        disabled ? theme.palette.grey[500] : theme.palette.grey[600],
+      transition: "transform 0.150s ease",
+      transform: ({ open }) => (open ? "rotate(180deg)" : "rotate(0deg)"),
+    },
+  })
+);
+
+const useTreeItemStyles = makeStyles<Theme>((theme) => ({
+  label: {
+    fontSize: theme.typography.body2.fontSize,
+
+    [theme.breakpoints.up("xs")]: {
+      "&": {
+        fontSize: theme.typography.body2.fontSize,
+      },
+    },
+  },
+}));
+
+const TreeItemContent = React.forwardRef<
+  unknown,
+  {
+    classes: Record<TreeItemContentClassKey, string>;
+    className?: string;
+    displayIcon?: React.ReactNode;
+    expansionIcon?: React.ReactNode;
+    icon?: React.ReactNode;
+    label?: React.ReactNode;
+    onClick?: React.MouseEventHandler;
+    nodeId: string;
+    onMouseDown?: React.MouseEventHandler;
+    "data-selectable"?: boolean;
+  }
+>(function TreeItemContent(props, ref) {
+  const {
+    classes,
+    className,
+    displayIcon,
+    expansionIcon,
+    icon: iconProp,
+    label,
+    nodeId,
+    onClick,
+    onMouseDown,
+
+    ...other
+  } = props;
+
+  const selectable = other["data-selectable"];
+
+  const {
+    disabled,
+    expanded,
+    selected,
+    focused,
+    handleExpansion,
+    handleSelection,
+    preventSelection,
+  } = useTreeItem(nodeId);
+
+  const icon = iconProp || expansionIcon || displayIcon;
+
+  const handleMouseDown = useEvent((event: React.MouseEvent) => {
+    preventSelection(event);
+
+    if (onMouseDown) {
+      onMouseDown(event);
+    }
+  });
+
+  const handleClickLabel = useEvent((event: React.MouseEvent) => {
+    if (selectable === false) {
+      handleExpansion(event);
+      return;
+    }
+    preventSelection(event);
+    handleSelection(event);
+
+    if (onClick) {
+      onClick(event);
+    }
+  });
+
+  const handleClickIcon = useEvent((event: React.MouseEvent) => {
+    handleExpansion(event);
+  });
+
+  return (
+    /* eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-static-element-interactions -- Key event is handled by the TreeView */
+    <div
+      className={clsx(className, classes.root, {
+        [classes.expanded]: expanded,
+        [classes.selected]: selected,
+        [classes.focused]: focused,
+        [classes.disabled]: disabled,
+      })}
+      onMouseDown={handleMouseDown}
+      ref={ref as React.ForwardedRef<HTMLDivElement>}
+      {...other}
+    >
+      <div onClick={handleClickIcon} className={clsx(classes.iconContainer)}>
+        {icon}
+      </div>
+      <div onClick={handleClickLabel} className={classes.label}>
+        {label}
+      </div>
+    </div>
+  );
+});
+
+const TreeItem = (props: TreeItemProps) => {
+  return <MUITreeItem {...props} ContentComponent={TreeItemContent} />;
+};
+
+type Tree = {
+  value: string;
+  label: string;
+  children?: Tree;
+  selectable?: boolean;
+}[];
+
+type NodeId = string;
+
+export type SelectTreeProps = {
+  options: Tree;
+  value: NodeId | undefined;
+  controls?: React.ReactNode;
+  onChange: (ev: { target: { value: NodeId } }) => void;
+  disabled?: boolean;
+  tooltipText?: string;
+  label?: string;
+};
+
+function SelectTree({
+  label,
+  options,
+  value,
+  onChange,
+  tooltipText,
+  disabled,
+  controls,
+}: SelectTreeProps) {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement>();
+  const [minMenuWidth, setMinMenuWidth] = useState<number>();
+
+  const handleClick = useEventCallback((ev: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(ev.currentTarget);
+    setMinMenuWidth(ev.currentTarget.clientWidth);
+  });
+  const handleClose = useEventCallback(() => {
+    setAnchorEl(undefined);
+  });
+  const open = !!anchorEl;
+  const classes = useStyles({ disabled, open });
+
+  const parentsRef = React.useRef({} as Record<NodeId, NodeId>);
+  const labelsByValue = useMemo(() => {
+    parentsRef.current = {} as Record<NodeId, NodeId>;
+    const res: Record<string, string> = {};
+    const registerNode = ({ value, label, children }: Tree[number]) => {
+      res[value] = label;
+      if (children && children.length > 0) {
+        for (let child of children) {
+          registerNode(child);
+          parentsRef.current[child.value as unknown as NodeId] = value;
+        }
+      }
+    };
+    for (let root of options) {
+      registerNode(root);
+    }
+    return res;
+  }, [options]);
+
+  const defaultExpanded = useMemo(() => {
+    const res = [];
+    let cur = value;
+    const parents = parentsRef.current;
+    while (cur && parents[cur]) {
+      res.push(parents[cur]);
+      cur = parents[cur];
+    }
+    return res;
+  }, [value]);
+
+  const handleNodeSelect = useEventCallback((_ev, value: NodeId) => {
+    onChange({ target: { value: value } });
+    handleClose();
+  });
+
+  const treeItemClasses = useTreeItemStyles();
+  const renderTreeContent = useCallback(
+    (nodesData: Tree) => {
+      return (
+        <>
+          {nodesData.map(({ value, label, children, selectable }) => {
+            return (
+              <TreeItem
+                key={value}
+                nodeId={value}
+                defaultExpanded={defaultExpanded}
+                label={label}
+                expandIcon={
+                  children && children.length > 0 ? <ChevronRightIcon /> : null
+                }
+                classes={treeItemClasses}
+                ContentProps={{
+                  // @ts-expect-error - TS says we cannot put a data attribute
+                  // on the HTML element, but we know we can.
+                  "data-selectable": selectable,
+                }}
+              >
+                {children ? renderTreeContent(children) : null}
+              </TreeItem>
+            );
+          })}
+        </>
+      );
+    },
+    [defaultExpanded, treeItemClasses]
+  );
+
+  const menuRef = React.useRef<PopoverActions>(null);
+  const handleNodeToggle = () => {
+    setTimeout(() => {
+      menuRef.current?.updatePosition();
+    }, 500);
+    setTimeout(() => {
+      menuRef.current?.updatePosition();
+    }, 1000);
+    setTimeout(() => {
+      menuRef.current?.updatePosition();
+    }, 2000);
+  };
+
+  const paperProps = useMemo(() => {
+    return {
+      style: {
+        minWidth: minMenuWidth === undefined ? 0 : minMenuWidth,
+      },
+    };
+  }, [minMenuWidth]);
+
+  const transitionProps = useMemo(() => {
+    return {
+      /**
+       * Adds transition for top, as we need to reposition the paper when a node is toggled.
+       * This needs to be done like this since the Grow transition component imperatively
+       * changes the node.style.transition on entering.
+       */
+      onEnter: (node: HTMLElement, isAppearing: boolean) => {
+        if (isAppearing) {
+          node.style.transition = `${node.style.transition}, top 158ms cubic-bezier(0.4, 0, 0.2, 1)`;
+        }
+      },
+    };
+  }, []);
+
+  const id = useId();
+
+  return (
+    <div>
+      {label && (
+        <Label htmlFor={id!} smaller tooltipText={tooltipText} sx={{ mb: 1 }}>
+          {label} {controls}
+        </Label>
+      )}
+      <OutlinedInput
+        id={id}
+        readOnly
+        value={value ? labelsByValue[value] : undefined}
+        disabled={disabled}
+        size="small"
+        className={classes.input}
+        onClick={disabled ? undefined : handleClick}
+        endAdornment={<Icon className={classes.icon} name="caretDown" />}
+      />
+      <Menu
+        anchorOrigin={{
+          vertical: "top",
+          horizontal: "left",
+        }}
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        action={menuRef}
+        PaperProps={paperProps}
+        TransitionProps={transitionProps}
+      >
+        <TreeView
+          defaultSelected={value}
+          defaultExpanded={defaultExpanded}
+          onNodeSelect={handleNodeSelect}
+          onNodeToggle={handleNodeToggle}
+          defaultCollapseIcon={<ExpandMoreIcon />}
+          defaultExpandIcon={<ChevronRightIcon />}
+          // onNodeSelect={handleNodeSelect}
+          sx={{ flexGrow: 1, overflowY: "auto", pb: 2, "user-select": "none" }}
+        >
+          {renderTreeContent(options)}
+        </TreeView>
+      </Menu>
+    </div>
+  );
+}
+
+export default SelectTree;

--- a/app/components/select-tree.tsx
+++ b/app/components/select-tree.tsx
@@ -179,7 +179,9 @@ const TreeItemContent = React.forwardRef<
   });
 
   const handleClickLabel = useEvent((event: React.MouseEvent) => {
-    handleExpansion(event);
+    if (!event.defaultPrevented) {
+      handleExpansion(event);
+    }
   });
 
   const handleClickIcon = useEvent((event: React.MouseEvent) => {
@@ -187,6 +189,7 @@ const TreeItemContent = React.forwardRef<
   });
 
   const handleSelect = useEvent((event: React.MouseEvent) => {
+    event.preventDefault();
     if (selectable === false) {
       return;
     }

--- a/app/components/select-tree.tsx
+++ b/app/components/select-tree.tsx
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import MUITreeItem, {
@@ -223,11 +224,13 @@ const TreeItemContent = React.forwardRef<
         className={classes.label}
       >
         {label}
-        <div className={ownClasses.action} onClick={handleSelect}>
-          <Typography variant="caption">
-            {selectable && hasChildren ? "Select" : ""}
-          </Typography>
-        </div>
+        {selectable && hasChildren ? (
+          <div className={ownClasses.action} onClick={handleSelect}>
+            <Typography variant="caption">
+              <Trans id="controls.tree.select-value">Select</Trans>
+            </Typography>
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/app/components/select-tree.tsx
+++ b/app/components/select-tree.tsx
@@ -298,21 +298,17 @@ function SelectTree({
   }, [options]);
 
   const defaultExpanded = useMemo(() => {
-    const res = [];
+    if (!value && options.length > 0) {
+      return options[0].value ? [options[0].value] : [];
+    }
+    const res = value ? [value] : [];
     let cur = value;
     const parents = parentsRef.current;
     while (cur && parents[cur]) {
       res.push(parents[cur]);
       cur = parents[cur];
     }
-    if (res.length === 0) {
-      const children = options[0].children;
-      if (children) {
-        res.push(options[0].value);
-      }
-    }
 
-    console.log("expanded", res);
     return res;
   }, [value, options]);
 

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -54,19 +54,19 @@ import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import { isStandardErrorDimension, isTemporalDimension } from "@/domain/data";
 import {
   DataCubeMetadataWithComponentValuesQuery,
+  HierarchyValue,
   PossibleFiltersDocument,
   PossibleFiltersQuery,
   PossibleFiltersQueryVariables,
   useDataCubeMetadataWithComponentValuesQuery,
+  useDimensionHierarchyQuery,
 } from "@/graphql/query-hooks";
 import { DataCubeMetadata } from "@/graphql/types";
 import { Icon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
-import { makeOptionGroups } from "@/utils/hierarchy";
 import useEvent from "@/utils/use-event";
 
 import { ChartTypeSelector } from "./chart-type-selector";
-import useHierarchyParents from "./use-hierarchy-parents";
 
 const DataFilterSelectGeneric = ({
   dimension,
@@ -83,18 +83,18 @@ const DataFilterSelectGeneric = ({
   const [state] = useConfiguratorState(isConfiguring);
   const locale = useLocale();
   const [pause, setPause] = useState(true);
-  const { data: hierarchyParents, fetching: fetchingHierarchy } =
-    useHierarchyParents({
-      datasetIri: state.dataSet,
-      dataSource: state.dataSource,
-      dimension,
+  const [hierarchyResp] = useDimensionHierarchyQuery({
+    variables: {
+      cubeIri: state.dataSet,
+      sourceUrl: state.dataSource.url,
+      sourceType: state.dataSource.type,
+      dimensionIri: dimension?.iri,
       locale,
-      pause,
-    });
-
-  const optionGroups = useMemo(() => {
-    return makeOptionGroups(hierarchyParents);
-  }, [hierarchyParents]);
+    },
+    pause,
+  });
+  const hierarchy =
+    hierarchyResp?.data?.dataCubeByIri?.dimensionByIri?.hierarchy;
 
   const handleOpen = useEvent(() => setPause(false));
 
@@ -146,9 +146,10 @@ const DataFilterSelectGeneric = ({
     return (
       <DataFilterSelect
         {...sharedProps}
-        optionGroups={optionGroups}
+        options={values}
+        hierarchy={hierarchy as HierarchyValue[]}
         onOpen={handleOpen}
-        loading={fetchingHierarchy}
+        loading={hierarchyResp.fetching}
       />
     );
   }

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -146,7 +146,6 @@ const DataFilterSelectGeneric = ({
     return (
       <DataFilterSelect
         {...sharedProps}
-        options={values}
         hierarchy={hierarchy as HierarchyValue[]}
         onOpen={handleOpen}
         loading={hierarchyResp.fetching}

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -68,6 +68,8 @@ import { useLocale } from "@/locales/use-locale";
 import { getPalette } from "@/palettes";
 import { makeDimensionValueSorters } from "@/utils/sorting-values";
 
+import useDisclosure from "./use-disclosure";
+
 const useFieldEditIconStyles = makeStyles<Theme>((theme) => ({
   root: {
     color: theme.palette.primary.main,
@@ -216,11 +218,24 @@ export const DataFilterSelect = ({
     return hierarchyToOptions(hierarchy);
   }, [hierarchy]);
 
+  const { open, close, isOpen } = useDisclosure();
+  const handleOpen = () => {
+    open();
+    onOpen?.();
+  };
+
+  const handleClose = () => {
+    close();
+  };
+
   if (hierarchy && hierarchyOptions) {
     return (
       <SelectTree
         label={isOptional ? `${label} (${optionalLabel})` : label}
         options={hierarchyOptions}
+        onClose={handleClose}
+        onOpen={handleOpen}
+        open={isOpen}
         disabled={disabled}
         controls={controls}
         tooltipText={tooltipText}
@@ -238,7 +253,9 @@ export const DataFilterSelect = ({
       sortOptions={false}
       controls={controls}
       tooltipText={tooltipText}
-      onOpen={onOpen}
+      open={isOpen}
+      onClose={handleClose}
+      onOpen={handleOpen}
       loading={loading}
       {...fieldProps}
     />

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -395,7 +395,11 @@ export const useSingleFilterSelect = ({
   const [state, dispatch] = useConfiguratorState();
 
   const onChange = useCallback<
-    (e: Pick<SelectChangeEvent<unknown>, "target">) => void
+    (
+      e:
+        | Pick<SelectChangeEvent<unknown>, "target">
+        | { target: { value: string } }
+    ) => void
   >(
     (e) => {
       dispatch({

--- a/app/docs/form.docs.tsx
+++ b/app/docs/form.docs.tsx
@@ -13,6 +13,7 @@ import {
   Switch,
   MinimalisticSelect,
 } from "@/components/form";
+import SelectTree from "@/components/select-tree";
 import { BrowseStateProvider } from "@/configurator/components/dataset-browse";
 
 const SwitchExample = ({ initialChecked }: { initialChecked?: boolean }) => {
@@ -24,6 +25,49 @@ const SwitchExample = ({ initialChecked }: { initialChecked?: boolean }) => {
       name={"foo"}
       checked={checked}
       onChange={() => toggle(!checked)}
+    />
+  );
+};
+
+const numberOptions = Array(200)
+  .fill(null)
+  .map((_x, i) => ({
+    value: `example_${i}`,
+    label: `Example ${i}`,
+  }));
+
+const SelectTreeExample = () => {
+  const [value, setValue] = useState("5");
+  return (
+    <SelectTree
+      value={value}
+      onChange={({ target: { value } }) => setValue(value)}
+      options={[
+        {
+          value: "1",
+          label: "Applications",
+          children: [{ value: "2", label: "Calendar" }],
+        },
+        {
+          value: "5",
+          label: "Documents",
+          selectable: false,
+          children: [
+            { value: "10", label: "OSS" },
+            {
+              value: "6",
+              label: "MUI",
+              children: [{ value: "8", label: "index.js" }],
+            },
+          ],
+        },
+        {
+          label: "Numbers",
+          value: "numbers",
+          selectable: false,
+          children: numberOptions,
+        },
+      ]}
     />
   );
 };
@@ -217,6 +261,14 @@ ${(
             />
           )}
         />
+      </ReactSpecimen>
+    )}
+
+    ## Select tree
+
+    ${(
+      <ReactSpecimen>
+        <SelectTreeExample />
       </ReactSpecimen>
     )}
 

--- a/app/docs/form.docs.tsx
+++ b/app/docs/form.docs.tsx
@@ -45,19 +45,29 @@ const SelectTreeExample = () => {
       options={[
         {
           value: "1",
-          label: "Applications",
+          label: "Root",
           children: [{ value: "2", label: "Calendar" }],
         },
         {
           value: "5",
-          label: "Documents",
+          label: "Switzerland",
           selectable: false,
           children: [
-            { value: "10", label: "OSS" },
+            { value: "10", label: "Bern" },
             {
               value: "6",
-              label: "MUI",
-              children: [{ value: "8", label: "index.js" }],
+              label: "Zürich",
+              children: [
+                {
+                  value: "9",
+                  label: "Bürkliplatz",
+                  children: [{ value: "7", label: "Pavillion" }],
+                },
+                {
+                  value: "8",
+                  label: "Langstrasse",
+                },
+              ],
             },
           ],
         },
@@ -264,7 +274,7 @@ ${(
       </ReactSpecimen>
     )}
 
-    ## Select tree
+  ## Select tree
 
     ${(
       <ReactSpecimen>

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -13,23 +13,23 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:655
+#: app/configurator/components/chart-configurator.tsx:629
 msgid "Add filter"
 msgstr "Filter hinzufügen"
 
-#: app/configurator/components/chart-configurator.tsx:628
+#: app/configurator/components/chart-configurator.tsx:602
 msgid "Drag filters to reorganize"
 msgstr "Ziehen Sie die Filter per Drag & Drop, um sie neu zu organisieren"
 
-#: app/configurator/components/chart-configurator.tsx:625
+#: app/configurator/components/chart-configurator.tsx:599
 msgid "Move filter down"
 msgstr "Filter nach unten verschieben"
 
-#: app/configurator/components/chart-configurator.tsx:622
+#: app/configurator/components/chart-configurator.tsx:596
 msgid "Move filter up"
 msgstr "Filter nach oben verschieben"
 
-#: app/configurator/components/dataset-browse.tsx:1043
+#: app/configurator/components/dataset-browse.tsx:1048
 msgid "No results"
 msgstr "Kein Ergebnis"
 
@@ -41,11 +41,11 @@ msgstr "[ Ohne Beschreibung ]"
 msgid "annotation.add.title"
 msgstr "[ Ohne Titel ]"
 
-#: app/configurator/components/dataset-browse.tsx:974
+#: app/configurator/components/dataset-browse.tsx:979
 msgid "browse-panel.organizations"
 msgstr "Organisationen"
 
-#: app/configurator/components/dataset-browse.tsx:956
+#: app/configurator/components/dataset-browse.tsx:961
 msgid "browse-panel.themes"
 msgstr "Kategorien"
 
@@ -53,11 +53,11 @@ msgstr "Kategorien"
 msgid "browse.dataset.create-visualization"
 msgstr "Visualisierung von diesem Datensatz erstellen"
 
-#: app/configurator/components/select-dataset-step.tsx:295
+#: app/configurator/components/select-dataset-step.tsx:290
 msgid "browse.datasets.all-datasets"
 msgstr "Alle Datensätze"
 
-#: app/configurator/components/select-dataset-step.tsx:189
+#: app/configurator/components/select-dataset-step.tsx:183
 msgid "browse.datasets.description"
 msgstr "Erkunden Sie die vom LINDAS Linked Data Service bereitgestellten Datensätze, indem Sie entweder nach Kategorien oder Organisationen filtern oder direkt nach bestimmten Stichworten suchen. Klicken Sie auf einen Datensatz, um detailliertere Informationen zu erhalten und Ihre eigenen Visualisierungen zu erstellen."
 
@@ -122,8 +122,8 @@ msgstr "Teilen"
 msgid "chart.map.layers.area"
 msgstr "Flächen"
 
-#: app/configurator/components/chart-configurator.tsx:704
-#: app/configurator/components/chart-options-selector.tsx:989
+#: app/configurator/components/chart-configurator.tsx:678
+#: app/configurator/components/chart-options-selector.tsx:986
 #: app/configurator/components/field-i18n.ts:31
 msgid "chart.map.layers.base"
 msgstr "Kartenanzeige"
@@ -174,11 +174,11 @@ msgstr "Heatmap"
 msgid "columnStyle.text"
 msgstr "Schrift"
 
-#: app/configurator/table/table-chart-options.tsx:397
+#: app/configurator/table/table-chart-options.tsx:400
 msgid "columnStyle.textStyle.bold"
 msgstr "Fett"
 
-#: app/configurator/table/table-chart-options.tsx:390
+#: app/configurator/table/table-chart-options.tsx:393
 msgid "columnStyle.textStyle.regular"
 msgstr "Normal"
 
@@ -322,35 +322,36 @@ msgstr "Beschreibung hinzufügen"
 #~ msgid "controls.dimension.none"
 #~ msgstr "Keine"
 
-#: app/charts/shared/chart-data-filters.tsx:218
+#: app/charts/shared/chart-data-filters.tsx:246
+#: app/charts/shared/chart-data-filters.tsx:290
 msgid "controls.dimensionvalue.none"
 msgstr "Kein Filter"
 
-#: app/configurator/components/filters.tsx:450
+#: app/configurator/components/filters.tsx:407
 msgid "controls.filter.nb-elements"
 msgstr "{0} von {1}"
 
-#: app/configurator/components/filters.tsx:238
+#: app/configurator/components/filters.tsx:189
 msgid "controls.filter.select.all"
 msgstr "Alle auswählen"
 
-#: app/configurator/components/filters.tsx:245
+#: app/configurator/components/filters.tsx:196
 msgid "controls.filter.select.none"
 msgstr "Alle abwählen"
 
-#: app/configurator/components/filters.tsx:401
+#: app/configurator/components/filters.tsx:358
 msgid "controls.filters.select.filters"
 msgstr "Filter"
 
-#: app/configurator/components/filters.tsx:431
+#: app/configurator/components/filters.tsx:388
 msgid "controls.filters.select.refresh-colors"
 msgstr "Farben auffrischen"
 
-#: app/configurator/components/filters.tsx:415
+#: app/configurator/components/filters.tsx:372
 msgid "controls.filters.select.reset-colors"
 msgstr "Farben zurücksetzen"
 
-#: app/configurator/components/filters.tsx:408
+#: app/configurator/components/filters.tsx:365
 msgid "controls.filters.select.selected-filters"
 msgstr "Ausgewählte Filter"
 
@@ -382,12 +383,12 @@ msgstr "-"
 msgid "controls.imputation.type.zeros"
 msgstr "Nullen"
 
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:122
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:137
 msgid "controls.interactive.filters.dataFilter"
 msgstr "Datenfilter"
 
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:115
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:102
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:117
 msgid "controls.interactive.filters.timeSlider"
 msgstr "Zeitschieber"
 
@@ -436,11 +437,15 @@ msgstr "Italienisch"
 msgid "controls.measure"
 msgstr "Messwert"
 
+#: app/configurator/components/configurator.tsx:110
+msgid "controls.nav.back-to-preview"
+msgstr ""
+
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:292
 msgid "controls.none"
 msgstr "Keine"
 
-#: app/configurator/components/chart-controls/control-tab.tsx:312
+#: app/configurator/components/chart-controls/control-tab.tsx:338
 msgid "controls.option.isActive"
 msgstr "Ein"
 
@@ -456,7 +461,7 @@ msgstr "Aus"
 msgid "controls.scale.type"
 msgstr "Skalierungstyp"
 
-#: app/components/form.tsx:566
+#: app/components/form.tsx:624
 msgid "controls.search.clear"
 msgstr "Suche zurücksetzen"
 
@@ -464,7 +469,7 @@ msgstr "Suche zurücksetzen"
 msgid "controls.section.additional-information"
 msgstr "Zusätzliche Informationen"
 
-#: app/configurator/components/chart-configurator.tsx:552
+#: app/configurator/components/chart-configurator.tsx:526
 msgid "controls.section.chart.options"
 msgstr "Diagramm-Einstellungen"
 
@@ -476,7 +481,7 @@ msgstr "Spalten"
 msgid "controls.section.columnstyle"
 msgstr "Spaltenstil"
 
-#: app/configurator/components/chart-configurator.tsx:570
+#: app/configurator/components/chart-configurator.tsx:544
 msgid "controls.section.data.filters"
 msgstr "Filter"
 
@@ -505,7 +510,8 @@ msgstr "Fehlende Werte"
 msgid "controls.section.imputation.explanation"
 msgstr "Für diesen Diagrammtyp sollten fehlenden Werten Ersatzwerte zugewiesen werden. Entscheiden Sie sich für die Imputationslogik oder wechseln Sie zu einem anderen Diagrammtyp."
 
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:83
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:98
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:157
 msgid "controls.section.interactive.filters"
 msgstr "Interaktive Filter hinzufügen"
 
@@ -521,7 +527,7 @@ msgstr "Standardfehler anzeigen"
 msgid "controls.section.sorting"
 msgstr "Sortieren"
 
-#: app/configurator/table/table-chart-options.tsx:482
+#: app/configurator/table/table-chart-options.tsx:485
 msgid "controls.section.tableSettings"
 msgstr "Tabelleneinstellungen"
 
@@ -537,7 +543,7 @@ msgstr "Tabellenoptionen"
 msgid "controls.section.title.warning"
 msgstr "Fügen Sie einen Titel oder eine Beschreibung hinzu"
 
-#: app/configurator/components/chart-configurator.tsx:537
+#: app/configurator/components/chart-configurator.tsx:518
 #: app/configurator/components/chart-type-selector.tsx:131
 #: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
@@ -551,35 +557,35 @@ msgstr "Spaltenstil"
 msgid "controls.select.columnStyle"
 msgstr "Spaltenstil"
 
-#: app/configurator/table/table-chart-options.tsx:457
+#: app/configurator/table/table-chart-options.tsx:460
 msgid "controls.select.columnStyle.barColorBackground"
 msgstr "Hintergrundfarbe"
 
-#: app/configurator/table/table-chart-options.tsx:449
+#: app/configurator/table/table-chart-options.tsx:452
 msgid "controls.select.columnStyle.barColorNegative"
 msgstr "Negative Balkenfarbe"
 
-#: app/configurator/table/table-chart-options.tsx:441
+#: app/configurator/table/table-chart-options.tsx:444
 msgid "controls.select.columnStyle.barColorPositive"
 msgstr "Positive Balkenfarbe"
 
-#: app/configurator/table/table-chart-options.tsx:465
+#: app/configurator/table/table-chart-options.tsx:468
 msgid "controls.select.columnStyle.barShowBackground"
 msgstr "Hintergrundfarbe anzeigen"
 
-#: app/configurator/table/table-chart-options.tsx:414
+#: app/configurator/table/table-chart-options.tsx:417
 msgid "controls.select.columnStyle.columnColor"
 msgstr "Spaltenfarbe"
 
-#: app/configurator/table/table-chart-options.tsx:406
+#: app/configurator/table/table-chart-options.tsx:409
 msgid "controls.select.columnStyle.textColor"
 msgstr "Schriftfarbe"
 
-#: app/configurator/table/table-chart-options.tsx:383
+#: app/configurator/table/table-chart-options.tsx:386
 msgid "controls.select.columnStyle.textStyle"
 msgstr "Schriftstil"
 
-#: app/configurator/components/chart-options-selector.tsx:220
+#: app/configurator/components/chart-options-selector.tsx:217
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:310
 msgid "controls.select.dimension"
 msgstr "Dimension auswählen"
@@ -597,15 +603,15 @@ msgstr "Messwert auswählen"
 #~ msgid "controls.select.optional"
 #~ msgstr "optional"
 
-#: app/configurator/components/filters.tsx:794
+#: app/configurator/components/filters.tsx:760
 msgid "controls.set-filters"
 msgstr "Filter bearbeiten"
 
-#: app/configurator/components/filters.tsx:801
+#: app/configurator/components/filters.tsx:768
 msgid "controls.set-filters-caption"
 msgstr "Für beste Ergebnisse wählen Sie nicht mehr als 7 Werte für die Visualisierung aus"
 
-#: app/configurator/components/filters.tsx:840
+#: app/configurator/components/filters.tsx:808
 msgid "controls.set-values-apply"
 msgstr "Filter anwenden"
 
@@ -701,7 +707,7 @@ msgstr "Einstellungen"
 msgid "controls.table.sorting"
 msgstr "Sortierung"
 
-#: app/configurator/table/table-chart-options.tsx:486
+#: app/configurator/table/table-chart-options.tsx:489
 msgid "controls.tableSettings.showSearch"
 msgstr "Suche anzeigen"
 
@@ -709,15 +715,19 @@ msgstr "Suche anzeigen"
 msgid "controls.title"
 msgstr "Titel hinzufügen"
 
-#: app/pages/_cube-checker.tsx:166
+#: app/components/select-tree.tsx:230
+msgid "controls.tree.select-value"
+msgstr "Auswählen"
+
+#: app/pages/_cube-checker.tsx:257
 msgid "cube-checker.cube-checker"
 msgstr "Cube Prüfer"
 
-#: app/pages/_cube-checker.tsx:169
+#: app/pages/_cube-checker.tsx:260
 msgid "cube-checker.description"
 msgstr "Cube Checker hilft Ihnen zu verstehen, ob ein Cube alle hat notwendige Attribute und Eigenschaften, um angezeigt zu werden visualize.admin.ch."
 
-#: app/pages/_cube-checker.tsx:183
+#: app/pages/_cube-checker.tsx:274
 msgid "cube-checker.field-placeholder"
 msgstr "Cube IRI"
 
@@ -729,7 +739,7 @@ msgstr "Datenquelle"
 msgid "data.source.notTrusted"
 msgstr "Dieses Diagramm verwendet keine vertrauenswürdige Datenquelle."
 
-#: app/configurator/components/select-dataset-step.tsx:221
+#: app/configurator/components/select-dataset-step.tsx:216
 msgid "dataset-preview.back-to-results"
 msgstr "Zurück zu den Datensätzen"
 
@@ -749,7 +759,7 @@ msgstr "Neuestes Update"
 msgid "dataset.hasImputedValues"
 msgstr "Einige Daten in diesem Datensatz fehlen und wurden interpoliert, um die Lücken zu füllen."
 
-#: app/configurator/components/dataset-browse.tsx:447
+#: app/configurator/components/dataset-browse.tsx:449
 msgid "dataset.includeDrafts"
 msgstr "Entwürfe einschließen"
 
@@ -778,15 +788,15 @@ msgstr "Quelle"
 msgid "dataset.metadata.version"
 msgstr "Version"
 
-#: app/configurator/components/dataset-browse.tsx:404
+#: app/configurator/components/dataset-browse.tsx:413
 msgid "dataset.order.newest"
 msgstr "Neueste"
 
-#: app/configurator/components/dataset-browse.tsx:396
+#: app/configurator/components/dataset-browse.tsx:405
 msgid "dataset.order.relevance"
 msgstr "Relevanz"
 
-#: app/configurator/components/dataset-browse.tsx:400
+#: app/configurator/components/dataset-browse.tsx:409
 msgid "dataset.order.title"
 msgstr "Titel"
 
@@ -800,23 +810,23 @@ msgstr "Achtung, dieser Datensatz ist im Entwurfs-Stadium.<0/><1>Diese Grafik ni
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Achtung, dieser Datensatz ist abgelaufen.<0/><1>Diese Grafik nicht für Berichte verwenden.</1>"
 
-#: app/configurator/components/dataset-browse.tsx:435
+#: app/configurator/components/dataset-browse.tsx:437
 msgid "dataset.results"
 msgstr "{0, plural, zero {Keine Datensätze} one {# Datensatz} other {# Datensätze}}"
 
-#: app/configurator/components/dataset-browse.tsx:328
+#: app/configurator/components/dataset-browse.tsx:337
 msgid "dataset.search.label"
 msgstr "Suchen"
 
-#: app/configurator/components/dataset-browse.tsx:333
+#: app/configurator/components/dataset-browse.tsx:342
 msgid "dataset.search.placeholder"
 msgstr "Name, Organisation, Stichwort..."
 
-#: app/configurator/components/dataset-browse.tsx:452
+#: app/configurator/components/dataset-browse.tsx:461
 msgid "dataset.sortby"
 msgstr "Sortieren nach"
 
-#: app/configurator/components/dataset-browse.tsx:1153
+#: app/configurator/components/dataset-browse.tsx:1157
 msgid "dataset.tag.draft"
 msgstr "Entwurf"
 
@@ -880,6 +890,7 @@ msgstr "Daten-Ladefehler"
 msgid "hint.how.to.share"
 msgstr "Sie können diese Visualisierung teilen oder sie einbetten. Zudem können Sie eine neue Visualisierung erstellen oder die gezeigte Visualisierung kopieren."
 
+#: app/components/form.tsx:291
 #: app/components/hint.tsx:111
 msgid "hint.loading.data"
 msgstr "Lade Daten …"
@@ -908,11 +919,11 @@ msgstr "Negative Werte"
 msgid "hint.publication.success"
 msgstr "Die Visualisierung ist jetzt veröffentlicht. Sie können sie teilen oder einbetten, indem Sie die URL kopieren oder das Menü unten verwenden."
 
-#: app/charts/shared/chart-data-filters.tsx:83
+#: app/charts/shared/chart-data-filters.tsx:93
 msgid "interactive.data.filters.hide"
 msgstr "Filter ausblenden"
 
-#: app/charts/shared/chart-data-filters.tsx:85
+#: app/charts/shared/chart-data-filters.tsx:95
 msgid "interactive.data.filters.show"
 msgstr "Filter anzeigen"
 
@@ -977,9 +988,8 @@ msgstr "Hier ist eine Visualisierung, die ich mit visualize.admin.ch erstellt ha
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
-#: app/configurator/components/dataset-browse.tsx:333
-#: app/configurator/components/dataset-browse.tsx:369
-#: app/configurator/components/filters.tsx:810
+#: app/configurator/components/dataset-browse.tsx:378
+#: app/configurator/components/filters.tsx:777
 msgid "select.controls.filters.search"
 msgstr "Suche"
 

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -13,23 +13,23 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:655
+#: app/configurator/components/chart-configurator.tsx:629
 msgid "Add filter"
 msgstr "Add filter"
 
-#: app/configurator/components/chart-configurator.tsx:628
+#: app/configurator/components/chart-configurator.tsx:602
 msgid "Drag filters to reorganize"
 msgstr "Drag filters to reorganize"
 
-#: app/configurator/components/chart-configurator.tsx:625
+#: app/configurator/components/chart-configurator.tsx:599
 msgid "Move filter down"
 msgstr "Move filter down"
 
-#: app/configurator/components/chart-configurator.tsx:622
+#: app/configurator/components/chart-configurator.tsx:596
 msgid "Move filter up"
 msgstr "Move filter up"
 
-#: app/configurator/components/dataset-browse.tsx:1043
+#: app/configurator/components/dataset-browse.tsx:1048
 msgid "No results"
 msgstr "No results"
 
@@ -41,11 +41,11 @@ msgstr "[ No Description ]"
 msgid "annotation.add.title"
 msgstr "[ No Title ]"
 
-#: app/configurator/components/dataset-browse.tsx:974
+#: app/configurator/components/dataset-browse.tsx:979
 msgid "browse-panel.organizations"
 msgstr "Organizations"
 
-#: app/configurator/components/dataset-browse.tsx:956
+#: app/configurator/components/dataset-browse.tsx:961
 msgid "browse-panel.themes"
 msgstr "Categories"
 
@@ -53,11 +53,11 @@ msgstr "Categories"
 msgid "browse.dataset.create-visualization"
 msgstr "Start a visualization"
 
-#: app/configurator/components/select-dataset-step.tsx:295
+#: app/configurator/components/select-dataset-step.tsx:290
 msgid "browse.datasets.all-datasets"
 msgstr "All datasets"
 
-#: app/configurator/components/select-dataset-step.tsx:189
+#: app/configurator/components/select-dataset-step.tsx:183
 msgid "browse.datasets.description"
 msgstr "Explore datasets provided by the LINDAS Linked Data Service by either filtering by categories or organisations or search directly for specific keywords. Click on a dataset to see more detailed information and start creating your own visualizations."
 
@@ -142,8 +142,8 @@ msgstr "Areas"
 #~ msgid "chart.map.layers.area.discretization.quantize"
 #~ msgstr "Quantize (equal intervals)"
 
-#: app/configurator/components/chart-configurator.tsx:704
-#: app/configurator/components/chart-options-selector.tsx:989
+#: app/configurator/components/chart-configurator.tsx:678
+#: app/configurator/components/chart-options-selector.tsx:986
 #: app/configurator/components/field-i18n.ts:31
 msgid "chart.map.layers.base"
 msgstr "Map Display"
@@ -194,11 +194,11 @@ msgstr "Heat Map"
 msgid "columnStyle.text"
 msgstr "Text"
 
-#: app/configurator/table/table-chart-options.tsx:397
+#: app/configurator/table/table-chart-options.tsx:400
 msgid "columnStyle.textStyle.bold"
 msgstr "Bold"
 
-#: app/configurator/table/table-chart-options.tsx:390
+#: app/configurator/table/table-chart-options.tsx:393
 msgid "columnStyle.textStyle.regular"
 msgstr "Regular"
 
@@ -342,35 +342,36 @@ msgstr "Description"
 #~ msgid "controls.dimension.none"
 #~ msgstr "None"
 
-#: app/charts/shared/chart-data-filters.tsx:218
+#: app/charts/shared/chart-data-filters.tsx:246
+#: app/charts/shared/chart-data-filters.tsx:290
 msgid "controls.dimensionvalue.none"
 msgstr "No Filter"
 
-#: app/configurator/components/filters.tsx:450
+#: app/configurator/components/filters.tsx:407
 msgid "controls.filter.nb-elements"
 msgstr "{0} of {1}"
 
-#: app/configurator/components/filters.tsx:238
+#: app/configurator/components/filters.tsx:189
 msgid "controls.filter.select.all"
 msgstr "Select all"
 
-#: app/configurator/components/filters.tsx:245
+#: app/configurator/components/filters.tsx:196
 msgid "controls.filter.select.none"
 msgstr "Select none"
 
-#: app/configurator/components/filters.tsx:401
+#: app/configurator/components/filters.tsx:358
 msgid "controls.filters.select.filters"
 msgstr "Filters"
 
-#: app/configurator/components/filters.tsx:431
+#: app/configurator/components/filters.tsx:388
 msgid "controls.filters.select.refresh-colors"
 msgstr "Refresh colors"
 
-#: app/configurator/components/filters.tsx:415
+#: app/configurator/components/filters.tsx:372
 msgid "controls.filters.select.reset-colors"
 msgstr "Reset colors"
 
-#: app/configurator/components/filters.tsx:408
+#: app/configurator/components/filters.tsx:365
 msgid "controls.filters.select.selected-filters"
 msgstr "Selected filters"
 
@@ -402,12 +403,12 @@ msgstr "-"
 msgid "controls.imputation.type.zeros"
 msgstr "Zeros"
 
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:122
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:137
 msgid "controls.interactive.filters.dataFilter"
 msgstr "Data Filters"
 
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:115
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:102
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:117
 msgid "controls.interactive.filters.timeSlider"
 msgstr "Time slider"
 
@@ -456,7 +457,7 @@ msgstr "Italian"
 msgid "controls.measure"
 msgstr "Measure"
 
-#: app/configurator/components/configurator.tsx:107
+#: app/configurator/components/configurator.tsx:110
 msgid "controls.nav.back-to-preview"
 msgstr "Back to preview"
 
@@ -476,7 +477,7 @@ msgstr "Off"
 msgid "controls.scale.type"
 msgstr "Scale type"
 
-#: app/components/form.tsx:566
+#: app/components/form.tsx:624
 msgid "controls.search.clear"
 msgstr "Clear search field"
 
@@ -484,7 +485,7 @@ msgstr "Clear search field"
 msgid "controls.section.additional-information"
 msgstr "Additional information"
 
-#: app/configurator/components/chart-configurator.tsx:552
+#: app/configurator/components/chart-configurator.tsx:526
 msgid "controls.section.chart.options"
 msgstr "Chart Options"
 
@@ -496,7 +497,7 @@ msgstr "Columns"
 msgid "controls.section.columnstyle"
 msgstr "Column Style"
 
-#: app/configurator/components/chart-configurator.tsx:570
+#: app/configurator/components/chart-configurator.tsx:544
 msgid "controls.section.data.filters"
 msgstr "Filters"
 
@@ -525,7 +526,8 @@ msgstr "Missing values"
 msgid "controls.section.imputation.explanation"
 msgstr "For this chart type, replacement values should be assigned to missing values. Decide on the imputation logic or switch to another chart type."
 
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:83
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:98
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:157
 msgid "controls.section.interactive.filters"
 msgstr "Interactive Filters"
 
@@ -541,7 +543,7 @@ msgstr "Show standard error"
 msgid "controls.section.sorting"
 msgstr "Sort"
 
-#: app/configurator/table/table-chart-options.tsx:482
+#: app/configurator/table/table-chart-options.tsx:485
 msgid "controls.section.tableSettings"
 msgstr "Table Settings"
 
@@ -557,7 +559,7 @@ msgstr "Table Options"
 msgid "controls.section.title.warning"
 msgstr "Please add a title or description."
 
-#: app/configurator/components/chart-configurator.tsx:537
+#: app/configurator/components/chart-configurator.tsx:518
 #: app/configurator/components/chart-type-selector.tsx:131
 #: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
@@ -571,35 +573,35 @@ msgstr "Column layout"
 msgid "controls.select.columnStyle"
 msgstr "Column Style"
 
-#: app/configurator/table/table-chart-options.tsx:457
+#: app/configurator/table/table-chart-options.tsx:460
 msgid "controls.select.columnStyle.barColorBackground"
 msgstr "Background color"
 
-#: app/configurator/table/table-chart-options.tsx:449
+#: app/configurator/table/table-chart-options.tsx:452
 msgid "controls.select.columnStyle.barColorNegative"
 msgstr "Negative bar color"
 
-#: app/configurator/table/table-chart-options.tsx:441
+#: app/configurator/table/table-chart-options.tsx:444
 msgid "controls.select.columnStyle.barColorPositive"
 msgstr "Positive bar color"
 
-#: app/configurator/table/table-chart-options.tsx:465
+#: app/configurator/table/table-chart-options.tsx:468
 msgid "controls.select.columnStyle.barShowBackground"
 msgstr "Show bar background"
 
-#: app/configurator/table/table-chart-options.tsx:414
+#: app/configurator/table/table-chart-options.tsx:417
 msgid "controls.select.columnStyle.columnColor"
 msgstr "Column Color"
 
-#: app/configurator/table/table-chart-options.tsx:406
+#: app/configurator/table/table-chart-options.tsx:409
 msgid "controls.select.columnStyle.textColor"
 msgstr "Text Color"
 
-#: app/configurator/table/table-chart-options.tsx:383
+#: app/configurator/table/table-chart-options.tsx:386
 msgid "controls.select.columnStyle.textStyle"
 msgstr "Text Style"
 
-#: app/configurator/components/chart-options-selector.tsx:220
+#: app/configurator/components/chart-options-selector.tsx:217
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:310
 msgid "controls.select.dimension"
 msgstr "Select a dimension"
@@ -617,15 +619,15 @@ msgstr "Select a measure"
 #~ msgid "controls.select.optional"
 #~ msgstr "optional"
 
-#: app/configurator/components/filters.tsx:794
+#: app/configurator/components/filters.tsx:760
 msgid "controls.set-filters"
 msgstr "Edit filters"
 
-#: app/configurator/components/filters.tsx:801
+#: app/configurator/components/filters.tsx:768
 msgid "controls.set-filters-caption"
 msgstr "For best results, do not select more than 7 values in the visualization."
 
-#: app/configurator/components/filters.tsx:840
+#: app/configurator/components/filters.tsx:808
 msgid "controls.set-values-apply"
 msgstr "Apply filters"
 
@@ -721,7 +723,7 @@ msgstr "Settings"
 msgid "controls.table.sorting"
 msgstr "Sorting"
 
-#: app/configurator/table/table-chart-options.tsx:486
+#: app/configurator/table/table-chart-options.tsx:489
 msgid "controls.tableSettings.showSearch"
 msgstr "Show search field"
 
@@ -729,15 +731,19 @@ msgstr "Show search field"
 msgid "controls.title"
 msgstr "Title"
 
-#: app/pages/_cube-checker.tsx:166
+#: app/components/select-tree.tsx:230
+msgid "controls.tree.select-value"
+msgstr "Select"
+
+#: app/pages/_cube-checker.tsx:257
 msgid "cube-checker.cube-checker"
 msgstr "Cube checker"
 
-#: app/pages/_cube-checker.tsx:169
+#: app/pages/_cube-checker.tsx:260
 msgid "cube-checker.description"
 msgstr "Cube checker helps you understand if a cube has all the necessary attributes and properties to be viewable in visualize.admin.ch."
 
-#: app/pages/_cube-checker.tsx:183
+#: app/pages/_cube-checker.tsx:274
 msgid "cube-checker.field-placeholder"
 msgstr "Cube IRI"
 
@@ -749,7 +755,7 @@ msgstr "Data source"
 msgid "data.source.notTrusted"
 msgstr "This chart is not using a trusted data source."
 
-#: app/configurator/components/select-dataset-step.tsx:221
+#: app/configurator/components/select-dataset-step.tsx:216
 msgid "dataset-preview.back-to-results"
 msgstr "Back to the datasets"
 
@@ -769,7 +775,7 @@ msgstr "Latest update"
 msgid "dataset.hasImputedValues"
 msgstr "Some data in this dataset is missing and has been interpolated to fill the gaps."
 
-#: app/configurator/components/dataset-browse.tsx:447
+#: app/configurator/components/dataset-browse.tsx:449
 msgid "dataset.includeDrafts"
 msgstr "Include draft datasets"
 
@@ -802,15 +808,15 @@ msgstr "Source"
 msgid "dataset.metadata.version"
 msgstr "Version"
 
-#: app/configurator/components/dataset-browse.tsx:404
+#: app/configurator/components/dataset-browse.tsx:413
 msgid "dataset.order.newest"
 msgstr "Newest"
 
-#: app/configurator/components/dataset-browse.tsx:396
+#: app/configurator/components/dataset-browse.tsx:405
 msgid "dataset.order.relevance"
 msgstr "Relevance"
 
-#: app/configurator/components/dataset-browse.tsx:400
+#: app/configurator/components/dataset-browse.tsx:409
 msgid "dataset.order.title"
 msgstr "Title"
 
@@ -824,23 +830,23 @@ msgstr "Careful, this dataset is only a draft.<0/><1>Don't use for reporting!</1
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Careful, the data for this chart has expired.<0/><1>Don't use for reporting!</1>"
 
-#: app/configurator/components/dataset-browse.tsx:435
+#: app/configurator/components/dataset-browse.tsx:437
 msgid "dataset.results"
 msgstr "{0, plural, zero {No datasets} one {# dataset} other {# datasets}}"
 
-#: app/configurator/components/dataset-browse.tsx:328
+#: app/configurator/components/dataset-browse.tsx:337
 msgid "dataset.search.label"
 msgstr "Search datasets"
 
-#: app/configurator/components/dataset-browse.tsx:333
+#: app/configurator/components/dataset-browse.tsx:342
 msgid "dataset.search.placeholder"
 msgstr "Name, organization, keyword..."
 
-#: app/configurator/components/dataset-browse.tsx:452
+#: app/configurator/components/dataset-browse.tsx:461
 msgid "dataset.sortby"
 msgstr "Sort by"
 
-#: app/configurator/components/dataset-browse.tsx:1153
+#: app/configurator/components/dataset-browse.tsx:1157
 msgid "dataset.tag.draft"
 msgstr "Draft"
 
@@ -904,6 +910,7 @@ msgstr "Data loading error"
 msgid "hint.how.to.share"
 msgstr "You can share this visualization by copying the URL or by embedding it on your own website. You can also create a new visualization from scratch or start by copying the visualization above."
 
+#: app/components/form.tsx:291
 #: app/components/hint.tsx:111
 msgid "hint.loading.data"
 msgstr "Loading data..."
@@ -932,11 +939,11 @@ msgstr "Negative Values"
 msgid "hint.publication.success"
 msgstr "Your visualization is now published. Share it by copying the URL or use the Embed menu below."
 
-#: app/charts/shared/chart-data-filters.tsx:83
+#: app/charts/shared/chart-data-filters.tsx:93
 msgid "interactive.data.filters.hide"
 msgstr "Hide Filters"
 
-#: app/charts/shared/chart-data-filters.tsx:85
+#: app/charts/shared/chart-data-filters.tsx:95
 msgid "interactive.data.filters.show"
 msgstr "Show Filters"
 
@@ -1001,9 +1008,8 @@ msgstr "Here is a visualization I created using visualize.admin.ch"
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
-#: app/configurator/components/dataset-browse.tsx:333
-#: app/configurator/components/dataset-browse.tsx:369
-#: app/configurator/components/filters.tsx:810
+#: app/configurator/components/dataset-browse.tsx:378
+#: app/configurator/components/filters.tsx:777
 msgid "select.controls.filters.search"
 msgstr "Search"
 

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -13,23 +13,23 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:655
+#: app/configurator/components/chart-configurator.tsx:629
 msgid "Add filter"
 msgstr "Ajouter un filtre"
 
-#: app/configurator/components/chart-configurator.tsx:628
+#: app/configurator/components/chart-configurator.tsx:602
 msgid "Drag filters to reorganize"
 msgstr "Faites glisser les filtres pour les réorganiser"
 
-#: app/configurator/components/chart-configurator.tsx:625
+#: app/configurator/components/chart-configurator.tsx:599
 msgid "Move filter down"
 msgstr "Déplacer le filtre vers le bas"
 
-#: app/configurator/components/chart-configurator.tsx:622
+#: app/configurator/components/chart-configurator.tsx:596
 msgid "Move filter up"
 msgstr "Déplacer le filtre vers le haut"
 
-#: app/configurator/components/dataset-browse.tsx:1043
+#: app/configurator/components/dataset-browse.tsx:1048
 msgid "No results"
 msgstr "Aucun résultat"
 
@@ -41,11 +41,11 @@ msgstr "[ Pas de description ]"
 msgid "annotation.add.title"
 msgstr "[ Pas de titre ]"
 
-#: app/configurator/components/dataset-browse.tsx:974
+#: app/configurator/components/dataset-browse.tsx:979
 msgid "browse-panel.organizations"
 msgstr "Organisations"
 
-#: app/configurator/components/dataset-browse.tsx:956
+#: app/configurator/components/dataset-browse.tsx:961
 msgid "browse-panel.themes"
 msgstr "Catégories"
 
@@ -53,11 +53,11 @@ msgstr "Catégories"
 msgid "browse.dataset.create-visualization"
 msgstr "Démarrer une visualisation"
 
-#: app/configurator/components/select-dataset-step.tsx:295
+#: app/configurator/components/select-dataset-step.tsx:290
 msgid "browse.datasets.all-datasets"
 msgstr "Tous les jeux de données"
 
-#: app/configurator/components/select-dataset-step.tsx:189
+#: app/configurator/components/select-dataset-step.tsx:183
 msgid "browse.datasets.description"
 msgstr "Explorez les jeux de données liés fournis par LINDAS, en filtrant par catégories ou organisations, ou en recherchant par mots-clés. Cliquez sur un ensemble de données pour afficher des informations plus détaillées et commencer à créer vos propres visualisations. "
 
@@ -142,8 +142,8 @@ msgstr "Zones"
 #~ msgid "chart.map.layers.area.discretization.quantize"
 #~ msgstr "Intervalles égaux"
 
-#: app/configurator/components/chart-configurator.tsx:704
-#: app/configurator/components/chart-options-selector.tsx:989
+#: app/configurator/components/chart-configurator.tsx:678
+#: app/configurator/components/chart-options-selector.tsx:986
 #: app/configurator/components/field-i18n.ts:31
 msgid "chart.map.layers.base"
 msgstr "Affichage de la carte"
@@ -194,11 +194,11 @@ msgstr "Heatmap"
 msgid "columnStyle.text"
 msgstr "Texte"
 
-#: app/configurator/table/table-chart-options.tsx:397
+#: app/configurator/table/table-chart-options.tsx:400
 msgid "columnStyle.textStyle.bold"
 msgstr "Gras"
 
-#: app/configurator/table/table-chart-options.tsx:390
+#: app/configurator/table/table-chart-options.tsx:393
 msgid "columnStyle.textStyle.regular"
 msgstr "Normal"
 
@@ -342,35 +342,36 @@ msgstr "Description"
 #~ msgid "controls.dimension.none"
 #~ msgstr "Aucune"
 
-#: app/charts/shared/chart-data-filters.tsx:218
+#: app/charts/shared/chart-data-filters.tsx:246
+#: app/charts/shared/chart-data-filters.tsx:290
 msgid "controls.dimensionvalue.none"
 msgstr "Aucune filtre"
 
-#: app/configurator/components/filters.tsx:450
+#: app/configurator/components/filters.tsx:407
 msgid "controls.filter.nb-elements"
 msgstr "{0} sur {1}"
 
-#: app/configurator/components/filters.tsx:238
+#: app/configurator/components/filters.tsx:189
 msgid "controls.filter.select.all"
 msgstr "Tout sélectionner"
 
-#: app/configurator/components/filters.tsx:245
+#: app/configurator/components/filters.tsx:196
 msgid "controls.filter.select.none"
 msgstr "Tout déselectionner"
 
-#: app/configurator/components/filters.tsx:401
+#: app/configurator/components/filters.tsx:358
 msgid "controls.filters.select.filters"
 msgstr "Filtres"
 
-#: app/configurator/components/filters.tsx:431
+#: app/configurator/components/filters.tsx:388
 msgid "controls.filters.select.refresh-colors"
 msgstr "Renouveller les couleurs"
 
-#: app/configurator/components/filters.tsx:415
+#: app/configurator/components/filters.tsx:372
 msgid "controls.filters.select.reset-colors"
 msgstr "Réinitialiser les couleurs"
 
-#: app/configurator/components/filters.tsx:408
+#: app/configurator/components/filters.tsx:365
 msgid "controls.filters.select.selected-filters"
 msgstr "Filtres sélectionnés"
 
@@ -402,12 +403,12 @@ msgstr "-"
 msgid "controls.imputation.type.zeros"
 msgstr "Zéros"
 
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:122
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:137
 msgid "controls.interactive.filters.dataFilter"
 msgstr "Filtres de données"
 
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:115
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:102
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:117
 msgid "controls.interactive.filters.timeSlider"
 msgstr "Curseur temporel"
 
@@ -451,7 +452,7 @@ msgstr "Italien"
 msgid "controls.measure"
 msgstr "Variable mesurée"
 
-#: app/configurator/components/configurator.tsx:107
+#: app/configurator/components/configurator.tsx:110
 msgid "controls.nav.back-to-preview"
 msgstr "Retour à l'aperçu"
 
@@ -471,7 +472,7 @@ msgstr "Inactif"
 msgid "controls.scale.type"
 msgstr "Type d'échelle"
 
-#: app/components/form.tsx:566
+#: app/components/form.tsx:624
 msgid "controls.search.clear"
 msgstr "Effacer la recherche"
 
@@ -479,7 +480,7 @@ msgstr "Effacer la recherche"
 msgid "controls.section.additional-information"
 msgstr "Informations supplémentaires"
 
-#: app/configurator/components/chart-configurator.tsx:552
+#: app/configurator/components/chart-configurator.tsx:526
 msgid "controls.section.chart.options"
 msgstr "Paramètres graphiques"
 
@@ -491,7 +492,7 @@ msgstr "Colonnes"
 msgid "controls.section.columnstyle"
 msgstr "Style de la colonne"
 
-#: app/configurator/components/chart-configurator.tsx:570
+#: app/configurator/components/chart-configurator.tsx:544
 msgid "controls.section.data.filters"
 msgstr "Filtres"
 
@@ -520,7 +521,8 @@ msgstr "Valeurs manquantes"
 msgid "controls.section.imputation.explanation"
 msgstr "En raison du type de graphique sélectionné, les valeurs manquantes doivent être remplies. Décidez de la logique d'imputation ou choisissez un autre type de graphique."
 
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:83
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:98
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:157
 msgid "controls.section.interactive.filters"
 msgstr "Filtres interactifs"
 
@@ -536,7 +538,7 @@ msgstr "Afficher l'erreur type"
 msgid "controls.section.sorting"
 msgstr "Trier"
 
-#: app/configurator/table/table-chart-options.tsx:482
+#: app/configurator/table/table-chart-options.tsx:485
 msgid "controls.section.tableSettings"
 msgstr "Paramètres du tableau"
 
@@ -552,7 +554,7 @@ msgstr "Options du tableau"
 msgid "controls.section.title.warning"
 msgstr "Ajoutez un titre et une description"
 
-#: app/configurator/components/chart-configurator.tsx:537
+#: app/configurator/components/chart-configurator.tsx:518
 #: app/configurator/components/chart-type-selector.tsx:131
 #: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
@@ -566,35 +568,35 @@ msgstr "Mise en forme de la colonne"
 msgid "controls.select.columnStyle"
 msgstr "Style de la colonne"
 
-#: app/configurator/table/table-chart-options.tsx:457
+#: app/configurator/table/table-chart-options.tsx:460
 msgid "controls.select.columnStyle.barColorBackground"
 msgstr "Couleur de fond"
 
-#: app/configurator/table/table-chart-options.tsx:449
+#: app/configurator/table/table-chart-options.tsx:452
 msgid "controls.select.columnStyle.barColorNegative"
 msgstr "Couleur des valeurs négatives"
 
-#: app/configurator/table/table-chart-options.tsx:441
+#: app/configurator/table/table-chart-options.tsx:444
 msgid "controls.select.columnStyle.barColorPositive"
 msgstr "Couleur des valeurs positives"
 
-#: app/configurator/table/table-chart-options.tsx:465
+#: app/configurator/table/table-chart-options.tsx:468
 msgid "controls.select.columnStyle.barShowBackground"
 msgstr "Afficher la couleur de fond"
 
-#: app/configurator/table/table-chart-options.tsx:414
+#: app/configurator/table/table-chart-options.tsx:417
 msgid "controls.select.columnStyle.columnColor"
 msgstr "Couleur de la colonne"
 
-#: app/configurator/table/table-chart-options.tsx:406
+#: app/configurator/table/table-chart-options.tsx:409
 msgid "controls.select.columnStyle.textColor"
 msgstr "Couleur du texte"
 
-#: app/configurator/table/table-chart-options.tsx:383
+#: app/configurator/table/table-chart-options.tsx:386
 msgid "controls.select.columnStyle.textStyle"
 msgstr "Style du texte"
 
-#: app/configurator/components/chart-options-selector.tsx:220
+#: app/configurator/components/chart-options-selector.tsx:217
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:310
 msgid "controls.select.dimension"
 msgstr "Sélectionner une dimension"
@@ -612,15 +614,15 @@ msgstr "Sélectionner une variable"
 #~ msgid "controls.select.optional"
 #~ msgstr "optionnel"
 
-#: app/configurator/components/filters.tsx:794
+#: app/configurator/components/filters.tsx:760
 msgid "controls.set-filters"
 msgstr "Modifier les filtres"
 
-#: app/configurator/components/filters.tsx:801
+#: app/configurator/components/filters.tsx:768
 msgid "controls.set-filters-caption"
 msgstr "Pour de meilleurs résultats, ne sélectionnez pas plus de 7 valeurs dans la visualisation."
 
-#: app/configurator/components/filters.tsx:840
+#: app/configurator/components/filters.tsx:808
 msgid "controls.set-values-apply"
 msgstr "Appliquer les filtres"
 
@@ -716,7 +718,7 @@ msgstr "Paramètres"
 msgid "controls.table.sorting"
 msgstr "Tri"
 
-#: app/configurator/table/table-chart-options.tsx:486
+#: app/configurator/table/table-chart-options.tsx:489
 msgid "controls.tableSettings.showSearch"
 msgstr "Afficher le champ de recherche"
 
@@ -724,15 +726,19 @@ msgstr "Afficher le champ de recherche"
 msgid "controls.title"
 msgstr "Titre"
 
-#: app/pages/_cube-checker.tsx:166
+#: app/components/select-tree.tsx:230
+msgid "controls.tree.select-value"
+msgstr "Sélectionner"
+
+#: app/pages/_cube-checker.tsx:257
 msgid "cube-checker.cube-checker"
 msgstr "Vérificateur de cube"
 
-#: app/pages/_cube-checker.tsx:169
+#: app/pages/_cube-checker.tsx:260
 msgid "cube-checker.description"
 msgstr "Cet outil vous permet de vérifier qu'un cube a tous les attributs nécessaires pour être affiché dans visualize.admin.ch"
 
-#: app/pages/_cube-checker.tsx:183
+#: app/pages/_cube-checker.tsx:274
 msgid "cube-checker.field-placeholder"
 msgstr "IRI du cube"
 
@@ -744,7 +750,7 @@ msgstr "Source des données"
 msgid "data.source.notTrusted"
 msgstr "Ce graphique n'utilise pas une source de données fiable."
 
-#: app/configurator/components/select-dataset-step.tsx:221
+#: app/configurator/components/select-dataset-step.tsx:216
 msgid "dataset-preview.back-to-results"
 msgstr "Revenir aux jeux de données"
 
@@ -764,7 +770,7 @@ msgstr "Mise à jour"
 msgid "dataset.hasImputedValues"
 msgstr "Certaines données de cet ensemble de données sont manquantes et ont été interpolées pour combler les lacunes."
 
-#: app/configurator/components/dataset-browse.tsx:447
+#: app/configurator/components/dataset-browse.tsx:449
 msgid "dataset.includeDrafts"
 msgstr "Inclure les brouillons"
 
@@ -793,15 +799,15 @@ msgstr "Source"
 msgid "dataset.metadata.version"
 msgstr "Version"
 
-#: app/configurator/components/dataset-browse.tsx:404
+#: app/configurator/components/dataset-browse.tsx:413
 msgid "dataset.order.newest"
 msgstr "Plus récent en premier"
 
-#: app/configurator/components/dataset-browse.tsx:396
+#: app/configurator/components/dataset-browse.tsx:405
 msgid "dataset.order.relevance"
 msgstr "Pertinence"
 
-#: app/configurator/components/dataset-browse.tsx:400
+#: app/configurator/components/dataset-browse.tsx:409
 msgid "dataset.order.title"
 msgstr "Titre"
 
@@ -815,23 +821,23 @@ msgstr "Attention, ce jeu de données est à l'état d'ébauche.<0/><1>Ne l'util
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Attention, ce jeu de données est expiré.<0/><1>Ne l'utilisez pas pour une publication!</1>"
 
-#: app/configurator/components/dataset-browse.tsx:435
+#: app/configurator/components/dataset-browse.tsx:437
 msgid "dataset.results"
 msgstr "{0, plural, zero {Aucun jeu de données} one {# jeu de données} other {# jeux de données}}"
 
-#: app/configurator/components/dataset-browse.tsx:328
+#: app/configurator/components/dataset-browse.tsx:337
 msgid "dataset.search.label"
 msgstr "Chercher"
 
-#: app/configurator/components/dataset-browse.tsx:333
+#: app/configurator/components/dataset-browse.tsx:342
 msgid "dataset.search.placeholder"
 msgstr "Nom, organisation, mots clés..."
 
-#: app/configurator/components/dataset-browse.tsx:452
+#: app/configurator/components/dataset-browse.tsx:461
 msgid "dataset.sortby"
 msgstr "Trier par"
 
-#: app/configurator/components/dataset-browse.tsx:1153
+#: app/configurator/components/dataset-browse.tsx:1157
 msgid "dataset.tag.draft"
 msgstr "Brouillon"
 
@@ -895,6 +901,7 @@ msgstr "Problème de téléchargement des données"
 msgid "hint.how.to.share"
 msgstr "Vous pouvez partager cette visualisation en copiant l'URL ou en l'intégrant sur votre site Web. Vous pouvez également créer une toute nouvelle visualisation, ou bien copier et modifier la visualisation ci-dessus."
 
+#: app/components/form.tsx:291
 #: app/components/hint.tsx:111
 msgid "hint.loading.data"
 msgstr "Chargement des données..."
@@ -923,11 +930,11 @@ msgstr "Valeurs négatives"
 msgid "hint.publication.success"
 msgstr "Votre visualisation est à présent publiée. Partagez-là en copiant l'URL ou en utilisant les options d'intégration."
 
-#: app/charts/shared/chart-data-filters.tsx:83
+#: app/charts/shared/chart-data-filters.tsx:93
 msgid "interactive.data.filters.hide"
 msgstr "Masquer les filtres"
 
-#: app/charts/shared/chart-data-filters.tsx:85
+#: app/charts/shared/chart-data-filters.tsx:95
 msgid "interactive.data.filters.show"
 msgstr "Afficher les filtres"
 
@@ -992,9 +999,8 @@ msgstr "Voici une visualisation que j'ai créée sur visualize.admin.ch"
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
-#: app/configurator/components/dataset-browse.tsx:333
-#: app/configurator/components/dataset-browse.tsx:369
-#: app/configurator/components/filters.tsx:810
+#: app/configurator/components/dataset-browse.tsx:378
+#: app/configurator/components/filters.tsx:777
 msgid "select.controls.filters.search"
 msgstr "Chercher"
 

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -13,23 +13,23 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:655
+#: app/configurator/components/chart-configurator.tsx:629
 msgid "Add filter"
 msgstr "Aggiungi filtro"
 
-#: app/configurator/components/chart-configurator.tsx:628
+#: app/configurator/components/chart-configurator.tsx:602
 msgid "Drag filters to reorganize"
 msgstr "Trascina i filtri per riorganizzarli"
 
-#: app/configurator/components/chart-configurator.tsx:625
+#: app/configurator/components/chart-configurator.tsx:599
 msgid "Move filter down"
 msgstr "Sposta il filtro in basso"
 
-#: app/configurator/components/chart-configurator.tsx:622
+#: app/configurator/components/chart-configurator.tsx:596
 msgid "Move filter up"
 msgstr "Sposta il filtro in alto"
 
-#: app/configurator/components/dataset-browse.tsx:1043
+#: app/configurator/components/dataset-browse.tsx:1048
 msgid "No results"
 msgstr "Nessun risultato"
 
@@ -41,11 +41,11 @@ msgstr "[ Nessuna descrizione ]"
 msgid "annotation.add.title"
 msgstr "[ Nessun titolo ]"
 
-#: app/configurator/components/dataset-browse.tsx:974
+#: app/configurator/components/dataset-browse.tsx:979
 msgid "browse-panel.organizations"
 msgstr "Organizzazioni"
 
-#: app/configurator/components/dataset-browse.tsx:956
+#: app/configurator/components/dataset-browse.tsx:961
 msgid "browse-panel.themes"
 msgstr "Categorie"
 
@@ -53,11 +53,11 @@ msgstr "Categorie"
 msgid "browse.dataset.create-visualization"
 msgstr "Iniziare una visualizzazione"
 
-#: app/configurator/components/select-dataset-step.tsx:295
+#: app/configurator/components/select-dataset-step.tsx:290
 msgid "browse.datasets.all-datasets"
 msgstr "Tutti i set di dati"
 
-#: app/configurator/components/select-dataset-step.tsx:189
+#: app/configurator/components/select-dataset-step.tsx:183
 msgid "browse.datasets.description"
 msgstr "Esplora i set di dati forniti dal LINDAS Linked Data Service filtrando per categorie o organizzazioni oppure cercando direttamente per parole chiave specifiche. Clicca su un set di dati per vedere informazioni più dettagliate e iniziare a creare le tue visualizzazioni."
 
@@ -142,8 +142,8 @@ msgstr "Aree"
 #~ msgid "chart.map.layers.area.discretization.quantize"
 #~ msgstr "Intervalli uguali"
 
-#: app/configurator/components/chart-configurator.tsx:704
-#: app/configurator/components/chart-options-selector.tsx:989
+#: app/configurator/components/chart-configurator.tsx:678
+#: app/configurator/components/chart-options-selector.tsx:986
 #: app/configurator/components/field-i18n.ts:31
 msgid "chart.map.layers.base"
 msgstr "Visualizzazione della mappa"
@@ -194,11 +194,11 @@ msgstr "Mappa di calore"
 msgid "columnStyle.text"
 msgstr "Testo"
 
-#: app/configurator/table/table-chart-options.tsx:397
+#: app/configurator/table/table-chart-options.tsx:400
 msgid "columnStyle.textStyle.bold"
 msgstr "Grassetto"
 
-#: app/configurator/table/table-chart-options.tsx:390
+#: app/configurator/table/table-chart-options.tsx:393
 msgid "columnStyle.textStyle.regular"
 msgstr "Regular"
 
@@ -342,35 +342,36 @@ msgstr "Descrizione"
 #~ msgid "controls.dimension.none"
 #~ msgstr "Nessuno"
 
-#: app/charts/shared/chart-data-filters.tsx:218
+#: app/charts/shared/chart-data-filters.tsx:246
+#: app/charts/shared/chart-data-filters.tsx:290
 msgid "controls.dimensionvalue.none"
 msgstr "Nessun filtro"
 
-#: app/configurator/components/filters.tsx:450
+#: app/configurator/components/filters.tsx:407
 msgid "controls.filter.nb-elements"
 msgstr "{0} di {1}"
 
-#: app/configurator/components/filters.tsx:238
+#: app/configurator/components/filters.tsx:189
 msgid "controls.filter.select.all"
 msgstr "Seleziona tutti"
 
-#: app/configurator/components/filters.tsx:245
+#: app/configurator/components/filters.tsx:196
 msgid "controls.filter.select.none"
 msgstr "Deseleziona tutto"
 
-#: app/configurator/components/filters.tsx:401
+#: app/configurator/components/filters.tsx:358
 msgid "controls.filters.select.filters"
 msgstr "Filtri"
 
-#: app/configurator/components/filters.tsx:431
+#: app/configurator/components/filters.tsx:388
 msgid "controls.filters.select.refresh-colors"
 msgstr "Aggiorna i colori"
 
-#: app/configurator/components/filters.tsx:415
+#: app/configurator/components/filters.tsx:372
 msgid "controls.filters.select.reset-colors"
 msgstr "Reimpostare i colori"
 
-#: app/configurator/components/filters.tsx:408
+#: app/configurator/components/filters.tsx:365
 msgid "controls.filters.select.selected-filters"
 msgstr "Filtri selezionati"
 
@@ -402,12 +403,12 @@ msgstr "-"
 msgid "controls.imputation.type.zeros"
 msgstr "Zeri"
 
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:122
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:137
 msgid "controls.interactive.filters.dataFilter"
 msgstr "Filtri di dati"
 
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:115
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:102
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:117
 msgid "controls.interactive.filters.timeSlider"
 msgstr "Cursore del tempo"
 
@@ -456,7 +457,7 @@ msgstr "Italiano"
 msgid "controls.measure"
 msgstr "Misura"
 
-#: app/configurator/components/configurator.tsx:107
+#: app/configurator/components/configurator.tsx:110
 msgid "controls.nav.back-to-preview"
 msgstr "Torna all'anteprima"
 
@@ -476,7 +477,7 @@ msgstr "Inattivo"
 msgid "controls.scale.type"
 msgstr "Tipo di scala"
 
-#: app/components/form.tsx:566
+#: app/components/form.tsx:624
 msgid "controls.search.clear"
 msgstr "Cancella la ricerca"
 
@@ -484,7 +485,7 @@ msgstr "Cancella la ricerca"
 msgid "controls.section.additional-information"
 msgstr "Informazioni aggiuntive"
 
-#: app/configurator/components/chart-configurator.tsx:552
+#: app/configurator/components/chart-configurator.tsx:526
 msgid "controls.section.chart.options"
 msgstr "Opzioni del grafico"
 
@@ -496,7 +497,7 @@ msgstr "Colonne"
 msgid "controls.section.columnstyle"
 msgstr "Stile della colonna"
 
-#: app/configurator/components/chart-configurator.tsx:570
+#: app/configurator/components/chart-configurator.tsx:544
 msgid "controls.section.data.filters"
 msgstr "Filtri"
 
@@ -525,7 +526,8 @@ msgstr "Valori mancanti"
 msgid "controls.section.imputation.explanation"
 msgstr "Per questo tipo di grafico, i valori di sostituzione devono essere assegnati ai valori mancanti. Decidi la logica di imputazione o passa a un altro tipo di grafico."
 
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:83
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:98
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:157
 msgid "controls.section.interactive.filters"
 msgstr "Filtri interattivi"
 
@@ -541,7 +543,7 @@ msgstr "Mostra l'errore standard"
 msgid "controls.section.sorting"
 msgstr "Ordina"
 
-#: app/configurator/table/table-chart-options.tsx:482
+#: app/configurator/table/table-chart-options.tsx:485
 msgid "controls.section.tableSettings"
 msgstr "Impostazioni della tabella"
 
@@ -557,7 +559,7 @@ msgstr "Opzioni della tabella"
 msgid "controls.section.title.warning"
 msgstr "Aggiungi un titolo o una descrizione"
 
-#: app/configurator/components/chart-configurator.tsx:537
+#: app/configurator/components/chart-configurator.tsx:518
 #: app/configurator/components/chart-type-selector.tsx:131
 #: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
@@ -571,35 +573,35 @@ msgstr "Layout a colonne"
 msgid "controls.select.columnStyle"
 msgstr "Stile della colonna"
 
-#: app/configurator/table/table-chart-options.tsx:457
+#: app/configurator/table/table-chart-options.tsx:460
 msgid "controls.select.columnStyle.barColorBackground"
 msgstr "Colore dello sfondo"
 
-#: app/configurator/table/table-chart-options.tsx:449
+#: app/configurator/table/table-chart-options.tsx:452
 msgid "controls.select.columnStyle.barColorNegative"
 msgstr "Colore dei valori negativi"
 
-#: app/configurator/table/table-chart-options.tsx:441
+#: app/configurator/table/table-chart-options.tsx:444
 msgid "controls.select.columnStyle.barColorPositive"
 msgstr "Colore dei valori positivi"
 
-#: app/configurator/table/table-chart-options.tsx:465
+#: app/configurator/table/table-chart-options.tsx:468
 msgid "controls.select.columnStyle.barShowBackground"
 msgstr "Mostra il colore dello sfondo"
 
-#: app/configurator/table/table-chart-options.tsx:414
+#: app/configurator/table/table-chart-options.tsx:417
 msgid "controls.select.columnStyle.columnColor"
 msgstr "Colore della colonna"
 
-#: app/configurator/table/table-chart-options.tsx:406
+#: app/configurator/table/table-chart-options.tsx:409
 msgid "controls.select.columnStyle.textColor"
 msgstr "Colore del testo"
 
-#: app/configurator/table/table-chart-options.tsx:383
+#: app/configurator/table/table-chart-options.tsx:386
 msgid "controls.select.columnStyle.textStyle"
 msgstr "Stile del testo"
 
-#: app/configurator/components/chart-options-selector.tsx:220
+#: app/configurator/components/chart-options-selector.tsx:217
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:310
 msgid "controls.select.dimension"
 msgstr "Seleziona una dimensione"
@@ -617,15 +619,15 @@ msgstr "Seleziona una misura"
 #~ msgid "controls.select.optional"
 #~ msgstr "facoltativo"
 
-#: app/configurator/components/filters.tsx:794
+#: app/configurator/components/filters.tsx:760
 msgid "controls.set-filters"
 msgstr "Modificare i filtri"
 
-#: app/configurator/components/filters.tsx:801
+#: app/configurator/components/filters.tsx:768
 msgid "controls.set-filters-caption"
 msgstr "Pour de meilleurs résultats, ne sélectionnez pas plus de 7 valeurs dans la visualisation"
 
-#: app/configurator/components/filters.tsx:840
+#: app/configurator/components/filters.tsx:808
 msgid "controls.set-values-apply"
 msgstr "Appliquer les filtres"
 
@@ -721,7 +723,7 @@ msgstr "Opzioni"
 msgid "controls.table.sorting"
 msgstr "Ordinamento"
 
-#: app/configurator/table/table-chart-options.tsx:486
+#: app/configurator/table/table-chart-options.tsx:489
 msgid "controls.tableSettings.showSearch"
 msgstr "Mostra il campo di ricerca"
 
@@ -729,15 +731,19 @@ msgstr "Mostra il campo di ricerca"
 msgid "controls.title"
 msgstr "Titolo"
 
-#: app/pages/_cube-checker.tsx:166
+#: app/components/select-tree.tsx:230
+msgid "controls.tree.select-value"
+msgstr "Selezionare"
+
+#: app/pages/_cube-checker.tsx:257
 msgid "cube-checker.cube-checker"
 msgstr "Cube checker"
 
-#: app/pages/_cube-checker.tsx:169
+#: app/pages/_cube-checker.tsx:260
 msgid "cube-checker.description"
 msgstr "Cube checker ti aiuta a capire se un cubo ha tutti i attributi e proprietà necessari per essere visualizzati su visualizza.admin.ch."
 
-#: app/pages/_cube-checker.tsx:183
+#: app/pages/_cube-checker.tsx:274
 msgid "cube-checker.field-placeholder"
 msgstr "Cubo IRI"
 
@@ -749,7 +755,7 @@ msgstr "Fonte di dati"
 msgid "data.source.notTrusted"
 msgstr "Questo grafico non utilizza una fonte di dati affidabile."
 
-#: app/configurator/components/select-dataset-step.tsx:221
+#: app/configurator/components/select-dataset-step.tsx:216
 msgid "dataset-preview.back-to-results"
 msgstr "Torna ai set di dati"
 
@@ -769,7 +775,7 @@ msgstr "Ultimo aggiornamento"
 msgid "dataset.hasImputedValues"
 msgstr "In questo set di dati mancano alcuni dati. Questi sono stati interpolati per colmare le lacune.."
 
-#: app/configurator/components/dataset-browse.tsx:447
+#: app/configurator/components/dataset-browse.tsx:449
 msgid "dataset.includeDrafts"
 msgstr "Includere le bozze"
 
@@ -798,15 +804,15 @@ msgstr "Fonte"
 msgid "dataset.metadata.version"
 msgstr "versione"
 
-#: app/configurator/components/dataset-browse.tsx:404
+#: app/configurator/components/dataset-browse.tsx:413
 msgid "dataset.order.newest"
 msgstr "Più recente"
 
-#: app/configurator/components/dataset-browse.tsx:396
+#: app/configurator/components/dataset-browse.tsx:405
 msgid "dataset.order.relevance"
 msgstr "Rilevanza"
 
-#: app/configurator/components/dataset-browse.tsx:400
+#: app/configurator/components/dataset-browse.tsx:409
 msgid "dataset.order.title"
 msgstr "Titolo"
 
@@ -820,23 +826,23 @@ msgstr "Attenzione, questo set di dati è una bozza.<0/><1>Non utilizzare questo
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Attenzione, questo set di dati è scaduto.<0/><1>Non utilizzare questo grafico per un rapporto!</1>"
 
-#: app/configurator/components/dataset-browse.tsx:435
+#: app/configurator/components/dataset-browse.tsx:437
 msgid "dataset.results"
 msgstr "{0, plural, zero {Nessun set di dati} one {# set di dati} other {# set di dati}}"
 
-#: app/configurator/components/dataset-browse.tsx:328
+#: app/configurator/components/dataset-browse.tsx:337
 msgid "dataset.search.label"
 msgstr "Cerca"
 
-#: app/configurator/components/dataset-browse.tsx:333
+#: app/configurator/components/dataset-browse.tsx:342
 msgid "dataset.search.placeholder"
 msgstr "Nome, organizzazione, parola chiave..."
 
-#: app/configurator/components/dataset-browse.tsx:452
+#: app/configurator/components/dataset-browse.tsx:461
 msgid "dataset.sortby"
 msgstr "Ordina per"
 
-#: app/configurator/components/dataset-browse.tsx:1153
+#: app/configurator/components/dataset-browse.tsx:1157
 msgid "dataset.tag.draft"
 msgstr "Bozza"
 
@@ -900,6 +906,7 @@ msgstr "Problema di caricamento dei dati"
 msgid "hint.how.to.share"
 msgstr "È possibile condividere questa visualizzazione copiando l'URL o incorporandola nel vostro sito Web. Puoi anche creare una nuova visualizzazione partendo da zero oppure copiando e modificando la visualizzazione sopra."
 
+#: app/components/form.tsx:291
 #: app/components/hint.tsx:111
 msgid "hint.loading.data"
 msgstr "Caricamento dei dati..."
@@ -928,11 +935,11 @@ msgstr "Valori negativi"
 msgid "hint.publication.success"
 msgstr "La tua visualizzazione è ora pubblicata. Condividila copiando l'URL o utilizzando le opzioni di incorporamento."
 
-#: app/charts/shared/chart-data-filters.tsx:83
+#: app/charts/shared/chart-data-filters.tsx:93
 msgid "interactive.data.filters.hide"
 msgstr "Nascondi i filtri"
 
-#: app/charts/shared/chart-data-filters.tsx:85
+#: app/charts/shared/chart-data-filters.tsx:95
 msgid "interactive.data.filters.show"
 msgstr "Mostra i filtri"
 
@@ -997,9 +1004,8 @@ msgstr "Ecco una visualizzazione che ho creato usando visualize.admin.ch"
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
-#: app/configurator/components/dataset-browse.tsx:333
-#: app/configurator/components/dataset-browse.tsx:369
-#: app/configurator/components/filters.tsx:810
+#: app/configurator/components/dataset-browse.tsx:378
+#: app/configurator/components/filters.tsx:777
 msgid "select.controls.filters.search"
 msgstr "Cerca"
 

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -501,6 +501,13 @@ const makeServerFilter = (filters: Filters) => {
   };
 };
 
+export const hasHierarchy = (dim: CubeDimension) => {
+  return (
+    dim.out(ns.cubeMeta.inHierarchy).values.length > 0 ||
+    dim.out(ns.cubeMeta.hasHierarchy).values.length > 0
+  );
+};
+
 const buildFilters = ({
   cube,
   view,
@@ -557,11 +564,9 @@ const buildFilters = ({
       );
     }
 
-    const hasHierarchy =
-      cubeDimension.out(ns.cubeMeta.inHierarchy).values.length > 0 ||
-      cubeDimension.out(ns.cubeMeta.hasHierarchy).values.length > 0;
+    const dimensionHasHierarchy = hasHierarchy(cubeDimension);
     const toRDFValue = (value: string): NamedNode | Literal => {
-      return dataType && !hasHierarchy
+      return dataType && !dimensionHasHierarchy
         ? parsedCubeDimension.data.hasUndefinedValues &&
           value === DIMENSION_VALUE_UNDEFINED
           ? rdf.literal("", ns.cube.Undefined)

--- a/app/themes/federal.tsx
+++ b/app/themes/federal.tsx
@@ -220,6 +220,20 @@ theme.components = {
       },
     },
   },
+  MuiTreeItem: {
+    styleOverrides: {
+      content: {
+        minHeight: "32px",
+      },
+      label: {
+        fontSize: theme.typography.body2.fontSize,
+
+        [theme.breakpoints.up("md")]: {
+          fontSize: theme.typography.body2.fontSize,
+        },
+      },
+    },
+  },
   MuiButton: {
     variants: [
       {

--- a/app/themes/federal.tsx
+++ b/app/themes/federal.tsx
@@ -231,31 +231,6 @@ theme.components = {
         },
       },
       {
-        props: { variant: "selectColorPicker" },
-        style: {
-          color: "grey.700",
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-          bg: "monochrome100",
-          p: 1,
-          height: "40px",
-          borderWidth: "1px",
-          borderStyle: "solid",
-          borderColor: theme.palette.divider,
-          ":hover": {
-            bg: "monochrome100",
-          },
-          ":active": {
-            backgroundColor: "grey.100",
-          },
-          ":disabled": {
-            cursor: "initial",
-            backgroundColor: "muted.main",
-          },
-        },
-      },
-      {
         props: { variant: "inline" },
         style: {
           backgroundColor: "transparent",

--- a/app/themes/index.ts
+++ b/app/themes/index.ts
@@ -51,7 +51,6 @@ declare module "@mui/material" {
   }
 
   interface ButtonPropsVariantOverrides {
-    selectColorPicker: true;
     inline: true;
     inverted: true;
   }

--- a/e2e/actions.ts
+++ b/e2e/actions.ts
@@ -50,8 +50,13 @@ export const createActions = ({
   /** Actions on MUI elements, options, selects, dialogs */
   mui: {
     selectOption: async (optionText: string) => {
-      const locator = await selectors.mui.popover().findByText(optionText);
-      await locator.click();
+      const item = await await selectors.mui.popover().findByText(optionText);
+      await item.click();
+      const select = await item.locator("..").locator("text=Select");
+      const count = await select.count();
+      if (count) {
+        await select.click();
+      }
     },
   },
   editor: {

--- a/e2e/actions.ts
+++ b/e2e/actions.ts
@@ -28,7 +28,7 @@ export const createActions = ({
   datasetPreview: {
     load: async (iri: string, dataSource: "Int" | "Prod") => {
       await page.goto(
-        `en/browse/dataset/${encodeURIComponent(iri)}?dataSource=${dataSource}`
+        `en/browse?dataset/${encodeURIComponent(iri)}?dataSource=${dataSource}`
       );
 
       await selectors.datasetPreview.loaded();

--- a/e2e/tooltip.spec.ts
+++ b/e2e/tooltip.spec.ts
@@ -11,7 +11,9 @@ test("tooltip content", async ({ actions, selectors, within, page }) => {
   );
 
   await filterLocator.getByText("Greenhouse gas").click();
-  await actions.mui.selectOption("Methane");
+  await selectors.mui.popover().findByText("Synthetic gases");
+
+  await actions.mui.selectOption("Synthetic gases");
 
   await selectors.chart.loaded();
 

--- a/e2e/unversioned.spec.ts
+++ b/e2e/unversioned.spec.ts
@@ -3,11 +3,13 @@ import { test } from "./common";
 test("Unversioned dataset > should be possible to open a link to an unversioned dataset", async ({
   page,
   screen,
+  actions,
 }) => {
-  await page.goto(
-    `/en/browse/dataset/https%3A%2F%2Fculture.ld.admin.ch%2Fsfa%2FStateAccounts_Function?dataSource=Int`
+  await actions.datasetPreview.load(
+    "https://culture.ld.admin.ch/sfa/StateAccounts_Function",
+    "Int"
   );
-  await screen.findByText("State accounts - Function", undefined, {
+  await screen.findAllByText("State accounts - Function", undefined, {
     timeout: 10 * 1000,
   });
 });


### PR DESCRIPTION
## How to test

- Use bathing water with hierarchies (check draft when searching)
- In the data filters, the "observation location" select should display the hierarchy as a tree
- When activating interactive filters, the interactive filter also displays the hierarchy as a tree

## TODO

- [x] When you first open the select, it loads the hierarchy and then closes the select, and you have to open it again

