### PR TITLE
feat: Sort columns properly in downloaded files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 - Enhancements:
   - Cube Checker:
     - Introduced a Temporal dimensions scaleType & timeFormat checks
+  - Data download:
+    - Order of columns in downloaded files now matches the order visible in the dataset preview (based on shacl:order)
 - Bug fixes:
   - Correctly retrieve min & max values for Temporal dimensions when scaleType is not equal to Interval
 

--- a/app/components/data-download.tsx
+++ b/app/components/data-download.tsx
@@ -28,6 +28,7 @@ import { OperationResult, useClient } from "urql";
 
 import { QueryFilters } from "@/charts/shared/chart-helpers";
 import { DataSource } from "@/configurator";
+import { getSortedColumns } from "@/configurator/components/datatable";
 import { useLocale } from "@/src";
 
 import { Observation } from "../domain/data";
@@ -84,6 +85,7 @@ export type FileFormat = typeof FILE_FORMATS[number];
 const makeColumnLabel = (dim: DimensionMetadataFragment) => {
   return `${dim.label}${dim.unit ? ` (${dim.unit})` : ""}`;
 };
+
 const prepareData = ({
   dimensions,
   measures,
@@ -93,7 +95,7 @@ const prepareData = ({
   measures: DimensionMetadataFragment[];
   observations: Observation[];
 }) => {
-  const columns = keyBy([...dimensions, ...measures], (d) => d.iri);
+  const columns = keyBy(getSortedColumns(dimensions, measures), (d) => d.iri);
   const data = observations.map((obs) =>
     Object.keys(obs).reduce((acc, key) => {
       const col = columns[key];

--- a/app/configurator/components/datatable.tsx
+++ b/app/configurator/components/datatable.tsx
@@ -187,7 +187,7 @@ export const DataSetPreviewTable = ({
   observations: Observation[];
 }) => {
   const headers = useMemo(() => {
-    return getSortedHeaders(dimensions, measures);
+    return getSortedColumns(dimensions, measures);
   }, [dimensions, measures]);
 
   if (observations) {
@@ -231,7 +231,8 @@ export const DataSetTable = ({
     if (!data?.dataCubeByIri) {
       return [];
     }
-    return getSortedHeaders(
+
+    return getSortedColumns(
       data.dataCubeByIri.dimensions,
       data.dataCubeByIri.measures
     );
@@ -252,13 +253,13 @@ export const DataSetTable = ({
   }
 };
 
-function getSortedHeaders(
+export const getSortedColumns = (
   dimensions: DimensionMetadataFragment[],
   measures: DimensionMetadataFragment[]
-) {
+) => {
   const allDimensions = [...dimensions, ...measures];
   allDimensions.sort((a, b) =>
     ascending(a.order ?? Infinity, b.order ?? Infinity)
   );
   return allDimensions;
-}
+};


### PR DESCRIPTION
Closes #753.

### How to test
1. Go to `/en/browse/dataset/https%3A%2F%2Fenvironment.ld.admin.ch%2Ffoen%2Fubd010701%2F7?previous=%7B"includeDrafts"%3Afalse%7D&dataSource=Prod` (or any other dataset).
2. Download a CSV or Excel file.
3. The order of columns in the downloaded file should match what's visible in the dataset preview.