### PR TITLE
fix: Y axis formatting for small values

### DIFF
--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -95,7 +95,7 @@ const useAreasState = (
     aspectRatio,
   } = chartProps;
   const width = useWidth();
-  const formatNumber = useFormatNumber();
+  const formatNumber = useFormatNumber({ decimals: "auto" });
   const estimateNumberWidth = (d: number) => estimateTextWidth(formatNumber(d));
   const timeFormatUnit = useTimeFormatUnit();
 

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -101,7 +101,7 @@ const useGroupedColumnsState = (
     aspectRatio,
   } = chartProps;
   const width = useWidth();
-  const formatNumber = useFormatNumber();
+  const formatNumber = useFormatNumber({ decimals: "auto" });
 
   const xDimension = dimensions.find((d) => d.iri === fields.x.componentIri);
 

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -101,7 +101,7 @@ const useColumnsStackedState = (
     aspectRatio,
   } = chartProps;
   const width = useWidth();
-  const formatNumber = useFormatNumber();
+  const formatNumber = useFormatNumber({ decimals: "auto" });
 
   const xDimension = dimensions.find((d) => d.iri === fields.x.componentIri);
 

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -99,7 +99,7 @@ const useColumnsState = (
     aspectRatio,
   } = chartProps;
   const width = useWidth();
-  const formatNumber = useFormatNumber();
+  const formatNumber = useFormatNumber({ decimals: "auto" });
   const timeFormatUnit = useTimeFormatUnit();
 
   const dimensionsByIri = useMemo(

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -90,7 +90,7 @@ const useLinesState = (
   } = chartProps;
   const theme = useTheme();
   const width = useWidth();
-  const formatNumber = useFormatNumber();
+  const formatNumber = useFormatNumber({ decimals: "auto" });
   const timeFormatUnit = useTimeFormatUnit();
 
   const xDimension = dimensions.find((d) => d.iri === fields.x.componentIri);

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -65,7 +65,7 @@ const useScatterplotState = ({
   aspectRatio: number;
 }): ScatterplotState => {
   const width = useWidth();
-  const formatNumber = useFormatNumber();
+  const formatNumber = useFormatNumber({ decimals: "auto" });
 
   const getX = useOptionalNumericVariable(fields.x.componentIri);
   const getY = useOptionalNumericVariable(fields.y.componentIri);

--- a/app/charts/shared/axis-height-linear.tsx
+++ b/app/charts/shared/axis-height-linear.tsx
@@ -21,7 +21,7 @@ export const getTickNumber = (height: number) => {
 
 export const AxisHeightLinear = () => {
   const ref = useRef<SVGGElement>(null);
-  const formatNumber = useFormatNumber();
+  const formatNumber = useFormatNumber({ decimals: "auto" });
 
   const { yScale, yAxisLabel, yAxisDescription, bounds } = useChartState() as
     | AreasState

--- a/app/formatters.ts
+++ b/app/formatters.ts
@@ -297,17 +297,21 @@ export const useTimeFormatUnit = () => {
   return formatter;
 };
 
-export const useFormatNumber = () => {
+export const useFormatNumber = (props?: { decimals: number | "auto" }) => {
+  const { decimals } = props || { decimals: 2 };
   const formatter = useMemo(() => {
     const { format } = getD3FormatLocale();
-    const formatter = format(",.2~f");
+    const specifier = decimals === "auto" ? ",~f" : `,.${decimals}~f`;
+    const formatter = format(specifier);
+
     return (x: NumberValue | null | undefined) => {
       if (x === null || x === undefined) {
         return "–";
       }
       return `${formatter(x)}`;
     };
-  }, []);
+  }, [decimals]);
+
   return formatter;
 };
 


### PR DESCRIPTION
Fixes #861.

E2E test fixed in #866 (update of the dataset)

### How to test
1. Go to /en/browse/dataset/https%3A%2F%2Fenvironment.ld.admin.ch%2Ffoen%2Fubd000502_sad_01%2F6?dataSource=Int and create a new chart.
2. Select `Gas = Methane` and `Source of emission = Forest land`.
3. Check that Y axis looks correct.
4. Optional: Switch Source of emission filter to other values and see that the axis looks correct for all combinations of filters.