### PR TITLE
feat: Sort table values properly

### DIFF
--- a/app/utils/sorting-values.ts
+++ b/app/utils/sorting-values.ts
@@ -24,7 +24,13 @@ export const makeDimensionValueSorters = (
       >["dimensions"][number]
     | undefined,
   options: {
-    sorting?: NonNullable<SortingField["sorting"]> | undefined;
+    sorting?:
+      | NonNullable<SortingField["sorting"]>
+      | {
+          sortingType: "byTableSortingType";
+          sortingOrder: "asc";
+        }
+      | undefined;
     sumsBySegment?: Record<string, number | null>;
     measureBySegment?: Record<string, number | null>;
   } = {}
@@ -74,6 +80,8 @@ export const makeDimensionValueSorters = (
     case "byAuto":
       sorters = [getPosition, getIdentifier];
       break;
+    case "byTableSortingType":
+      sorters = [getPosition, getLabel];
     default:
       sorters = defaultSorters;
   }

--- a/app/utils/sorting-values.ts
+++ b/app/utils/sorting-values.ts
@@ -3,15 +3,18 @@ import { DimensionValue } from "@/domain/data";
 
 import { DataCubeObservationsQuery } from "../graphql/query-hooks";
 
-const maybeInt = (s?: string) => {
-  if (!s) {
+const maybeInt = (value?: string): number | string => {
+  if (!value) {
     return Infinity;
   }
-  try {
-    return parseInt(s, 10);
-  } catch {
-    return s;
+
+  const maybeInt = parseInt(value, 10);
+
+  if (isNaN(maybeInt)) {
+    return value;
   }
+
+  return maybeInt;
 };
 
 export const makeDimensionValueSorters = (

--- a/e2e/filters.spec.ts
+++ b/e2e/filters.spec.ts
@@ -24,7 +24,7 @@ describe("Filters", () => {
       // ---
       "3. Evaluation type",
       "4. Reference area",
-      "5. Inventory",
+      "5. Grid",
     ]);
 
     const productionRegionFilter = selectors.edition.dataFilterInput(


### PR DESCRIPTION
Closes #871.

`position -> label`?

### How to test
1. Go to `/en/browse?dataset=https%3A%2F%2Fenvironment.ld.admin.ch%2Ffoen%2Fubd003001_colors%2F2&dataSource=Int`.
2. Create a table chart.
3. Look at the values inside the table and see that they are sorted left to right, according to `position -> identifier -> label`.
4. Check that it's still possible to sort individual columns and that they still take the above logic into account. Best visible with `Status` column.