### PR TITLE
feat: Sort hierarchy by id + add search input

### DIFF
--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -55,7 +55,10 @@ import {
 } from "@/formatters";
 import { TemporalDimension, TimeUnit } from "@/graphql/query-hooks";
 import { getPalette } from "@/palettes";
-import { makeDimensionValueSorters } from "@/utils/sorting-values";
+import {
+  getSortingOrders,
+  makeDimensionValueSorters,
+} from "@/utils/sorting-values";
 
 export interface ColumnsState extends CommonChartState {
   chartType: "column";
@@ -167,7 +170,14 @@ const useColumnsState = (
   const { xScale, yScale, xEntireScale, xScaleInteraction, bandDomain } =
     useMemo(() => {
       // x
-      const bandDomain = [...new Set(preparedData.map(getX))];
+      const sorters = makeDimensionValueSorters(xDimension, {
+        sorting: fields.x.sorting,
+      });
+      const bandDomain = orderBy(
+        [...new Set(preparedData.map(getX))],
+        sorters,
+        getSortingOrders(sorters, fields.x.sorting)
+      );
       const xScale = scaleBand()
         .domain(bandDomain)
         .paddingInner(PADDING_INNER)

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -15,7 +15,7 @@ import {
   OptionGroup,
   Option,
 } from "@/configurator";
-import { hierarchyToOptions, TimeInput } from "@/configurator/components/field";
+import { TimeInput } from "@/configurator/components/field";
 import {
   getTimeIntervalFormattedSelectOptions,
   getTimeIntervalWithProps,
@@ -33,6 +33,7 @@ import {
 } from "@/graphql/query-hooks";
 import { Icon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
+import { hierarchyToOptions } from "@/utils/hierarchy";
 
 export const ChartDataFilters = ({
   dataSet,

--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -43,6 +43,7 @@ import { useBrowseContext } from "@/configurator/components/dataset-browse";
 import { Icon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
 import { MaybeTooltip } from "@/utils/maybe-tooltip";
+import { valueComparator } from "@/utils/sorting-values";
 
 export const Label = ({
   htmlFor,
@@ -248,13 +249,7 @@ const getSelectOptions = (
   const restOptions = options.filter((o) => !o.isNoneValue);
 
   if (sortOptions) {
-    restOptions.sort((a, b) => {
-      if (a.position !== undefined && b.position !== undefined) {
-        return a.position < b.position;
-      } else {
-        return a.label.localeCompare(b.label, locale);
-      }
-    });
+    restOptions.sort(valueComparator(locale));
   }
 
   return [...noneOptions, ...restOptions];

--- a/app/components/select-tree.tsx
+++ b/app/components/select-tree.tsx
@@ -338,9 +338,9 @@ function SelectTree({
     return res;
   }, [options]);
 
-  const handleOpen = useEventCallback((ev: React.MouseEvent<HTMLElement>) => {
+  const handleOpen = useEventCallback(() => {
     setOpenState(true);
-    setMinMenuWidth(ev.currentTarget.clientWidth);
+    setMinMenuWidth(inputRef.current?.clientLeft);
     onOpen?.();
   });
 
@@ -463,7 +463,8 @@ function SelectTree({
   const handleKeyDown: React.HTMLAttributes<HTMLInputElement>["onKeyDown"] =
     useEvent((ev) => {
       if (ev.key === "Enter" || ev.key == " ") {
-        handleOpen(ev);
+        handleOpen();
+        ev.preventDefault();
       }
     });
 
@@ -510,6 +511,7 @@ function SelectTree({
           value={inputValue}
           sx={{ p: 1, width: "100%" }}
           InputProps={{
+            autoFocus: true,
             startAdornment: <Icon name="search" size={16} color="#555" />,
             endAdornment: (
               <IconButton size="small" onClick={handleClickResetInput}>

--- a/app/components/select-tree.tsx
+++ b/app/components/select-tree.tsx
@@ -247,8 +247,12 @@ const TreeItem = (props: TreeItemProps) => {
   return <MUITreeItem {...props} ContentComponent={TreeItemContent} />;
 };
 
-type TreeHierachyValue = HierarchyValue & {
+type TreeHierachyValue = Omit<
+  HierarchyValue,
+  "depth" | "dimensionIri" | "children"
+> & {
   selectable?: boolean;
+  children?: TreeHierachyValue[];
 };
 
 type Tree = TreeHierachyValue[];
@@ -268,12 +272,12 @@ export type SelectTreeProps = {
   open?: boolean;
 };
 
-const getFilteredOptions = (options: HierarchyValue[], value: string) => {
+const getFilteredOptions = (options: Tree, value: string) => {
   return value === ""
     ? options
-    : pruneTree(options, (d) =>
+    : (pruneTree(options as HierarchyValue[], (d) =>
         d.label.toLowerCase().includes(value.toLowerCase())
-      );
+      ) as Tree);
 };
 
 function SelectTree({
@@ -355,7 +359,9 @@ function SelectTree({
       const newExpanded = Array.from(
         new Set([
           ...curExpanded,
-          ...flattenTree(filteredOptions).map((v) => v.value),
+          ...flattenTree(filteredOptions as HierarchyValue[]).map(
+            (v) => v.value
+          ),
         ])
       );
       return newExpanded;

--- a/app/components/select-tree.tsx
+++ b/app/components/select-tree.tsx
@@ -273,10 +273,12 @@ export type SelectTreeProps = {
 };
 
 const getFilteredOptions = (options: Tree, value: string) => {
+  const rx = new RegExp(`^${value}|\\s${value}`, "i");
   return value === ""
     ? options
-    : (pruneTree(options as HierarchyValue[], (d) =>
-        d.label.toLowerCase().includes(value.toLowerCase())
+    : (pruneTree(
+        options as HierarchyValue[],
+        (d) => !!d.label.match(rx)
       ) as Tree);
 };
 

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -12,6 +12,7 @@ import {
   FormControlLabel,
   FormControlLabelProps,
   Badge,
+  BadgeProps,
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import isEmpty from "lodash/isEmpty";
@@ -493,7 +494,7 @@ const InteractiveDataFilterCheckbox = ({
   );
 };
 
-const FiltersBadge = () => {
+const FiltersBadge = ({ sx }: { sx?: BadgeProps["sx"] }) => {
   const ctx = useControlSectionContext();
   const [state] = useConfiguratorState(isConfiguring);
   return (
@@ -501,7 +502,7 @@ const FiltersBadge = () => {
       invisible={ctx.isOpen}
       badgeContent={Object.values(state.chartConfig.filters).length}
       color="secondary"
-      sx={{ display: "block", mr: 4 }}
+      sx={{ display: "block", ...sx }}
     />
   );
 };
@@ -576,11 +577,7 @@ export const ChartConfigurator = ({
       {filterDimensions.length === 0 &&
       addableDimensions.length === 0 ? null : (
         <ControlSection className={classes.filterSection} collapse>
-          <SectionTitle
-            titleId="controls-data"
-            gutterBottom={false}
-            sx={{ justifyContent: "space-between" }}
-          >
+          <SectionTitle titleId="controls-data" gutterBottom={false}>
             <Trans id="controls.section.data.filters">Filters</Trans>{" "}
             {fetching ? (
               <CircularProgress
@@ -588,7 +585,7 @@ export const ChartConfigurator = ({
                 className={classes.loadingIndicator}
               />
             ) : null}
-            <FiltersBadge />
+            <FiltersBadge sx={{ ml: "auto", mr: 4 }} />
           </SectionTitle>
 
           <ControlSectionContent

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -58,14 +58,12 @@ import {
 import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import { truthy } from "@/domain/types";
 import { useTimeFormatLocale } from "@/formatters";
-import {
-  DimensionMetadataFragment,
-  HierarchyValue,
-  TimeUnit,
-} from "@/graphql/query-hooks";
+import { DimensionMetadataFragment, TimeUnit } from "@/graphql/query-hooks";
+import { HierarchyValue } from "@/graphql/resolver-types";
 import SvgIcEdit from "@/icons/components/IcEdit";
 import { useLocale } from "@/locales/use-locale";
 import { getPalette } from "@/palettes";
+import { sortTree } from "@/rdf/tree-utils";
 import { makeDimensionValueSorters } from "@/utils/sorting-values";
 
 import useDisclosure from "./use-disclosure";
@@ -126,7 +124,7 @@ export const hierarchyToOptions = (hierarchy: HierarchyValue[]) => {
           : undefined,
     };
   };
-  return hierarchy.map((h) => transform(h));
+  return sortTree(hierarchy).map((h) => transform(h));
 };
 
 export const OnOffControlTabField = ({

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -23,7 +23,7 @@ import {
   Slider,
   Switch,
 } from "@/components/form";
-import SelectTree, { SelectTreeProps } from "@/components/select-tree";
+import SelectTree from "@/components/select-tree";
 import { ColorPickerMenu } from "@/configurator/components/chart-controls/color-picker";
 import {
   AnnotatorTab,
@@ -63,7 +63,7 @@ import { HierarchyValue } from "@/graphql/resolver-types";
 import SvgIcEdit from "@/icons/components/IcEdit";
 import { useLocale } from "@/locales/use-locale";
 import { getPalette } from "@/palettes";
-import { sortTree } from "@/rdf/tree-utils";
+import { hierarchyToOptions } from "@/utils/hierarchy";
 import { makeDimensionValueSorters } from "@/utils/sorting-values";
 
 import useDisclosure from "./use-disclosure";
@@ -111,20 +111,6 @@ export const ControlTabField = ({
       rightIcon={<FieldEditIcon />}
     />
   );
-};
-
-export const hierarchyToOptions = (hierarchy: HierarchyValue[]) => {
-  const transform = (h: HierarchyValue): SelectTreeProps["options"][number] => {
-    return {
-      ...h,
-      selectable: !!h.hasValue,
-      children:
-        h.children && h.children.length > 0
-          ? h.children.map(transform)
-          : undefined,
-    };
-  };
-  return sortTree(hierarchy).map((h) => transform(h));
 };
 
 export const OnOffControlTabField = ({

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -76,7 +76,7 @@ import {
   getOptionsFromTree,
   joinParents,
   pruneTree,
-  sortTree,
+  sortHierarchy,
 } from "@/rdf/tree-utils";
 import { valueComparator } from "@/utils/sorting-values";
 import useEvent from "@/utils/use-event";
@@ -224,7 +224,7 @@ const MultiFilterContent = ({
   const classes = useStyles();
 
   const { sortedTree, flatOptions, optionsByValue } = useMemo(() => {
-    const sortedTree = sortTree(tree);
+    const sortedTree = sortHierarchy(tree);
     const flatOptions = getOptionsFromTree(sortedTree);
     const optionsByValue = keyBy(flatOptions, (x) => x.value);
     return {

--- a/app/rdf/tree-utils.ts
+++ b/app/rdf/tree-utils.ts
@@ -175,3 +175,9 @@ export const getOptionsFromTree = (tree: HierarchyValue[]) => {
 export const joinParents = (parents?: HierarchyValue[]) => {
   return parents?.map((x) => x.label).join(" > ") || "";
 };
+
+export const flattenTree = (tree: HierarchyValue[]) => {
+  const res: HierarchyValue[] = [];
+  dfs(tree, (x) => res.push(x));
+  return res;
+};

--- a/app/rdf/tree-utils.ts
+++ b/app/rdf/tree-utils.ts
@@ -4,11 +4,11 @@ import sortBy from "lodash/sortBy";
 import { HierarchyValue } from "@/graphql/resolver-types";
 import { dfs } from "@/utils/dfs";
 
-export const mapTree = (
-  tree: HierarchyValue[],
-  cb: (h: HierarchyValue) => HierarchyValue
+export const mapTree = <T extends { children?: T[] | null }>(
+  tree: T[],
+  cb: (h: T) => T
 ) => {
-  return tree.map((t): HierarchyValue => {
+  return tree.map((t): T => {
     return {
       ...cb(t),
       children: t.children ? mapTree(t.children, cb) : undefined,
@@ -16,26 +16,12 @@ export const mapTree = (
   });
 };
 
-/** Sorts the tree by default chain of sorters (position -> identifier -> label). */
-export const sortTree = (tree: HierarchyValue[]): HierarchyValue[] => {
-  const sortedTree = orderBy(
-    tree,
-    ["depth", "position", "identifier", "label"],
-    ["desc", "asc", "asc", "asc"]
-  ) as HierarchyValue[];
-
-  return sortedTree.map((d) => ({
-    ...d,
-    children: d.children ? sortTree(d.children) : undefined,
-  }));
-};
-
-const filterTreeHelper = (
-  tree: HierarchyValue[],
-  predicate: (h: HierarchyValue) => boolean
+const filterTreeHelper = <T extends { children?: T[] | null }>(
+  tree: T[],
+  predicate: (h: T) => boolean
 ) => {
   return tree
-    .map((t): HierarchyValue => {
+    .map((t): T => {
       return {
         ...t,
         children: t.children
@@ -50,11 +36,11 @@ const filterTreeHelper = (
  * Given a tree and a list of nodes, will remove any parent/onde that do not contain
  * at least of the provided nodes in their descendant
  */
-export const pruneTree = (
-  tree: HierarchyValue[],
-  predicate: (v: HierarchyValue) => boolean
-): HierarchyValue[] => {
-  const isUsed = (v: HierarchyValue): boolean => {
+export const pruneTree = <T extends { children?: T[] | null }>(
+  tree: T[],
+  predicate: (v: T) => boolean
+): T[] => {
+  const isUsed = (v: T): boolean => {
     if (predicate(v)) {
       return true;
     } else if (v.children) {
@@ -67,45 +53,19 @@ export const pruneTree = (
 };
 
 type Value = string;
-type CheckboxState = "checked" | "unchecked" | "indeterminate";
-type CheckboxStateMap = Map<string, CheckboxState>;
 
-/**
- * Given a list of checked values and a hierarchy for these values,
- * returns a map from node id to its state "checked" / "unchecked" / "indeterminate".
- *
- * A node is considered "underterminate" when some of its descendants are "checked"
- * and it is not "checked".
- */
-export const getCheckboxStates = (
-  tree: HierarchyValue[],
-  checkedValues: Set<Value>
-): CheckboxStateMap => {
-  const res = new Map<string, CheckboxState>();
-  const collect = (node: HierarchyValue): boolean => {
-    let checked = false;
-    if (checkedValues.has(node.value)) {
-      res.set(node.value, "checked");
-      checked = true;
-    }
+/** Sorts the tree by default chain of sorters (position -> identifier -> label). */
+export const sortHierarchy = (tree: HierarchyValue[]): HierarchyValue[] => {
+  const sortedTree = orderBy(
+    tree,
+    ["depth", "position", "identifier", "label"],
+    ["desc", "asc", "asc", "asc"]
+  ) as HierarchyValue[];
 
-    if (node.children && node.children.length > 0) {
-      for (let c of node.children) {
-        const childrenHasBeenChecked = collect(c);
-        checked = checked || childrenHasBeenChecked;
-      }
-    }
-
-    const val = res.get(node.value);
-    if (val !== "checked") {
-      res.set(node.value, checked ? "indeterminate" : "unchecked");
-    }
-    return checked;
-  };
-  for (let root of tree) {
-    collect(root);
-  }
-  return res;
+  return sortedTree.map((d) => ({
+    ...d,
+    children: d.children ? sortHierarchy(d.children) : undefined,
+  }));
 };
 
 /**

--- a/app/utils/hierarchy.ts
+++ b/app/utils/hierarchy.ts
@@ -4,7 +4,7 @@ import { SelectTreeProps } from "@/components/select-tree";
 import { OptionGroup, Option } from "@/configurator";
 import { HierarchyParents } from "@/configurator/components/use-hierarchy-parents";
 import { HierarchyValue } from "@/graphql/resolver-types";
-import { sortTree } from "@/rdf/tree-utils";
+import { sortHierarchy } from "@/rdf/tree-utils";
 
 const asGroup = (
   parents: Omit<HierarchyValue, "depth" | "__typename" | "children">[]
@@ -43,5 +43,5 @@ export const hierarchyToOptions = (hierarchy: HierarchyValue[]) => {
           : undefined,
     };
   };
-  return sortTree(hierarchy).map((h) => transform(h));
+  return sortHierarchy(hierarchy).map((h) => transform(h));
 };

--- a/app/utils/hierarchy.ts
+++ b/app/utils/hierarchy.ts
@@ -1,8 +1,10 @@
 import { ascending } from "d3";
 
+import { SelectTreeProps } from "@/components/select-tree";
 import { OptionGroup, Option } from "@/configurator";
 import { HierarchyParents } from "@/configurator/components/use-hierarchy-parents";
-import { HierarchyValue } from "@/graphql/query-hooks";
+import { HierarchyValue } from "@/graphql/resolver-types";
+import { sortTree } from "@/rdf/tree-utils";
 
 const asGroup = (
   parents: Omit<HierarchyValue, "depth" | "__typename" | "children">[]
@@ -28,4 +30,18 @@ export const makeOptionGroups = (
         ]
     )
     .sort((a, b) => ascending(a[1][0].depth, b[1][0].depth));
+};
+
+export const hierarchyToOptions = (hierarchy: HierarchyValue[]) => {
+  const transform = (h: HierarchyValue): SelectTreeProps["options"][number] => {
+    return {
+      ...h,
+      selectable: !!h.hasValue,
+      children:
+        h.children && h.children.length > 0
+          ? h.children.map(transform)
+          : undefined,
+    };
+  };
+  return sortTree(hierarchy).map((h) => transform(h));
 };

--- a/app/utils/sorting-values.ts
+++ b/app/utils/sorting-values.ts
@@ -92,10 +92,13 @@ export const makeDimensionValueSorters = (
 interface Value {
   label: string;
   position?: number;
+  identifier?: number;
 }
 
 export const valueComparator = (locale: string) => (a: Value, b: Value) => {
-  if (a.position !== undefined && b.position !== undefined) {
+  if (a.identifier !== undefined && b.identifier !== undefined) {
+    return a.identifier < b.identifier ? -1 : 1;
+  } else if (a.position !== undefined && b.position !== undefined) {
     return a.position < b.position ? -1 : 1;
   } else {
     return a.label.localeCompare(b.label, locale);


### PR DESCRIPTION
Hierarchies inside filters are sorted by identifier.
A search input helps navigate a value inside a large hierarchy.

## How to test

Open a dataset with a hierarchy ([bathing water with hierarchy](https://visualization-tool-git-feat-tree-sort-search-ixt1.vercel.app/en/browse?previous=%7B%22includeDrafts%22%3Atrue%2C%22order%22%3A%22SCORE%22%2C%22search%22%3A%22bathing+water%22%7D&dataset=https%3A%2F%2Fenvironment.ld.admin.ch%2Ffoen%2Fubd0104%2F11&dataSource=Int), [photovoltaik](https://visualization-tool-git-feat-tree-sort-search-ixt1.vercel.app/en/browse?previous=%7B%22includeDrafts%22%3Atrue%2C%22order%22%3A%22SCORE%22%2C%22search%22%3A%22photovoltaik%22%7D&dataset=https%3A%2F%2Fenergy.ld.admin.ch%2Fsfoe%2Fbfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen%2F13&dataSource=Int), [gas emissions](https://visualization-tool-git-feat-tree-sort-search-ixt1.vercel.app/en/browse?previous=%7B%22includeDrafts%22%3Atrue%2C%22order%22%3A%22SCORE%22%2C%22search%22%3A%22emissions%22%7D&dataset=https%3A%2F%2Fenvironment.ld.admin.ch%2Ffoen%2Fubd000502_sad_01%2F7&dataSource=Int) )
In the left filters, inside the tree, values should be sorted by id (zurich at the top)
You can search inside the tree via the search box

Fix https://github.com/visualize-admin/visualization-tool/issues/840 (search input inside select tree)
Fix https://github.com/visualize-admin/visualization-tool/issues/909
Fix https://github.com/visualize-admin/visualization-tool/issues/907 (order by id inside filters)
Fix https://github.com/visualize-admin/visualization-tool/issues/904 (order by id inside filters)