### PR TITLE
fix: Render expand button for depth > 0

### DIFF
--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -664,7 +664,7 @@ const Tree = ({
             // Has value is only present for hierarchies.
             selectable={isHierarchyOptionSelectable(d)}
             expandable={hasChildren}
-            renderExpandButton={currentDepthsMetadata.expandable}
+            renderExpandButton={currentDepthsMetadata.expandable || depth > 0}
             renderColorCheckbox={
               showColors && (currentDepthsMetadata.selectable || d.depth === -1)
             }


### PR DESCRIPTION
Closes #891.

For first-level depths (-1 or 0), we depend on expandability of the whole group to render expand buttons; for following levels, we should always render (and conditionally show / hide) them, so that the indent is correct.