### PR TITLE
In place interactive filters

### DIFF
--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -9,10 +9,7 @@ import { QueryFilters } from "@/charts/shared/chart-helpers";
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { Ruler } from "@/charts/shared/interaction/ruler";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
-import {
-  InteractiveLegendColor,
-  LegendColor,
-} from "@/charts/shared/legend-color";
+import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import {
   AreaConfig,
@@ -95,11 +92,13 @@ export const ChartAreas = memo(
           <Tooltip type={fields.segment ? "multiple" : "single"} />
           <Ruler />
         </ChartContainer>
-        {fields.segment && interactiveFiltersConfig?.legend.active === true ? (
-          <InteractiveLegendColor />
-        ) : fields.segment ? (
-          <LegendColor symbol="square" />
-        ) : null}
+
+        <LegendColor
+          symbol="square"
+          interactive={
+            fields.segment && interactiveFiltersConfig?.legend.active === true
+          }
+        />
       </AreaChart>
     );
   }

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -18,10 +18,7 @@ import {
 import { BrushTime } from "@/charts/shared/brush";
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
-import {
-  InteractiveLegendColor,
-  LegendColor,
-} from "@/charts/shared/legend-color";
+import { LegendColor } from "@/charts/shared/legend-color";
 import {
   ColumnConfig,
   ColumnFields,
@@ -107,11 +104,13 @@ export const ChartColumns = memo(
               </ChartSvg>
               <Tooltip type="multiple" />
             </ChartContainer>
-            {fields.segment && interactiveFiltersConfig?.legend.active ? (
-              <InteractiveLegendColor />
-            ) : fields.segment ? (
-              <LegendColor symbol="square" />
-            ) : null}
+
+            <LegendColor
+              symbol="square"
+              interactive={
+                fields.segment && interactiveFiltersConfig?.legend.active
+              }
+            />
           </StackedColumnsChart>
         ) : fields.segment?.componentIri &&
           fields.segment.type === "grouped" ? (
@@ -136,11 +135,12 @@ export const ChartColumns = memo(
               <Tooltip type="multiple" />
             </ChartContainer>
 
-            {fields.segment && interactiveFiltersConfig?.legend.active ? (
-              <InteractiveLegendColor />
-            ) : fields.segment ? (
-              <LegendColor symbol="square" />
-            ) : null}
+            <LegendColor
+              symbol="square"
+              interactive={
+                fields.segment && interactiveFiltersConfig?.legend.active
+              }
+            />
           </GroupedColumnChart>
         ) : (
           <ColumnChart

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -9,10 +9,7 @@ import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { HoverDotMultiple } from "@/charts/shared/interaction/hover-dots-multiple";
 import { Ruler } from "@/charts/shared/interaction/ruler";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
-import {
-  InteractiveLegendColor,
-  LegendColor,
-} from "@/charts/shared/legend-color";
+import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import {
   DataSource,
@@ -100,11 +97,10 @@ export const ChartLines = memo(function ChartLines({
         <Tooltip type={fields.segment ? "multiple" : "single"} />
       </ChartContainer>
 
-      {fields.segment && interactiveFiltersConfig?.legend.active ? (
-        <InteractiveLegendColor />
-      ) : fields.segment ? (
-        <LegendColor symbol="line" />
-      ) : null}
+      <LegendColor
+        symbol="line"
+        interactive={fields.segment && interactiveFiltersConfig?.legend.active}
+      />
     </LineChart>
   );
 });

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -6,10 +6,7 @@ import { PieChart } from "@/charts/pie/pie-state";
 import { A11yTable } from "@/charts/shared/a11y-table";
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
-import {
-  InteractiveLegendColor,
-  LegendColor,
-} from "@/charts/shared/legend-color";
+import { LegendColor } from "@/charts/shared/legend-color";
 import {
   Loading,
   LoadingDataError,
@@ -122,11 +119,12 @@ export const ChartPie = memo(
           </ChartSvg>
           <Tooltip type="single" />
         </ChartContainer>
-        {fields.segment && interactiveFiltersConfig?.legend.active === true ? (
-          <InteractiveLegendColor />
-        ) : fields.segment ? (
-          <LegendColor symbol="square" />
-        ) : null}{" "}
+        <LegendColor
+          symbol="square"
+          interactive={
+            fields.segment && interactiveFiltersConfig?.legend.active === true
+          }
+        />
       </PieChart>
     );
   }

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -12,10 +12,7 @@ import {
 } from "@/charts/shared/axis-width-linear";
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
-import {
-  InteractiveLegendColor,
-  LegendColor,
-} from "@/charts/shared/legend-color";
+import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionVoronoi } from "@/charts/shared/overlay-voronoi";
 import {
   DataSource,
@@ -100,11 +97,13 @@ export const ChartScatterplot = memo(
           </ChartSvg>
           <Tooltip type="single" />
         </ChartContainer>
-        {fields.segment && interactiveFiltersConfig?.legend.active === true ? (
-          <InteractiveLegendColor />
-        ) : fields.segment ? (
-          <LegendColor symbol="circle" />
-        ) : null}{" "}
+
+        <LegendColor
+          symbol="circle"
+          interactive={
+            fields.segment && interactiveFiltersConfig?.legend.active === true
+          }
+        />
       </ScatterplotChart>
     );
   }

--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -46,6 +46,9 @@ const useStyles = makeStyles<Theme>((theme) => ({
   },
   legendContainerNoGroups: {
     gridTemplateColumns: "1fr",
+    "& $legendGroup": {
+      flexDirection: "row",
+    },
   },
   legendGroup: {
     display: "flex",

--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/charts/shared/use-chart-state";
 import { useInteractiveFilters } from "@/charts/shared/use-interactive-filters";
 import Flex from "@/components/flex";
-import { Checkbox } from "@/components/form";
+import { Checkbox, CheckboxProps } from "@/components/form";
 import {
   DataSource,
   isSegmentInConfig,
@@ -31,7 +31,7 @@ import { getLegendGroups } from "./legend-color-helpers";
 
 type LegendSymbol = "square" | "line" | "circle";
 
-const useStyles = makeStyles<Theme>(() => ({
+const useStyles = makeStyles<Theme>((theme) => ({
   legendContainer: {
     position: "relative",
     justifyContent: "flex-start",
@@ -51,6 +51,10 @@ const useStyles = makeStyles<Theme>(() => ({
     display: "flex",
     flexWrap: "wrap",
     columnGap: "1rem",
+    flexDirection: "column",
+  },
+  groupHeader: {
+    marginBottom: theme.spacing(1),
   },
 }));
 
@@ -80,66 +84,11 @@ const useItemStyles = makeStyles<
       borderRadius: ({ symbol }) => (symbol === "circle" ? "50%" : 0),
     },
   },
+
+  legendCheckbox: {
+    marginTop: () => "0.25rem",
+  },
 }));
-
-export const InteractiveLegendColor = () => {
-  const [state, dispatch] = useInteractiveFilters();
-  const { categories } = state;
-
-  const activeInteractiveFilters = useMemo(() => {
-    return new Set(Object.keys(categories));
-  }, [categories]);
-
-  const { colors } = useChartState() as ColorsChartState;
-
-  const setFilter = useEvent((item: string) => {
-    if (activeInteractiveFilters.has(item)) {
-      dispatch({
-        type: "REMOVE_INTERACTIVE_FILTER",
-        value: item,
-      });
-    } else {
-      dispatch({
-        type: "ADD_INTERACTIVE_FILTER",
-        value: item,
-      });
-    }
-  });
-
-  const groups = useMemo(() => {
-    return [{ label: undefined, value: "", values: colors.domain() }];
-  }, [colors]);
-  const classes = useStyles();
-  return (
-    <Flex
-      className={clsx(
-        classes.legendContainer,
-        groups.length === 1 ? classes.legendContainerNoGroups : undefined
-      )}
-    >
-      {groups.map((group) => {
-        return (
-          <div key={group.value}>
-            {group.label ? (
-              <Typography variant="h4">{group.label}</Typography>
-            ) : null}
-            {colors.domain().map((item, i) => (
-              <Checkbox
-                label={item}
-                name={item}
-                value={item}
-                checked={!activeInteractiveFilters.has(item)}
-                onChange={() => setFilter(item)}
-                key={i}
-                color={colors(item)}
-              />
-            ))}
-          </div>
-        );
-      })}
-    </Flex>
-  );
-};
 
 const useDimension = ({
   dataset,
@@ -228,8 +177,10 @@ const useLegendGroups = ({
 
 export const LegendColor = memo(function LegendColor({
   symbol,
+  interactive,
 }: {
   symbol: LegendSymbol;
+  interactive?: boolean;
 }) {
   const { colors, getSegmentLabel } = useChartState() as ColorsChartState;
   const groups = useLegendGroups({ labels: colors.domain() });
@@ -240,6 +191,7 @@ export const LegendColor = memo(function LegendColor({
       getColor={(v) => colors(v)}
       getLabel={getSegmentLabel}
       symbol={symbol}
+      interactive={interactive}
     />
   );
 });
@@ -282,13 +234,37 @@ const LegendColorContent = ({
   getColor,
   getLabel,
   symbol,
+  interactive,
 }: {
   groups: ReturnType<typeof useLegendGroups>;
   getColor: (d: string) => string;
   getLabel: (d: string) => string;
   symbol: LegendSymbol;
+  interactive?: boolean;
 }) => {
   const classes = useStyles();
+  const [state, dispatch] = useInteractiveFilters();
+  const { categories } = state;
+
+  const activeInteractiveFilters = useMemo(() => {
+    return new Set(Object.keys(categories));
+  }, [categories]);
+
+  const handleToggle: CheckboxProps["onChange"] = useEvent((ev) => {
+    const item = ev.target.value;
+    console.log({ item });
+    if (activeInteractiveFilters.has(item)) {
+      dispatch({
+        type: "REMOVE_INTERACTIVE_FILTER",
+        value: item,
+      });
+    } else {
+      dispatch({
+        type: "ADD_INTERACTIVE_FILTER",
+        value: item,
+      });
+    }
+  });
 
   return (
     <Flex
@@ -300,7 +276,6 @@ const LegendColorContent = ({
       {groups
         ? groups.map(([g, colorValues]) => {
             const headerLabelsArray = g.map((n) => n.label);
-
             return (
               <div
                 className={classes.legendGroup}
@@ -308,7 +283,12 @@ const LegendColorContent = ({
                 data-testid="colorLegend"
               >
                 {headerLabelsArray.length > 0 ? (
-                  <Typography variant="h5" display="flex" alignItems="center">
+                  <Typography
+                    variant="h5"
+                    display="flex"
+                    alignItems="center"
+                    className={classes.groupHeader}
+                  >
                     {interlace(
                       g.map((n) => n.label),
                       <SvgIcChevronRight />
@@ -321,6 +301,11 @@ const LegendColorContent = ({
                     item={getLabel(d)}
                     color={getColor(d)}
                     symbol={symbol}
+                    interactive={interactive}
+                    onToggle={handleToggle}
+                    checked={
+                      interactive && !activeInteractiveFilters.has(getLabel(d))
+                    }
                   />
                 ))}
               </div>
@@ -335,15 +320,36 @@ export const LegendItem = ({
   item,
   color,
   symbol,
+  interactive,
+  onToggle,
+  checked,
 }: {
   item: string;
   color: string;
   symbol: LegendSymbol;
+  interactive?: boolean;
+  onToggle?: CheckboxProps["onChange"];
+  checked?: boolean;
 }) => {
   const classes = useItemStyles({ symbol, color });
   return (
-    <Flex data-testid="legendItem" className={classes.legendItem}>
-      {item}
-    </Flex>
+    <>
+      {interactive && onToggle ? (
+        <Checkbox
+          label={item}
+          name={item}
+          value={item}
+          checked={checked !== undefined ? checked : true}
+          onChange={onToggle}
+          key={item}
+          color={color}
+          className={classes.legendCheckbox}
+        />
+      ) : (
+        <Flex data-testid="legendItem" className={classes.legendItem}>
+          {item}
+        </Flex>
+      )}
+    </>
   );
 };

--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -195,7 +195,7 @@ export const Checkbox = ({
   smaller,
   indeterminate,
 }: {
-  label: string;
+  label: string | React.ReactNode;
   disabled?: boolean;
   color?: string;
   smaller?: boolean;

--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -185,6 +185,15 @@ export const Slider = ({
   );
 };
 
+export type CheckboxProps = {
+  label: FormControlLabelProps["label"];
+  disabled?: boolean;
+  color?: string;
+  smaller?: boolean;
+  indeterminate?: boolean;
+  className?: string;
+} & FieldProps;
+
 export const Checkbox = ({
   label,
   name,
@@ -195,17 +204,13 @@ export const Checkbox = ({
   color,
   smaller,
   indeterminate,
-}: {
-  label: FormControlLabelProps["label"];
-  disabled?: boolean;
-  color?: string;
-  smaller?: boolean;
-  indeterminate?: boolean;
-} & FieldProps) => (
+  className,
+}: CheckboxProps) => (
   <FormControlLabel
     label={label || "-"}
     htmlFor={`${name}`}
     disabled={disabled}
+    className={className}
     componentsProps={{
       typography: {
         variant: smaller ? "caption" : "body2",

--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -23,6 +23,7 @@ import {
   Stack,
   styled,
   PaperProps,
+  FormControlLabelProps,
 } from "@mui/material";
 import { useId } from "@reach/auto-id";
 import { timeFormat } from "d3-time-format";
@@ -195,7 +196,7 @@ export const Checkbox = ({
   smaller,
   indeterminate,
 }: {
-  label: string | React.ReactNode;
+  label: FormControlLabelProps["label"];
   disabled?: boolean;
   color?: string;
   smaller?: boolean;

--- a/app/configurator/components/chart-annotator.tsx
+++ b/app/configurator/components/chart-annotator.tsx
@@ -9,11 +9,9 @@ import {
 } from "@/configurator/components/chart-controls/section";
 import { AnnotatorTabField } from "@/configurator/components/field";
 import { getFieldLabel } from "@/configurator/components/field-i18n";
-import { InteractiveFiltersConfigurator } from "@/configurator/interactive-filters/interactive-filters-configurator";
 import SvgIcExclamation from "@/icons/components/IcExclamation";
 import { useConfiguratorState, useLocale } from "@/src";
 
-import { ConfiguratorStateConfiguringChart } from "../config-types";
 import { isConfiguring } from "../configurator-state";
 
 const WarnTitleDescription = () => {
@@ -41,7 +39,12 @@ const WarnTitleDescription = () => {
 
 export const TitleAndDescriptionConfigurator = () => {
   return (
-    <ControlSection role="tablist" aria-labelledby="controls-design" collapse>
+    <ControlSection
+      role="tablist"
+      aria-labelledby="controls-design"
+      collapse
+      defaultExpanded={false}
+    >
       <SectionTitle
         titleId="controls-design"
         gutterBottom={false}

--- a/app/configurator/components/chart-annotator.tsx
+++ b/app/configurator/components/chart-annotator.tsx
@@ -74,20 +74,3 @@ export const TitleAndDescriptionConfigurator = () => {
     </ControlSection>
   );
 };
-
-export const ChartAnnotator = ({
-  state,
-}: {
-  state: ConfiguratorStateConfiguringChart;
-}) => {
-  return (
-    <>
-      {/* Title & Description */}
-      <TitleAndDescriptionConfigurator />
-      {/* Filters */}
-      {state.chartConfig.chartType !== "table" && (
-        <InteractiveFiltersConfigurator state={state} />
-      )}
-    </>
-  );
-};

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -53,7 +53,6 @@ import {
   moveFilterField,
   useConfiguratorState,
 } from "@/configurator/configurator-state";
-import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import { isStandardErrorDimension, isTemporalDimension } from "@/domain/data";
 import {
   DataCubeMetadataWithComponentValuesQuery,
@@ -351,10 +350,9 @@ const useFilterReorder = ({
 
   const handleRemoveDimensionFilter = useEvent((dimension: Dimension) => {
     dispatch({
-      type: "CHART_CONFIG_FILTER_SET_SINGLE",
+      type: "CHART_CONFIG_FILTER_REMOVE_SINGLE",
       value: {
         dimensionIri: dimension.iri,
-        value: FIELD_VALUE_NONE,
       },
     });
   });

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -11,6 +11,7 @@ import {
   Switch,
   FormControlLabel,
   FormControlLabelProps,
+  Badge,
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import isEmpty from "lodash/isEmpty";
@@ -37,6 +38,7 @@ import {
   ControlSectionContent,
   ControlSectionSkeleton,
   SectionTitle,
+  useControlSectionContext,
 } from "@/configurator/components/chart-controls/section";
 import {
   ControlTabField,
@@ -69,7 +71,9 @@ import { useLocale } from "@/locales/use-locale";
 import useEvent from "@/utils/use-event";
 
 import { useInteractiveDataFilterToggle } from "../interactive-filters/interactive-filters-config-state";
+import { InteractiveFiltersConfigurator } from "../interactive-filters/interactive-filters-configurator";
 
+import { TitleAndDescriptionConfigurator } from "./chart-annotator";
 import { ChartTypeSelector } from "./chart-type-selector";
 
 const DataFilterSelectGeneric = ({
@@ -558,8 +562,16 @@ export const ChartConfigurator = ({
       </ControlSection>
       {filterDimensions.length === 0 &&
       addableDimensions.length === 0 ? null : (
-        <ControlSection className={classes.filterSection} collapse>
-          <SectionTitle titleId="controls-data" gutterBottom={false}>
+        <ControlSection
+          className={classes.filterSection}
+          collapse
+          defaultExpanded={false}
+        >
+          <SectionTitle
+            titleId="controls-data"
+            gutterBottom={false}
+            sx={{ justifyContent: "space-between" }}
+          >
             <Trans id="controls.section.data.filters">Filters</Trans>{" "}
             {fetching ? (
               <CircularProgress

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -674,6 +674,10 @@ export const ChartConfigurator = ({
           </ControlSectionContent>
         </ControlSection>
       )}
+      <TitleAndDescriptionConfigurator />
+      {state.chartConfig.chartType !== "table" && (
+        <InteractiveFiltersConfigurator state={state} />
+      )}
     </>
   );
 };

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -496,8 +496,9 @@ const InteractiveDataFilterCheckbox = ({
 const FiltersBadge = () => {
   const ctx = useControlSectionContext();
   const [state] = useConfiguratorState(isConfiguring);
-  return ctx.isOpen ? null : (
+  return (
     <Badge
+      invisible={ctx.isOpen}
       badgeContent={Object.values(state.chartConfig.filters).length}
       color="primary"
       sx={{ display: "block", mr: 4 }}

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -69,7 +69,7 @@ import { Icon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
 import useEvent from "@/utils/use-event";
 
-import { useInteractiveDataFilter } from "../interactive-filters/interactive-filters-config-options";
+import { useInteractiveDataFilterToggle } from "../interactive-filters/interactive-filters-config-state";
 
 import { ChartTypeSelector } from "./chart-type-selector";
 
@@ -478,7 +478,7 @@ const InteractiveDataFilterCheckbox = ({
   value,
   ...props
 }: { value: string } & Omit<FormControlLabelProps, "control" | "label">) => {
-  const { checked, toggle } = useInteractiveDataFilter(value);
+  const { checked, toggle } = useInteractiveDataFilterToggle(value);
   return (
     <FormControlLabel
       componentsProps={{

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -493,6 +493,18 @@ const InteractiveDataFilterCheckbox = ({
   );
 };
 
+const FiltersBadge = () => {
+  const ctx = useControlSectionContext();
+  const [state] = useConfiguratorState(isConfiguring);
+  return ctx.isOpen ? null : (
+    <Badge
+      badgeContent={Object.values(state.chartConfig.filters).length}
+      color="primary"
+      sx={{ display: "block", mr: 4 }}
+    />
+  );
+};
+
 export const ChartConfigurator = ({
   state,
 }: {
@@ -579,6 +591,7 @@ export const ChartConfigurator = ({
                 className={classes.loadingIndicator}
               />
             ) : null}
+            <FiltersBadge />
           </SectionTitle>
 
           <ControlSectionContent

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -575,11 +575,7 @@ export const ChartConfigurator = ({
       </ControlSection>
       {filterDimensions.length === 0 &&
       addableDimensions.length === 0 ? null : (
-        <ControlSection
-          className={classes.filterSection}
-          collapse
-          defaultExpanded={false}
-        >
+        <ControlSection className={classes.filterSection} collapse>
           <SectionTitle
             titleId="controls-data"
             gutterBottom={false}

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -500,7 +500,7 @@ const FiltersBadge = () => {
     <Badge
       invisible={ctx.isOpen}
       badgeContent={Object.values(state.chartConfig.filters).length}
-      color="primary"
+      color="secondary"
       sx={{ display: "block", mr: 4 }}
     />
   );

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -8,6 +8,9 @@ import {
   MenuItem,
   Theme,
   Typography,
+  Switch,
+  FormControlLabel,
+  FormControlLabelProps,
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import isEmpty from "lodash/isEmpty";
@@ -65,6 +68,8 @@ import { DataCubeMetadata } from "@/graphql/types";
 import { Icon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
 import useEvent from "@/utils/use-event";
+
+import { useInteractiveDataFilter } from "../interactive-filters/interactive-filters-config-options";
 
 import { ChartTypeSelector } from "./chart-type-selector";
 
@@ -469,6 +474,23 @@ const useStyles = makeStyles<
   },
 }));
 
+const InteractiveDataFilterCheckbox = ({
+  value,
+  ...props
+}: { value: string } & Omit<FormControlLabelProps, "control" | "label">) => {
+  const { checked, toggle } = useInteractiveDataFilter(value);
+  return (
+    <FormControlLabel
+      componentsProps={{
+        typography: { variant: "caption", color: "text.secondary" },
+      }}
+      {...props}
+      control={<Switch checked={checked} onChange={() => toggle()} />}
+      label={<Trans id="controls.filter.interactive.toggle">Interactive</Trans>}
+    />
+  );
+};
+
 export const ChartConfigurator = ({
   state,
 }: {
@@ -580,6 +602,12 @@ export const ChartConfigurator = ({
                             {...provided.dragHandleProps}
                             {...provided.draggableProps}
                           >
+                            <div>
+                              <InteractiveDataFilterCheckbox
+                                value={dimension.iri}
+                                sx={{ mb: 1 }}
+                              />
+                            </div>
                             <DataFilterSelectGeneric
                               key={dimension.iri}
                               dimension={dimension}
@@ -589,6 +617,7 @@ export const ChartConfigurator = ({
                                 handleRemoveDimensionFilter(dimension)
                               }
                             />
+
                             <Box className={classes.dragButtons}>
                               <MoveDragButtons
                                 moveUpButtonProps={{

--- a/app/configurator/components/chart-controls/section.tsx
+++ b/app/configurator/components/chart-controls/section.tsx
@@ -102,10 +102,22 @@ export const ControlSection = forwardRef<
     isHighlighted?: boolean;
     sx?: BoxProps["sx"];
     collapse?: boolean;
+    defaultExpanded?: boolean;
   } & Omit<HTMLProps<HTMLDivElement>, "ref">
->(({ role, children, isHighlighted, sx, collapse = false, ...props }, ref) => {
+>(function ControlSection(
+  {
+    role,
+    children,
+    isHighlighted,
+    sx,
+    collapse = false,
+    defaultExpanded = true,
+    ...props
+  },
+  ref
+) {
   const classes = useControlSectionStyles({ isHighlighted });
-  const disclosure = useDisclosure(true);
+  const disclosure = useDisclosure(defaultExpanded);
   const ctx = useMemo(
     () => ({ ...disclosure, collapse }),
     [collapse, disclosure]
@@ -186,7 +198,7 @@ export const ControlSectionContent = ({
   );
 };
 
-const useControlSectionContext = () => useContext(ControlSectionContext);
+export const useControlSectionContext = () => useContext(ControlSectionContext);
 
 export const SectionTitle = ({
   color,

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -406,7 +406,11 @@ const ChartFieldMultiFilter = ({
 
   return encoding.filters && component ? (
     <ControlSection data-testid="chart-edition-right-filters">
-      <SectionTitle disabled={!component} iconName="filter">
+      <SectionTitle
+        disabled={!component}
+        iconName="filter"
+        gutterBottom={false}
+      >
         <Trans id="controls.section.filter">Filter</Trans>
       </SectionTitle>
       <ControlSectionContent component="fieldset" gap="none">

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -405,7 +405,7 @@ const ChartFieldMultiFilter = ({
     | undefined;
 
   return encoding.filters && component ? (
-    <ControlSection data-testid="chart-edition-right-filters">
+    <ControlSection data-testid="chart-edition-multi-filters">
       <SectionTitle
         disabled={!component}
         iconName="filter"

--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -23,7 +23,6 @@ import useEvent from "@/utils/use-event";
 import { InteractiveFiltersOptions } from "../interactive-filters/interactive-filters-config-options";
 import { isInteractiveFilterType } from "../interactive-filters/interactive-filters-configurator";
 
-import { ChartAnnotator } from "./chart-annotator";
 import { ChartOptionsSelector } from "./chart-options-selector";
 
 const BackContainer = ({ children }: { children: React.ReactNode }) => {
@@ -113,10 +112,7 @@ const ConfigureChartStep = () => {
         {state.chartConfig.chartType === "table" ? (
           <ChartConfiguratorTable state={state} />
         ) : (
-          <>
-            <ChartConfigurator state={state} />
-            <ChartAnnotator state={state} />
-          </>
+          <ChartConfigurator state={state} />
         )}
       </PanelLeftWrapper>
       <PanelMiddleWrapper>

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -83,7 +83,7 @@ import useEvent from "@/utils/use-event";
 
 import { interlace } from "../../utils/interlace";
 import { ConfiguratorState, GenericSegmentField } from "../config-types";
-import { useInteractiveLegendFiltersToggle } from "../interactive-filters/interactive-filters-config-state";
+import { useInteractiveFiltersToggle } from "../interactive-filters/interactive-filters-config-state";
 
 import { ControlSectionSkeleton } from "./chart-controls/section";
 
@@ -342,21 +342,23 @@ const MultiFilterContent = ({
     );
   }, [colorConfig?.colorMapping, dimensionIri, colorComponent]);
 
-  const interactiveFilterProps = useInteractiveLegendFiltersToggle();
+  const interactiveFilterProps = useInteractiveFiltersToggle("legend");
 
   return (
     <Box sx={{ position: "relative" }}>
       <Box mb={4}>
         <Box sx={{ justifyContent: "space-between", display: "flex" }}>
-          <FormControlLabel
-            componentsProps={{ typography: { variant: "caption" } }}
-            control={<Switch {...interactiveFilterProps} />}
-            label={
-              <Trans id="controls.filters.interactive.toggle">
-                Interactive
-              </Trans>
-            }
-          />
+          {config.activeField === "segment" ? (
+            <FormControlLabel
+              componentsProps={{ typography: { variant: "caption" } }}
+              control={<Switch {...interactiveFilterProps} />}
+              label={
+                <Trans id="controls.filters.interactive.toggle">
+                  Interactive
+                </Trans>
+              }
+            />
+          ) : null}
           <Button
             variant="contained"
             size="small"

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -13,6 +13,8 @@ import {
   AccordionDetails,
   InputAdornment,
   Input,
+  FormControlLabel,
+  Switch,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { makeStyles } from "@mui/styles";
@@ -81,6 +83,7 @@ import useEvent from "@/utils/use-event";
 
 import { interlace } from "../../utils/interlace";
 import { ConfiguratorState, GenericSegmentField } from "../config-types";
+import { useInteractiveLegendFiltersToggle } from "../interactive-filters/interactive-filters-config-state";
 
 import { ControlSectionSkeleton } from "./chart-controls/section";
 
@@ -339,19 +342,31 @@ const MultiFilterContent = ({
     );
   }, [colorConfig?.colorMapping, dimensionIri, colorComponent]);
 
+  const interactiveFilterProps = useInteractiveLegendFiltersToggle();
+
   return (
     <Box sx={{ position: "relative" }}>
       <Box mb={4}>
-        <Button
-          variant="contained"
-          size="small"
-          color="primary"
-          onClick={handleOpenAutocomplete}
-          fullWidth
-          sx={{ justifyContent: "center", mb: 2 }}
-        >
-          <Trans id="controls.set-filters">Edit filters</Trans>
-        </Button>
+        <Box sx={{ justifyContent: "space-between", display: "flex" }}>
+          <FormControlLabel
+            componentsProps={{ typography: { variant: "caption" } }}
+            control={<Switch {...interactiveFilterProps} />}
+            label={
+              <Trans id="controls.filters.interactive.toggle">
+                Interactive
+              </Trans>
+            }
+          />
+          <Button
+            variant="contained"
+            size="small"
+            color="primary"
+            onClick={handleOpenAutocomplete}
+            sx={{ justifyContent: "center", mb: 2 }}
+          >
+            <Trans id="controls.set-filters">Edit filters</Trans>
+          </Button>
+        </Box>
         <Divider sx={{ mt: "0.5rem", mb: "0.7rem" }} />
         <Flex justifyContent="space-between">
           <Typography variant="h5">

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -816,9 +816,8 @@ export const handleChartFieldChanged = (
         draft.chartConfig.interactiveFiltersConfig.dataFilters.componentIris =
           newComponentIris;
 
-        if (newComponentIris.length === 0) {
-          draft.chartConfig.interactiveFiltersConfig.dataFilters.active = false;
-        }
+        draft.chartConfig.interactiveFiltersConfig.dataFilters.active =
+          newComponentIris.length > 0;
       }
     } else if (isMapConfig(draft.chartConfig)) {
       initializeMapField({

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -809,10 +809,16 @@ export const handleChartFieldChanged = (
 
       // Remove this component from the interactive filter, if it is there
       if (draft.chartConfig.interactiveFiltersConfig) {
-        draft.chartConfig.interactiveFiltersConfig.dataFilters.componentIris =
+        const newComponentIris =
           draft.chartConfig.interactiveFiltersConfig.dataFilters.componentIris.filter(
             (c) => c !== componentIri
           );
+        draft.chartConfig.interactiveFiltersConfig.dataFilters.componentIris =
+          newComponentIris;
+
+        if (newComponentIris.length === 0) {
+          draft.chartConfig.interactiveFiltersConfig.dataFilters.active = false;
+        }
       }
     } else if (isMapConfig(draft.chartConfig)) {
       initializeMapField({

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -93,6 +93,8 @@ import { migrateChartConfig } from "@/utils/chart-config/versioning";
 import { createChartId } from "@/utils/create-chart-id";
 import { unreachableError } from "@/utils/unreachable";
 
+import { toggleInteractiveFilterDataDimension } from "./interactive-filters/interactive-filters-config-state";
+
 export type ConfiguratorStateAction =
   | {
       type: "INITIALIZED";
@@ -201,6 +203,10 @@ export type ConfiguratorStateAction =
   | {
       type: "CHART_CONFIG_FILTER_SET_SINGLE";
       value: { dimensionIri: string; value: string };
+    }
+  | {
+      type: "CHART_CONFIG_FILTER_REMOVE_SINGLE";
+      value: { dimensionIri: string };
     }
   | {
       type: "CHART_CONFIG_FILTERS_UPDATE";
@@ -1242,6 +1248,19 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
             value,
           };
         }
+      }
+      return draft;
+
+    case "CHART_CONFIG_FILTER_REMOVE_SINGLE":
+      if (draft.state === "CONFIGURING_CHART") {
+        const { dimensionIri } = action.value;
+        delete draft.chartConfig.filters[dimensionIri];
+        const newIFConfig = toggleInteractiveFilterDataDimension(
+          draft.chartConfig.interactiveFiltersConfig,
+          dimensionIri,
+          false
+        );
+        draft.chartConfig.interactiveFiltersConfig = newIFConfig;
       }
       return draft;
 

--- a/app/configurator/interactive-filters/helpers.ts
+++ b/app/configurator/interactive-filters/helpers.ts
@@ -1,11 +1,16 @@
-import { getFieldComponentIri } from "@/charts";
+import { getFieldComponentIri, getFieldComponentIris } from "@/charts";
 import { isTemporalDimension } from "@/domain/data";
 import {
+  DataCubeMetadataWithComponentValuesQuery,
   DimensionMetadataFragment,
   TemporalDimension,
+  TimeUnit,
 } from "@/graphql/query-hooks";
 
-import { ChartConfig } from "../config-types";
+import {
+  ChartConfig,
+  ConfiguratorStateConfiguringChart,
+} from "../config-types";
 
 export const getTimeSliderFilterDimensions = ({
   chartConfig,
@@ -33,4 +38,23 @@ export const getTimeSliderFilterDimensions = ({
   }
 
   return [];
+};
+
+export const getDataFilterDimensions = (
+  chartConfig: ConfiguratorStateConfiguringChart["chartConfig"],
+  dataCube: NonNullable<
+    DataCubeMetadataWithComponentValuesQuery["dataCubeByIri"]
+  >
+) => {
+  const mappedIris = getFieldComponentIris(chartConfig.fields);
+  // Dimensions that are not encoded in the visualization
+  // excluding temporal and numerical dimensions
+  const configurableDimensions = dataCube.dimensions.filter(
+    (d) =>
+      !mappedIris.has(d.iri) &&
+      (!isTemporalDimension(d) || d.timeUnit === TimeUnit.Year) &&
+      !d.isNumerical
+  );
+
+  return configurableDimensions;
 };

--- a/app/configurator/interactive-filters/interactive-filters-config-options.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-config-options.tsx
@@ -10,7 +10,7 @@ import React, {
   useRef,
 } from "react";
 
-import { getFieldComponentIri, getFieldComponentIris } from "@/charts";
+import { getFieldComponentIri } from "@/charts";
 import { Checkbox, Select } from "@/components/form";
 import { Loading } from "@/components/hint";
 import {
@@ -33,19 +33,20 @@ import {
   useInteractiveTimeSliderFiltersSelect,
 } from "@/configurator/interactive-filters/interactive-filters-config-state";
 import { InteractiveFilterType } from "@/configurator/interactive-filters/interactive-filters-configurator";
-import { isTemporalDimension } from "@/domain/data";
 import { useFormatFullDateAuto } from "@/formatters";
 import {
   DimensionMetadataFragment,
   TemporalDimension,
-  TimeUnit,
   useDataCubeMetadataWithComponentValuesQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
 import { FIELD_VALUE_NONE } from "../constants";
 
-import { getTimeSliderFilterDimensions } from "./helpers";
+import {
+  getTimeSliderFilterDimensions,
+  getDataFilterDimensions,
+} from "./helpers";
 
 export const InteractiveFiltersOptions = ({
   state,
@@ -358,15 +359,11 @@ const InteractiveDataFilterOptions = ({
   });
 
   if (data?.dataCubeByIri) {
-    const mappedIris = getFieldComponentIris(chartConfig.fields);
-
     // Dimensions that are not encoded in the visualization
     // excluding temporal and numerical dimensions
-    const configurableDimensions = data.dataCubeByIri.dimensions.filter(
-      (d) =>
-        !mappedIris.has(d.iri) &&
-        (!isTemporalDimension(d) || d.timeUnit === TimeUnit.Year) &&
-        !d.isNumerical
+    const configurableDimensions = getDataFilterDimensions(
+      chartConfig,
+      data?.dataCubeByIri
     );
 
     return (

--- a/app/configurator/interactive-filters/interactive-filters-config-options.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-config-options.tsx
@@ -1,5 +1,5 @@
 import { t, Trans } from "@lingui/macro";
-import { Box } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import { extent } from "d3";
 import get from "lodash/get";
 import React, {
@@ -325,9 +325,9 @@ const InteractiveDataFiltersToggle = ({
   disabled = false,
   dimensions,
 }: {
-  label: string;
+  label: React.ComponentProps<typeof Checkbox>["label"];
   defaultChecked?: boolean;
-  disabled?: boolean;
+  disabled?: React.ComponentProps<typeof Checkbox>["disabled"];
   dimensions: DimensionMetadataFragment[];
 }) => {
   const fieldProps = useInteractiveDataFiltersToggle({ dimensions });
@@ -372,26 +372,48 @@ const InteractiveDataFilterOptions = ({
     return (
       <>
         <InteractiveDataFiltersToggle
-          label={t({
-            id: "controls.interactiveFilters.dataFilters.toggledataFilters",
-            message: "Show data filters",
-          })}
+          label={
+            <>
+              <Typography variant="body2">
+                {t({
+                  id: "controls.interactiveFilters.dataFilters.toggledataFilters",
+                  message: "Show data filters",
+                })}
+              </Typography>
+              {configurableDimensions.length === 0 ? (
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  display="block"
+                  sx={{ my: 1 }}
+                >
+                  <Trans id="controls.interactiveFilters.dataFilters.unavailable">
+                    All dimensions have been encoded onto the chart, no
+                    dimensions are available to server as interactive data
+                    filters.
+                  </Trans>
+                </Typography>
+              ) : null}
+            </>
+          }
           defaultChecked={false}
-          disabled={false}
+          disabled={configurableDimensions.length === 0}
           dimensions={configurableDimensions}
         />
-        <Box sx={{ my: 3 }}>
-          {configurableDimensions.map((d, i) => (
-            <InteractiveDataFilterOptionsCheckbox
-              key={i}
-              label={d.label}
-              value={d.iri}
-              disabled={
-                !chartConfig.interactiveFiltersConfig?.dataFilters.active
-              }
-            />
-          ))}
-        </Box>
+        {configurableDimensions.length > 0 ? (
+          <Box sx={{ my: 3 }}>
+            {configurableDimensions.map((d, i) => (
+              <InteractiveDataFilterOptionsCheckbox
+                key={i}
+                label={d.label}
+                value={d.iri}
+                disabled={
+                  !chartConfig.interactiveFiltersConfig?.dataFilters.active
+                }
+              />
+            ))}
+          </Box>
+        ) : null}
       </>
     );
   } else {

--- a/app/configurator/interactive-filters/interactive-filters-config-options.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-config-options.tsx
@@ -14,13 +14,8 @@ import {
 } from "@/configurator/components/chart-controls/section";
 import { parseDate } from "@/configurator/components/ui-helpers";
 import { ConfiguratorStateConfiguringChart } from "@/configurator/config-types";
-import {
-  isConfiguring,
-  useConfiguratorState,
-} from "@/configurator/configurator-state";
 import { EditorBrush } from "@/configurator/interactive-filters/editor-time-brush";
 import {
-  toggleInteractiveFilterDataDimension,
   useInteractiveTimeRangeFiltersToggle,
   useInteractiveTimeSliderFiltersSelect,
 } from "@/configurator/interactive-filters/interactive-filters-config-state";
@@ -31,7 +26,6 @@ import {
   useDataCubeMetadataWithComponentValuesQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
-import useEvent from "@/utils/use-event";
 
 import { FIELD_VALUE_NONE } from "../constants";
 
@@ -274,26 +268,4 @@ const InteractiveTimeSliderFilterOptionsSelect = ({
       {...fieldProps}
     />
   );
-};
-
-export const useInteractiveDataFilter = (dimensionIri: string) => {
-  const [state, dispatch] = useConfiguratorState(isConfiguring);
-  const toggle = useEvent(() => {
-    const { interactiveFiltersConfig } = state.chartConfig;
-    const newIFConfig = toggleInteractiveFilterDataDimension(
-      interactiveFiltersConfig,
-      dimensionIri
-    );
-
-    dispatch({
-      type: "INTERACTIVE_FILTER_CHANGED",
-      value: newIFConfig,
-    });
-  });
-  const checked =
-    state.chartConfig.interactiveFiltersConfig?.dataFilters.componentIris?.includes(
-      dimensionIri
-    );
-
-  return { checked, toggle };
 };

--- a/app/configurator/interactive-filters/interactive-filters-config-options.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-config-options.tsx
@@ -418,17 +418,8 @@ const InteractiveDataFilterOptions = ({
   }
 };
 
-const InteractiveDataFilterOptionsCheckbox = ({
-  value,
-  label,
-  disabled,
-}: {
-  value: string;
-  label: string;
-  disabled: boolean;
-}) => {
+const useInteractiveDataFilter = (value: string) => {
   const [state, dispatch] = useConfiguratorState(isConfiguring);
-
   const onChange = useCallback<(e: ChangeEvent<HTMLInputElement>) => void>(
     (e) => {
       const { interactiveFiltersConfig } = state.chartConfig;
@@ -449,6 +440,19 @@ const InteractiveDataFilterOptionsCheckbox = ({
       value
     );
 
+  return { checked, onChange };
+};
+
+const InteractiveDataFilterOptionsCheckbox = ({
+  value,
+  label,
+  disabled,
+}: {
+  value: string;
+  label: string;
+  disabled: boolean;
+}) => {
+  const { checked, onChange } = useInteractiveDataFilter(value);
   return (
     <Checkbox
       name={`interactive-filter-${label}`}

--- a/app/configurator/interactive-filters/interactive-filters-config-state.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-config-state.tsx
@@ -150,6 +150,9 @@ export const useInteractiveTimeSliderFiltersSelect = () => {
   };
 };
 
+/**
+ * Toggles all data filters
+ */
 export const useInteractiveDataFiltersToggle = ({
   dimensions,
 }: {
@@ -199,9 +202,34 @@ export const useInteractiveDataFiltersToggle = ({
   };
 };
 
+/**
+ * Toggles a single data filter
+ */
+export const useInteractiveDataFilterToggle = (dimensionIri: string) => {
+  const [state, dispatch] = useConfiguratorState(isConfiguring);
+  const toggle = useEvent(() => {
+    const { interactiveFiltersConfig } = state.chartConfig;
+    const newIFConfig = toggleInteractiveFilterDataDimension(
+      interactiveFiltersConfig,
+      dimensionIri
+    );
+
+    dispatch({
+      type: "INTERACTIVE_FILTER_CHANGED",
+      value: newIFConfig,
+    });
+  });
+  const checked =
+    state.chartConfig.interactiveFiltersConfig?.dataFilters.componentIris?.includes(
+      dimensionIri
+    );
+
+  return { checked, toggle };
+};
+
 // Add or remove a dimension from the interactive
 // data filters dimensions list
-export const toggleInteractiveFilterDataDimension = produce(
+const toggleInteractiveFilterDataDimension = produce(
   (config: InteractiveFiltersConfig, iri: string): InteractiveFiltersConfig => {
     if (!config?.dataFilters.componentIris) {
       return config;

--- a/app/configurator/interactive-filters/interactive-filters-config-state.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-config-state.tsx
@@ -229,16 +229,22 @@ export const useInteractiveDataFilterToggle = (dimensionIri: string) => {
 
 // Add or remove a dimension from the interactive
 // data filters dimensions list
-const toggleInteractiveFilterDataDimension = produce(
-  (config: InteractiveFiltersConfig, iri: string): InteractiveFiltersConfig => {
+export const toggleInteractiveFilterDataDimension = produce(
+  (
+    config: InteractiveFiltersConfig,
+    iri: string,
+    newValue?: boolean
+  ): InteractiveFiltersConfig => {
     if (!config?.dataFilters.componentIris) {
       return config;
     }
 
     const currentComponentIris = config.dataFilters.componentIris;
-    let newComponentIris = currentComponentIris.includes(iri)
-      ? config.dataFilters.componentIris.filter((d) => d !== iri)
-      : [...currentComponentIris, iri];
+    const shouldAdd =
+      newValue === undefined ? !currentComponentIris.includes(iri) : newValue;
+    const newComponentIris = shouldAdd
+      ? [...currentComponentIris, iri]
+      : config.dataFilters.componentIris.filter((d) => d !== iri);
     const newDataFilters = {
       ...config.dataFilters,
       componentIris: newComponentIris,

--- a/app/configurator/interactive-filters/interactive-filters-config-state.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-config-state.tsx
@@ -207,25 +207,15 @@ export const toggleInteractiveFilterDataDimension = produce(
       return config;
     }
 
-    if (config.dataFilters.componentIris.includes(iri)) {
-      const newComponentIris = config.dataFilters.componentIris.filter(
-        (d) => d !== iri
-      );
-      const newDataFilters = {
-        ...config.dataFilters,
-        componentIris: newComponentIris,
-      };
-      return { ...config, dataFilters: newDataFilters };
-    } else if (!config.dataFilters.componentIris.includes(iri)) {
-      const newComponentIris = [...config.dataFilters.componentIris, iri];
-      const newDataFilters = {
-        ...config.dataFilters,
-        componentIris: newComponentIris,
-      };
-
-      return { ...config, dataFilters: newDataFilters };
-    } else {
-      return config;
-    }
+    const currentComponentIris = config.dataFilters.componentIris;
+    let newComponentIris = currentComponentIris.includes(iri)
+      ? config.dataFilters.componentIris.filter((d) => d !== iri)
+      : [...currentComponentIris, iri];
+    const newDataFilters = {
+      ...config.dataFilters,
+      componentIris: newComponentIris,
+    };
+    newDataFilters.active = newComponentIris.length > 0;
+    return { ...config, dataFilters: newDataFilters };
   }
 );

--- a/app/configurator/interactive-filters/interactive-filters-config-state.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-config-state.tsx
@@ -13,14 +13,14 @@ import useEvent from "@/utils/use-event";
 
 import { FIELD_VALUE_NONE } from "../constants";
 
-export const useInteractiveLegendFiltersToggle = () => {
+export const useInteractiveFiltersToggle = (target: "legend") => {
   const [state, dispatch] = useConfiguratorState(isConfiguring);
   const onChange = useEvent((e: ChangeEvent<HTMLInputElement>) => {
     const newConfig = produce(
       state.chartConfig.interactiveFiltersConfig,
       (draft) => {
-        if (draft?.legend) {
-          draft.legend.active = e.currentTarget.checked;
+        if (draft?.[target]) {
+          draft[target].active = e.currentTarget.checked;
         }
 
         return draft;
@@ -35,12 +35,12 @@ export const useInteractiveLegendFiltersToggle = () => {
 
   const stateValue = get(
     state,
-    "chartConfig.interactiveFiltersConfig.legend.active"
+    `chartConfig.interactiveFiltersConfig.${target}.active`
   );
   const checked = stateValue ? stateValue : false;
 
   return {
-    name: "legend",
+    name: target,
     checked,
     onChange,
   };

--- a/app/configurator/interactive-filters/interactive-filters-configurator.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-configurator.tsx
@@ -82,6 +82,7 @@ export const InteractiveFiltersConfigurator = ({
         role="tablist"
         aria-labelledby="controls-interactive-filters"
         collapse
+        defaultExpanded={false}
       >
         <SectionTitle
           titleId="controls-interactive-filters"

--- a/app/configurator/interactive-filters/interactive-filters-configurator.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-configurator.tsx
@@ -21,10 +21,7 @@ import { isTemporalDimension } from "@/domain/data";
 import { useDataCubeMetadataWithComponentValuesQuery } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
-import {
-  getDataFilterDimensions,
-  getTimeSliderFilterDimensions,
-} from "./helpers";
+import { getTimeSliderFilterDimensions } from "./helpers";
 
 const ENABLE_TIME_SLIDER = typeof window !== "undefined" && flag("timeslider");
 
@@ -68,30 +65,17 @@ export const InteractiveFiltersConfigurator = ({
     const xComponentIri = getFieldComponentIri(fields, "x");
     const xComponent = allComponents.find((d) => d.iri === xComponentIri);
 
-    const segmentComponentIri = getFieldComponentIri(fields, "segment");
-    const segmentComponent = allComponents.find(
-      (d) => d.iri === segmentComponentIri
-    );
-
     const timeSliderDimensions = getTimeSliderFilterDimensions({
       chartConfig,
       dataCubeByIri: data.dataCubeByIri,
     });
 
-    const canFilterLegend =
-      chartConfigOptionsUISpec[chartType].interactiveFilters.includes("legend");
     const canFilterTimeRange =
       chartConfigOptionsUISpec[chartType].interactiveFilters.includes(
         "timeRange"
       );
     const canFilterTimeSlider =
       ENABLE_TIME_SLIDER && timeSliderDimensions.length > 0;
-
-    const dataFilterDimensions = getDataFilterDimensions(
-      chartConfig,
-      data?.dataCubeByIri
-    );
-    const canFilterData = dataFilterDimensions.length > 0;
 
     return (
       <ControlSection

--- a/app/configurator/interactive-filters/interactive-filters-configurator.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-configurator.tsx
@@ -50,7 +50,7 @@ export const InteractiveFiltersConfigurator = ({
 }: {
   state: ConfiguratorStateConfiguringChart;
 }) => {
-  const { chartType, fields, filters } = chartConfig;
+  const { chartType, fields } = chartConfig;
   const locale = useLocale();
   const [{ data }] = useDataCubeMetadataWithComponentValuesQuery({
     variables: {

--- a/app/configurator/interactive-filters/interactive-filters-configurator.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-configurator.tsx
@@ -128,14 +128,6 @@ export const InteractiveFiltersConfigurator = ({
               }
             />
           )}
-          {/* Legend */}
-          {segmentComponent && canFilterLegend && (
-            <InteractiveFilterTabField
-              value="legend"
-              icon="segment"
-              label={segmentComponent.label}
-            />
-          )}
         </ControlSectionContent>
       </ControlSection>
     );

--- a/app/configurator/interactive-filters/interactive-filters-configurator.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-configurator.tsx
@@ -71,11 +71,17 @@ export const InteractiveFiltersConfigurator = ({
     });
 
     const canFilterTimeRange =
+      isTemporalDimension(xComponent) &&
       chartConfigOptionsUISpec[chartType].interactiveFilters.includes(
         "timeRange"
       );
+
     const canFilterTimeSlider =
       ENABLE_TIME_SLIDER && timeSliderDimensions.length > 0;
+
+    if (!canFilterTimeRange && !canFilterTimeSlider) {
+      return null;
+    }
 
     return (
       <ControlSection
@@ -94,11 +100,11 @@ export const InteractiveFiltersConfigurator = ({
         </SectionTitle>
         <ControlSectionContent px="small" gap="none">
           {/* Time range */}
-          {isTemporalDimension(xComponent) && canFilterTimeRange && (
+          {canFilterTimeRange && (
             <InteractiveFilterTabField
               value="timeRange"
               icon="time"
-              label={xComponent.label}
+              label={xComponent!.label}
             />
           )}
           {/* Time slider */}

--- a/app/configurator/interactive-filters/interactive-filters-configurator.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-configurator.tsx
@@ -136,18 +136,6 @@ export const InteractiveFiltersConfigurator = ({
               label={segmentComponent.label}
             />
           )}
-          {/* Data Filters */}
-          {canFilterData && (
-            <InteractiveFilterTabField
-              value="dataFilters"
-              icon="filter"
-              label={
-                <Trans id="controls.interactive.filters.dataFilter">
-                  Filter Data
-                </Trans>
-              }
-            />
-          )}
         </ControlSectionContent>
       </ControlSection>
     );

--- a/app/configurator/interactive-filters/interactive-filters-configurator.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-configurator.tsx
@@ -21,7 +21,10 @@ import { isTemporalDimension } from "@/domain/data";
 import { useDataCubeMetadataWithComponentValuesQuery } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
-import { getTimeSliderFilterDimensions } from "./helpers";
+import {
+  getDataFilterDimensions,
+  getTimeSliderFilterDimensions,
+} from "./helpers";
 
 const ENABLE_TIME_SLIDER = typeof window !== "undefined" && flag("timeslider");
 
@@ -83,7 +86,12 @@ export const InteractiveFiltersConfigurator = ({
       );
     const canFilterTimeSlider =
       ENABLE_TIME_SLIDER && timeSliderDimensions.length > 0;
-    const canFilterData = Object.keys(filters).length > 0;
+
+    const dataFilterDimensions = getDataFilterDimensions(
+      chartConfig,
+      data?.dataCubeByIri
+    );
+    const canFilterData = dataFilterDimensions.length > 0;
 
     return (
       <ControlSection

--- a/app/docs/lines.docs.tsx
+++ b/app/docs/lines.docs.tsx
@@ -7,10 +7,30 @@ import { AxisHeightLinear } from "@/charts/shared/axis-height-linear";
 import { AxisTime, AxisTimeDomain } from "@/charts/shared/axis-width-time";
 import { BrushTime } from "@/charts/shared/brush";
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
-import { InteractiveLegendColor } from "@/charts/shared/legend-color";
+import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractiveFiltersProvider } from "@/charts/shared/use-interactive-filters";
-import { SortingField } from "@/configurator";
+import { InteractiveFiltersConfig, SortingField } from "@/configurator";
+import { PublishedConfiguratorStateProvider } from "@/configurator/configurator-state";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
+
+const interactiveFiltersConfig: InteractiveFiltersConfig = {
+  legend: {
+    active: true,
+    componentIri: "",
+  },
+  timeRange: {
+    active: true,
+    componentIri: "",
+    presets: { type: "range", from: "", to: "" },
+  },
+  timeSlider: {
+    componentIri: "",
+  },
+  dataFilters: {
+    active: false,
+    componentIris: [],
+  },
+};
 
 export const Docs = () => markdown`
 
@@ -18,50 +38,51 @@ export const Docs = () => markdown`
 
 ${(
   <ReactSpecimen span={6}>
-    <InteractiveFiltersProvider>
-      <LineChart
-        data={observations}
-        fields={fields}
-        dimensions={dimensions}
-        measures={measures}
-        interactiveFiltersConfig={{
-          legend: {
-            active: true,
-            componentIri: "",
-          },
-          timeRange: {
-            active: true,
-            componentIri: "",
-            presets: { type: "range", from: "", to: "" },
-          },
-          timeSlider: {
-            componentIri: "",
-          },
-          dataFilters: {
-            active: false,
-            componentIris: [],
-          },
-        }}
-        aspectRatio={0.4}
-      >
-        <ChartContainer>
-          <ChartSvg>
-            <BrushTime />
-            <AxisHeightLinear /> <AxisTime /> <AxisTimeDomain />
-            <Lines />
-            {/* <InteractionHorizontal /> */}
-          </ChartSvg>
+    <PublishedConfiguratorStateProvider
+      initialState={{
+        state: "PUBLISHING",
+        activeField: undefined,
+        // @ts-ignore
+        meta: { title: {}, description: {} },
+        dataSource: { type: "sparql", url: "" },
+        dataSet: "",
+        chartConfig: {
+          chartType: "line",
+          filters: {},
+          version: "0.0.1",
+          interactiveFiltersConfig,
+          fields,
+        },
+      }}
+    >
+      <InteractiveFiltersProvider>
+        <LineChart
+          data={observations}
+          fields={fields}
+          dimensions={dimensions}
+          measures={measures}
+          interactiveFiltersConfig={interactiveFiltersConfig}
+          aspectRatio={0.4}
+        >
+          <ChartContainer>
+            <ChartSvg>
+              <BrushTime />
+              <AxisHeightLinear /> <AxisTime /> <AxisTimeDomain />
+              <Lines />
+              {/* <InteractionHorizontal /> */}
+            </ChartSvg>
 
-          {/* <Ruler />
+            {/* <Ruler />
 
         <HoverDotMultiple />
 
         <Tooltip type={fields.segment ? "multiple" : "single"} /> */}
-        </ChartContainer>
+          </ChartContainer>
 
-        {fields.segment && <InteractiveLegendColor />}
-      </LineChart>
-    </InteractiveFiltersProvider>
+          {fields.segment && <LegendColor symbol="line" interactive />}
+        </LineChart>
+      </InteractiveFiltersProvider>
+    </PublishedConfiguratorStateProvider>
   </ReactSpecimen>
 )}
 `;

--- a/app/docs/scatterplot.docs.tsx
+++ b/app/docs/scatterplot.docs.tsx
@@ -13,10 +13,31 @@ import {
 } from "@/charts/shared/axis-width-linear";
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
-import { InteractiveLegendColor } from "@/charts/shared/legend-color";
+import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionVoronoi } from "@/charts/shared/overlay-voronoi";
 import { InteractiveFiltersProvider } from "@/charts/shared/use-interactive-filters";
+import { InteractiveFiltersConfig } from "@/configurator";
+import { PublishedConfiguratorStateProvider } from "@/configurator/configurator-state";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
+
+const interactiveFiltersConfig: InteractiveFiltersConfig = {
+  legend: {
+    active: true,
+    componentIri: "",
+  },
+  timeRange: {
+    active: false,
+    componentIri: "",
+    presets: { type: "range", from: "", to: "" },
+  },
+  timeSlider: {
+    componentIri: "",
+  },
+  dataFilters: {
+    active: false,
+    componentIris: [],
+  },
+};
 
 export const Docs = () => markdown`
 
@@ -24,46 +45,49 @@ export const Docs = () => markdown`
 
 ${(
   <ReactSpecimen span={6}>
-    <InteractiveFiltersProvider>
-      <ScatterplotChart
-        data={scatterplotObservations}
-        fields={scatterplotFields}
-        dimensions={scatterplotDimensions}
-        measures={scatterplotMeasures}
-        interactiveFiltersConfig={{
-          legend: {
-            active: true,
-            componentIri: "",
-          },
-          timeRange: {
-            active: false,
-            componentIri: "",
-            presets: { type: "range", from: "", to: "" },
-          },
-          timeSlider: {
-            componentIri: "",
-          },
-          dataFilters: {
-            active: false,
-            componentIris: [],
-          },
-        }}
-        aspectRatio={1}
-      >
-        <ChartContainer>
-          <ChartSvg>
-            <AxisWidthLinear />
-            <AxisHeightLinear />
-            <AxisWidthLinearDomain />
-            <AxisHeightLinearDomain />
-            <Scatterplot />
-            <InteractionVoronoi />
-          </ChartSvg>
-          <Tooltip type="single" />
-        </ChartContainer>
-        {scatterplotFields.segment && <InteractiveLegendColor />}
-      </ScatterplotChart>
-    </InteractiveFiltersProvider>
+    <PublishedConfiguratorStateProvider
+      initialState={{
+        state: "PUBLISHING",
+        activeField: undefined,
+        // @ts-ignore
+        meta: { title: {}, description: {} },
+        dataSource: { type: "sparql", url: "" },
+        dataSet: "",
+        chartConfig: {
+          chartType: "scatterplot",
+          filters: {},
+          version: "0.0.1",
+          interactiveFiltersConfig,
+          fields: scatterplotFields,
+        },
+      }}
+    >
+      <InteractiveFiltersProvider>
+        <ScatterplotChart
+          data={scatterplotObservations}
+          fields={scatterplotFields}
+          dimensions={scatterplotDimensions}
+          measures={scatterplotMeasures}
+          interactiveFiltersConfig={interactiveFiltersConfig}
+          aspectRatio={1}
+        >
+          <ChartContainer>
+            <ChartSvg>
+              <AxisWidthLinear />
+              <AxisHeightLinear />
+              <AxisWidthLinearDomain />
+              <AxisHeightLinearDomain />
+              <Scatterplot />
+              <InteractionVoronoi />
+            </ChartSvg>
+            <Tooltip type="single" />
+          </ChartContainer>
+          {scatterplotFields.segment && (
+            <LegendColor symbol="square" interactive />
+          )}
+        </ScatterplotChart>
+      </InteractiveFiltersProvider>
+    </PublishedConfiguratorStateProvider>
   </ReactSpecimen>
 )}
 `;

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -13,19 +13,19 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:628
+#: app/configurator/components/chart-configurator.tsx:657
 msgid "Add filter"
 msgstr "Filter hinzufügen"
 
-#: app/configurator/components/chart-configurator.tsx:601
+#: app/configurator/components/chart-configurator.tsx:630
 msgid "Drag filters to reorganize"
 msgstr "Ziehen Sie die Filter per Drag & Drop, um sie neu zu organisieren"
 
-#: app/configurator/components/chart-configurator.tsx:598
+#: app/configurator/components/chart-configurator.tsx:627
 msgid "Move filter down"
 msgstr "Filter nach unten verschieben"
 
-#: app/configurator/components/chart-configurator.tsx:595
+#: app/configurator/components/chart-configurator.tsx:624
 msgid "Move filter up"
 msgstr "Filter nach oben verschieben"
 
@@ -122,17 +122,17 @@ msgstr "Teilen"
 msgid "chart.map.layers.area"
 msgstr "Flächen"
 
-#: app/configurator/components/chart-configurator.tsx:677
-#: app/configurator/components/chart-options-selector.tsx:986
+#: app/configurator/components/chart-configurator.tsx:706
+#: app/configurator/components/chart-options-selector.tsx:992
 #: app/configurator/components/field-i18n.ts:31
 msgid "chart.map.layers.base"
 msgstr "Kartenanzeige"
 
-#: app/configurator/components/chart-options-selector.tsx:990
+#: app/configurator/components/chart-options-selector.tsx:996
 msgid "chart.map.layers.base.show"
 msgstr "Weltkarte anzeigen"
 
-#: app/configurator/components/chart-options-selector.tsx:998
+#: app/configurator/components/chart-options-selector.tsx:1004
 msgid "chart.map.layers.base.view.locked"
 msgstr "Gesperrte Ansicht"
 
@@ -157,28 +157,28 @@ msgstr "Kompakte Ansicht"
 msgid "chart.table.number.of.lines"
 msgstr "Anzahl Zeilen"
 
-#: app/configurator/table/table-chart-options.tsx:190
+#: app/configurator/table/table-chart-options.tsx:194
 msgid "columnStyle.bar"
 msgstr "Säulendiagramm"
 
-#: app/configurator/table/table-chart-options.tsx:200
+#: app/configurator/table/table-chart-options.tsx:204
 msgid "columnStyle.categories"
 msgstr "Kategorien"
 
-#: app/configurator/table/table-chart-options.tsx:186
+#: app/configurator/table/table-chart-options.tsx:190
 msgid "columnStyle.heatmap"
 msgstr "Heatmap"
 
-#: app/configurator/table/table-chart-options.tsx:182
-#: app/configurator/table/table-chart-options.tsx:196
+#: app/configurator/table/table-chart-options.tsx:186
+#: app/configurator/table/table-chart-options.tsx:200
 msgid "columnStyle.text"
 msgstr "Schrift"
 
-#: app/configurator/table/table-chart-options.tsx:400
+#: app/configurator/table/table-chart-options.tsx:405
 msgid "columnStyle.textStyle.bold"
 msgstr "Fett"
 
-#: app/configurator/table/table-chart-options.tsx:393
+#: app/configurator/table/table-chart-options.tsx:398
 msgid "columnStyle.textStyle.regular"
 msgstr "Normal"
 
@@ -234,7 +234,7 @@ msgstr "Scatterplot"
 msgid "controls.chart.type.table"
 msgstr "Tabelle"
 
-#: app/configurator/components/chart-options-selector.tsx:717
+#: app/configurator/components/chart-options-selector.tsx:723
 #: app/configurator/components/field-i18n.ts:17
 msgid "controls.color"
 msgstr "Farbe"
@@ -243,7 +243,7 @@ msgstr "Farbe"
 msgid "controls.color.add"
 msgstr "Hinzufügen …"
 
-#: app/configurator/components/chart-options-selector.tsx:746
+#: app/configurator/components/chart-options-selector.tsx:752
 msgid "controls.color.opacity"
 msgstr "Transparenz"
 
@@ -264,35 +264,35 @@ msgstr "Farbpalette zurücksetzen"
 msgid "controls.color.palette.sequential"
 msgstr "Sequentiell"
 
-#: app/configurator/components/chart-options-selector.tsx:833
+#: app/configurator/components/chart-options-selector.tsx:839
 msgid "controls.color.scale.discretization.jenks"
 msgstr "Jenks (Natural Breaks)"
 
-#: app/configurator/components/chart-options-selector.tsx:826
+#: app/configurator/components/chart-options-selector.tsx:832
 msgid "controls.color.scale.discretization.quantiles"
 msgstr "Quantile (gleiche Anzahl Werte)"
 
-#: app/configurator/components/chart-options-selector.tsx:819
+#: app/configurator/components/chart-options-selector.tsx:825
 msgid "controls.color.scale.discretization.quantize"
 msgstr "Quantisierung (gleiche Wertebereiche)"
 
-#: app/configurator/components/chart-options-selector.tsx:811
+#: app/configurator/components/chart-options-selector.tsx:817
 msgid "controls.color.scale.interpolation"
 msgstr "Interpolation"
 
-#: app/configurator/components/chart-options-selector.tsx:843
+#: app/configurator/components/chart-options-selector.tsx:849
 msgid "controls.color.scale.number.of.classes"
 msgstr "Anzahl Klassen"
 
-#: app/configurator/components/chart-options-selector.tsx:783
+#: app/configurator/components/chart-options-selector.tsx:789
 msgid "controls.color.scale.type.continuous"
 msgstr "Kontinuierlich"
 
-#: app/configurator/components/chart-options-selector.tsx:794
+#: app/configurator/components/chart-options-selector.tsx:800
 msgid "controls.color.scale.type.discrete"
 msgstr "Diskret"
 
-#: app/configurator/components/chart-options-selector.tsx:736
+#: app/configurator/components/chart-options-selector.tsx:742
 msgid "controls.color.select"
 msgstr "Farbe auswählen"
 
@@ -327,31 +327,36 @@ msgstr "Beschreibung hinzufügen"
 msgid "controls.dimensionvalue.none"
 msgstr "Kein Filter"
 
-#: app/configurator/components/filters.tsx:400
+#: app/configurator/components/filters.tsx:415
 msgid "controls.filter.nb-elements"
 msgstr "{0} von {1}"
 
-#: app/configurator/components/filters.tsx:194
+#: app/configurator/components/filters.tsx:197
 msgid "controls.filter.select.all"
 msgstr "Alle auswählen"
 
-#: app/configurator/components/filters.tsx:201
+#: app/configurator/components/filters.tsx:204
 msgid "controls.filter.select.none"
 msgstr "Alle abwählen"
+
+#: app/configurator/components/chart-configurator.tsx:488
+#: app/configurator/components/filters.tsx:355
+msgid "controls.filters.interactive.toggle"
+msgstr "Interaktive"
 
 #: app/configurator/components/filters.tsx:358
 #~ msgid "controls.filters.select.filters"
 #~ msgstr "Filter"
 
-#: app/configurator/components/filters.tsx:381
+#: app/configurator/components/filters.tsx:396
 msgid "controls.filters.select.refresh-colors"
 msgstr "Farben auffrischen"
 
-#: app/configurator/components/filters.tsx:365
+#: app/configurator/components/filters.tsx:380
 msgid "controls.filters.select.reset-colors"
 msgstr "Farben zurücksetzen"
 
-#: app/configurator/components/filters.tsx:358
+#: app/configurator/components/filters.tsx:373
 msgid "controls.filters.select.selected-filters"
 msgstr "Ausgewählte Filter"
 
@@ -367,44 +372,44 @@ msgstr "Ziehen Sie Spalten hierher, um Gruppen zu erstellen."
 msgid "controls.imputation"
 msgstr "Imputationstyp"
 
-#: app/configurator/components/chart-options-selector.tsx:878
+#: app/configurator/components/chart-options-selector.tsx:884
 #: app/configurator/components/field-i18n.ts:99
 msgid "controls.imputation.type.linear"
 msgstr "Lineare Interpolation"
 
-#: app/configurator/components/chart-options-selector.tsx:871
-#: app/configurator/components/chart-options-selector.tsx:883
+#: app/configurator/components/chart-options-selector.tsx:877
+#: app/configurator/components/chart-options-selector.tsx:889
 #: app/configurator/components/field-i18n.ts:91
 msgid "controls.imputation.type.none"
 msgstr "-"
 
-#: app/configurator/components/chart-options-selector.tsx:873
+#: app/configurator/components/chart-options-selector.tsx:879
 #: app/configurator/components/field-i18n.ts:95
 msgid "controls.imputation.type.zeros"
 msgstr "Nullen"
 
 #: app/configurator/interactive-filters/interactive-filters-configurator.tsx:137
-msgid "controls.interactive.filters.dataFilter"
-msgstr "Datenfilter"
+#~ msgid "controls.interactive.filters.dataFilter"
+#~ msgstr "Datenfilter"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:115
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:117
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:80
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:109
 msgid "controls.interactive.filters.timeSlider"
 msgstr "Zeitschieber"
 
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:375
-msgid "controls.interactiveFilters.dataFilters.toggledataFilters"
-msgstr "Datenfilter anzeigen"
+#~ msgid "controls.interactiveFilters.dataFilters.toggledataFilters"
+#~ msgstr "Datenfilter anzeigen"
 
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:89
-msgid "controls.interactiveFilters.legend.toggleInteractiveLegend"
-msgstr "Filterbare Legende anzeigen"
+#~ msgid "controls.interactiveFilters.legend.toggleInteractiveLegend"
+#~ msgstr "Filterbare Legende anzeigen"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:233
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:185
 msgid "controls.interactiveFilters.time.noTimeDimension"
 msgstr "Keine Zeitdimension verfügbar!"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:208
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:160
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Zeitfilter anzeigen"
 
@@ -445,7 +450,7 @@ msgstr "Zurück zur Übersicht"
 msgid "controls.nav.back-to-preview"
 msgstr "Zurück zur Vorschau"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:292
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:244
 msgid "controls.none"
 msgstr "Keine"
 
@@ -461,19 +466,19 @@ msgstr "Aus"
 #~ msgid "controls.option.none"
 #~ msgstr "Keine"
 
-#: app/configurator/components/chart-options-selector.tsx:776
+#: app/configurator/components/chart-options-selector.tsx:782
 msgid "controls.scale.type"
 msgstr "Skalierungstyp"
 
-#: app/components/form.tsx:624
+#: app/components/form.tsx:625
 msgid "controls.search.clear"
 msgstr "Suche zurücksetzen"
 
-#: app/configurator/components/chart-options-selector.tsx:353
+#: app/configurator/components/chart-options-selector.tsx:355
 msgid "controls.section.additional-information"
 msgstr "Zusätzliche Informationen"
 
-#: app/configurator/components/chart-configurator.tsx:525
+#: app/configurator/components/chart-configurator.tsx:547
 msgid "controls.section.chart.options"
 msgstr "Diagramm-Einstellungen"
 
@@ -481,11 +486,11 @@ msgstr "Diagramm-Einstellungen"
 msgid "controls.section.columns"
 msgstr "Spalten"
 
-#: app/configurator/table/table-chart-options.tsx:244
+#: app/configurator/table/table-chart-options.tsx:248
 msgid "controls.section.columnstyle"
 msgstr "Spaltenstil"
 
-#: app/configurator/components/chart-configurator.tsx:543
+#: app/configurator/components/chart-configurator.tsx:565
 msgid "controls.section.data.filters"
 msgstr "Filter"
 
@@ -493,12 +498,12 @@ msgstr "Filter"
 msgid "controls.section.description"
 msgstr "Titel & Beschreibung"
 
-#: app/configurator/components/chart-options-selector.tsx:408
-#: app/configurator/components/chart-options-selector.tsx:412
-#: app/configurator/table/table-chart-options.tsx:314
-#: app/configurator/table/table-chart-options.tsx:318
-#: app/configurator/table/table-chart-options.tsx:338
-#: app/configurator/table/table-chart-options.tsx:342
+#: app/configurator/components/chart-options-selector.tsx:414
+#: app/configurator/components/chart-options-selector.tsx:418
+#: app/configurator/table/table-chart-options.tsx:319
+#: app/configurator/table/table-chart-options.tsx:323
+#: app/configurator/table/table-chart-options.tsx:343
+#: app/configurator/table/table-chart-options.tsx:347
 msgid "controls.section.filter"
 msgstr "Filter"
 
@@ -506,32 +511,32 @@ msgstr "Filter"
 msgid "controls.section.groups"
 msgstr "Gruppierungen"
 
-#: app/configurator/components/chart-options-selector.tsx:912
+#: app/configurator/components/chart-options-selector.tsx:918
 msgid "controls.section.imputation"
 msgstr "Fehlende Werte"
 
-#: app/configurator/components/chart-options-selector.tsx:917
+#: app/configurator/components/chart-options-selector.tsx:923
 msgid "controls.section.imputation.explanation"
 msgstr "Für diesen Diagrammtyp sollten fehlenden Werten Ersatzwerte zugewiesen werden. Entscheiden Sie sich für die Imputationslogik oder wechseln Sie zu einem anderen Diagrammtyp."
 
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:98
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:157
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:90
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:129
 msgid "controls.section.interactive.filters"
 msgstr "Interaktive Filter hinzufügen"
 
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:128
-msgid "controls.section.interactiveFilters.dataFilters"
-msgstr "Datenfilter"
+#~ msgid "controls.section.interactiveFilters.dataFilters"
+#~ msgstr "Datenfilter"
 
-#: app/configurator/components/chart-options-selector.tsx:362
+#: app/configurator/components/chart-options-selector.tsx:364
 msgid "controls.section.show-standard-error"
 msgstr "Standardfehler anzeigen"
 
-#: app/configurator/components/chart-options-selector.tsx:554
+#: app/configurator/components/chart-options-selector.tsx:560
 msgid "controls.section.sorting"
 msgstr "Sortieren"
 
-#: app/configurator/table/table-chart-options.tsx:485
+#: app/configurator/table/table-chart-options.tsx:490
 msgid "controls.section.tableSettings"
 msgstr "Tabelleneinstellungen"
 
@@ -547,56 +552,56 @@ msgstr "Tabellenoptionen"
 msgid "controls.section.title.warning"
 msgstr "Fügen Sie einen Titel oder eine Beschreibung hinzu"
 
-#: app/configurator/components/chart-configurator.tsx:517
+#: app/configurator/components/chart-configurator.tsx:539
 #: app/configurator/components/chart-type-selector.tsx:131
 #: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
 msgstr "Diagrammtyp"
 
-#: app/configurator/components/chart-options-selector.tsx:458
+#: app/configurator/components/chart-options-selector.tsx:464
 msgid "controls.select.column.layout"
 msgstr "Spaltenstil"
 
-#: app/configurator/table/table-chart-options.tsx:249
+#: app/configurator/table/table-chart-options.tsx:253
 msgid "controls.select.columnStyle"
 msgstr "Spaltenstil"
 
-#: app/configurator/table/table-chart-options.tsx:460
+#: app/configurator/table/table-chart-options.tsx:465
 msgid "controls.select.columnStyle.barColorBackground"
 msgstr "Hintergrundfarbe"
 
-#: app/configurator/table/table-chart-options.tsx:452
+#: app/configurator/table/table-chart-options.tsx:457
 msgid "controls.select.columnStyle.barColorNegative"
 msgstr "Negative Balkenfarbe"
 
-#: app/configurator/table/table-chart-options.tsx:444
+#: app/configurator/table/table-chart-options.tsx:449
 msgid "controls.select.columnStyle.barColorPositive"
 msgstr "Positive Balkenfarbe"
 
-#: app/configurator/table/table-chart-options.tsx:468
+#: app/configurator/table/table-chart-options.tsx:473
 msgid "controls.select.columnStyle.barShowBackground"
 msgstr "Hintergrundfarbe anzeigen"
 
-#: app/configurator/table/table-chart-options.tsx:417
+#: app/configurator/table/table-chart-options.tsx:422
 msgid "controls.select.columnStyle.columnColor"
 msgstr "Spaltenfarbe"
 
-#: app/configurator/table/table-chart-options.tsx:409
+#: app/configurator/table/table-chart-options.tsx:414
 msgid "controls.select.columnStyle.textColor"
 msgstr "Schriftfarbe"
 
-#: app/configurator/table/table-chart-options.tsx:386
+#: app/configurator/table/table-chart-options.tsx:391
 msgid "controls.select.columnStyle.textStyle"
 msgstr "Schriftstil"
 
-#: app/configurator/components/chart-options-selector.tsx:217
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:310
+#: app/configurator/components/chart-options-selector.tsx:219
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:262
 msgid "controls.select.dimension"
 msgstr "Dimension auswählen"
 
-#: app/configurator/components/chart-options-selector.tsx:218
-#: app/configurator/components/chart-options-selector.tsx:644
-#: app/configurator/components/chart-options-selector.tsx:722
+#: app/configurator/components/chart-options-selector.tsx:220
+#: app/configurator/components/chart-options-selector.tsx:650
+#: app/configurator/components/chart-options-selector.tsx:728
 msgid "controls.select.measure"
 msgstr "Messwert auswählen"
 
@@ -607,20 +612,20 @@ msgstr "Messwert auswählen"
 #~ msgid "controls.select.optional"
 #~ msgstr "optional"
 
-#: app/configurator/components/filters.tsx:353
-#: app/configurator/components/filters.tsx:767
+#: app/configurator/components/filters.tsx:367
+#: app/configurator/components/filters.tsx:783
 msgid "controls.set-filters"
 msgstr "Filter bearbeiten"
 
-#: app/configurator/components/filters.tsx:775
+#: app/configurator/components/filters.tsx:791
 msgid "controls.set-filters-caption"
 msgstr "Für beste Ergebnisse wählen Sie nicht mehr als 7 Werte für die Visualisierung aus"
 
-#: app/configurator/components/filters.tsx:814
+#: app/configurator/components/filters.tsx:830
 msgid "controls.set-values-apply"
 msgstr "Filter anwenden"
 
-#: app/configurator/components/chart-options-selector.tsx:636
+#: app/configurator/components/chart-options-selector.tsx:642
 msgid "controls.size"
 msgstr "Grösse"
 
@@ -628,12 +633,12 @@ msgstr "Grösse"
 msgid "controls.sorting.addDimension"
 msgstr "Dimension hinzufügen"
 
-#: app/configurator/components/chart-options-selector.tsx:506
+#: app/configurator/components/chart-options-selector.tsx:512
 msgid "controls.sorting.byAuto"
 msgstr "Auto"
 
-#: app/configurator/components/chart-options-selector.tsx:500
-#: app/configurator/components/chart-options-selector.tsx:510
+#: app/configurator/components/chart-options-selector.tsx:506
+#: app/configurator/components/chart-options-selector.tsx:516
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Name"
 
@@ -647,7 +652,7 @@ msgstr "A → Z"
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
-#: app/configurator/components/chart-options-selector.tsx:502
+#: app/configurator/components/chart-options-selector.tsx:508
 msgid "controls.sorting.byMeasure"
 msgstr "Messwert"
 
@@ -659,7 +664,7 @@ msgstr "1 → 9"
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
-#: app/configurator/components/chart-options-selector.tsx:504
+#: app/configurator/components/chart-options-selector.tsx:510
 msgid "controls.sorting.byTotalSize"
 msgstr "Gesamtgrösse"
 
@@ -696,11 +701,11 @@ msgstr "Sortieren nach"
 msgid "controls.switch.chart.type"
 msgstr "Wechseln Sie zu einem anderen Diagrammtyp unter Beibehaltung der meisten Filtereinstellungen"
 
-#: app/configurator/table/table-chart-options.tsx:221
+#: app/configurator/table/table-chart-options.tsx:225
 msgid "controls.table.column.group"
 msgstr "Gruppieren"
 
-#: app/configurator/table/table-chart-options.tsx:231
+#: app/configurator/table/table-chart-options.tsx:235
 msgid "controls.table.column.hide"
 msgstr "Spalte ausblenden"
 
@@ -712,7 +717,7 @@ msgstr "Einstellungen"
 msgid "controls.table.sorting"
 msgstr "Sortierung"
 
-#: app/configurator/table/table-chart-options.tsx:489
+#: app/configurator/table/table-chart-options.tsx:494
 msgid "controls.tableSettings.showSearch"
 msgstr "Suche anzeigen"
 
@@ -895,7 +900,7 @@ msgstr "Daten-Ladefehler"
 msgid "hint.how.to.share"
 msgstr "Sie können diese Visualisierung teilen oder sie einbetten. Zudem können Sie eine neue Visualisierung erstellen oder die gezeigte Visualisierung kopieren."
 
-#: app/components/form.tsx:291
+#: app/components/form.tsx:292
 #: app/components/hint.tsx:111
 msgid "hint.loading.data"
 msgstr "Lade Daten …"
@@ -994,7 +999,7 @@ msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
 #: app/configurator/components/dataset-browse.tsx:378
-#: app/configurator/components/filters.tsx:784
+#: app/configurator/components/filters.tsx:800
 msgid "select.controls.filters.search"
 msgstr "Suche"
 

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -13,19 +13,19 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:628
+#: app/configurator/components/chart-configurator.tsx:657
 msgid "Add filter"
 msgstr "Add filter"
 
-#: app/configurator/components/chart-configurator.tsx:601
+#: app/configurator/components/chart-configurator.tsx:630
 msgid "Drag filters to reorganize"
 msgstr "Drag filters to reorganize"
 
-#: app/configurator/components/chart-configurator.tsx:598
+#: app/configurator/components/chart-configurator.tsx:627
 msgid "Move filter down"
 msgstr "Move filter down"
 
-#: app/configurator/components/chart-configurator.tsx:595
+#: app/configurator/components/chart-configurator.tsx:624
 msgid "Move filter up"
 msgstr "Move filter up"
 
@@ -142,17 +142,17 @@ msgstr "Areas"
 #~ msgid "chart.map.layers.area.discretization.quantize"
 #~ msgstr "Quantize (equal intervals)"
 
-#: app/configurator/components/chart-configurator.tsx:677
-#: app/configurator/components/chart-options-selector.tsx:986
+#: app/configurator/components/chart-configurator.tsx:706
+#: app/configurator/components/chart-options-selector.tsx:992
 #: app/configurator/components/field-i18n.ts:31
 msgid "chart.map.layers.base"
 msgstr "Map Display"
 
-#: app/configurator/components/chart-options-selector.tsx:990
+#: app/configurator/components/chart-options-selector.tsx:996
 msgid "chart.map.layers.base.show"
 msgstr "Show Worldmap"
 
-#: app/configurator/components/chart-options-selector.tsx:998
+#: app/configurator/components/chart-options-selector.tsx:1004
 msgid "chart.map.layers.base.view.locked"
 msgstr "Locked view"
 
@@ -177,28 +177,28 @@ msgstr "Compact view"
 msgid "chart.table.number.of.lines"
 msgstr "Total number of lines:"
 
-#: app/configurator/table/table-chart-options.tsx:190
+#: app/configurator/table/table-chart-options.tsx:194
 msgid "columnStyle.bar"
 msgstr "Bar Chart"
 
-#: app/configurator/table/table-chart-options.tsx:200
+#: app/configurator/table/table-chart-options.tsx:204
 msgid "columnStyle.categories"
 msgstr "Categories"
 
-#: app/configurator/table/table-chart-options.tsx:186
+#: app/configurator/table/table-chart-options.tsx:190
 msgid "columnStyle.heatmap"
 msgstr "Heat Map"
 
-#: app/configurator/table/table-chart-options.tsx:182
-#: app/configurator/table/table-chart-options.tsx:196
+#: app/configurator/table/table-chart-options.tsx:186
+#: app/configurator/table/table-chart-options.tsx:200
 msgid "columnStyle.text"
 msgstr "Text"
 
-#: app/configurator/table/table-chart-options.tsx:400
+#: app/configurator/table/table-chart-options.tsx:405
 msgid "columnStyle.textStyle.bold"
 msgstr "Bold"
 
-#: app/configurator/table/table-chart-options.tsx:393
+#: app/configurator/table/table-chart-options.tsx:398
 msgid "columnStyle.textStyle.regular"
 msgstr "Regular"
 
@@ -254,7 +254,7 @@ msgstr "Scatterplot"
 msgid "controls.chart.type.table"
 msgstr "Table"
 
-#: app/configurator/components/chart-options-selector.tsx:717
+#: app/configurator/components/chart-options-selector.tsx:723
 #: app/configurator/components/field-i18n.ts:17
 msgid "controls.color"
 msgstr "Color"
@@ -263,7 +263,7 @@ msgstr "Color"
 msgid "controls.color.add"
 msgstr "Add ..."
 
-#: app/configurator/components/chart-options-selector.tsx:746
+#: app/configurator/components/chart-options-selector.tsx:752
 msgid "controls.color.opacity"
 msgstr "Opacity"
 
@@ -284,35 +284,35 @@ msgstr "Reset color palette"
 msgid "controls.color.palette.sequential"
 msgstr "Sequential"
 
-#: app/configurator/components/chart-options-selector.tsx:833
+#: app/configurator/components/chart-options-selector.tsx:839
 msgid "controls.color.scale.discretization.jenks"
 msgstr "Jenks (natural breaks)"
 
-#: app/configurator/components/chart-options-selector.tsx:826
+#: app/configurator/components/chart-options-selector.tsx:832
 msgid "controls.color.scale.discretization.quantiles"
 msgstr "Quantiles (equal distribution of values)"
 
-#: app/configurator/components/chart-options-selector.tsx:819
+#: app/configurator/components/chart-options-selector.tsx:825
 msgid "controls.color.scale.discretization.quantize"
 msgstr "Quantize (equal intervals)"
 
-#: app/configurator/components/chart-options-selector.tsx:811
+#: app/configurator/components/chart-options-selector.tsx:817
 msgid "controls.color.scale.interpolation"
 msgstr "Interpolation"
 
-#: app/configurator/components/chart-options-selector.tsx:843
+#: app/configurator/components/chart-options-selector.tsx:849
 msgid "controls.color.scale.number.of.classes"
 msgstr "Number of classes"
 
-#: app/configurator/components/chart-options-selector.tsx:783
+#: app/configurator/components/chart-options-selector.tsx:789
 msgid "controls.color.scale.type.continuous"
 msgstr "Continuous"
 
-#: app/configurator/components/chart-options-selector.tsx:794
+#: app/configurator/components/chart-options-selector.tsx:800
 msgid "controls.color.scale.type.discrete"
 msgstr "Discrete"
 
-#: app/configurator/components/chart-options-selector.tsx:736
+#: app/configurator/components/chart-options-selector.tsx:742
 msgid "controls.color.select"
 msgstr "Select a color"
 
@@ -347,31 +347,40 @@ msgstr "Description"
 msgid "controls.dimensionvalue.none"
 msgstr "No Filter"
 
-#: app/configurator/components/filters.tsx:400
+#: app/configurator/components/chart-configurator.tsx:487
+#~ msgid "controls.filter.interactive.toggle"
+#~ msgstr "Interactive"
+
+#: app/configurator/components/filters.tsx:415
 msgid "controls.filter.nb-elements"
 msgstr "{0} of {1}"
 
-#: app/configurator/components/filters.tsx:194
+#: app/configurator/components/filters.tsx:197
 msgid "controls.filter.select.all"
 msgstr "Select all"
 
-#: app/configurator/components/filters.tsx:201
+#: app/configurator/components/filters.tsx:204
 msgid "controls.filter.select.none"
 msgstr "Select none"
+
+#: app/configurator/components/chart-configurator.tsx:488
+#: app/configurator/components/filters.tsx:355
+msgid "controls.filters.interactive.toggle"
+msgstr "Interactive"
 
 #: app/configurator/components/filters.tsx:358
 #~ msgid "controls.filters.select.filters"
 #~ msgstr "Filters"
 
-#: app/configurator/components/filters.tsx:381
+#: app/configurator/components/filters.tsx:396
 msgid "controls.filters.select.refresh-colors"
 msgstr "Refresh colors"
 
-#: app/configurator/components/filters.tsx:365
+#: app/configurator/components/filters.tsx:380
 msgid "controls.filters.select.reset-colors"
 msgstr "Reset colors"
 
-#: app/configurator/components/filters.tsx:358
+#: app/configurator/components/filters.tsx:373
 msgid "controls.filters.select.selected-filters"
 msgstr "Selected filters"
 
@@ -387,44 +396,44 @@ msgstr "Drag and drop columns here to make groups."
 msgid "controls.imputation"
 msgstr "Imputation type"
 
-#: app/configurator/components/chart-options-selector.tsx:878
+#: app/configurator/components/chart-options-selector.tsx:884
 #: app/configurator/components/field-i18n.ts:99
 msgid "controls.imputation.type.linear"
 msgstr "Linear interpolation"
 
-#: app/configurator/components/chart-options-selector.tsx:871
-#: app/configurator/components/chart-options-selector.tsx:883
+#: app/configurator/components/chart-options-selector.tsx:877
+#: app/configurator/components/chart-options-selector.tsx:889
 #: app/configurator/components/field-i18n.ts:91
 msgid "controls.imputation.type.none"
 msgstr "-"
 
-#: app/configurator/components/chart-options-selector.tsx:873
+#: app/configurator/components/chart-options-selector.tsx:879
 #: app/configurator/components/field-i18n.ts:95
 msgid "controls.imputation.type.zeros"
 msgstr "Zeros"
 
 #: app/configurator/interactive-filters/interactive-filters-configurator.tsx:137
-msgid "controls.interactive.filters.dataFilter"
-msgstr "Data Filters"
+#~ msgid "controls.interactive.filters.dataFilter"
+#~ msgstr "Data Filters"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:115
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:117
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:80
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:109
 msgid "controls.interactive.filters.timeSlider"
 msgstr "Time slider"
 
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:375
-msgid "controls.interactiveFilters.dataFilters.toggledataFilters"
-msgstr "Show data filters"
+#~ msgid "controls.interactiveFilters.dataFilters.toggledataFilters"
+#~ msgstr "Show data filters"
 
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:89
-msgid "controls.interactiveFilters.legend.toggleInteractiveLegend"
-msgstr "Show legend filter"
+#~ msgid "controls.interactiveFilters.legend.toggleInteractiveLegend"
+#~ msgstr "Show legend filter"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:233
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:185
 msgid "controls.interactiveFilters.time.noTimeDimension"
 msgstr "There is no time dimension!"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:208
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:160
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Show time filter"
 
@@ -465,7 +474,7 @@ msgstr "Back to main"
 msgid "controls.nav.back-to-preview"
 msgstr "Back to preview"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:292
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:244
 msgid "controls.none"
 msgstr "None"
 
@@ -477,19 +486,19 @@ msgstr "On"
 msgid "controls.option.isNotActive"
 msgstr "Off"
 
-#: app/configurator/components/chart-options-selector.tsx:776
+#: app/configurator/components/chart-options-selector.tsx:782
 msgid "controls.scale.type"
 msgstr "Scale type"
 
-#: app/components/form.tsx:624
+#: app/components/form.tsx:625
 msgid "controls.search.clear"
 msgstr "Clear search field"
 
-#: app/configurator/components/chart-options-selector.tsx:353
+#: app/configurator/components/chart-options-selector.tsx:355
 msgid "controls.section.additional-information"
 msgstr "Additional information"
 
-#: app/configurator/components/chart-configurator.tsx:525
+#: app/configurator/components/chart-configurator.tsx:547
 msgid "controls.section.chart.options"
 msgstr "Chart Options"
 
@@ -497,11 +506,11 @@ msgstr "Chart Options"
 msgid "controls.section.columns"
 msgstr "Columns"
 
-#: app/configurator/table/table-chart-options.tsx:244
+#: app/configurator/table/table-chart-options.tsx:248
 msgid "controls.section.columnstyle"
 msgstr "Column Style"
 
-#: app/configurator/components/chart-configurator.tsx:543
+#: app/configurator/components/chart-configurator.tsx:565
 msgid "controls.section.data.filters"
 msgstr "Filters"
 
@@ -509,12 +518,12 @@ msgstr "Filters"
 msgid "controls.section.description"
 msgstr "Title & Description"
 
-#: app/configurator/components/chart-options-selector.tsx:408
-#: app/configurator/components/chart-options-selector.tsx:412
-#: app/configurator/table/table-chart-options.tsx:314
-#: app/configurator/table/table-chart-options.tsx:318
-#: app/configurator/table/table-chart-options.tsx:338
-#: app/configurator/table/table-chart-options.tsx:342
+#: app/configurator/components/chart-options-selector.tsx:414
+#: app/configurator/components/chart-options-selector.tsx:418
+#: app/configurator/table/table-chart-options.tsx:319
+#: app/configurator/table/table-chart-options.tsx:323
+#: app/configurator/table/table-chart-options.tsx:343
+#: app/configurator/table/table-chart-options.tsx:347
 msgid "controls.section.filter"
 msgstr "Filter"
 
@@ -522,32 +531,32 @@ msgstr "Filter"
 msgid "controls.section.groups"
 msgstr "Groups"
 
-#: app/configurator/components/chart-options-selector.tsx:912
+#: app/configurator/components/chart-options-selector.tsx:918
 msgid "controls.section.imputation"
 msgstr "Missing values"
 
-#: app/configurator/components/chart-options-selector.tsx:917
+#: app/configurator/components/chart-options-selector.tsx:923
 msgid "controls.section.imputation.explanation"
 msgstr "For this chart type, replacement values should be assigned to missing values. Decide on the imputation logic or switch to another chart type."
 
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:98
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:157
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:90
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:129
 msgid "controls.section.interactive.filters"
 msgstr "Interactive Filters"
 
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:128
-msgid "controls.section.interactiveFilters.dataFilters"
-msgstr "Data Filters"
+#~ msgid "controls.section.interactiveFilters.dataFilters"
+#~ msgstr "Data Filters"
 
-#: app/configurator/components/chart-options-selector.tsx:362
+#: app/configurator/components/chart-options-selector.tsx:364
 msgid "controls.section.show-standard-error"
 msgstr "Show standard error"
 
-#: app/configurator/components/chart-options-selector.tsx:554
+#: app/configurator/components/chart-options-selector.tsx:560
 msgid "controls.section.sorting"
 msgstr "Sort"
 
-#: app/configurator/table/table-chart-options.tsx:485
+#: app/configurator/table/table-chart-options.tsx:490
 msgid "controls.section.tableSettings"
 msgstr "Table Settings"
 
@@ -563,56 +572,56 @@ msgstr "Table Options"
 msgid "controls.section.title.warning"
 msgstr "Please add a title or description."
 
-#: app/configurator/components/chart-configurator.tsx:517
+#: app/configurator/components/chart-configurator.tsx:539
 #: app/configurator/components/chart-type-selector.tsx:131
 #: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
 msgstr "Chart Type"
 
-#: app/configurator/components/chart-options-selector.tsx:458
+#: app/configurator/components/chart-options-selector.tsx:464
 msgid "controls.select.column.layout"
 msgstr "Column layout"
 
-#: app/configurator/table/table-chart-options.tsx:249
+#: app/configurator/table/table-chart-options.tsx:253
 msgid "controls.select.columnStyle"
 msgstr "Column Style"
 
-#: app/configurator/table/table-chart-options.tsx:460
+#: app/configurator/table/table-chart-options.tsx:465
 msgid "controls.select.columnStyle.barColorBackground"
 msgstr "Background color"
 
-#: app/configurator/table/table-chart-options.tsx:452
+#: app/configurator/table/table-chart-options.tsx:457
 msgid "controls.select.columnStyle.barColorNegative"
 msgstr "Negative bar color"
 
-#: app/configurator/table/table-chart-options.tsx:444
+#: app/configurator/table/table-chart-options.tsx:449
 msgid "controls.select.columnStyle.barColorPositive"
 msgstr "Positive bar color"
 
-#: app/configurator/table/table-chart-options.tsx:468
+#: app/configurator/table/table-chart-options.tsx:473
 msgid "controls.select.columnStyle.barShowBackground"
 msgstr "Show bar background"
 
-#: app/configurator/table/table-chart-options.tsx:417
+#: app/configurator/table/table-chart-options.tsx:422
 msgid "controls.select.columnStyle.columnColor"
 msgstr "Column Color"
 
-#: app/configurator/table/table-chart-options.tsx:409
+#: app/configurator/table/table-chart-options.tsx:414
 msgid "controls.select.columnStyle.textColor"
 msgstr "Text Color"
 
-#: app/configurator/table/table-chart-options.tsx:386
+#: app/configurator/table/table-chart-options.tsx:391
 msgid "controls.select.columnStyle.textStyle"
 msgstr "Text Style"
 
-#: app/configurator/components/chart-options-selector.tsx:217
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:310
+#: app/configurator/components/chart-options-selector.tsx:219
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:262
 msgid "controls.select.dimension"
 msgstr "Select a dimension"
 
-#: app/configurator/components/chart-options-selector.tsx:218
-#: app/configurator/components/chart-options-selector.tsx:644
-#: app/configurator/components/chart-options-selector.tsx:722
+#: app/configurator/components/chart-options-selector.tsx:220
+#: app/configurator/components/chart-options-selector.tsx:650
+#: app/configurator/components/chart-options-selector.tsx:728
 msgid "controls.select.measure"
 msgstr "Select a measure"
 
@@ -623,20 +632,20 @@ msgstr "Select a measure"
 #~ msgid "controls.select.optional"
 #~ msgstr "optional"
 
-#: app/configurator/components/filters.tsx:353
-#: app/configurator/components/filters.tsx:767
+#: app/configurator/components/filters.tsx:367
+#: app/configurator/components/filters.tsx:783
 msgid "controls.set-filters"
 msgstr "Edit filters"
 
-#: app/configurator/components/filters.tsx:775
+#: app/configurator/components/filters.tsx:791
 msgid "controls.set-filters-caption"
 msgstr "For best results, do not select more than 7 values in the visualization."
 
-#: app/configurator/components/filters.tsx:814
+#: app/configurator/components/filters.tsx:830
 msgid "controls.set-values-apply"
 msgstr "Apply filters"
 
-#: app/configurator/components/chart-options-selector.tsx:636
+#: app/configurator/components/chart-options-selector.tsx:642
 msgid "controls.size"
 msgstr "Size"
 
@@ -644,12 +653,12 @@ msgstr "Size"
 msgid "controls.sorting.addDimension"
 msgstr "Add dimension"
 
-#: app/configurator/components/chart-options-selector.tsx:506
+#: app/configurator/components/chart-options-selector.tsx:512
 msgid "controls.sorting.byAuto"
 msgstr "Automatic"
 
-#: app/configurator/components/chart-options-selector.tsx:500
-#: app/configurator/components/chart-options-selector.tsx:510
+#: app/configurator/components/chart-options-selector.tsx:506
+#: app/configurator/components/chart-options-selector.tsx:516
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Name"
 
@@ -663,7 +672,7 @@ msgstr "A → Z"
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
-#: app/configurator/components/chart-options-selector.tsx:502
+#: app/configurator/components/chart-options-selector.tsx:508
 msgid "controls.sorting.byMeasure"
 msgstr "Measure"
 
@@ -675,7 +684,7 @@ msgstr "1 → 9"
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
-#: app/configurator/components/chart-options-selector.tsx:504
+#: app/configurator/components/chart-options-selector.tsx:510
 msgid "controls.sorting.byTotalSize"
 msgstr "Total size"
 
@@ -712,11 +721,11 @@ msgstr "Sort by"
 msgid "controls.switch.chart.type"
 msgstr "Switch to another chart type while maintaining most filter settings."
 
-#: app/configurator/table/table-chart-options.tsx:221
+#: app/configurator/table/table-chart-options.tsx:225
 msgid "controls.table.column.group"
 msgstr "Use as group"
 
-#: app/configurator/table/table-chart-options.tsx:231
+#: app/configurator/table/table-chart-options.tsx:235
 msgid "controls.table.column.hide"
 msgstr "Hide column"
 
@@ -728,7 +737,7 @@ msgstr "Settings"
 msgid "controls.table.sorting"
 msgstr "Sorting"
 
-#: app/configurator/table/table-chart-options.tsx:489
+#: app/configurator/table/table-chart-options.tsx:494
 msgid "controls.tableSettings.showSearch"
 msgstr "Show search field"
 
@@ -915,7 +924,7 @@ msgstr "Data loading error"
 msgid "hint.how.to.share"
 msgstr "You can share this visualization by copying the URL or by embedding it on your own website. You can also create a new visualization from scratch or start by copying the visualization above."
 
-#: app/components/form.tsx:291
+#: app/components/form.tsx:292
 #: app/components/hint.tsx:111
 msgid "hint.loading.data"
 msgstr "Loading data..."
@@ -1014,7 +1023,7 @@ msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
 #: app/configurator/components/dataset-browse.tsx:378
-#: app/configurator/components/filters.tsx:784
+#: app/configurator/components/filters.tsx:800
 msgid "select.controls.filters.search"
 msgstr "Search"
 

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -13,19 +13,19 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:628
+#: app/configurator/components/chart-configurator.tsx:657
 msgid "Add filter"
 msgstr "Ajouter un filtre"
 
-#: app/configurator/components/chart-configurator.tsx:601
+#: app/configurator/components/chart-configurator.tsx:630
 msgid "Drag filters to reorganize"
 msgstr "Faites glisser les filtres pour les réorganiser"
 
-#: app/configurator/components/chart-configurator.tsx:598
+#: app/configurator/components/chart-configurator.tsx:627
 msgid "Move filter down"
 msgstr "Déplacer le filtre vers le bas"
 
-#: app/configurator/components/chart-configurator.tsx:595
+#: app/configurator/components/chart-configurator.tsx:624
 msgid "Move filter up"
 msgstr "Déplacer le filtre vers le haut"
 
@@ -142,17 +142,17 @@ msgstr "Zones"
 #~ msgid "chart.map.layers.area.discretization.quantize"
 #~ msgstr "Intervalles égaux"
 
-#: app/configurator/components/chart-configurator.tsx:677
-#: app/configurator/components/chart-options-selector.tsx:986
+#: app/configurator/components/chart-configurator.tsx:706
+#: app/configurator/components/chart-options-selector.tsx:992
 #: app/configurator/components/field-i18n.ts:31
 msgid "chart.map.layers.base"
 msgstr "Affichage de la carte"
 
-#: app/configurator/components/chart-options-selector.tsx:990
+#: app/configurator/components/chart-options-selector.tsx:996
 msgid "chart.map.layers.base.show"
 msgstr "Afficher la carte du monde"
 
-#: app/configurator/components/chart-options-selector.tsx:998
+#: app/configurator/components/chart-options-selector.tsx:1004
 msgid "chart.map.layers.base.view.locked"
 msgstr "Carte verrouillée"
 
@@ -177,28 +177,28 @@ msgstr "Vue compacte"
 msgid "chart.table.number.of.lines"
 msgstr "Nombre total de lignes:"
 
-#: app/configurator/table/table-chart-options.tsx:190
+#: app/configurator/table/table-chart-options.tsx:194
 msgid "columnStyle.bar"
 msgstr "Barres"
 
-#: app/configurator/table/table-chart-options.tsx:200
+#: app/configurator/table/table-chart-options.tsx:204
 msgid "columnStyle.categories"
 msgstr "Catégories"
 
-#: app/configurator/table/table-chart-options.tsx:186
+#: app/configurator/table/table-chart-options.tsx:190
 msgid "columnStyle.heatmap"
 msgstr "Heatmap"
 
-#: app/configurator/table/table-chart-options.tsx:182
-#: app/configurator/table/table-chart-options.tsx:196
+#: app/configurator/table/table-chart-options.tsx:186
+#: app/configurator/table/table-chart-options.tsx:200
 msgid "columnStyle.text"
 msgstr "Texte"
 
-#: app/configurator/table/table-chart-options.tsx:400
+#: app/configurator/table/table-chart-options.tsx:405
 msgid "columnStyle.textStyle.bold"
 msgstr "Gras"
 
-#: app/configurator/table/table-chart-options.tsx:393
+#: app/configurator/table/table-chart-options.tsx:398
 msgid "columnStyle.textStyle.regular"
 msgstr "Normal"
 
@@ -254,7 +254,7 @@ msgstr "Nuage de points"
 msgid "controls.chart.type.table"
 msgstr "Tableau"
 
-#: app/configurator/components/chart-options-selector.tsx:717
+#: app/configurator/components/chart-options-selector.tsx:723
 #: app/configurator/components/field-i18n.ts:17
 msgid "controls.color"
 msgstr "Couleur"
@@ -263,7 +263,7 @@ msgstr "Couleur"
 msgid "controls.color.add"
 msgstr "Ajouter…"
 
-#: app/configurator/components/chart-options-selector.tsx:746
+#: app/configurator/components/chart-options-selector.tsx:752
 msgid "controls.color.opacity"
 msgstr "Transparence"
 
@@ -284,35 +284,35 @@ msgstr "Réinitialiser la palette de couleurs"
 msgid "controls.color.palette.sequential"
 msgstr "Séquentielle"
 
-#: app/configurator/components/chart-options-selector.tsx:833
+#: app/configurator/components/chart-options-selector.tsx:839
 msgid "controls.color.scale.discretization.jenks"
 msgstr "Jenks (intervalles naturels)"
 
-#: app/configurator/components/chart-options-selector.tsx:826
+#: app/configurator/components/chart-options-selector.tsx:832
 msgid "controls.color.scale.discretization.quantiles"
 msgstr "Quantiles (distribution homogène des valeurs)"
 
-#: app/configurator/components/chart-options-selector.tsx:819
+#: app/configurator/components/chart-options-selector.tsx:825
 msgid "controls.color.scale.discretization.quantize"
 msgstr "Intervalles égaux"
 
-#: app/configurator/components/chart-options-selector.tsx:811
+#: app/configurator/components/chart-options-selector.tsx:817
 msgid "controls.color.scale.interpolation"
 msgstr "Interpolation"
 
-#: app/configurator/components/chart-options-selector.tsx:843
+#: app/configurator/components/chart-options-selector.tsx:849
 msgid "controls.color.scale.number.of.classes"
 msgstr "Nombre de classes"
 
-#: app/configurator/components/chart-options-selector.tsx:783
+#: app/configurator/components/chart-options-selector.tsx:789
 msgid "controls.color.scale.type.continuous"
 msgstr "Continue"
 
-#: app/configurator/components/chart-options-selector.tsx:794
+#: app/configurator/components/chart-options-selector.tsx:800
 msgid "controls.color.scale.type.discrete"
 msgstr "Discrète"
 
-#: app/configurator/components/chart-options-selector.tsx:736
+#: app/configurator/components/chart-options-selector.tsx:742
 msgid "controls.color.select"
 msgstr "Sélectionner une couleur"
 
@@ -347,31 +347,40 @@ msgstr "Description"
 msgid "controls.dimensionvalue.none"
 msgstr "Aucune filtre"
 
-#: app/configurator/components/filters.tsx:400
+#: app/configurator/components/chart-configurator.tsx:487
+#~ msgid "controls.filter.interactive.toggle"
+#~ msgstr ""
+
+#: app/configurator/components/filters.tsx:415
 msgid "controls.filter.nb-elements"
 msgstr "{0} sur {1}"
 
-#: app/configurator/components/filters.tsx:194
+#: app/configurator/components/filters.tsx:197
 msgid "controls.filter.select.all"
 msgstr "Tout sélectionner"
 
-#: app/configurator/components/filters.tsx:201
+#: app/configurator/components/filters.tsx:204
 msgid "controls.filter.select.none"
 msgstr "Tout déselectionner"
+
+#: app/configurator/components/chart-configurator.tsx:488
+#: app/configurator/components/filters.tsx:355
+msgid "controls.filters.interactive.toggle"
+msgstr "Interactif"
 
 #: app/configurator/components/filters.tsx:358
 #~ msgid "controls.filters.select.filters"
 #~ msgstr "Filtres"
 
-#: app/configurator/components/filters.tsx:381
+#: app/configurator/components/filters.tsx:396
 msgid "controls.filters.select.refresh-colors"
 msgstr "Renouveller les couleurs"
 
-#: app/configurator/components/filters.tsx:365
+#: app/configurator/components/filters.tsx:380
 msgid "controls.filters.select.reset-colors"
 msgstr "Réinitialiser les couleurs"
 
-#: app/configurator/components/filters.tsx:358
+#: app/configurator/components/filters.tsx:373
 msgid "controls.filters.select.selected-filters"
 msgstr "Filtres sélectionnés"
 
@@ -387,44 +396,44 @@ msgstr "Glisser-déposer des colonnes ici pour créer des groupes."
 msgid "controls.imputation"
 msgstr "Type d'imputation"
 
-#: app/configurator/components/chart-options-selector.tsx:878
+#: app/configurator/components/chart-options-selector.tsx:884
 #: app/configurator/components/field-i18n.ts:99
 msgid "controls.imputation.type.linear"
 msgstr "Interpolation linéaire"
 
-#: app/configurator/components/chart-options-selector.tsx:871
-#: app/configurator/components/chart-options-selector.tsx:883
+#: app/configurator/components/chart-options-selector.tsx:877
+#: app/configurator/components/chart-options-selector.tsx:889
 #: app/configurator/components/field-i18n.ts:91
 msgid "controls.imputation.type.none"
 msgstr "-"
 
-#: app/configurator/components/chart-options-selector.tsx:873
+#: app/configurator/components/chart-options-selector.tsx:879
 #: app/configurator/components/field-i18n.ts:95
 msgid "controls.imputation.type.zeros"
 msgstr "Zéros"
 
 #: app/configurator/interactive-filters/interactive-filters-configurator.tsx:137
-msgid "controls.interactive.filters.dataFilter"
-msgstr "Filtres de données"
+#~ msgid "controls.interactive.filters.dataFilter"
+#~ msgstr "Filtres de données"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:115
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:117
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:80
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:109
 msgid "controls.interactive.filters.timeSlider"
 msgstr "Curseur temporel"
 
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:375
-msgid "controls.interactiveFilters.dataFilters.toggledataFilters"
-msgstr "Afficher les filtres de données"
+#~ msgid "controls.interactiveFilters.dataFilters.toggledataFilters"
+#~ msgstr "Afficher les filtres de données"
 
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:89
-msgid "controls.interactiveFilters.legend.toggleInteractiveLegend"
-msgstr "Afficher la légende filtrante"
+#~ msgid "controls.interactiveFilters.legend.toggleInteractiveLegend"
+#~ msgstr "Afficher la légende filtrante"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:233
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:185
 msgid "controls.interactiveFilters.time.noTimeDimension"
 msgstr "Il n'y a pas de dimension temporelle!"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:208
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:160
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Afficher le filtre temporel"
 
@@ -460,7 +469,7 @@ msgstr "Retour aux paramètres généraux"
 msgid "controls.nav.back-to-preview"
 msgstr "Retour à l'aperçu"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:292
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:244
 msgid "controls.none"
 msgstr "Aucun"
 
@@ -472,19 +481,19 @@ msgstr "Actif"
 msgid "controls.option.isNotActive"
 msgstr "Inactif"
 
-#: app/configurator/components/chart-options-selector.tsx:776
+#: app/configurator/components/chart-options-selector.tsx:782
 msgid "controls.scale.type"
 msgstr "Type d'échelle"
 
-#: app/components/form.tsx:624
+#: app/components/form.tsx:625
 msgid "controls.search.clear"
 msgstr "Effacer la recherche"
 
-#: app/configurator/components/chart-options-selector.tsx:353
+#: app/configurator/components/chart-options-selector.tsx:355
 msgid "controls.section.additional-information"
 msgstr "Informations supplémentaires"
 
-#: app/configurator/components/chart-configurator.tsx:525
+#: app/configurator/components/chart-configurator.tsx:547
 msgid "controls.section.chart.options"
 msgstr "Paramètres graphiques"
 
@@ -492,11 +501,11 @@ msgstr "Paramètres graphiques"
 msgid "controls.section.columns"
 msgstr "Colonnes"
 
-#: app/configurator/table/table-chart-options.tsx:244
+#: app/configurator/table/table-chart-options.tsx:248
 msgid "controls.section.columnstyle"
 msgstr "Style de la colonne"
 
-#: app/configurator/components/chart-configurator.tsx:543
+#: app/configurator/components/chart-configurator.tsx:565
 msgid "controls.section.data.filters"
 msgstr "Filtres"
 
@@ -504,12 +513,12 @@ msgstr "Filtres"
 msgid "controls.section.description"
 msgstr "Titre & description"
 
-#: app/configurator/components/chart-options-selector.tsx:408
-#: app/configurator/components/chart-options-selector.tsx:412
-#: app/configurator/table/table-chart-options.tsx:314
-#: app/configurator/table/table-chart-options.tsx:318
-#: app/configurator/table/table-chart-options.tsx:338
-#: app/configurator/table/table-chart-options.tsx:342
+#: app/configurator/components/chart-options-selector.tsx:414
+#: app/configurator/components/chart-options-selector.tsx:418
+#: app/configurator/table/table-chart-options.tsx:319
+#: app/configurator/table/table-chart-options.tsx:323
+#: app/configurator/table/table-chart-options.tsx:343
+#: app/configurator/table/table-chart-options.tsx:347
 msgid "controls.section.filter"
 msgstr "Filtre"
 
@@ -517,32 +526,32 @@ msgstr "Filtre"
 msgid "controls.section.groups"
 msgstr "Groupes"
 
-#: app/configurator/components/chart-options-selector.tsx:912
+#: app/configurator/components/chart-options-selector.tsx:918
 msgid "controls.section.imputation"
 msgstr "Valeurs manquantes"
 
-#: app/configurator/components/chart-options-selector.tsx:917
+#: app/configurator/components/chart-options-selector.tsx:923
 msgid "controls.section.imputation.explanation"
 msgstr "En raison du type de graphique sélectionné, les valeurs manquantes doivent être remplies. Décidez de la logique d'imputation ou choisissez un autre type de graphique."
 
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:98
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:157
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:90
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:129
 msgid "controls.section.interactive.filters"
 msgstr "Filtres interactifs"
 
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:128
-msgid "controls.section.interactiveFilters.dataFilters"
-msgstr "Filtres de données"
+#~ msgid "controls.section.interactiveFilters.dataFilters"
+#~ msgstr "Filtres de données"
 
-#: app/configurator/components/chart-options-selector.tsx:362
+#: app/configurator/components/chart-options-selector.tsx:364
 msgid "controls.section.show-standard-error"
 msgstr "Afficher l'erreur type"
 
-#: app/configurator/components/chart-options-selector.tsx:554
+#: app/configurator/components/chart-options-selector.tsx:560
 msgid "controls.section.sorting"
 msgstr "Trier"
 
-#: app/configurator/table/table-chart-options.tsx:485
+#: app/configurator/table/table-chart-options.tsx:490
 msgid "controls.section.tableSettings"
 msgstr "Paramètres du tableau"
 
@@ -558,56 +567,56 @@ msgstr "Options du tableau"
 msgid "controls.section.title.warning"
 msgstr "Ajoutez un titre et une description"
 
-#: app/configurator/components/chart-configurator.tsx:517
+#: app/configurator/components/chart-configurator.tsx:539
 #: app/configurator/components/chart-type-selector.tsx:131
 #: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
 msgstr "Type de graphique"
 
-#: app/configurator/components/chart-options-selector.tsx:458
+#: app/configurator/components/chart-options-selector.tsx:464
 msgid "controls.select.column.layout"
 msgstr "Mise en forme de la colonne"
 
-#: app/configurator/table/table-chart-options.tsx:249
+#: app/configurator/table/table-chart-options.tsx:253
 msgid "controls.select.columnStyle"
 msgstr "Style de la colonne"
 
-#: app/configurator/table/table-chart-options.tsx:460
+#: app/configurator/table/table-chart-options.tsx:465
 msgid "controls.select.columnStyle.barColorBackground"
 msgstr "Couleur de fond"
 
-#: app/configurator/table/table-chart-options.tsx:452
+#: app/configurator/table/table-chart-options.tsx:457
 msgid "controls.select.columnStyle.barColorNegative"
 msgstr "Couleur des valeurs négatives"
 
-#: app/configurator/table/table-chart-options.tsx:444
+#: app/configurator/table/table-chart-options.tsx:449
 msgid "controls.select.columnStyle.barColorPositive"
 msgstr "Couleur des valeurs positives"
 
-#: app/configurator/table/table-chart-options.tsx:468
+#: app/configurator/table/table-chart-options.tsx:473
 msgid "controls.select.columnStyle.barShowBackground"
 msgstr "Afficher la couleur de fond"
 
-#: app/configurator/table/table-chart-options.tsx:417
+#: app/configurator/table/table-chart-options.tsx:422
 msgid "controls.select.columnStyle.columnColor"
 msgstr "Couleur de la colonne"
 
-#: app/configurator/table/table-chart-options.tsx:409
+#: app/configurator/table/table-chart-options.tsx:414
 msgid "controls.select.columnStyle.textColor"
 msgstr "Couleur du texte"
 
-#: app/configurator/table/table-chart-options.tsx:386
+#: app/configurator/table/table-chart-options.tsx:391
 msgid "controls.select.columnStyle.textStyle"
 msgstr "Style du texte"
 
-#: app/configurator/components/chart-options-selector.tsx:217
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:310
+#: app/configurator/components/chart-options-selector.tsx:219
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:262
 msgid "controls.select.dimension"
 msgstr "Sélectionner une dimension"
 
-#: app/configurator/components/chart-options-selector.tsx:218
-#: app/configurator/components/chart-options-selector.tsx:644
-#: app/configurator/components/chart-options-selector.tsx:722
+#: app/configurator/components/chart-options-selector.tsx:220
+#: app/configurator/components/chart-options-selector.tsx:650
+#: app/configurator/components/chart-options-selector.tsx:728
 msgid "controls.select.measure"
 msgstr "Sélectionner une variable"
 
@@ -618,20 +627,20 @@ msgstr "Sélectionner une variable"
 #~ msgid "controls.select.optional"
 #~ msgstr "optionnel"
 
-#: app/configurator/components/filters.tsx:353
-#: app/configurator/components/filters.tsx:767
+#: app/configurator/components/filters.tsx:367
+#: app/configurator/components/filters.tsx:783
 msgid "controls.set-filters"
 msgstr "Modifier les filtres"
 
-#: app/configurator/components/filters.tsx:775
+#: app/configurator/components/filters.tsx:791
 msgid "controls.set-filters-caption"
 msgstr "Pour de meilleurs résultats, ne sélectionnez pas plus de 7 valeurs dans la visualisation."
 
-#: app/configurator/components/filters.tsx:814
+#: app/configurator/components/filters.tsx:830
 msgid "controls.set-values-apply"
 msgstr "Appliquer les filtres"
 
-#: app/configurator/components/chart-options-selector.tsx:636
+#: app/configurator/components/chart-options-selector.tsx:642
 msgid "controls.size"
 msgstr "Taille"
 
@@ -639,12 +648,12 @@ msgstr "Taille"
 msgid "controls.sorting.addDimension"
 msgstr "Ajouter une dimension"
 
-#: app/configurator/components/chart-options-selector.tsx:506
+#: app/configurator/components/chart-options-selector.tsx:512
 msgid "controls.sorting.byAuto"
 msgstr "Auto"
 
-#: app/configurator/components/chart-options-selector.tsx:500
-#: app/configurator/components/chart-options-selector.tsx:510
+#: app/configurator/components/chart-options-selector.tsx:506
+#: app/configurator/components/chart-options-selector.tsx:516
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Nom"
 
@@ -658,7 +667,7 @@ msgstr "A → Z"
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
-#: app/configurator/components/chart-options-selector.tsx:502
+#: app/configurator/components/chart-options-selector.tsx:508
 msgid "controls.sorting.byMeasure"
 msgstr "Mesure"
 
@@ -670,7 +679,7 @@ msgstr "1 → 9"
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
-#: app/configurator/components/chart-options-selector.tsx:504
+#: app/configurator/components/chart-options-selector.tsx:510
 msgid "controls.sorting.byTotalSize"
 msgstr "Taille totale"
 
@@ -707,11 +716,11 @@ msgstr "Trier par"
 msgid "controls.switch.chart.type"
 msgstr "Passer à une autre visualisation tout en conservant la plupart des filtres"
 
-#: app/configurator/table/table-chart-options.tsx:221
+#: app/configurator/table/table-chart-options.tsx:225
 msgid "controls.table.column.group"
 msgstr "Grouper selon cette colonne"
 
-#: app/configurator/table/table-chart-options.tsx:231
+#: app/configurator/table/table-chart-options.tsx:235
 msgid "controls.table.column.hide"
 msgstr "Masquer la colonne"
 
@@ -723,7 +732,7 @@ msgstr "Paramètres"
 msgid "controls.table.sorting"
 msgstr "Tri"
 
-#: app/configurator/table/table-chart-options.tsx:489
+#: app/configurator/table/table-chart-options.tsx:494
 msgid "controls.tableSettings.showSearch"
 msgstr "Afficher le champ de recherche"
 
@@ -906,7 +915,7 @@ msgstr "Problème de téléchargement des données"
 msgid "hint.how.to.share"
 msgstr "Vous pouvez partager cette visualisation en copiant l'URL ou en l'intégrant sur votre site Web. Vous pouvez également créer une toute nouvelle visualisation, ou bien copier et modifier la visualisation ci-dessus."
 
-#: app/components/form.tsx:291
+#: app/components/form.tsx:292
 #: app/components/hint.tsx:111
 msgid "hint.loading.data"
 msgstr "Chargement des données..."
@@ -1005,7 +1014,7 @@ msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
 #: app/configurator/components/dataset-browse.tsx:378
-#: app/configurator/components/filters.tsx:784
+#: app/configurator/components/filters.tsx:800
 msgid "select.controls.filters.search"
 msgstr "Chercher"
 

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -13,19 +13,19 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:628
+#: app/configurator/components/chart-configurator.tsx:657
 msgid "Add filter"
 msgstr "Aggiungi filtro"
 
-#: app/configurator/components/chart-configurator.tsx:601
+#: app/configurator/components/chart-configurator.tsx:630
 msgid "Drag filters to reorganize"
 msgstr "Trascina i filtri per riorganizzarli"
 
-#: app/configurator/components/chart-configurator.tsx:598
+#: app/configurator/components/chart-configurator.tsx:627
 msgid "Move filter down"
 msgstr "Sposta il filtro in basso"
 
-#: app/configurator/components/chart-configurator.tsx:595
+#: app/configurator/components/chart-configurator.tsx:624
 msgid "Move filter up"
 msgstr "Sposta il filtro in alto"
 
@@ -142,17 +142,17 @@ msgstr "Aree"
 #~ msgid "chart.map.layers.area.discretization.quantize"
 #~ msgstr "Intervalli uguali"
 
-#: app/configurator/components/chart-configurator.tsx:677
-#: app/configurator/components/chart-options-selector.tsx:986
+#: app/configurator/components/chart-configurator.tsx:706
+#: app/configurator/components/chart-options-selector.tsx:992
 #: app/configurator/components/field-i18n.ts:31
 msgid "chart.map.layers.base"
 msgstr "Visualizzazione della mappa"
 
-#: app/configurator/components/chart-options-selector.tsx:990
+#: app/configurator/components/chart-options-selector.tsx:996
 msgid "chart.map.layers.base.show"
 msgstr "Mostra mappa del mondo"
 
-#: app/configurator/components/chart-options-selector.tsx:998
+#: app/configurator/components/chart-options-selector.tsx:1004
 msgid "chart.map.layers.base.view.locked"
 msgstr "Vista bloccata"
 
@@ -177,28 +177,28 @@ msgstr "Vista compatta"
 msgid "chart.table.number.of.lines"
 msgstr "Numero totale di linee:"
 
-#: app/configurator/table/table-chart-options.tsx:190
+#: app/configurator/table/table-chart-options.tsx:194
 msgid "columnStyle.bar"
 msgstr "Grafico a barre"
 
-#: app/configurator/table/table-chart-options.tsx:200
+#: app/configurator/table/table-chart-options.tsx:204
 msgid "columnStyle.categories"
 msgstr "Categorie"
 
-#: app/configurator/table/table-chart-options.tsx:186
+#: app/configurator/table/table-chart-options.tsx:190
 msgid "columnStyle.heatmap"
 msgstr "Mappa di calore"
 
-#: app/configurator/table/table-chart-options.tsx:182
-#: app/configurator/table/table-chart-options.tsx:196
+#: app/configurator/table/table-chart-options.tsx:186
+#: app/configurator/table/table-chart-options.tsx:200
 msgid "columnStyle.text"
 msgstr "Testo"
 
-#: app/configurator/table/table-chart-options.tsx:400
+#: app/configurator/table/table-chart-options.tsx:405
 msgid "columnStyle.textStyle.bold"
 msgstr "Grassetto"
 
-#: app/configurator/table/table-chart-options.tsx:393
+#: app/configurator/table/table-chart-options.tsx:398
 msgid "columnStyle.textStyle.regular"
 msgstr "Regular"
 
@@ -254,7 +254,7 @@ msgstr "Scatterplot"
 msgid "controls.chart.type.table"
 msgstr "Tabella"
 
-#: app/configurator/components/chart-options-selector.tsx:717
+#: app/configurator/components/chart-options-selector.tsx:723
 #: app/configurator/components/field-i18n.ts:17
 msgid "controls.color"
 msgstr "Colore"
@@ -263,7 +263,7 @@ msgstr "Colore"
 msgid "controls.color.add"
 msgstr "Aggiungi ..."
 
-#: app/configurator/components/chart-options-selector.tsx:746
+#: app/configurator/components/chart-options-selector.tsx:752
 msgid "controls.color.opacity"
 msgstr "Trasparenza"
 
@@ -284,35 +284,35 @@ msgstr "Ripristina la tavolozza dei colori"
 msgid "controls.color.palette.sequential"
 msgstr "Sequenziale"
 
-#: app/configurator/components/chart-options-selector.tsx:833
+#: app/configurator/components/chart-options-selector.tsx:839
 msgid "controls.color.scale.discretization.jenks"
 msgstr "Jenks (interruzioni naturali)"
 
-#: app/configurator/components/chart-options-selector.tsx:826
+#: app/configurator/components/chart-options-selector.tsx:832
 msgid "controls.color.scale.discretization.quantiles"
 msgstr "Quantili (distribuzione omogenea dei valori)"
 
-#: app/configurator/components/chart-options-selector.tsx:819
+#: app/configurator/components/chart-options-selector.tsx:825
 msgid "controls.color.scale.discretization.quantize"
 msgstr "Intervalli uguali"
 
-#: app/configurator/components/chart-options-selector.tsx:811
+#: app/configurator/components/chart-options-selector.tsx:817
 msgid "controls.color.scale.interpolation"
 msgstr "Interpolazione"
 
-#: app/configurator/components/chart-options-selector.tsx:843
+#: app/configurator/components/chart-options-selector.tsx:849
 msgid "controls.color.scale.number.of.classes"
 msgstr "Numero di classi"
 
-#: app/configurator/components/chart-options-selector.tsx:783
+#: app/configurator/components/chart-options-selector.tsx:789
 msgid "controls.color.scale.type.continuous"
 msgstr "Continuo"
 
-#: app/configurator/components/chart-options-selector.tsx:794
+#: app/configurator/components/chart-options-selector.tsx:800
 msgid "controls.color.scale.type.discrete"
 msgstr "Discreto"
 
-#: app/configurator/components/chart-options-selector.tsx:736
+#: app/configurator/components/chart-options-selector.tsx:742
 msgid "controls.color.select"
 msgstr "Seleziona un colore"
 
@@ -347,31 +347,40 @@ msgstr "Descrizione"
 msgid "controls.dimensionvalue.none"
 msgstr "Nessun filtro"
 
-#: app/configurator/components/filters.tsx:400
+#: app/configurator/components/chart-configurator.tsx:487
+#~ msgid "controls.filter.interactive.toggle"
+#~ msgstr ""
+
+#: app/configurator/components/filters.tsx:415
 msgid "controls.filter.nb-elements"
 msgstr "{0} di {1}"
 
-#: app/configurator/components/filters.tsx:194
+#: app/configurator/components/filters.tsx:197
 msgid "controls.filter.select.all"
 msgstr "Seleziona tutti"
 
-#: app/configurator/components/filters.tsx:201
+#: app/configurator/components/filters.tsx:204
 msgid "controls.filter.select.none"
 msgstr "Deseleziona tutto"
+
+#: app/configurator/components/chart-configurator.tsx:488
+#: app/configurator/components/filters.tsx:355
+msgid "controls.filters.interactive.toggle"
+msgstr "Interattivo"
 
 #: app/configurator/components/filters.tsx:358
 #~ msgid "controls.filters.select.filters"
 #~ msgstr "Filtri"
 
-#: app/configurator/components/filters.tsx:381
+#: app/configurator/components/filters.tsx:396
 msgid "controls.filters.select.refresh-colors"
 msgstr "Aggiorna i colori"
 
-#: app/configurator/components/filters.tsx:365
+#: app/configurator/components/filters.tsx:380
 msgid "controls.filters.select.reset-colors"
 msgstr "Reimpostare i colori"
 
-#: app/configurator/components/filters.tsx:358
+#: app/configurator/components/filters.tsx:373
 msgid "controls.filters.select.selected-filters"
 msgstr "Filtri selezionati"
 
@@ -387,44 +396,44 @@ msgstr "Trascina qui le colonne per creare gruppi."
 msgid "controls.imputation"
 msgstr "Tipo di imputazione"
 
-#: app/configurator/components/chart-options-selector.tsx:878
+#: app/configurator/components/chart-options-selector.tsx:884
 #: app/configurator/components/field-i18n.ts:99
 msgid "controls.imputation.type.linear"
 msgstr "Interpolazione lineare"
 
-#: app/configurator/components/chart-options-selector.tsx:871
-#: app/configurator/components/chart-options-selector.tsx:883
+#: app/configurator/components/chart-options-selector.tsx:877
+#: app/configurator/components/chart-options-selector.tsx:889
 #: app/configurator/components/field-i18n.ts:91
 msgid "controls.imputation.type.none"
 msgstr "-"
 
-#: app/configurator/components/chart-options-selector.tsx:873
+#: app/configurator/components/chart-options-selector.tsx:879
 #: app/configurator/components/field-i18n.ts:95
 msgid "controls.imputation.type.zeros"
 msgstr "Zeri"
 
 #: app/configurator/interactive-filters/interactive-filters-configurator.tsx:137
-msgid "controls.interactive.filters.dataFilter"
-msgstr "Filtri di dati"
+#~ msgid "controls.interactive.filters.dataFilter"
+#~ msgstr "Filtri di dati"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:115
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:117
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:80
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:109
 msgid "controls.interactive.filters.timeSlider"
 msgstr "Cursore del tempo"
 
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:375
-msgid "controls.interactiveFilters.dataFilters.toggledataFilters"
-msgstr "Mostra i filtri di dati"
+#~ msgid "controls.interactiveFilters.dataFilters.toggledataFilters"
+#~ msgstr "Mostra i filtri di dati"
 
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:89
-msgid "controls.interactiveFilters.legend.toggleInteractiveLegend"
-msgstr "Mostra la legenda filtrante"
+#~ msgid "controls.interactiveFilters.legend.toggleInteractiveLegend"
+#~ msgstr "Mostra la legenda filtrante"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:233
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:185
 msgid "controls.interactiveFilters.time.noTimeDimension"
 msgstr "Nessuna dimensione temporale disponibile!"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:208
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:160
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Mostra i filtri temporali"
 
@@ -465,7 +474,7 @@ msgstr "Torna alle impostazioni generali"
 msgid "controls.nav.back-to-preview"
 msgstr "Torna all'anteprima"
 
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:292
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:244
 msgid "controls.none"
 msgstr "Nessuno"
 
@@ -477,19 +486,19 @@ msgstr "Attivo"
 msgid "controls.option.isNotActive"
 msgstr "Inattivo"
 
-#: app/configurator/components/chart-options-selector.tsx:776
+#: app/configurator/components/chart-options-selector.tsx:782
 msgid "controls.scale.type"
 msgstr "Tipo di scala"
 
-#: app/components/form.tsx:624
+#: app/components/form.tsx:625
 msgid "controls.search.clear"
 msgstr "Cancella la ricerca"
 
-#: app/configurator/components/chart-options-selector.tsx:353
+#: app/configurator/components/chart-options-selector.tsx:355
 msgid "controls.section.additional-information"
 msgstr "Informazioni aggiuntive"
 
-#: app/configurator/components/chart-configurator.tsx:525
+#: app/configurator/components/chart-configurator.tsx:547
 msgid "controls.section.chart.options"
 msgstr "Opzioni del grafico"
 
@@ -497,11 +506,11 @@ msgstr "Opzioni del grafico"
 msgid "controls.section.columns"
 msgstr "Colonne"
 
-#: app/configurator/table/table-chart-options.tsx:244
+#: app/configurator/table/table-chart-options.tsx:248
 msgid "controls.section.columnstyle"
 msgstr "Stile della colonna"
 
-#: app/configurator/components/chart-configurator.tsx:543
+#: app/configurator/components/chart-configurator.tsx:565
 msgid "controls.section.data.filters"
 msgstr "Filtri"
 
@@ -509,12 +518,12 @@ msgstr "Filtri"
 msgid "controls.section.description"
 msgstr "Titolo e descrizione"
 
-#: app/configurator/components/chart-options-selector.tsx:408
-#: app/configurator/components/chart-options-selector.tsx:412
-#: app/configurator/table/table-chart-options.tsx:314
-#: app/configurator/table/table-chart-options.tsx:318
-#: app/configurator/table/table-chart-options.tsx:338
-#: app/configurator/table/table-chart-options.tsx:342
+#: app/configurator/components/chart-options-selector.tsx:414
+#: app/configurator/components/chart-options-selector.tsx:418
+#: app/configurator/table/table-chart-options.tsx:319
+#: app/configurator/table/table-chart-options.tsx:323
+#: app/configurator/table/table-chart-options.tsx:343
+#: app/configurator/table/table-chart-options.tsx:347
 msgid "controls.section.filter"
 msgstr "Filtro"
 
@@ -522,32 +531,32 @@ msgstr "Filtro"
 msgid "controls.section.groups"
 msgstr "Gruppi"
 
-#: app/configurator/components/chart-options-selector.tsx:912
+#: app/configurator/components/chart-options-selector.tsx:918
 msgid "controls.section.imputation"
 msgstr "Valori mancanti"
 
-#: app/configurator/components/chart-options-selector.tsx:917
+#: app/configurator/components/chart-options-selector.tsx:923
 msgid "controls.section.imputation.explanation"
 msgstr "Per questo tipo di grafico, i valori di sostituzione devono essere assegnati ai valori mancanti. Decidi la logica di imputazione o passa a un altro tipo di grafico."
 
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:98
-#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:157
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:90
+#: app/configurator/interactive-filters/interactive-filters-configurator.tsx:129
 msgid "controls.section.interactive.filters"
 msgstr "Filtri interattivi"
 
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:128
-msgid "controls.section.interactiveFilters.dataFilters"
-msgstr "Filtri di dati"
+#~ msgid "controls.section.interactiveFilters.dataFilters"
+#~ msgstr "Filtri di dati"
 
-#: app/configurator/components/chart-options-selector.tsx:362
+#: app/configurator/components/chart-options-selector.tsx:364
 msgid "controls.section.show-standard-error"
 msgstr "Mostra l'errore standard"
 
-#: app/configurator/components/chart-options-selector.tsx:554
+#: app/configurator/components/chart-options-selector.tsx:560
 msgid "controls.section.sorting"
 msgstr "Ordina"
 
-#: app/configurator/table/table-chart-options.tsx:485
+#: app/configurator/table/table-chart-options.tsx:490
 msgid "controls.section.tableSettings"
 msgstr "Impostazioni della tabella"
 
@@ -563,56 +572,56 @@ msgstr "Opzioni della tabella"
 msgid "controls.section.title.warning"
 msgstr "Aggiungi un titolo o una descrizione"
 
-#: app/configurator/components/chart-configurator.tsx:517
+#: app/configurator/components/chart-configurator.tsx:539
 #: app/configurator/components/chart-type-selector.tsx:131
 #: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
 msgstr "Tipo di grafico"
 
-#: app/configurator/components/chart-options-selector.tsx:458
+#: app/configurator/components/chart-options-selector.tsx:464
 msgid "controls.select.column.layout"
 msgstr "Layout a colonne"
 
-#: app/configurator/table/table-chart-options.tsx:249
+#: app/configurator/table/table-chart-options.tsx:253
 msgid "controls.select.columnStyle"
 msgstr "Stile della colonna"
 
-#: app/configurator/table/table-chart-options.tsx:460
+#: app/configurator/table/table-chart-options.tsx:465
 msgid "controls.select.columnStyle.barColorBackground"
 msgstr "Colore dello sfondo"
 
-#: app/configurator/table/table-chart-options.tsx:452
+#: app/configurator/table/table-chart-options.tsx:457
 msgid "controls.select.columnStyle.barColorNegative"
 msgstr "Colore dei valori negativi"
 
-#: app/configurator/table/table-chart-options.tsx:444
+#: app/configurator/table/table-chart-options.tsx:449
 msgid "controls.select.columnStyle.barColorPositive"
 msgstr "Colore dei valori positivi"
 
-#: app/configurator/table/table-chart-options.tsx:468
+#: app/configurator/table/table-chart-options.tsx:473
 msgid "controls.select.columnStyle.barShowBackground"
 msgstr "Mostra il colore dello sfondo"
 
-#: app/configurator/table/table-chart-options.tsx:417
+#: app/configurator/table/table-chart-options.tsx:422
 msgid "controls.select.columnStyle.columnColor"
 msgstr "Colore della colonna"
 
-#: app/configurator/table/table-chart-options.tsx:409
+#: app/configurator/table/table-chart-options.tsx:414
 msgid "controls.select.columnStyle.textColor"
 msgstr "Colore del testo"
 
-#: app/configurator/table/table-chart-options.tsx:386
+#: app/configurator/table/table-chart-options.tsx:391
 msgid "controls.select.columnStyle.textStyle"
 msgstr "Stile del testo"
 
-#: app/configurator/components/chart-options-selector.tsx:217
-#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:310
+#: app/configurator/components/chart-options-selector.tsx:219
+#: app/configurator/interactive-filters/interactive-filters-config-options.tsx:262
 msgid "controls.select.dimension"
 msgstr "Seleziona una dimensione"
 
-#: app/configurator/components/chart-options-selector.tsx:218
-#: app/configurator/components/chart-options-selector.tsx:644
-#: app/configurator/components/chart-options-selector.tsx:722
+#: app/configurator/components/chart-options-selector.tsx:220
+#: app/configurator/components/chart-options-selector.tsx:650
+#: app/configurator/components/chart-options-selector.tsx:728
 msgid "controls.select.measure"
 msgstr "Seleziona una misura"
 
@@ -623,20 +632,20 @@ msgstr "Seleziona una misura"
 #~ msgid "controls.select.optional"
 #~ msgstr "facoltativo"
 
-#: app/configurator/components/filters.tsx:353
-#: app/configurator/components/filters.tsx:767
+#: app/configurator/components/filters.tsx:367
+#: app/configurator/components/filters.tsx:783
 msgid "controls.set-filters"
 msgstr "Modificare i filtri"
 
-#: app/configurator/components/filters.tsx:775
+#: app/configurator/components/filters.tsx:791
 msgid "controls.set-filters-caption"
 msgstr "Pour de meilleurs résultats, ne sélectionnez pas plus de 7 valeurs dans la visualisation"
 
-#: app/configurator/components/filters.tsx:814
+#: app/configurator/components/filters.tsx:830
 msgid "controls.set-values-apply"
 msgstr "Appliquer les filtres"
 
-#: app/configurator/components/chart-options-selector.tsx:636
+#: app/configurator/components/chart-options-selector.tsx:642
 msgid "controls.size"
 msgstr "Grandezza"
 
@@ -644,12 +653,12 @@ msgstr "Grandezza"
 msgid "controls.sorting.addDimension"
 msgstr "Aggiungi una dimensione"
 
-#: app/configurator/components/chart-options-selector.tsx:506
+#: app/configurator/components/chart-options-selector.tsx:512
 msgid "controls.sorting.byAuto"
 msgstr ""
 
-#: app/configurator/components/chart-options-selector.tsx:500
-#: app/configurator/components/chart-options-selector.tsx:510
+#: app/configurator/components/chart-options-selector.tsx:506
+#: app/configurator/components/chart-options-selector.tsx:516
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Nome"
 
@@ -663,7 +672,7 @@ msgstr "A → Z"
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
-#: app/configurator/components/chart-options-selector.tsx:502
+#: app/configurator/components/chart-options-selector.tsx:508
 msgid "controls.sorting.byMeasure"
 msgstr "Misura"
 
@@ -675,7 +684,7 @@ msgstr "1 → 9"
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
-#: app/configurator/components/chart-options-selector.tsx:504
+#: app/configurator/components/chart-options-selector.tsx:510
 msgid "controls.sorting.byTotalSize"
 msgstr "Grandezza totale"
 
@@ -712,11 +721,11 @@ msgstr "Ordina per"
 msgid "controls.switch.chart.type"
 msgstr "Passa a un altro tipo di grafico mantenendo la maggior parte delle impostazioni dei filtri"
 
-#: app/configurator/table/table-chart-options.tsx:221
+#: app/configurator/table/table-chart-options.tsx:225
 msgid "controls.table.column.group"
 msgstr "Raggruppa secondo questa colonna"
 
-#: app/configurator/table/table-chart-options.tsx:231
+#: app/configurator/table/table-chart-options.tsx:235
 msgid "controls.table.column.hide"
 msgstr "Nascondi la colonna"
 
@@ -728,7 +737,7 @@ msgstr "Opzioni"
 msgid "controls.table.sorting"
 msgstr "Ordinamento"
 
-#: app/configurator/table/table-chart-options.tsx:489
+#: app/configurator/table/table-chart-options.tsx:494
 msgid "controls.tableSettings.showSearch"
 msgstr "Mostra il campo di ricerca"
 
@@ -911,7 +920,7 @@ msgstr "Problema di caricamento dei dati"
 msgid "hint.how.to.share"
 msgstr "È possibile condividere questa visualizzazione copiando l'URL o incorporandola nel vostro sito Web. Puoi anche creare una nuova visualizzazione partendo da zero oppure copiando e modificando la visualizzazione sopra."
 
-#: app/components/form.tsx:291
+#: app/components/form.tsx:292
 #: app/components/hint.tsx:111
 msgid "hint.loading.data"
 msgstr "Caricamento dei dati..."
@@ -1010,7 +1019,7 @@ msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
 #: app/configurator/components/dataset-browse.tsx:378
-#: app/configurator/components/filters.tsx:784
+#: app/configurator/components/filters.tsx:800
 msgid "select.controls.filters.search"
 msgstr "Cerca"
 

--- a/app/themes/federal.tsx
+++ b/app/themes/federal.tsx
@@ -387,6 +387,15 @@ theme.components = {
       },
     },
   },
+  MuiBadge: {
+    styleOverrides: {
+      badge: {
+        minWidth: 18,
+        height: 18,
+        padding: [0, 3],
+      },
+    },
+  },
   MuiInputBase: {
     styleOverrides: {
       input: {

--- a/app/themes/federal.tsx
+++ b/app/themes/federal.tsx
@@ -174,8 +174,8 @@ theme.typography = merge(theme.typography, {
     fontWeight: "regular",
   }),
   caption: createTypographyVariant(theme, {
-    fontSize: [10, 12],
-    lineHeight: [16, 18],
+    fontSize: [12],
+    lineHeight: [18],
     fontWeight: "regular",
   }),
 });

--- a/e2e/filters.spec.ts
+++ b/e2e/filters.spec.ts
@@ -14,7 +14,7 @@ describe("Filters", () => {
 
     await filters.locator("label").first().waitFor({ timeout: 30_000 });
 
-    const labels = filters.locator("label");
+    const labels = filters.locator("label[for^=select-single-filter]");
 
     const texts = await labels.allTextContents();
     expect(texts).toEqual([
@@ -30,8 +30,9 @@ describe("Filters", () => {
     const productionRegionFilter = selectors.edition.dataFilterInput(
       "1. Production region"
     );
+
     const productionRegionFilterValue = await productionRegionFilter
-      .locator("input")
+      .locator("input[name^=select-single-filter]")
       .inputValue();
     expect(productionRegionFilterValue).toEqual(
       "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/Switzerland"
@@ -40,7 +41,7 @@ describe("Filters", () => {
     const standStructureFilter =
       selectors.edition.dataFilterInput("2. Stand structure");
     const standStructureFilterValue = await standStructureFilter
-      .locator("input")
+      .locator("input[name^=select-single-filter]")
       .inputValue();
 
     // Following expect is broken
@@ -70,7 +71,7 @@ describe("Filters", () => {
 
     await filters.locator("label").first().waitFor({ timeout: 30_000 });
 
-    const labels = filters.locator("label");
+    const labels = filters.locator("label[for^=select-single-filter]");
 
     const texts = await labels.allTextContents();
     expect(texts).toEqual(["1. Jahr der Vergütung"]);

--- a/e2e/tooltip.spec.ts
+++ b/e2e/tooltip.spec.ts
@@ -29,5 +29,5 @@ test("tooltip content", async ({ actions, selectors, within, page }) => {
   const tooltip = page.locator('[data-testid="chart-tooltip"]');
   await tooltip.waitFor();
   const textContent = await tooltip.textContent();
-  expect(textContent).toEqual("1996-5.5605700320583 Mt");
+  expect(textContent).toEqual("1996-5.561 Mt");
 });


### PR DESCRIPTION
This moves the checkbox for "interactive" from the dedicated "interactive filters" section to the data filters and segment settings. The date filters changes will be in another PR.

## How to test

- Go to any dataset
- "Interactive" switches should be inside the "Filters" section on the left
- "Interactive" switch is also available for segments