### PR TITLE
feat: Use abbreviations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 ## Unreleased
 
 - Metadata is now shown in a dedicated panel that can be reached both from editor & published mode
+- It's now possible to use abbreviations in color segmentations and X fields for dimension values with schema:alternateName properties
 
 ## [3.15.0] - 2022-11-29
 

--- a/app/charts/chart-config-ui-options.ts
+++ b/app/charts/chart-config-ui-options.ts
@@ -22,11 +22,13 @@ export type EncodingOption =
       type: "component";
       optional: boolean;
       componentTypes: ComponentType[];
+      enableUseAbbreviations: boolean;
     }
   | { field: "imputationType" }
   | { field: "showStandardError" }
   | { field: "sorting" }
-  | { field: "size"; componentTypes: ComponentType[]; optional: boolean };
+  | { field: "size"; componentTypes: ComponentType[]; optional: boolean }
+  | { field: "useAbbreviations" };
 
 /**
  * @todo
@@ -120,6 +122,7 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
         options: [
           { field: "color", type: "palette" },
           { field: "imputationType" },
+          { field: "useAbbreviations" },
         ],
       },
     ],
@@ -151,6 +154,7 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
           { sortingType: "byMeasure", sortingOrder: ["asc", "desc"] },
           { sortingType: "byDimensionLabel", sortingOrder: ["asc", "desc"] },
         ],
+        options: [{ field: "useAbbreviations" }],
       },
       {
         field: "segment",
@@ -161,6 +165,7 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
         options: [
           { field: "chartSubType" },
           { field: "color", type: "palette" },
+          { field: "useAbbreviations" },
         ],
       },
     ],
@@ -187,7 +192,10 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
         componentTypes: SEGMENT_COMPONENT_TYPES,
         filters: true,
         sorting: LINE_SEGMENT_SORTING,
-        options: [{ field: "color", type: "palette" }],
+        options: [
+          { field: "color", type: "palette" },
+          { field: "useAbbreviations" },
+        ],
       },
     ],
     interactiveFilters: ["legend", "timeRange"],
@@ -214,6 +222,7 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
             type: "component",
             componentTypes: ["NumericalMeasure", "OrdinalMeasure"],
             optional: false,
+            enableUseAbbreviations: true,
           },
         ],
       },
@@ -241,6 +250,7 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
               "OrdinalDimension",
             ],
             optional: true,
+            enableUseAbbreviations: true,
           },
         ],
       },
@@ -262,7 +272,10 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
         componentTypes: SEGMENT_COMPONENT_TYPES,
         filters: true,
         sorting: PIE_SEGMENT_SORTING,
-        options: [{ field: "color", type: "palette" }],
+        options: [
+          { field: "color", type: "palette" },
+          { field: "useAbbreviations" },
+        ],
       },
     ],
     interactiveFilters: ["legend"],
@@ -293,6 +306,7 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
     interactiveFilters: ["legend"],
   },
   table: {
+    // TODO: Add abbreviations here.
     chartType: "table",
     encodings: [],
     interactiveFilters: [],

--- a/app/charts/chart-config-ui-options.ts
+++ b/app/charts/chart-config-ui-options.ts
@@ -300,7 +300,10 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
         optional: true,
         componentTypes: SEGMENT_COMPONENT_TYPES,
         filters: true,
-        options: [{ field: "color", type: "palette" }],
+        options: [
+          { field: "color", type: "palette" },
+          { field: "useAbbreviations" },
+        ],
       },
     ],
     interactiveFilters: ["legend"],

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -16,9 +16,8 @@ import {
   sum,
 } from "d3";
 import get from "lodash/get";
-import keyBy from "lodash/keyBy";
 import orderBy from "lodash/orderBy";
-import React, { ReactNode, useCallback, useMemo } from "react";
+import React, { ReactNode, useMemo } from "react";
 
 import {
   BOTTOM_MARGIN_OFFSET,
@@ -32,13 +31,13 @@ import {
   useDataAfterInteractiveFilters,
   useOptionalNumericVariable,
   usePlottableData,
-  useSegment,
   useStringVariable,
   useTemporalVariable,
 } from "@/charts/shared/chart-helpers";
 import { CommonChartState } from "@/charts/shared/chart-state";
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
 import { useChartPadding } from "@/charts/shared/padding";
+import { useMaybeAbbreviations } from "@/charts/shared/use-abbreviations";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
@@ -49,7 +48,11 @@ import {
   useErrorMeasure,
   useErrorRange,
 } from "@/configurator/components/ui-helpers";
-import { isTemporalDimension, Observation } from "@/domain/data";
+import {
+  DimensionValue,
+  isTemporalDimension,
+  Observation,
+} from "@/domain/data";
 import { useFormatNumber, formatNumberWithUnit } from "@/formatters";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 import { getPalette } from "@/palettes";
@@ -117,27 +120,27 @@ const useGroupedColumnsState = (
   const getY = useOptionalNumericVariable(fields.y.componentIri);
   const errorMeasure = useErrorMeasure(chartProps, fields.y.componentIri);
   const getYErrorRange = useErrorRange(errorMeasure, getY);
-  const getSegment = useSegment(fields.segment?.componentIri);
+
+  const segmentDimension = dimensions.find(
+    (d) => d.iri === fields.segment?.componentIri
+  );
+
+  const {
+    getAbbreviationOrLabelByValue: getSegment,
+    getLabelByAbbreviation: getSegmentLabel,
+    abbreviationOrLabelLookup: segmentsByAbbreviationOrLabel,
+  } = useMaybeAbbreviations({
+    useAbbreviations: fields.segment?.useAbbreviations ?? false,
+    dimension: segmentDimension,
+  });
+
+  const segmentsByValue = useMemo(() => {
+    const values = (segmentDimension?.values || []) as DimensionValue[];
+
+    return new Map(values.map((d) => [d.value, d]));
+  }, [segmentDimension?.values]);
 
   const showStandardError = get(fields, ["y", "showStandardError"], true);
-
-  const { segmentValuesByValue } = useMemo(() => {
-    const segmentDimension = dimensions.find(
-      (d) => d.iri === fields.segment?.componentIri
-    ) || { values: [] };
-    return {
-      segmentValuesByValue: keyBy(segmentDimension.values, (x) => x.value),
-      segmentValuesByLabel: keyBy(segmentDimension.values, (x) => x.label),
-    };
-  }, [dimensions, fields.segment?.componentIri]);
-
-  /** When segment values are IRIs, we need to find show the label */
-  const getSegmentLabel = useCallback(
-    (segment: string): string => {
-      return segmentValuesByValue[segment]?.label || segment;
-    },
-    [segmentValuesByValue]
-  );
 
   // Sort
   const xSorting = fields.x.sorting;
@@ -191,22 +194,20 @@ const useGroupedColumnsState = (
     const uniqueSegments = Array.from(
       new Set(plottableSortedData.map((d) => getSegment(d)))
     );
-    const dimension = dimensions.find(
-      (d) => d.iri === fields.segment?.componentIri
-    );
 
     const sorting = fields?.segment?.sorting;
-    const sorters = makeDimensionValueSorters(dimension, {
+    const sorters = makeDimensionValueSorters(segmentDimension, {
       sorting,
       sumsBySegment,
+      useAbbreviations: fields.segment?.useAbbreviations,
     });
 
     return orderBy(uniqueSegments, sorters, getSortingOrders(sorters, sorting));
   }, [
     plottableSortedData,
-    dimensions,
+    segmentDimension,
     fields.segment?.sorting,
-    fields.segment?.componentIri,
+    fields.segment?.useAbbreviations,
     sumsBySegment,
     getSegment,
   ]);
@@ -228,10 +229,10 @@ const useGroupedColumnsState = (
 
     if (fields.segment && segmentDimension && fields.segment.colorMapping) {
       const orderedSegmentLabelsAndColors = segments.map((segment) => {
-        const dvIri = segmentDimension.values.find(
-          (s: { label: string; value: string }) =>
-            s.label === segment || s.value === segment
-        ).value;
+        const dvIri =
+          segmentsByAbbreviationOrLabel.get(segment)?.value ||
+          segmentsByValue.get(segment)?.value ||
+          "";
 
         return {
           label: segment,
@@ -299,6 +300,8 @@ const useGroupedColumnsState = (
     fields.segment,
     preparedData,
     segments,
+    segmentsByAbbreviationOrLabel,
+    segmentsByValue,
     plottableSortedData,
     getX,
     getXAsDate,

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -31,7 +31,6 @@ import {
   useDataAfterInteractiveFilters,
   useOptionalNumericVariable,
   usePlottableData,
-  useStringVariable,
   useTemporalVariable,
 } from "@/charts/shared/chart-helpers";
 import { CommonChartState } from "@/charts/shared/chart-state";
@@ -115,7 +114,11 @@ const useGroupedColumnsState = (
 
   const xIsTime = isTemporalDimension(xDimension);
 
-  const getX = useStringVariable(fields.x.componentIri);
+  const { getAbbreviationOrLabelByValue: getX } = useMaybeAbbreviations({
+    useAbbreviations: fields.x.useAbbreviations ?? false,
+    dimension: xDimension,
+  });
+
   const getXAsDate = useTemporalVariable(fields.x.componentIri);
   const getY = useOptionalNumericVariable(fields.y.componentIri);
   const errorMeasure = useErrorMeasure(chartProps, fields.y.componentIri);

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -36,7 +36,6 @@ import {
   useDataAfterInteractiveFilters,
   useOptionalNumericVariable,
   usePlottableData,
-  useStringVariable,
   useTemporalVariable,
 } from "@/charts/shared/chart-helpers";
 import { CommonChartState } from "@/charts/shared/chart-state";
@@ -107,19 +106,23 @@ const useColumnsStackedState = (
   const width = useWidth();
   const formatNumber = useFormatNumber({ decimals: "auto" });
 
-  const xDimension = dimensions.find((d) => d.iri === fields.x.componentIri);
+  const xKey = fields.x.componentIri;
+
+  const xDimension = dimensions.find((d) => d.iri === xKey);
 
   if (!xDimension) {
-    throw Error(`No dimension <${fields.x.componentIri}> in cube!`);
+    throw Error(`No dimension <${xKey}> in cube!`);
   }
 
   const xIsTime = isTemporalDimension(xDimension);
 
-  const getX = useStringVariable(fields.x.componentIri);
-  const getXAsDate = useTemporalVariable(fields.x.componentIri);
-  const getY = useOptionalNumericVariable(fields.y.componentIri);
+  const { getAbbreviationOrLabelByValue: getX } = useMaybeAbbreviations({
+    useAbbreviations: fields.x.useAbbreviations ?? false,
+    dimension: xDimension,
+  });
 
-  const xKey = fields.x.componentIri;
+  const getXAsDate = useTemporalVariable(xKey);
+  const getY = useOptionalNumericVariable(fields.y.componentIri);
 
   const segmentDimension = dimensions.find(
     (d) => d.iri === fields.segment?.componentIri

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -223,6 +223,8 @@ const useColumnsState = (
       getYErrorRange,
       plottableSortedData,
       preparedData,
+      fields.x.sorting,
+      xDimension,
     ]);
 
   const yMeasure = measures.find((d) => d.iri === fields.y.componentIri);

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -30,12 +30,12 @@ import {
   useOptionalNumericVariable,
   usePlottableData,
   useSegment,
-  useStringVariable,
   useTemporalVariable,
 } from "@/charts/shared/chart-helpers";
 import { CommonChartState } from "@/charts/shared/chart-state";
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
 import { useChartPadding } from "@/charts/shared/padding";
+import { useMaybeAbbreviations } from "@/charts/shared/use-abbreviations";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
@@ -123,7 +123,11 @@ const useColumnsState = (
     ? (xDimension as TemporalDimension).timeUnit
     : undefined;
 
-  const getX = useStringVariable(fields.x.componentIri);
+  const { getAbbreviationOrLabelByValue: getX } = useMaybeAbbreviations({
+    useAbbreviations: fields.x.useAbbreviations ?? false,
+    dimension: xDimension,
+  });
+
   const getXAsDate = useTemporalVariable(fields.x.componentIri);
   const getY = useOptionalNumericVariable(fields.y.componentIri);
   const errorMeasure = useErrorMeasure(chartProps, fields.y.componentIri);
@@ -176,6 +180,7 @@ const useColumnsState = (
       // x
       const sorters = makeDimensionValueSorters(xDimension, {
         sorting: fields.x.sorting,
+        useAbbreviations: fields.x.useAbbreviations,
       });
       const bandDomain = orderBy(
         [...new Set(preparedData.map(getX))],
@@ -224,6 +229,7 @@ const useColumnsState = (
       plottableSortedData,
       preparedData,
       fields.x.sorting,
+      fields.x.useAbbreviations,
       xDimension,
     ]);
 

--- a/app/charts/map/map-legend.tsx
+++ b/app/charts/map/map-legend.tsx
@@ -198,6 +198,7 @@ export const MapLegend = () => {
         <MapLegendColor
           component={areaLayer.colors.component}
           getColor={areaLayer.colors.getColor}
+          useAbbreviations={areaLayer.colors.useAbbreviations}
         />
       )}
 
@@ -207,6 +208,7 @@ export const MapLegend = () => {
           <MapLegendColor
             component={symbolLayer.colors.component}
             getColor={symbolLayer.colors.getColor}
+            useAbbreviations={symbolLayer.colors.useAbbreviations}
           />
         )}
     </Box>

--- a/app/charts/map/map-tooltip.tsx
+++ b/app/charts/map/map-tooltip.tsx
@@ -140,7 +140,7 @@ export const MapTooltip = () => {
           preparedColors = {
             type: "categorical" as "categorical",
             component: colors.component,
-            value: obs[colors.component.iri] as string,
+            value: colors.getValue(obs),
             error: null,
             color,
             textColor,

--- a/app/charts/shared/axis-width-band.tsx
+++ b/app/charts/shared/axis-width-band.tsx
@@ -34,7 +34,7 @@ export const AxisWidthBand = () => {
     const fontSize =
       xScale.bandwidth() > labelFontSize ? labelFontSize : xScale.bandwidth();
 
-    g.call(axis);
+    g.call(axis).attr("data-testid", "axis-width-band");
 
     g.select(".domain").remove();
     g.selectAll(".tick line").attr(

--- a/app/charts/shared/use-abbreviations.tsx
+++ b/app/charts/shared/use-abbreviations.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+
+import { DimensionValue, Observation } from "@/domain/data";
+import { DimensionMetadataFragment } from "@/graphql/query-hooks";
+
+export const useMaybeAbbreviations = ({
+  useAbbreviations,
+  dimension,
+}: {
+  useAbbreviations: boolean;
+  dimension: DimensionMetadataFragment | undefined;
+}) => {
+  const { labelLookup, abbreviationOrLabelLookup } = React.useMemo(() => {
+    const values: DimensionValue[] = dimension?.values ?? [];
+
+    const labelLookup = new Map(values.map((d) => [d.label, d]));
+    const abbreviationOrLabelLookup = new Map(
+      Array.from(labelLookup, (d) => [
+        useAbbreviations ? d[1].alternateName ?? d[1].label : d[1].label,
+        d[1],
+      ])
+    );
+
+    return {
+      labelLookup,
+      abbreviationOrLabelLookup,
+    };
+  }, [dimension?.values, useAbbreviations]);
+
+  const getAbbreviationOrLabelByValue = React.useCallback(
+    (d: Observation) => {
+      const v = d[dimension?.iri || ""] as string | undefined;
+
+      if (!v) {
+        return "";
+      }
+
+      const lookedUpValue = labelLookup.get(v);
+
+      return useAbbreviations
+        ? lookedUpValue?.alternateName ?? lookedUpValue?.label ?? ""
+        : v;
+    },
+    [dimension?.iri, labelLookup, useAbbreviations]
+  );
+
+  const getLabelByAbbreviation = React.useCallback(
+    (d: string) => {
+      const v = abbreviationOrLabelLookup.get(d);
+
+      return useAbbreviations ? v?.alternateName ?? v?.label ?? "" : d;
+    },
+    [abbreviationOrLabelLookup, useAbbreviations]
+  );
+
+  return {
+    abbreviationOrLabelLookup,
+    getAbbreviationOrLabelByValue,
+    getLabelByAbbreviation,
+  };
+};

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -423,6 +423,7 @@ const ChartFieldAbbreviations = ({
 
   return (
     <ChartOptionCheckboxField
+      data-testid="use-abbreviations"
       label={getFieldLabel("abbreviations")}
       field={field}
       path={path ? `${path}.useAbbreviations` : "useAbbreviations"}

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -53,7 +53,11 @@ import {
   DimensionValuesMultiFilter,
   TimeFilter,
 } from "@/configurator/components/filters";
-import { getIconName } from "@/configurator/components/ui-helpers";
+import {
+  canUseAbbreviations,
+  getIconName,
+} from "@/configurator/components/ui-helpers";
+import { GenericField } from "@/configurator/config-types";
 import { TableColumnOptions } from "@/configurator/table/table-chart-options";
 import {
   getDimensionsByDimensionType,
@@ -260,14 +264,27 @@ const EncodingOptionsPanel = ({
     otherFieldsIris,
   ]);
 
+  const allDimensions = useMemo(() => {
+    return [...measures, ...dimensions];
+  }, [measures, dimensions]);
+
+  const fieldDimension = useMemo(() => {
+    const encodingIri = (
+      (fields as any)?.[encoding.field] as GenericField | undefined
+    )?.componentIri;
+
+    return allDimensions.find((d) => d.iri === encodingIri);
+  }, [allDimensions, fields, encoding.field]);
+
   const hasStandardError = useMemo(() => {
-    return [...measures, ...dimensions].find((m) =>
-      m.related?.some(
+    return allDimensions.find((d) =>
+      d.related?.some(
         (r) => r.type === "StandardError" && r.iri === component?.iri
       )
     );
-  }, [dimensions, measures, component]);
+  }, [allDimensions, component]);
 
+  // TODO: Add proper types here.
   const optionsByField = useMemo(
     () => keyBy(encoding.options, (enc) => enc.field),
     [encoding]
@@ -295,6 +312,14 @@ const EncodingOptionsPanel = ({
               optional={encoding.optional}
               options={options}
             />
+            {optionsByField["useAbbreviations"] && (
+              <Box mt={3}>
+                <ChartFieldAbbreviations
+                  field={field}
+                  dimension={fieldDimension}
+                />
+              </Box>
+            )}
             {encoding.options && (
               <ChartFieldOptions
                 disabled={!component}
@@ -347,6 +372,9 @@ const EncodingOptionsPanel = ({
             componentTypes={optionsByField["color"].componentTypes}
             dataSetMetadata={metaData}
             optional={optionsByField["color"].optional}
+            enableUseAbbreviations={
+              optionsByField["color"].enableUseAbbreviations
+            }
           />
         )}
       {optionsByField["showStandardError"] && hasStandardError && (
@@ -377,6 +405,29 @@ const EncodingOptionsPanel = ({
         metaData={metaData}
       />
     </div>
+  );
+};
+
+const ChartFieldAbbreviations = ({
+  field,
+  path,
+  dimension,
+}: {
+  field: string;
+  path?: string;
+  dimension: DimensionMetadataFragment | undefined;
+}) => {
+  const disabled = useMemo(() => {
+    return !canUseAbbreviations(dimension);
+  }, [dimension]);
+
+  return (
+    <ChartOptionCheckboxField
+      label={getFieldLabel("abbreviations")}
+      field={field}
+      path={path ? `${path}.useAbbreviations` : "useAbbreviations"}
+      disabled={disabled}
+    />
   );
 };
 
@@ -668,6 +719,7 @@ const ChartFieldColorComponent = ({
   componentTypes,
   dataSetMetadata,
   optional,
+  enableUseAbbreviations,
 }: {
   chartConfig: ChartConfig;
   field: EncodingFieldType;
@@ -675,6 +727,7 @@ const ChartFieldColorComponent = ({
   componentTypes: ComponentType[];
   dataSetMetadata: DataCubeMetadata;
   optional: boolean;
+  enableUseAbbreviations: boolean;
 }) => {
   const nbOptions = component.values.length;
   const measuresOptions = useMemo(() => {
@@ -735,6 +788,15 @@ const ChartFieldColorComponent = ({
           options={measuresOptions}
           isOptional={optional}
         />
+        {enableUseAbbreviations && (
+          <Box sx={{ mt: 1 }}>
+            <ChartFieldAbbreviations
+              field={field}
+              path="color"
+              dimension={colorComponent}
+            />
+          </Box>
+        )}
 
         {colorType === "fixed" ? (
           <>

--- a/app/configurator/components/field-i18n.ts
+++ b/app/configurator/components/field-i18n.ts
@@ -84,6 +84,10 @@ const fieldLabels = {
     id: "controls.sorting.byMeasure.descending",
     message: "9 → 1",
   }),
+  "controls.abbreviations": defineMessage({
+    id: "controls.abbreviations",
+    message: "Use abbreviations",
+  }),
   "controls.imputation": defineMessage({
     id: "controls.imputation",
     message: "Imputation type",
@@ -201,6 +205,8 @@ export function getFieldLabel(field: string): string {
       return i18n._(fieldLabels["controls.sorting.sortBy"]);
     case "imputation":
       return i18n._(fieldLabels["controls.imputation"]);
+    case "abbreviations":
+      return i18n._(fieldLabels["controls.abbreviations"]);
 
     case "bar.stacked.byDimensionLabel.asc":
     case "bar.grouped.byDimensionLabel.asc":

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -700,8 +700,8 @@ export const ChartFieldField = ({
   const { fetching, ...fieldProps } = useChartFieldField({ field });
 
   const noneLabel = t({
-    id: "controls.dimension.none",
-    message: `No dimension selected`,
+    id: "controls.none",
+    message: "None",
   });
 
   const optionalLabel = t({
@@ -872,7 +872,7 @@ export const ChartOptionSelectField = <ValueType extends {} = string>({
     getKey,
   });
   const noneLabel = t({
-    id: "controls.dimension.none",
+    id: "controls.none",
     message: "None",
   });
 

--- a/app/configurator/components/ui-helpers.ts
+++ b/app/configurator/components/ui-helpers.ts
@@ -237,3 +237,26 @@ export const useOrderedTableColumns = (fields: TableFields): TableColumn[] => {
     return getOrderedTableColumns(fields);
   }, [fields]);
 };
+
+export const canUseAbbreviations = (d?: DimensionMetadataFragment): boolean => {
+  if (!d) {
+    return false;
+  }
+
+  switch (d.__typename) {
+    case "GeoCoordinatesDimension":
+    case "GeoShapesDimension":
+    case "NominalDimension":
+    case "OrdinalDimension":
+    case "OrdinalMeasure":
+      break;
+    default:
+      return false;
+  }
+
+  const anyAbbreviationsPresent = !!(d.values as DimensionValue[]).find(
+    (d) => d.alternateName
+  );
+
+  return anyAbbreviationsPresent;
+};

--- a/app/configurator/config-types.ts
+++ b/app/configurator/config-types.ts
@@ -146,16 +146,17 @@ export type SortingType = t.TypeOf<typeof SortingType>;
 const ColorMapping = t.record(t.string, t.string);
 export type ColorMapping = t.TypeOf<typeof ColorMapping>;
 
-const GenericField = t.type({ componentIri: t.string });
+const GenericField = t.intersection([
+  t.type({ componentIri: t.string }),
+  t.partial({ useAbbreviations: t.boolean }),
+]);
 export type GenericField = t.TypeOf<typeof GenericField>;
 
 const GenericFields = t.record(t.string, t.union([GenericField, t.undefined]));
 export type GenericFields = t.TypeOf<typeof GenericFields>;
 
 const GenericSegmentField = t.intersection([
-  t.type({
-    componentIri: t.string,
-  }),
+  GenericField,
   t.type({
     palette: t.string,
   }),
@@ -184,12 +185,7 @@ export type ColumnSegmentField = t.TypeOf<typeof ColumnSegmentField>;
 
 const ColumnFields = t.intersection([
   t.type({
-    x: t.intersection([
-      t.type({
-        componentIri: t.string,
-      }),
-      SortingField,
-    ]),
+    x: t.intersection([GenericField, SortingField]),
     y: GenericField,
   }),
   t.partial({
@@ -454,12 +450,15 @@ const FixedColorField = t.type({
 });
 export type FixedColorField = t.TypeOf<typeof FixedColorField>;
 
-const CategoricalColorField = t.type({
-  type: t.literal("categorical"),
-  componentIri: t.string,
-  palette: t.string,
-  colorMapping: ColorMapping,
-});
+const CategoricalColorField = t.intersection([
+  t.type({
+    type: t.literal("categorical"),
+    componentIri: t.string,
+    palette: t.string,
+    colorMapping: ColorMapping,
+  }),
+  t.partial({ useAbbreviations: t.boolean }),
+]);
 
 export type CategoricalColorField = t.TypeOf<typeof CategoricalColorField>;
 

--- a/app/domain/data.ts
+++ b/app/domain/data.ts
@@ -26,6 +26,7 @@ export type DimensionValue = {
   position?: number;
   color?: string;
   identifier?: string;
+  alternateName?: string;
 };
 
 export type Observation = Record<string, ObservationValue>;

--- a/app/graphql/resolvers/rdf.ts
+++ b/app/graphql/resolvers/rdf.ts
@@ -308,7 +308,6 @@ export const dimensionValues: NonNullable<
   const loader = getDimensionValuesLoader(sparqlClient, loaders, filters);
   const values: Array<DimensionValue> = await loader.load(parent);
 
-  // TODO min max are now just `values` with 2 elements. Handle properly!
   return values.sort((a, b) =>
     ascending(
       a.position ?? a.value ?? undefined,

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -13,32 +13,32 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:691
+#: app/configurator/components/chart-configurator.tsx:695
 msgid "Add filter"
 msgstr "Filter hinzufügen"
 
-#: app/configurator/components/chart-configurator.tsx:664
+#: app/configurator/components/chart-configurator.tsx:668
 msgid "Drag filters to reorganize"
 msgstr "Ziehen Sie die Filter per Drag & Drop, um sie neu zu organisieren"
 
-#: app/configurator/components/chart-configurator.tsx:661
+#: app/configurator/components/chart-configurator.tsx:665
 msgid "Move filter down"
 msgstr "Filter nach unten verschieben"
 
-#: app/configurator/components/chart-configurator.tsx:658
+#: app/configurator/components/chart-configurator.tsx:662
 msgid "Move filter up"
 msgstr "Filter nach oben verschieben"
 
-#: app/components/select-tree.tsx:527
+#: app/components/select-tree.tsx:525
 #: app/configurator/components/dataset-browse.tsx:1046
 msgid "No results"
 msgstr "Kein Ergebnis"
 
-#: app/components/chart-preview.tsx:187
+#: app/components/chart-preview.tsx:184
 msgid "annotation.add.description"
 msgstr "[ Ohne Beschreibung ]"
 
-#: app/components/chart-preview.tsx:149
+#: app/components/chart-preview.tsx:148
 msgid "annotation.add.title"
 msgstr "[ Ohne Titel ]"
 
@@ -54,15 +54,15 @@ msgstr "Kategorien"
 msgid "browse.dataset.create-visualization"
 msgstr "Visualisierung von diesem Datensatz erstellen"
 
-#: app/configurator/components/select-dataset-step.tsx:296
+#: app/configurator/components/select-dataset-step.tsx:298
 msgid "browse.datasets.all-datasets"
 msgstr "Alle Datensätze"
 
-#: app/configurator/components/select-dataset-step.tsx:184
+#: app/configurator/components/select-dataset-step.tsx:186
 msgid "browse.datasets.description"
 msgstr "Erkunden Sie die vom LINDAS Linked Data Service bereitgestellten Datensätze, indem Sie entweder nach Kategorien oder Organisationen filtern oder direkt nach bestimmten Stichworten suchen. Klicken Sie auf einen Datensatz, um detailliertere Informationen zu erhalten und Ihre eigenen Visualisierungen zu erstellen."
 
-#: app/components/metadata-panel.tsx:318
+#: app/components/metadata-panel.tsx:409
 msgid "button.back"
 msgstr "Zurück"
 
@@ -119,17 +119,17 @@ msgstr "Teilen"
 msgid "chart.map.layers.area"
 msgstr "Flächen"
 
-#: app/configurator/components/chart-configurator.tsx:744
-#: app/configurator/components/chart-options-selector.tsx:992
+#: app/configurator/components/chart-configurator.tsx:748
+#: app/configurator/components/chart-options-selector.tsx:1034
 #: app/configurator/components/field-i18n.ts:31
 msgid "chart.map.layers.base"
 msgstr "Kartenanzeige"
 
-#: app/configurator/components/chart-options-selector.tsx:996
+#: app/configurator/components/chart-options-selector.tsx:1038
 msgid "chart.map.layers.base.show"
 msgstr "Weltkarte anzeigen"
 
-#: app/configurator/components/chart-options-selector.tsx:1004
+#: app/configurator/components/chart-options-selector.tsx:1046
 msgid "chart.map.layers.base.view.locked"
 msgstr "Gesperrte Ansicht"
 
@@ -174,6 +174,10 @@ msgstr "Normal"
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Standardeinstellung"
 
+#: app/configurator/components/field-i18n.ts:87
+msgid "controls.abbreviations"
+msgstr "Abkürzungen verwenden"
+
 #: app/configurator/components/chart-annotator.tsx:70
 msgid "controls.annotator.add-description-warning"
 msgstr "Fügen Sie eine Beschreibung hinzu"
@@ -190,39 +194,39 @@ msgstr "Horizontale Achse"
 msgid "controls.axis.vertical"
 msgstr "Vertikale Achse"
 
-#: app/configurator/components/field-i18n.ts:115
+#: app/configurator/components/field-i18n.ts:119
 msgid "controls.chart.type.area"
 msgstr "Flächen"
 
-#: app/configurator/components/field-i18n.ts:107
+#: app/configurator/components/field-i18n.ts:111
 msgid "controls.chart.type.bar"
 msgstr "Balken"
 
-#: app/configurator/components/field-i18n.ts:103
+#: app/configurator/components/field-i18n.ts:107
 msgid "controls.chart.type.column"
 msgstr "Säulen"
 
-#: app/configurator/components/field-i18n.ts:111
+#: app/configurator/components/field-i18n.ts:115
 msgid "controls.chart.type.line"
 msgstr "Linien"
 
-#: app/configurator/components/field-i18n.ts:131
+#: app/configurator/components/field-i18n.ts:135
 msgid "controls.chart.type.map"
 msgstr "Karte"
 
-#: app/configurator/components/field-i18n.ts:123
+#: app/configurator/components/field-i18n.ts:127
 msgid "controls.chart.type.pie"
 msgstr "Kreis"
 
-#: app/configurator/components/field-i18n.ts:119
+#: app/configurator/components/field-i18n.ts:123
 msgid "controls.chart.type.scatterplot"
 msgstr "Scatterplot"
 
-#: app/configurator/components/field-i18n.ts:127
+#: app/configurator/components/field-i18n.ts:131
 msgid "controls.chart.type.table"
 msgstr "Tabelle"
 
-#: app/configurator/components/chart-options-selector.tsx:723
+#: app/configurator/components/chart-options-selector.tsx:765
 #: app/configurator/components/field-i18n.ts:17
 msgid "controls.color"
 msgstr "Farbe"
@@ -231,7 +235,7 @@ msgstr "Farbe"
 msgid "controls.color.add"
 msgstr "Hinzufügen …"
 
-#: app/configurator/components/chart-options-selector.tsx:752
+#: app/configurator/components/chart-options-selector.tsx:794
 msgid "controls.color.opacity"
 msgstr "Transparenz"
 
@@ -252,35 +256,35 @@ msgstr "Farbpalette zurücksetzen"
 msgid "controls.color.palette.sequential"
 msgstr "Sequentiell"
 
-#: app/configurator/components/chart-options-selector.tsx:839
+#: app/configurator/components/chart-options-selector.tsx:881
 msgid "controls.color.scale.discretization.jenks"
 msgstr "Jenks (Natural Breaks)"
 
-#: app/configurator/components/chart-options-selector.tsx:832
+#: app/configurator/components/chart-options-selector.tsx:874
 msgid "controls.color.scale.discretization.quantiles"
 msgstr "Quantile (gleiche Anzahl Werte)"
 
-#: app/configurator/components/chart-options-selector.tsx:825
+#: app/configurator/components/chart-options-selector.tsx:867
 msgid "controls.color.scale.discretization.quantize"
 msgstr "Quantisierung (gleiche Wertebereiche)"
 
-#: app/configurator/components/chart-options-selector.tsx:817
+#: app/configurator/components/chart-options-selector.tsx:859
 msgid "controls.color.scale.interpolation"
 msgstr "Interpolation"
 
-#: app/configurator/components/chart-options-selector.tsx:849
+#: app/configurator/components/chart-options-selector.tsx:891
 msgid "controls.color.scale.number.of.classes"
 msgstr "Anzahl Klassen"
 
-#: app/configurator/components/chart-options-selector.tsx:789
+#: app/configurator/components/chart-options-selector.tsx:831
 msgid "controls.color.scale.type.continuous"
 msgstr "Kontinuierlich"
 
-#: app/configurator/components/chart-options-selector.tsx:800
+#: app/configurator/components/chart-options-selector.tsx:842
 msgid "controls.color.scale.type.discrete"
 msgstr "Diskret"
 
-#: app/configurator/components/chart-options-selector.tsx:742
+#: app/configurator/components/chart-options-selector.tsx:784
 msgid "controls.color.select"
 msgstr "Farbe auswählen"
 
@@ -300,8 +304,8 @@ msgstr "Gestapelt"
 msgid "controls.description"
 msgstr "Beschreibung hinzufügen"
 
-#: app/charts/shared/chart-data-filters.tsx:247
-#: app/charts/shared/chart-data-filters.tsx:291
+#: app/charts/shared/chart-data-filters.tsx:249
+#: app/charts/shared/chart-data-filters.tsx:296
 msgid "controls.dimensionvalue.none"
 msgstr "Kein Filter"
 
@@ -317,12 +321,12 @@ msgstr "Alle auswählen"
 msgid "controls.filter.select.none"
 msgstr "Alle abwählen"
 
-#: app/configurator/components/chart-configurator.tsx:506
+#: app/configurator/components/chart-configurator.tsx:510
 #: app/configurator/components/filters.tsx:366
 msgid "controls.filters.interactive.toggle"
 msgstr "Interaktiv"
 
-#: app/configurator/components/chart-configurator.tsx:499
+#: app/configurator/components/chart-configurator.tsx:503
 #: app/configurator/components/filters.tsx:360
 msgid "controls.filters.interactive.tooltip"
 msgstr "Erlauben Sie Benutzern, Filter zu ändern"
@@ -347,23 +351,23 @@ msgstr "Zeitspanne"
 msgid "controls.groups.empty-help"
 msgstr "Ziehen Sie Spalten hierher, um Gruppen zu erstellen."
 
-#: app/configurator/components/field-i18n.ts:87
+#: app/configurator/components/field-i18n.ts:91
 msgid "controls.imputation"
 msgstr "Imputationstyp"
 
-#: app/configurator/components/chart-options-selector.tsx:884
-#: app/configurator/components/field-i18n.ts:99
+#: app/configurator/components/chart-options-selector.tsx:926
+#: app/configurator/components/field-i18n.ts:103
 msgid "controls.imputation.type.linear"
 msgstr "Lineare Interpolation"
 
-#: app/configurator/components/chart-options-selector.tsx:877
-#: app/configurator/components/chart-options-selector.tsx:889
-#: app/configurator/components/field-i18n.ts:91
+#: app/configurator/components/chart-options-selector.tsx:919
+#: app/configurator/components/chart-options-selector.tsx:931
+#: app/configurator/components/field-i18n.ts:95
 msgid "controls.imputation.type.none"
 msgstr "-"
 
-#: app/configurator/components/chart-options-selector.tsx:879
-#: app/configurator/components/field-i18n.ts:95
+#: app/configurator/components/chart-options-selector.tsx:921
+#: app/configurator/components/field-i18n.ts:99
 msgid "controls.imputation.type.zeros"
 msgstr "Nullen"
 
@@ -380,19 +384,19 @@ msgstr "Keine Zeitdimension verfügbar!"
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Zeitfilter anzeigen"
 
-#: app/configurator/components/field-i18n.ts:135
+#: app/configurator/components/field-i18n.ts:139
 msgid "controls.language.english"
 msgstr "Englisch"
 
-#: app/configurator/components/field-i18n.ts:143
+#: app/configurator/components/field-i18n.ts:147
 msgid "controls.language.french"
 msgstr "Französisch"
 
-#: app/configurator/components/field-i18n.ts:139
+#: app/configurator/components/field-i18n.ts:143
 msgid "controls.language.german"
 msgstr "Deutsch"
 
-#: app/configurator/components/field-i18n.ts:147
+#: app/configurator/components/field-i18n.ts:151
 msgid "controls.language.italian"
 msgstr "Italienisch"
 
@@ -400,16 +404,16 @@ msgstr "Italienisch"
 msgid "controls.measure"
 msgstr "Messwert"
 
-#: app/components/metadata-panel.tsx:251
-#: app/components/metadata-panel.tsx:263
+#: app/components/metadata-panel.tsx:342
+#: app/components/metadata-panel.tsx:354
 msgid "controls.metadata-panel.metadata"
 msgstr "Metadata"
 
-#: app/components/metadata-panel.tsx:231
+#: app/components/metadata-panel.tsx:310
 msgid "controls.metadata-panel.section.data"
 msgstr "Daten"
 
-#: app/components/metadata-panel.tsx:221
+#: app/components/metadata-panel.tsx:300
 msgid "controls.metadata-panel.section.general"
 msgstr "Allgemeines"
 
@@ -433,19 +437,19 @@ msgstr "Ein"
 msgid "controls.option.isNotActive"
 msgstr "Aus"
 
-#: app/configurator/components/chart-options-selector.tsx:782
+#: app/configurator/components/chart-options-selector.tsx:824
 msgid "controls.scale.type"
 msgstr "Skalierungstyp"
 
-#: app/components/form.tsx:625
+#: app/components/form.tsx:611
 msgid "controls.search.clear"
 msgstr "Suche zurücksetzen"
 
-#: app/configurator/components/chart-options-selector.tsx:355
+#: app/configurator/components/chart-options-selector.tsx:378
 msgid "controls.section.additional-information"
 msgstr "Zusätzliche Informationen"
 
-#: app/configurator/components/chart-configurator.tsx:580
+#: app/configurator/components/chart-configurator.tsx:584
 msgid "controls.section.chart.options"
 msgstr "Diagramm-Einstellungen"
 
@@ -457,7 +461,7 @@ msgstr "Spalten"
 msgid "controls.section.columnstyle"
 msgstr "Spaltenstil"
 
-#: app/configurator/components/chart-configurator.tsx:598
+#: app/configurator/components/chart-configurator.tsx:602
 msgid "controls.section.data.filters"
 msgstr "Filter"
 
@@ -465,8 +469,8 @@ msgstr "Filter"
 msgid "controls.section.description"
 msgstr "Titel & Beschreibung"
 
-#: app/configurator/components/chart-options-selector.tsx:414
-#: app/configurator/components/chart-options-selector.tsx:418
+#: app/configurator/components/chart-options-selector.tsx:456
+#: app/configurator/components/chart-options-selector.tsx:460
 #: app/configurator/table/table-chart-options.tsx:319
 #: app/configurator/table/table-chart-options.tsx:323
 #: app/configurator/table/table-chart-options.tsx:343
@@ -478,11 +482,11 @@ msgstr "Filter"
 msgid "controls.section.groups"
 msgstr "Gruppierungen"
 
-#: app/configurator/components/chart-options-selector.tsx:918
+#: app/configurator/components/chart-options-selector.tsx:960
 msgid "controls.section.imputation"
 msgstr "Fehlende Werte"
 
-#: app/configurator/components/chart-options-selector.tsx:923
+#: app/configurator/components/chart-options-selector.tsx:965
 msgid "controls.section.imputation.explanation"
 msgstr "Für diesen Diagrammtyp sollten fehlenden Werten Ersatzwerte zugewiesen werden. Entscheiden Sie sich für die Imputationslogik oder wechseln Sie zu einem anderen Diagrammtyp."
 
@@ -491,11 +495,11 @@ msgstr "Für diesen Diagrammtyp sollten fehlenden Werten Ersatzwerte zugewiesen 
 msgid "controls.section.interactive.filters"
 msgstr "Interaktive Filter hinzufügen"
 
-#: app/configurator/components/chart-options-selector.tsx:364
+#: app/configurator/components/chart-options-selector.tsx:387
 msgid "controls.section.show-standard-error"
 msgstr "Standardfehler anzeigen"
 
-#: app/configurator/components/chart-options-selector.tsx:560
+#: app/configurator/components/chart-options-selector.tsx:602
 msgid "controls.section.sorting"
 msgstr "Sortieren"
 
@@ -515,13 +519,13 @@ msgstr "Tabellenoptionen"
 msgid "controls.section.title.warning"
 msgstr "Fügen Sie einen Titel oder eine Beschreibung hinzu"
 
-#: app/configurator/components/chart-configurator.tsx:572
+#: app/configurator/components/chart-configurator.tsx:576
 #: app/configurator/components/chart-type-selector.tsx:131
 #: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
 msgstr "Diagrammtyp"
 
-#: app/configurator/components/chart-options-selector.tsx:464
+#: app/configurator/components/chart-options-selector.tsx:506
 msgid "controls.select.column.layout"
 msgstr "Spaltenstil"
 
@@ -557,14 +561,14 @@ msgstr "Schriftfarbe"
 msgid "controls.select.columnStyle.textStyle"
 msgstr "Schriftstil"
 
-#: app/configurator/components/chart-options-selector.tsx:219
+#: app/configurator/components/chart-options-selector.tsx:223
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:262
 msgid "controls.select.dimension"
 msgstr "Dimension auswählen"
 
-#: app/configurator/components/chart-options-selector.tsx:220
-#: app/configurator/components/chart-options-selector.tsx:650
-#: app/configurator/components/chart-options-selector.tsx:728
+#: app/configurator/components/chart-options-selector.tsx:224
+#: app/configurator/components/chart-options-selector.tsx:692
+#: app/configurator/components/chart-options-selector.tsx:770
 msgid "controls.select.measure"
 msgstr "Messwert auswählen"
 
@@ -581,7 +585,7 @@ msgstr "Für beste Ergebnisse wählen Sie nicht mehr als 7 Werte für die Visual
 msgid "controls.set-values-apply"
 msgstr "Filter anwenden"
 
-#: app/configurator/components/chart-options-selector.tsx:642
+#: app/configurator/components/chart-options-selector.tsx:684
 msgid "controls.size"
 msgstr "Grösse"
 
@@ -589,12 +593,12 @@ msgstr "Grösse"
 msgid "controls.sorting.addDimension"
 msgstr "Dimension hinzufügen"
 
-#: app/configurator/components/chart-options-selector.tsx:512
+#: app/configurator/components/chart-options-selector.tsx:554
 msgid "controls.sorting.byAuto"
 msgstr "Auto"
 
-#: app/configurator/components/chart-options-selector.tsx:506
-#: app/configurator/components/chart-options-selector.tsx:516
+#: app/configurator/components/chart-options-selector.tsx:548
+#: app/configurator/components/chart-options-selector.tsx:558
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Name"
 
@@ -608,7 +612,7 @@ msgstr "A → Z"
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
-#: app/configurator/components/chart-options-selector.tsx:508
+#: app/configurator/components/chart-options-selector.tsx:550
 msgid "controls.sorting.byMeasure"
 msgstr "Messwert"
 
@@ -620,7 +624,7 @@ msgstr "1 → 9"
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
-#: app/configurator/components/chart-options-selector.tsx:510
+#: app/configurator/components/chart-options-selector.tsx:552
 msgid "controls.sorting.byTotalSize"
 msgstr "Gesamtgrösse"
 
@@ -701,11 +705,11 @@ msgstr "Cube IRI"
 msgid "data.source"
 msgstr "Datenquelle"
 
-#: app/components/chart-published.tsx:163
+#: app/components/chart-published.tsx:196
 msgid "data.source.notTrusted"
 msgstr "Dieses Diagramm verwendet keine vertrauenswürdige Datenquelle."
 
-#: app/configurator/components/select-dataset-step.tsx:217
+#: app/configurator/components/select-dataset-step.tsx:219
 msgid "dataset-preview.back-to-results"
 msgstr "Zurück zu den Datensätzen"
 
@@ -721,7 +725,7 @@ msgstr "Datensatz"
 msgid "dataset.footnotes.updated"
 msgstr "Neuestes Update"
 
-#: app/components/chart-published.tsx:172
+#: app/components/chart-published.tsx:205
 msgid "dataset.hasImputedValues"
 msgstr "Einige Daten in diesem Datensatz fehlen und wurden interpoliert, um die Lücken zu füllen."
 
@@ -766,13 +770,13 @@ msgstr "Relevanz"
 msgid "dataset.order.title"
 msgstr "Titel"
 
-#: app/components/chart-preview.tsx:116
-#: app/components/chart-published.tsx:141
+#: app/components/chart-preview.tsx:115
+#: app/components/chart-published.tsx:174
 #: app/configurator/components/dataset-preview.tsx:120
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Achtung, dieser Datensatz ist im Entwurfs-Stadium.<0/><1>Diese Grafik nicht für Berichte verwenden.</1>"
 
-#: app/components/chart-published.tsx:152
+#: app/components/chart-published.tsx:185
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Achtung, dieser Datensatz ist abgelaufen.<0/><1>Diese Grafik nicht für Berichte verwenden.</1>"
 
@@ -856,7 +860,7 @@ msgstr "Daten-Ladefehler"
 msgid "hint.how.to.share"
 msgstr "Sie können diese Visualisierung teilen oder sie einbetten. Zudem können Sie eine neue Visualisierung erstellen oder die gezeigte Visualisierung kopieren."
 
-#: app/components/form.tsx:292
+#: app/components/form.tsx:282
 #: app/components/hint.tsx:111
 msgid "hint.loading.data"
 msgstr "Lade Daten …"
@@ -885,11 +889,11 @@ msgstr "Negative Werte"
 msgid "hint.publication.success"
 msgstr "Die Visualisierung ist jetzt veröffentlicht. Sie können sie teilen oder einbetten, indem Sie die URL kopieren oder das Menü unten verwenden."
 
-#: app/charts/shared/chart-data-filters.tsx:94
+#: app/charts/shared/chart-data-filters.tsx:96
 msgid "interactive.data.filters.hide"
 msgstr "Filter ausblenden"
 
-#: app/charts/shared/chart-data-filters.tsx:96
+#: app/charts/shared/chart-data-filters.tsx:98
 msgid "interactive.data.filters.show"
 msgstr "Filter anzeigen"
 
@@ -955,7 +959,7 @@ msgstr "visualize.admin.ch"
 msgid "select.controls.filters.search"
 msgstr "Suche"
 
-#: app/components/metadata-panel.tsx:329
+#: app/components/metadata-panel.tsx:436
 msgid "select.controls.metadata.search"
 msgstr "Springen zu..."
 

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -13,32 +13,32 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:691
+#: app/configurator/components/chart-configurator.tsx:695
 msgid "Add filter"
 msgstr "Add filter"
 
-#: app/configurator/components/chart-configurator.tsx:664
+#: app/configurator/components/chart-configurator.tsx:668
 msgid "Drag filters to reorganize"
 msgstr "Drag filters to reorganize"
 
-#: app/configurator/components/chart-configurator.tsx:661
+#: app/configurator/components/chart-configurator.tsx:665
 msgid "Move filter down"
 msgstr "Move filter down"
 
-#: app/configurator/components/chart-configurator.tsx:658
+#: app/configurator/components/chart-configurator.tsx:662
 msgid "Move filter up"
 msgstr "Move filter up"
 
-#: app/components/select-tree.tsx:527
+#: app/components/select-tree.tsx:525
 #: app/configurator/components/dataset-browse.tsx:1046
 msgid "No results"
 msgstr "No results"
 
-#: app/components/chart-preview.tsx:187
+#: app/components/chart-preview.tsx:184
 msgid "annotation.add.description"
 msgstr "[ No Description ]"
 
-#: app/components/chart-preview.tsx:149
+#: app/components/chart-preview.tsx:148
 msgid "annotation.add.title"
 msgstr "[ No Title ]"
 
@@ -54,15 +54,15 @@ msgstr "Categories"
 msgid "browse.dataset.create-visualization"
 msgstr "Start a visualization"
 
-#: app/configurator/components/select-dataset-step.tsx:296
+#: app/configurator/components/select-dataset-step.tsx:298
 msgid "browse.datasets.all-datasets"
 msgstr "All datasets"
 
-#: app/configurator/components/select-dataset-step.tsx:184
+#: app/configurator/components/select-dataset-step.tsx:186
 msgid "browse.datasets.description"
 msgstr "Explore datasets provided by the LINDAS Linked Data Service by either filtering by categories or organisations or search directly for specific keywords. Click on a dataset to see more detailed information and start creating your own visualizations."
 
-#: app/components/metadata-panel.tsx:318
+#: app/components/metadata-panel.tsx:409
 msgid "button.back"
 msgstr "Back"
 
@@ -119,17 +119,17 @@ msgstr "Share"
 msgid "chart.map.layers.area"
 msgstr "Areas"
 
-#: app/configurator/components/chart-configurator.tsx:744
-#: app/configurator/components/chart-options-selector.tsx:992
+#: app/configurator/components/chart-configurator.tsx:748
+#: app/configurator/components/chart-options-selector.tsx:1034
 #: app/configurator/components/field-i18n.ts:31
 msgid "chart.map.layers.base"
 msgstr "Map Display"
 
-#: app/configurator/components/chart-options-selector.tsx:996
+#: app/configurator/components/chart-options-selector.tsx:1038
 msgid "chart.map.layers.base.show"
 msgstr "Show Worldmap"
 
-#: app/configurator/components/chart-options-selector.tsx:1004
+#: app/configurator/components/chart-options-selector.tsx:1046
 msgid "chart.map.layers.base.view.locked"
 msgstr "Locked view"
 
@@ -174,6 +174,10 @@ msgstr "Regular"
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Default Settings"
 
+#: app/configurator/components/field-i18n.ts:87
+msgid "controls.abbreviations"
+msgstr "Use abbreviations"
+
 #: app/configurator/components/chart-annotator.tsx:70
 msgid "controls.annotator.add-description-warning"
 msgstr "Please add a description"
@@ -190,39 +194,39 @@ msgstr "Horizontal Axis"
 msgid "controls.axis.vertical"
 msgstr "Vertical Axis"
 
-#: app/configurator/components/field-i18n.ts:115
+#: app/configurator/components/field-i18n.ts:119
 msgid "controls.chart.type.area"
 msgstr "Areas"
 
-#: app/configurator/components/field-i18n.ts:107
+#: app/configurator/components/field-i18n.ts:111
 msgid "controls.chart.type.bar"
 msgstr "Bars"
 
-#: app/configurator/components/field-i18n.ts:103
+#: app/configurator/components/field-i18n.ts:107
 msgid "controls.chart.type.column"
 msgstr "Columns"
 
-#: app/configurator/components/field-i18n.ts:111
+#: app/configurator/components/field-i18n.ts:115
 msgid "controls.chart.type.line"
 msgstr "Lines"
 
-#: app/configurator/components/field-i18n.ts:131
+#: app/configurator/components/field-i18n.ts:135
 msgid "controls.chart.type.map"
 msgstr "Map"
 
-#: app/configurator/components/field-i18n.ts:123
+#: app/configurator/components/field-i18n.ts:127
 msgid "controls.chart.type.pie"
 msgstr "Pie"
 
-#: app/configurator/components/field-i18n.ts:119
+#: app/configurator/components/field-i18n.ts:123
 msgid "controls.chart.type.scatterplot"
 msgstr "Scatterplot"
 
-#: app/configurator/components/field-i18n.ts:127
+#: app/configurator/components/field-i18n.ts:131
 msgid "controls.chart.type.table"
 msgstr "Table"
 
-#: app/configurator/components/chart-options-selector.tsx:723
+#: app/configurator/components/chart-options-selector.tsx:765
 #: app/configurator/components/field-i18n.ts:17
 msgid "controls.color"
 msgstr "Color"
@@ -231,7 +235,7 @@ msgstr "Color"
 msgid "controls.color.add"
 msgstr "Add ..."
 
-#: app/configurator/components/chart-options-selector.tsx:752
+#: app/configurator/components/chart-options-selector.tsx:794
 msgid "controls.color.opacity"
 msgstr "Opacity"
 
@@ -252,35 +256,35 @@ msgstr "Reset color palette"
 msgid "controls.color.palette.sequential"
 msgstr "Sequential"
 
-#: app/configurator/components/chart-options-selector.tsx:839
+#: app/configurator/components/chart-options-selector.tsx:881
 msgid "controls.color.scale.discretization.jenks"
 msgstr "Jenks (natural breaks)"
 
-#: app/configurator/components/chart-options-selector.tsx:832
+#: app/configurator/components/chart-options-selector.tsx:874
 msgid "controls.color.scale.discretization.quantiles"
 msgstr "Quantiles (equal distribution of values)"
 
-#: app/configurator/components/chart-options-selector.tsx:825
+#: app/configurator/components/chart-options-selector.tsx:867
 msgid "controls.color.scale.discretization.quantize"
 msgstr "Quantize (equal intervals)"
 
-#: app/configurator/components/chart-options-selector.tsx:817
+#: app/configurator/components/chart-options-selector.tsx:859
 msgid "controls.color.scale.interpolation"
 msgstr "Interpolation"
 
-#: app/configurator/components/chart-options-selector.tsx:849
+#: app/configurator/components/chart-options-selector.tsx:891
 msgid "controls.color.scale.number.of.classes"
 msgstr "Number of classes"
 
-#: app/configurator/components/chart-options-selector.tsx:789
+#: app/configurator/components/chart-options-selector.tsx:831
 msgid "controls.color.scale.type.continuous"
 msgstr "Continuous"
 
-#: app/configurator/components/chart-options-selector.tsx:800
+#: app/configurator/components/chart-options-selector.tsx:842
 msgid "controls.color.scale.type.discrete"
 msgstr "Discrete"
 
-#: app/configurator/components/chart-options-selector.tsx:742
+#: app/configurator/components/chart-options-selector.tsx:784
 msgid "controls.color.select"
 msgstr "Select a color"
 
@@ -300,8 +304,8 @@ msgstr "Stacked"
 msgid "controls.description"
 msgstr "Description"
 
-#: app/charts/shared/chart-data-filters.tsx:247
-#: app/charts/shared/chart-data-filters.tsx:291
+#: app/charts/shared/chart-data-filters.tsx:249
+#: app/charts/shared/chart-data-filters.tsx:296
 msgid "controls.dimensionvalue.none"
 msgstr "No Filter"
 
@@ -317,12 +321,12 @@ msgstr "Select all"
 msgid "controls.filter.select.none"
 msgstr "Select none"
 
-#: app/configurator/components/chart-configurator.tsx:506
+#: app/configurator/components/chart-configurator.tsx:510
 #: app/configurator/components/filters.tsx:366
 msgid "controls.filters.interactive.toggle"
 msgstr "Interactive"
 
-#: app/configurator/components/chart-configurator.tsx:499
+#: app/configurator/components/chart-configurator.tsx:503
 #: app/configurator/components/filters.tsx:360
 msgid "controls.filters.interactive.tooltip"
 msgstr "Allow users to change filters"
@@ -347,23 +351,23 @@ msgstr "Time Range"
 msgid "controls.groups.empty-help"
 msgstr "Drag and drop columns here to make groups."
 
-#: app/configurator/components/field-i18n.ts:87
+#: app/configurator/components/field-i18n.ts:91
 msgid "controls.imputation"
 msgstr "Imputation type"
 
-#: app/configurator/components/chart-options-selector.tsx:884
-#: app/configurator/components/field-i18n.ts:99
+#: app/configurator/components/chart-options-selector.tsx:926
+#: app/configurator/components/field-i18n.ts:103
 msgid "controls.imputation.type.linear"
 msgstr "Linear interpolation"
 
-#: app/configurator/components/chart-options-selector.tsx:877
-#: app/configurator/components/chart-options-selector.tsx:889
-#: app/configurator/components/field-i18n.ts:91
+#: app/configurator/components/chart-options-selector.tsx:919
+#: app/configurator/components/chart-options-selector.tsx:931
+#: app/configurator/components/field-i18n.ts:95
 msgid "controls.imputation.type.none"
 msgstr "-"
 
-#: app/configurator/components/chart-options-selector.tsx:879
-#: app/configurator/components/field-i18n.ts:95
+#: app/configurator/components/chart-options-selector.tsx:921
+#: app/configurator/components/field-i18n.ts:99
 msgid "controls.imputation.type.zeros"
 msgstr "Zeros"
 
@@ -380,19 +384,19 @@ msgstr "There is no time dimension!"
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Show time filter"
 
-#: app/configurator/components/field-i18n.ts:135
+#: app/configurator/components/field-i18n.ts:139
 msgid "controls.language.english"
 msgstr "English"
 
-#: app/configurator/components/field-i18n.ts:143
+#: app/configurator/components/field-i18n.ts:147
 msgid "controls.language.french"
 msgstr "French"
 
-#: app/configurator/components/field-i18n.ts:139
+#: app/configurator/components/field-i18n.ts:143
 msgid "controls.language.german"
 msgstr "German"
 
-#: app/configurator/components/field-i18n.ts:147
+#: app/configurator/components/field-i18n.ts:151
 msgid "controls.language.italian"
 msgstr "Italian"
 
@@ -400,16 +404,16 @@ msgstr "Italian"
 msgid "controls.measure"
 msgstr "Measure"
 
-#: app/components/metadata-panel.tsx:251
-#: app/components/metadata-panel.tsx:263
+#: app/components/metadata-panel.tsx:342
+#: app/components/metadata-panel.tsx:354
 msgid "controls.metadata-panel.metadata"
 msgstr "Metadata"
 
-#: app/components/metadata-panel.tsx:231
+#: app/components/metadata-panel.tsx:310
 msgid "controls.metadata-panel.section.data"
 msgstr "Data"
 
-#: app/components/metadata-panel.tsx:221
+#: app/components/metadata-panel.tsx:300
 msgid "controls.metadata-panel.section.general"
 msgstr "General"
 
@@ -433,19 +437,19 @@ msgstr "On"
 msgid "controls.option.isNotActive"
 msgstr "Off"
 
-#: app/configurator/components/chart-options-selector.tsx:782
+#: app/configurator/components/chart-options-selector.tsx:824
 msgid "controls.scale.type"
 msgstr "Scale type"
 
-#: app/components/form.tsx:625
+#: app/components/form.tsx:611
 msgid "controls.search.clear"
 msgstr "Clear search field"
 
-#: app/configurator/components/chart-options-selector.tsx:355
+#: app/configurator/components/chart-options-selector.tsx:378
 msgid "controls.section.additional-information"
 msgstr "Additional information"
 
-#: app/configurator/components/chart-configurator.tsx:580
+#: app/configurator/components/chart-configurator.tsx:584
 msgid "controls.section.chart.options"
 msgstr "Chart Options"
 
@@ -457,7 +461,7 @@ msgstr "Columns"
 msgid "controls.section.columnstyle"
 msgstr "Column Style"
 
-#: app/configurator/components/chart-configurator.tsx:598
+#: app/configurator/components/chart-configurator.tsx:602
 msgid "controls.section.data.filters"
 msgstr "Filters"
 
@@ -465,8 +469,8 @@ msgstr "Filters"
 msgid "controls.section.description"
 msgstr "Title & Description"
 
-#: app/configurator/components/chart-options-selector.tsx:414
-#: app/configurator/components/chart-options-selector.tsx:418
+#: app/configurator/components/chart-options-selector.tsx:456
+#: app/configurator/components/chart-options-selector.tsx:460
 #: app/configurator/table/table-chart-options.tsx:319
 #: app/configurator/table/table-chart-options.tsx:323
 #: app/configurator/table/table-chart-options.tsx:343
@@ -478,11 +482,11 @@ msgstr "Filter"
 msgid "controls.section.groups"
 msgstr "Groups"
 
-#: app/configurator/components/chart-options-selector.tsx:918
+#: app/configurator/components/chart-options-selector.tsx:960
 msgid "controls.section.imputation"
 msgstr "Missing values"
 
-#: app/configurator/components/chart-options-selector.tsx:923
+#: app/configurator/components/chart-options-selector.tsx:965
 msgid "controls.section.imputation.explanation"
 msgstr "For this chart type, replacement values should be assigned to missing values. Decide on the imputation logic or switch to another chart type."
 
@@ -491,11 +495,11 @@ msgstr "For this chart type, replacement values should be assigned to missing va
 msgid "controls.section.interactive.filters"
 msgstr "Interactive Filters"
 
-#: app/configurator/components/chart-options-selector.tsx:364
+#: app/configurator/components/chart-options-selector.tsx:387
 msgid "controls.section.show-standard-error"
 msgstr "Show standard error"
 
-#: app/configurator/components/chart-options-selector.tsx:560
+#: app/configurator/components/chart-options-selector.tsx:602
 msgid "controls.section.sorting"
 msgstr "Sort"
 
@@ -515,13 +519,13 @@ msgstr "Table Options"
 msgid "controls.section.title.warning"
 msgstr "Please add a title or description."
 
-#: app/configurator/components/chart-configurator.tsx:572
+#: app/configurator/components/chart-configurator.tsx:576
 #: app/configurator/components/chart-type-selector.tsx:131
 #: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
 msgstr "Chart Type"
 
-#: app/configurator/components/chart-options-selector.tsx:464
+#: app/configurator/components/chart-options-selector.tsx:506
 msgid "controls.select.column.layout"
 msgstr "Column layout"
 
@@ -557,14 +561,14 @@ msgstr "Text Color"
 msgid "controls.select.columnStyle.textStyle"
 msgstr "Text Style"
 
-#: app/configurator/components/chart-options-selector.tsx:219
+#: app/configurator/components/chart-options-selector.tsx:223
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:262
 msgid "controls.select.dimension"
 msgstr "Select a dimension"
 
-#: app/configurator/components/chart-options-selector.tsx:220
-#: app/configurator/components/chart-options-selector.tsx:650
-#: app/configurator/components/chart-options-selector.tsx:728
+#: app/configurator/components/chart-options-selector.tsx:224
+#: app/configurator/components/chart-options-selector.tsx:692
+#: app/configurator/components/chart-options-selector.tsx:770
 msgid "controls.select.measure"
 msgstr "Select a measure"
 
@@ -581,7 +585,7 @@ msgstr "For best results, do not select more than 7 values in the visualization.
 msgid "controls.set-values-apply"
 msgstr "Apply filters"
 
-#: app/configurator/components/chart-options-selector.tsx:642
+#: app/configurator/components/chart-options-selector.tsx:684
 msgid "controls.size"
 msgstr "Size"
 
@@ -589,12 +593,12 @@ msgstr "Size"
 msgid "controls.sorting.addDimension"
 msgstr "Add dimension"
 
-#: app/configurator/components/chart-options-selector.tsx:512
+#: app/configurator/components/chart-options-selector.tsx:554
 msgid "controls.sorting.byAuto"
 msgstr "Automatic"
 
-#: app/configurator/components/chart-options-selector.tsx:506
-#: app/configurator/components/chart-options-selector.tsx:516
+#: app/configurator/components/chart-options-selector.tsx:548
+#: app/configurator/components/chart-options-selector.tsx:558
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Name"
 
@@ -608,7 +612,7 @@ msgstr "A → Z"
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
-#: app/configurator/components/chart-options-selector.tsx:508
+#: app/configurator/components/chart-options-selector.tsx:550
 msgid "controls.sorting.byMeasure"
 msgstr "Measure"
 
@@ -620,7 +624,7 @@ msgstr "1 → 9"
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
-#: app/configurator/components/chart-options-selector.tsx:510
+#: app/configurator/components/chart-options-selector.tsx:552
 msgid "controls.sorting.byTotalSize"
 msgstr "Total size"
 
@@ -701,11 +705,11 @@ msgstr "Cube IRI"
 msgid "data.source"
 msgstr "Data source"
 
-#: app/components/chart-published.tsx:163
+#: app/components/chart-published.tsx:196
 msgid "data.source.notTrusted"
 msgstr "This chart is not using a trusted data source."
 
-#: app/configurator/components/select-dataset-step.tsx:217
+#: app/configurator/components/select-dataset-step.tsx:219
 msgid "dataset-preview.back-to-results"
 msgstr "Back to the datasets"
 
@@ -721,7 +725,7 @@ msgstr "Dataset"
 msgid "dataset.footnotes.updated"
 msgstr "Latest update"
 
-#: app/components/chart-published.tsx:172
+#: app/components/chart-published.tsx:205
 msgid "dataset.hasImputedValues"
 msgstr "Some data in this dataset is missing and has been interpolated to fill the gaps."
 
@@ -766,13 +770,13 @@ msgstr "Relevance"
 msgid "dataset.order.title"
 msgstr "Title"
 
-#: app/components/chart-preview.tsx:116
-#: app/components/chart-published.tsx:141
+#: app/components/chart-preview.tsx:115
+#: app/components/chart-published.tsx:174
 #: app/configurator/components/dataset-preview.tsx:120
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Careful, this dataset is only a draft.<0/><1>Don't use for reporting!</1>"
 
-#: app/components/chart-published.tsx:152
+#: app/components/chart-published.tsx:185
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Careful, the data for this chart has expired.<0/><1>Don't use for reporting!</1>"
 
@@ -856,7 +860,7 @@ msgstr "Data loading error"
 msgid "hint.how.to.share"
 msgstr "You can share this visualization by copying the URL or by embedding it on your own website. You can also create a new visualization from scratch or start by copying the visualization above."
 
-#: app/components/form.tsx:292
+#: app/components/form.tsx:282
 #: app/components/hint.tsx:111
 msgid "hint.loading.data"
 msgstr "Loading data..."
@@ -885,11 +889,11 @@ msgstr "Negative Values"
 msgid "hint.publication.success"
 msgstr "Your visualization is now published. Share it by copying the URL or use the Embed menu below."
 
-#: app/charts/shared/chart-data-filters.tsx:94
+#: app/charts/shared/chart-data-filters.tsx:96
 msgid "interactive.data.filters.hide"
 msgstr "Hide Filters"
 
-#: app/charts/shared/chart-data-filters.tsx:96
+#: app/charts/shared/chart-data-filters.tsx:98
 msgid "interactive.data.filters.show"
 msgstr "Show Filters"
 
@@ -955,7 +959,7 @@ msgstr "visualize.admin.ch"
 msgid "select.controls.filters.search"
 msgstr "Search"
 
-#: app/components/metadata-panel.tsx:329
+#: app/components/metadata-panel.tsx:436
 msgid "select.controls.metadata.search"
 msgstr "Jump to..."
 

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -13,32 +13,32 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:691
+#: app/configurator/components/chart-configurator.tsx:695
 msgid "Add filter"
 msgstr "Ajouter un filtre"
 
-#: app/configurator/components/chart-configurator.tsx:664
+#: app/configurator/components/chart-configurator.tsx:668
 msgid "Drag filters to reorganize"
 msgstr "Faites glisser les filtres pour les réorganiser"
 
-#: app/configurator/components/chart-configurator.tsx:661
+#: app/configurator/components/chart-configurator.tsx:665
 msgid "Move filter down"
 msgstr "Déplacer le filtre vers le bas"
 
-#: app/configurator/components/chart-configurator.tsx:658
+#: app/configurator/components/chart-configurator.tsx:662
 msgid "Move filter up"
 msgstr "Déplacer le filtre vers le haut"
 
-#: app/components/select-tree.tsx:527
+#: app/components/select-tree.tsx:525
 #: app/configurator/components/dataset-browse.tsx:1046
 msgid "No results"
 msgstr "Aucun résultat"
 
-#: app/components/chart-preview.tsx:187
+#: app/components/chart-preview.tsx:184
 msgid "annotation.add.description"
 msgstr "[ Pas de description ]"
 
-#: app/components/chart-preview.tsx:149
+#: app/components/chart-preview.tsx:148
 msgid "annotation.add.title"
 msgstr "[ Pas de titre ]"
 
@@ -54,15 +54,15 @@ msgstr "Catégories"
 msgid "browse.dataset.create-visualization"
 msgstr "Démarrer une visualisation"
 
-#: app/configurator/components/select-dataset-step.tsx:296
+#: app/configurator/components/select-dataset-step.tsx:298
 msgid "browse.datasets.all-datasets"
 msgstr "Tous les jeux de données"
 
-#: app/configurator/components/select-dataset-step.tsx:184
+#: app/configurator/components/select-dataset-step.tsx:186
 msgid "browse.datasets.description"
 msgstr "Explorez les jeux de données liés fournis par LINDAS, en filtrant par catégories ou organisations, ou en recherchant par mots-clés. Cliquez sur un ensemble de données pour afficher des informations plus détaillées et commencer à créer vos propres visualisations. "
 
-#: app/components/metadata-panel.tsx:318
+#: app/components/metadata-panel.tsx:409
 msgid "button.back"
 msgstr "Précédent"
 
@@ -119,17 +119,17 @@ msgstr "Partager"
 msgid "chart.map.layers.area"
 msgstr "Zones"
 
-#: app/configurator/components/chart-configurator.tsx:744
-#: app/configurator/components/chart-options-selector.tsx:992
+#: app/configurator/components/chart-configurator.tsx:748
+#: app/configurator/components/chart-options-selector.tsx:1034
 #: app/configurator/components/field-i18n.ts:31
 msgid "chart.map.layers.base"
 msgstr "Affichage de la carte"
 
-#: app/configurator/components/chart-options-selector.tsx:996
+#: app/configurator/components/chart-options-selector.tsx:1038
 msgid "chart.map.layers.base.show"
 msgstr "Afficher la carte du monde"
 
-#: app/configurator/components/chart-options-selector.tsx:1004
+#: app/configurator/components/chart-options-selector.tsx:1046
 msgid "chart.map.layers.base.view.locked"
 msgstr "Carte verrouillée"
 
@@ -174,6 +174,10 @@ msgstr "Normal"
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Paramètres d'origine"
 
+#: app/configurator/components/field-i18n.ts:87
+msgid "controls.abbreviations"
+msgstr "Utiliser des abréviations"
+
 #: app/configurator/components/chart-annotator.tsx:70
 msgid "controls.annotator.add-description-warning"
 msgstr "Ajoutez une description au graphique"
@@ -190,39 +194,39 @@ msgstr "Axe horizontal"
 msgid "controls.axis.vertical"
 msgstr "Axe vertical"
 
-#: app/configurator/components/field-i18n.ts:115
+#: app/configurator/components/field-i18n.ts:119
 msgid "controls.chart.type.area"
 msgstr "Surfaces"
 
-#: app/configurator/components/field-i18n.ts:107
+#: app/configurator/components/field-i18n.ts:111
 msgid "controls.chart.type.bar"
 msgstr "Barres"
 
-#: app/configurator/components/field-i18n.ts:103
+#: app/configurator/components/field-i18n.ts:107
 msgid "controls.chart.type.column"
 msgstr "Colonnes"
 
-#: app/configurator/components/field-i18n.ts:111
+#: app/configurator/components/field-i18n.ts:115
 msgid "controls.chart.type.line"
 msgstr "Lignes"
 
-#: app/configurator/components/field-i18n.ts:131
+#: app/configurator/components/field-i18n.ts:135
 msgid "controls.chart.type.map"
 msgstr "Carte"
 
-#: app/configurator/components/field-i18n.ts:123
+#: app/configurator/components/field-i18n.ts:127
 msgid "controls.chart.type.pie"
 msgstr "Secteurs"
 
-#: app/configurator/components/field-i18n.ts:119
+#: app/configurator/components/field-i18n.ts:123
 msgid "controls.chart.type.scatterplot"
 msgstr "Nuage de points"
 
-#: app/configurator/components/field-i18n.ts:127
+#: app/configurator/components/field-i18n.ts:131
 msgid "controls.chart.type.table"
 msgstr "Tableau"
 
-#: app/configurator/components/chart-options-selector.tsx:723
+#: app/configurator/components/chart-options-selector.tsx:765
 #: app/configurator/components/field-i18n.ts:17
 msgid "controls.color"
 msgstr "Couleur"
@@ -231,7 +235,7 @@ msgstr "Couleur"
 msgid "controls.color.add"
 msgstr "Ajouter…"
 
-#: app/configurator/components/chart-options-selector.tsx:752
+#: app/configurator/components/chart-options-selector.tsx:794
 msgid "controls.color.opacity"
 msgstr "Transparence"
 
@@ -252,35 +256,35 @@ msgstr "Réinitialiser la palette de couleurs"
 msgid "controls.color.palette.sequential"
 msgstr "Séquentielle"
 
-#: app/configurator/components/chart-options-selector.tsx:839
+#: app/configurator/components/chart-options-selector.tsx:881
 msgid "controls.color.scale.discretization.jenks"
 msgstr "Jenks (intervalles naturels)"
 
-#: app/configurator/components/chart-options-selector.tsx:832
+#: app/configurator/components/chart-options-selector.tsx:874
 msgid "controls.color.scale.discretization.quantiles"
 msgstr "Quantiles (distribution homogène des valeurs)"
 
-#: app/configurator/components/chart-options-selector.tsx:825
+#: app/configurator/components/chart-options-selector.tsx:867
 msgid "controls.color.scale.discretization.quantize"
 msgstr "Intervalles égaux"
 
-#: app/configurator/components/chart-options-selector.tsx:817
+#: app/configurator/components/chart-options-selector.tsx:859
 msgid "controls.color.scale.interpolation"
 msgstr "Interpolation"
 
-#: app/configurator/components/chart-options-selector.tsx:849
+#: app/configurator/components/chart-options-selector.tsx:891
 msgid "controls.color.scale.number.of.classes"
 msgstr "Nombre de classes"
 
-#: app/configurator/components/chart-options-selector.tsx:789
+#: app/configurator/components/chart-options-selector.tsx:831
 msgid "controls.color.scale.type.continuous"
 msgstr "Continue"
 
-#: app/configurator/components/chart-options-selector.tsx:800
+#: app/configurator/components/chart-options-selector.tsx:842
 msgid "controls.color.scale.type.discrete"
 msgstr "Discrète"
 
-#: app/configurator/components/chart-options-selector.tsx:742
+#: app/configurator/components/chart-options-selector.tsx:784
 msgid "controls.color.select"
 msgstr "Sélectionner une couleur"
 
@@ -300,8 +304,8 @@ msgstr "empilées"
 msgid "controls.description"
 msgstr "Description"
 
-#: app/charts/shared/chart-data-filters.tsx:247
-#: app/charts/shared/chart-data-filters.tsx:291
+#: app/charts/shared/chart-data-filters.tsx:249
+#: app/charts/shared/chart-data-filters.tsx:296
 msgid "controls.dimensionvalue.none"
 msgstr "Aucune filtre"
 
@@ -317,12 +321,12 @@ msgstr "Tout sélectionner"
 msgid "controls.filter.select.none"
 msgstr "Tout déselectionner"
 
-#: app/configurator/components/chart-configurator.tsx:506
+#: app/configurator/components/chart-configurator.tsx:510
 #: app/configurator/components/filters.tsx:366
 msgid "controls.filters.interactive.toggle"
 msgstr "Interactif"
 
-#: app/configurator/components/chart-configurator.tsx:499
+#: app/configurator/components/chart-configurator.tsx:503
 #: app/configurator/components/filters.tsx:360
 msgid "controls.filters.interactive.tooltip"
 msgstr "Permettre aux utilisateurs de changer le filtre"
@@ -347,23 +351,23 @@ msgstr "Intervalle de temps"
 msgid "controls.groups.empty-help"
 msgstr "Glisser-déposer des colonnes ici pour créer des groupes."
 
-#: app/configurator/components/field-i18n.ts:87
+#: app/configurator/components/field-i18n.ts:91
 msgid "controls.imputation"
 msgstr "Type d'imputation"
 
-#: app/configurator/components/chart-options-selector.tsx:884
-#: app/configurator/components/field-i18n.ts:99
+#: app/configurator/components/chart-options-selector.tsx:926
+#: app/configurator/components/field-i18n.ts:103
 msgid "controls.imputation.type.linear"
 msgstr "Interpolation linéaire"
 
-#: app/configurator/components/chart-options-selector.tsx:877
-#: app/configurator/components/chart-options-selector.tsx:889
-#: app/configurator/components/field-i18n.ts:91
+#: app/configurator/components/chart-options-selector.tsx:919
+#: app/configurator/components/chart-options-selector.tsx:931
+#: app/configurator/components/field-i18n.ts:95
 msgid "controls.imputation.type.none"
 msgstr "-"
 
-#: app/configurator/components/chart-options-selector.tsx:879
-#: app/configurator/components/field-i18n.ts:95
+#: app/configurator/components/chart-options-selector.tsx:921
+#: app/configurator/components/field-i18n.ts:99
 msgid "controls.imputation.type.zeros"
 msgstr "Zéros"
 
@@ -380,19 +384,19 @@ msgstr "Il n'y a pas de dimension temporelle!"
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Afficher le filtre temporel"
 
-#: app/configurator/components/field-i18n.ts:135
+#: app/configurator/components/field-i18n.ts:139
 msgid "controls.language.english"
 msgstr "Anglais"
 
-#: app/configurator/components/field-i18n.ts:143
+#: app/configurator/components/field-i18n.ts:147
 msgid "controls.language.french"
 msgstr "Français"
 
-#: app/configurator/components/field-i18n.ts:139
+#: app/configurator/components/field-i18n.ts:143
 msgid "controls.language.german"
 msgstr "Allemand"
 
-#: app/configurator/components/field-i18n.ts:147
+#: app/configurator/components/field-i18n.ts:151
 msgid "controls.language.italian"
 msgstr "Italien"
 
@@ -400,16 +404,16 @@ msgstr "Italien"
 msgid "controls.measure"
 msgstr "Variable mesurée"
 
-#: app/components/metadata-panel.tsx:251
-#: app/components/metadata-panel.tsx:263
+#: app/components/metadata-panel.tsx:342
+#: app/components/metadata-panel.tsx:354
 msgid "controls.metadata-panel.metadata"
 msgstr "Metadata"
 
-#: app/components/metadata-panel.tsx:231
+#: app/components/metadata-panel.tsx:310
 msgid "controls.metadata-panel.section.data"
 msgstr "Données"
 
-#: app/components/metadata-panel.tsx:221
+#: app/components/metadata-panel.tsx:300
 msgid "controls.metadata-panel.section.general"
 msgstr "Général"
 
@@ -433,19 +437,19 @@ msgstr "Actif"
 msgid "controls.option.isNotActive"
 msgstr "Inactif"
 
-#: app/configurator/components/chart-options-selector.tsx:782
+#: app/configurator/components/chart-options-selector.tsx:824
 msgid "controls.scale.type"
 msgstr "Type d'échelle"
 
-#: app/components/form.tsx:625
+#: app/components/form.tsx:611
 msgid "controls.search.clear"
 msgstr "Effacer la recherche"
 
-#: app/configurator/components/chart-options-selector.tsx:355
+#: app/configurator/components/chart-options-selector.tsx:378
 msgid "controls.section.additional-information"
 msgstr "Informations supplémentaires"
 
-#: app/configurator/components/chart-configurator.tsx:580
+#: app/configurator/components/chart-configurator.tsx:584
 msgid "controls.section.chart.options"
 msgstr "Paramètres graphiques"
 
@@ -457,7 +461,7 @@ msgstr "Colonnes"
 msgid "controls.section.columnstyle"
 msgstr "Style de la colonne"
 
-#: app/configurator/components/chart-configurator.tsx:598
+#: app/configurator/components/chart-configurator.tsx:602
 msgid "controls.section.data.filters"
 msgstr "Filtres"
 
@@ -465,8 +469,8 @@ msgstr "Filtres"
 msgid "controls.section.description"
 msgstr "Titre & description"
 
-#: app/configurator/components/chart-options-selector.tsx:414
-#: app/configurator/components/chart-options-selector.tsx:418
+#: app/configurator/components/chart-options-selector.tsx:456
+#: app/configurator/components/chart-options-selector.tsx:460
 #: app/configurator/table/table-chart-options.tsx:319
 #: app/configurator/table/table-chart-options.tsx:323
 #: app/configurator/table/table-chart-options.tsx:343
@@ -478,11 +482,11 @@ msgstr "Filtre"
 msgid "controls.section.groups"
 msgstr "Groupes"
 
-#: app/configurator/components/chart-options-selector.tsx:918
+#: app/configurator/components/chart-options-selector.tsx:960
 msgid "controls.section.imputation"
 msgstr "Valeurs manquantes"
 
-#: app/configurator/components/chart-options-selector.tsx:923
+#: app/configurator/components/chart-options-selector.tsx:965
 msgid "controls.section.imputation.explanation"
 msgstr "En raison du type de graphique sélectionné, les valeurs manquantes doivent être remplies. Décidez de la logique d'imputation ou choisissez un autre type de graphique."
 
@@ -491,11 +495,11 @@ msgstr "En raison du type de graphique sélectionné, les valeurs manquantes doi
 msgid "controls.section.interactive.filters"
 msgstr "Filtres interactifs"
 
-#: app/configurator/components/chart-options-selector.tsx:364
+#: app/configurator/components/chart-options-selector.tsx:387
 msgid "controls.section.show-standard-error"
 msgstr "Afficher l'erreur type"
 
-#: app/configurator/components/chart-options-selector.tsx:560
+#: app/configurator/components/chart-options-selector.tsx:602
 msgid "controls.section.sorting"
 msgstr "Trier"
 
@@ -515,13 +519,13 @@ msgstr "Options du tableau"
 msgid "controls.section.title.warning"
 msgstr "Ajoutez un titre et une description"
 
-#: app/configurator/components/chart-configurator.tsx:572
+#: app/configurator/components/chart-configurator.tsx:576
 #: app/configurator/components/chart-type-selector.tsx:131
 #: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
 msgstr "Type de graphique"
 
-#: app/configurator/components/chart-options-selector.tsx:464
+#: app/configurator/components/chart-options-selector.tsx:506
 msgid "controls.select.column.layout"
 msgstr "Mise en forme de la colonne"
 
@@ -557,14 +561,14 @@ msgstr "Couleur du texte"
 msgid "controls.select.columnStyle.textStyle"
 msgstr "Style du texte"
 
-#: app/configurator/components/chart-options-selector.tsx:219
+#: app/configurator/components/chart-options-selector.tsx:223
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:262
 msgid "controls.select.dimension"
 msgstr "Sélectionner une dimension"
 
-#: app/configurator/components/chart-options-selector.tsx:220
-#: app/configurator/components/chart-options-selector.tsx:650
-#: app/configurator/components/chart-options-selector.tsx:728
+#: app/configurator/components/chart-options-selector.tsx:224
+#: app/configurator/components/chart-options-selector.tsx:692
+#: app/configurator/components/chart-options-selector.tsx:770
 msgid "controls.select.measure"
 msgstr "Sélectionner une variable"
 
@@ -581,7 +585,7 @@ msgstr "Pour de meilleurs résultats, ne sélectionnez pas plus de 7 valeurs dan
 msgid "controls.set-values-apply"
 msgstr "Appliquer les filtres"
 
-#: app/configurator/components/chart-options-selector.tsx:642
+#: app/configurator/components/chart-options-selector.tsx:684
 msgid "controls.size"
 msgstr "Taille"
 
@@ -589,12 +593,12 @@ msgstr "Taille"
 msgid "controls.sorting.addDimension"
 msgstr "Ajouter une dimension"
 
-#: app/configurator/components/chart-options-selector.tsx:512
+#: app/configurator/components/chart-options-selector.tsx:554
 msgid "controls.sorting.byAuto"
 msgstr "Auto"
 
-#: app/configurator/components/chart-options-selector.tsx:506
-#: app/configurator/components/chart-options-selector.tsx:516
+#: app/configurator/components/chart-options-selector.tsx:548
+#: app/configurator/components/chart-options-selector.tsx:558
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Nom"
 
@@ -608,7 +612,7 @@ msgstr "A → Z"
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
-#: app/configurator/components/chart-options-selector.tsx:508
+#: app/configurator/components/chart-options-selector.tsx:550
 msgid "controls.sorting.byMeasure"
 msgstr "Mesure"
 
@@ -620,7 +624,7 @@ msgstr "1 → 9"
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
-#: app/configurator/components/chart-options-selector.tsx:510
+#: app/configurator/components/chart-options-selector.tsx:552
 msgid "controls.sorting.byTotalSize"
 msgstr "Taille totale"
 
@@ -701,11 +705,11 @@ msgstr "IRI du cube"
 msgid "data.source"
 msgstr "Source des données"
 
-#: app/components/chart-published.tsx:163
+#: app/components/chart-published.tsx:196
 msgid "data.source.notTrusted"
 msgstr "Ce graphique n'utilise pas une source de données fiable."
 
-#: app/configurator/components/select-dataset-step.tsx:217
+#: app/configurator/components/select-dataset-step.tsx:219
 msgid "dataset-preview.back-to-results"
 msgstr "Revenir aux jeux de données"
 
@@ -721,7 +725,7 @@ msgstr "Jeu de données"
 msgid "dataset.footnotes.updated"
 msgstr "Mise à jour"
 
-#: app/components/chart-published.tsx:172
+#: app/components/chart-published.tsx:205
 msgid "dataset.hasImputedValues"
 msgstr "Certaines données de cet ensemble de données sont manquantes et ont été interpolées pour combler les lacunes."
 
@@ -766,13 +770,13 @@ msgstr "Pertinence"
 msgid "dataset.order.title"
 msgstr "Titre"
 
-#: app/components/chart-preview.tsx:116
-#: app/components/chart-published.tsx:141
+#: app/components/chart-preview.tsx:115
+#: app/components/chart-published.tsx:174
 #: app/configurator/components/dataset-preview.tsx:120
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Attention, ce jeu de données est à l'état d'ébauche.<0/><1>Ne l'utilisez pas pour une publication!</1>"
 
-#: app/components/chart-published.tsx:152
+#: app/components/chart-published.tsx:185
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Attention, ce jeu de données est expiré.<0/><1>Ne l'utilisez pas pour une publication!</1>"
 
@@ -856,7 +860,7 @@ msgstr "Problème de téléchargement des données"
 msgid "hint.how.to.share"
 msgstr "Vous pouvez partager cette visualisation en copiant l'URL ou en l'intégrant sur votre site Web. Vous pouvez également créer une toute nouvelle visualisation, ou bien copier et modifier la visualisation ci-dessus."
 
-#: app/components/form.tsx:292
+#: app/components/form.tsx:282
 #: app/components/hint.tsx:111
 msgid "hint.loading.data"
 msgstr "Chargement des données..."
@@ -885,11 +889,11 @@ msgstr "Valeurs négatives"
 msgid "hint.publication.success"
 msgstr "Votre visualisation est à présent publiée. Partagez-là en copiant l'URL ou en utilisant les options d'intégration."
 
-#: app/charts/shared/chart-data-filters.tsx:94
+#: app/charts/shared/chart-data-filters.tsx:96
 msgid "interactive.data.filters.hide"
 msgstr "Masquer les filtres"
 
-#: app/charts/shared/chart-data-filters.tsx:96
+#: app/charts/shared/chart-data-filters.tsx:98
 msgid "interactive.data.filters.show"
 msgstr "Afficher les filtres"
 
@@ -955,7 +959,7 @@ msgstr "visualize.admin.ch"
 msgid "select.controls.filters.search"
 msgstr "Chercher"
 
-#: app/components/metadata-panel.tsx:329
+#: app/components/metadata-panel.tsx:436
 msgid "select.controls.metadata.search"
 msgstr "Sauter à..."
 

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -13,32 +13,32 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:691
+#: app/configurator/components/chart-configurator.tsx:695
 msgid "Add filter"
 msgstr "Aggiungi filtro"
 
-#: app/configurator/components/chart-configurator.tsx:664
+#: app/configurator/components/chart-configurator.tsx:668
 msgid "Drag filters to reorganize"
 msgstr "Trascina i filtri per riorganizzarli"
 
-#: app/configurator/components/chart-configurator.tsx:661
+#: app/configurator/components/chart-configurator.tsx:665
 msgid "Move filter down"
 msgstr "Sposta il filtro in basso"
 
-#: app/configurator/components/chart-configurator.tsx:658
+#: app/configurator/components/chart-configurator.tsx:662
 msgid "Move filter up"
 msgstr "Sposta il filtro in alto"
 
-#: app/components/select-tree.tsx:527
+#: app/components/select-tree.tsx:525
 #: app/configurator/components/dataset-browse.tsx:1046
 msgid "No results"
 msgstr "Nessun risultato"
 
-#: app/components/chart-preview.tsx:187
+#: app/components/chart-preview.tsx:184
 msgid "annotation.add.description"
 msgstr "[ Nessuna descrizione ]"
 
-#: app/components/chart-preview.tsx:149
+#: app/components/chart-preview.tsx:148
 msgid "annotation.add.title"
 msgstr "[ Nessun titolo ]"
 
@@ -54,15 +54,15 @@ msgstr "Categorie"
 msgid "browse.dataset.create-visualization"
 msgstr "Iniziare una visualizzazione"
 
-#: app/configurator/components/select-dataset-step.tsx:296
+#: app/configurator/components/select-dataset-step.tsx:298
 msgid "browse.datasets.all-datasets"
 msgstr "Tutti i set di dati"
 
-#: app/configurator/components/select-dataset-step.tsx:184
+#: app/configurator/components/select-dataset-step.tsx:186
 msgid "browse.datasets.description"
 msgstr "Esplora i set di dati forniti dal LINDAS Linked Data Service filtrando per categorie o organizzazioni oppure cercando direttamente per parole chiave specifiche. Clicca su un set di dati per vedere informazioni più dettagliate e iniziare a creare le tue visualizzazioni."
 
-#: app/components/metadata-panel.tsx:318
+#: app/components/metadata-panel.tsx:409
 msgid "button.back"
 msgstr "Torna indietro"
 
@@ -119,17 +119,17 @@ msgstr "Condividi"
 msgid "chart.map.layers.area"
 msgstr "Aree"
 
-#: app/configurator/components/chart-configurator.tsx:744
-#: app/configurator/components/chart-options-selector.tsx:992
+#: app/configurator/components/chart-configurator.tsx:748
+#: app/configurator/components/chart-options-selector.tsx:1034
 #: app/configurator/components/field-i18n.ts:31
 msgid "chart.map.layers.base"
 msgstr "Visualizzazione della mappa"
 
-#: app/configurator/components/chart-options-selector.tsx:996
+#: app/configurator/components/chart-options-selector.tsx:1038
 msgid "chart.map.layers.base.show"
 msgstr "Mostra mappa del mondo"
 
-#: app/configurator/components/chart-options-selector.tsx:1004
+#: app/configurator/components/chart-options-selector.tsx:1046
 msgid "chart.map.layers.base.view.locked"
 msgstr "Vista bloccata"
 
@@ -174,6 +174,10 @@ msgstr "Regular"
 msgid "controls..interactiveFilters.time.defaultSettings"
 msgstr "Impostazioni predefinite"
 
+#: app/configurator/components/field-i18n.ts:87
+msgid "controls.abbreviations"
+msgstr "Usa abbreviazioni"
+
 #: app/configurator/components/chart-annotator.tsx:70
 msgid "controls.annotator.add-description-warning"
 msgstr "Aggiungi una descrizione"
@@ -190,39 +194,39 @@ msgstr "Asse orizzontale"
 msgid "controls.axis.vertical"
 msgstr "Asse verticale"
 
-#: app/configurator/components/field-i18n.ts:115
+#: app/configurator/components/field-i18n.ts:119
 msgid "controls.chart.type.area"
 msgstr "Aree"
 
-#: app/configurator/components/field-i18n.ts:107
+#: app/configurator/components/field-i18n.ts:111
 msgid "controls.chart.type.bar"
 msgstr "Barre"
 
-#: app/configurator/components/field-i18n.ts:103
+#: app/configurator/components/field-i18n.ts:107
 msgid "controls.chart.type.column"
 msgstr "Colonne"
 
-#: app/configurator/components/field-i18n.ts:111
+#: app/configurator/components/field-i18n.ts:115
 msgid "controls.chart.type.line"
 msgstr "Linee"
 
-#: app/configurator/components/field-i18n.ts:131
+#: app/configurator/components/field-i18n.ts:135
 msgid "controls.chart.type.map"
 msgstr "Mappa"
 
-#: app/configurator/components/field-i18n.ts:123
+#: app/configurator/components/field-i18n.ts:127
 msgid "controls.chart.type.pie"
 msgstr "Torta"
 
-#: app/configurator/components/field-i18n.ts:119
+#: app/configurator/components/field-i18n.ts:123
 msgid "controls.chart.type.scatterplot"
 msgstr "Scatterplot"
 
-#: app/configurator/components/field-i18n.ts:127
+#: app/configurator/components/field-i18n.ts:131
 msgid "controls.chart.type.table"
 msgstr "Tabella"
 
-#: app/configurator/components/chart-options-selector.tsx:723
+#: app/configurator/components/chart-options-selector.tsx:765
 #: app/configurator/components/field-i18n.ts:17
 msgid "controls.color"
 msgstr "Colore"
@@ -231,7 +235,7 @@ msgstr "Colore"
 msgid "controls.color.add"
 msgstr "Aggiungi ..."
 
-#: app/configurator/components/chart-options-selector.tsx:752
+#: app/configurator/components/chart-options-selector.tsx:794
 msgid "controls.color.opacity"
 msgstr "Trasparenza"
 
@@ -252,35 +256,35 @@ msgstr "Ripristina la tavolozza dei colori"
 msgid "controls.color.palette.sequential"
 msgstr "Sequenziale"
 
-#: app/configurator/components/chart-options-selector.tsx:839
+#: app/configurator/components/chart-options-selector.tsx:881
 msgid "controls.color.scale.discretization.jenks"
 msgstr "Jenks (interruzioni naturali)"
 
-#: app/configurator/components/chart-options-selector.tsx:832
+#: app/configurator/components/chart-options-selector.tsx:874
 msgid "controls.color.scale.discretization.quantiles"
 msgstr "Quantili (distribuzione omogenea dei valori)"
 
-#: app/configurator/components/chart-options-selector.tsx:825
+#: app/configurator/components/chart-options-selector.tsx:867
 msgid "controls.color.scale.discretization.quantize"
 msgstr "Intervalli uguali"
 
-#: app/configurator/components/chart-options-selector.tsx:817
+#: app/configurator/components/chart-options-selector.tsx:859
 msgid "controls.color.scale.interpolation"
 msgstr "Interpolazione"
 
-#: app/configurator/components/chart-options-selector.tsx:849
+#: app/configurator/components/chart-options-selector.tsx:891
 msgid "controls.color.scale.number.of.classes"
 msgstr "Numero di classi"
 
-#: app/configurator/components/chart-options-selector.tsx:789
+#: app/configurator/components/chart-options-selector.tsx:831
 msgid "controls.color.scale.type.continuous"
 msgstr "Continuo"
 
-#: app/configurator/components/chart-options-selector.tsx:800
+#: app/configurator/components/chart-options-selector.tsx:842
 msgid "controls.color.scale.type.discrete"
 msgstr "Discreto"
 
-#: app/configurator/components/chart-options-selector.tsx:742
+#: app/configurator/components/chart-options-selector.tsx:784
 msgid "controls.color.select"
 msgstr "Seleziona un colore"
 
@@ -300,8 +304,8 @@ msgstr "impilate"
 msgid "controls.description"
 msgstr "Descrizione"
 
-#: app/charts/shared/chart-data-filters.tsx:247
-#: app/charts/shared/chart-data-filters.tsx:291
+#: app/charts/shared/chart-data-filters.tsx:249
+#: app/charts/shared/chart-data-filters.tsx:296
 msgid "controls.dimensionvalue.none"
 msgstr "Nessun filtro"
 
@@ -317,12 +321,12 @@ msgstr "Seleziona tutti"
 msgid "controls.filter.select.none"
 msgstr "Deseleziona tutto"
 
-#: app/configurator/components/chart-configurator.tsx:506
+#: app/configurator/components/chart-configurator.tsx:510
 #: app/configurator/components/filters.tsx:366
 msgid "controls.filters.interactive.toggle"
 msgstr "Interattivo"
 
-#: app/configurator/components/chart-configurator.tsx:499
+#: app/configurator/components/chart-configurator.tsx:503
 #: app/configurator/components/filters.tsx:360
 msgid "controls.filters.interactive.tooltip"
 msgstr "Consenti agli utenti di modificare il filtro"
@@ -347,23 +351,23 @@ msgstr "intervallo di tempo"
 msgid "controls.groups.empty-help"
 msgstr "Trascina qui le colonne per creare gruppi."
 
-#: app/configurator/components/field-i18n.ts:87
+#: app/configurator/components/field-i18n.ts:91
 msgid "controls.imputation"
 msgstr "Tipo di imputazione"
 
-#: app/configurator/components/chart-options-selector.tsx:884
-#: app/configurator/components/field-i18n.ts:99
+#: app/configurator/components/chart-options-selector.tsx:926
+#: app/configurator/components/field-i18n.ts:103
 msgid "controls.imputation.type.linear"
 msgstr "Interpolazione lineare"
 
-#: app/configurator/components/chart-options-selector.tsx:877
-#: app/configurator/components/chart-options-selector.tsx:889
-#: app/configurator/components/field-i18n.ts:91
+#: app/configurator/components/chart-options-selector.tsx:919
+#: app/configurator/components/chart-options-selector.tsx:931
+#: app/configurator/components/field-i18n.ts:95
 msgid "controls.imputation.type.none"
 msgstr "-"
 
-#: app/configurator/components/chart-options-selector.tsx:879
-#: app/configurator/components/field-i18n.ts:95
+#: app/configurator/components/chart-options-selector.tsx:921
+#: app/configurator/components/field-i18n.ts:99
 msgid "controls.imputation.type.zeros"
 msgstr "Zeri"
 
@@ -380,19 +384,19 @@ msgstr "Nessuna dimensione temporale disponibile!"
 msgid "controls.interactiveFilters.time.toggleTimeFilter"
 msgstr "Mostra i filtri temporali"
 
-#: app/configurator/components/field-i18n.ts:135
+#: app/configurator/components/field-i18n.ts:139
 msgid "controls.language.english"
 msgstr "Inglese"
 
-#: app/configurator/components/field-i18n.ts:143
+#: app/configurator/components/field-i18n.ts:147
 msgid "controls.language.french"
 msgstr "Francese"
 
-#: app/configurator/components/field-i18n.ts:139
+#: app/configurator/components/field-i18n.ts:143
 msgid "controls.language.german"
 msgstr "Tedesco"
 
-#: app/configurator/components/field-i18n.ts:147
+#: app/configurator/components/field-i18n.ts:151
 msgid "controls.language.italian"
 msgstr "Italiano"
 
@@ -400,16 +404,16 @@ msgstr "Italiano"
 msgid "controls.measure"
 msgstr "Misura"
 
-#: app/components/metadata-panel.tsx:251
-#: app/components/metadata-panel.tsx:263
+#: app/components/metadata-panel.tsx:342
+#: app/components/metadata-panel.tsx:354
 msgid "controls.metadata-panel.metadata"
 msgstr "Metadata"
 
-#: app/components/metadata-panel.tsx:231
+#: app/components/metadata-panel.tsx:310
 msgid "controls.metadata-panel.section.data"
 msgstr "Dati"
 
-#: app/components/metadata-panel.tsx:221
+#: app/components/metadata-panel.tsx:300
 msgid "controls.metadata-panel.section.general"
 msgstr "Generale"
 
@@ -433,19 +437,19 @@ msgstr "Attivo"
 msgid "controls.option.isNotActive"
 msgstr "Inattivo"
 
-#: app/configurator/components/chart-options-selector.tsx:782
+#: app/configurator/components/chart-options-selector.tsx:824
 msgid "controls.scale.type"
 msgstr "Tipo di scala"
 
-#: app/components/form.tsx:625
+#: app/components/form.tsx:611
 msgid "controls.search.clear"
 msgstr "Cancella la ricerca"
 
-#: app/configurator/components/chart-options-selector.tsx:355
+#: app/configurator/components/chart-options-selector.tsx:378
 msgid "controls.section.additional-information"
 msgstr "Informazioni aggiuntive"
 
-#: app/configurator/components/chart-configurator.tsx:580
+#: app/configurator/components/chart-configurator.tsx:584
 msgid "controls.section.chart.options"
 msgstr "Opzioni del grafico"
 
@@ -457,7 +461,7 @@ msgstr "Colonne"
 msgid "controls.section.columnstyle"
 msgstr "Stile della colonna"
 
-#: app/configurator/components/chart-configurator.tsx:598
+#: app/configurator/components/chart-configurator.tsx:602
 msgid "controls.section.data.filters"
 msgstr "Filtri"
 
@@ -465,8 +469,8 @@ msgstr "Filtri"
 msgid "controls.section.description"
 msgstr "Titolo e descrizione"
 
-#: app/configurator/components/chart-options-selector.tsx:414
-#: app/configurator/components/chart-options-selector.tsx:418
+#: app/configurator/components/chart-options-selector.tsx:456
+#: app/configurator/components/chart-options-selector.tsx:460
 #: app/configurator/table/table-chart-options.tsx:319
 #: app/configurator/table/table-chart-options.tsx:323
 #: app/configurator/table/table-chart-options.tsx:343
@@ -478,11 +482,11 @@ msgstr "Filtro"
 msgid "controls.section.groups"
 msgstr "Gruppi"
 
-#: app/configurator/components/chart-options-selector.tsx:918
+#: app/configurator/components/chart-options-selector.tsx:960
 msgid "controls.section.imputation"
 msgstr "Valori mancanti"
 
-#: app/configurator/components/chart-options-selector.tsx:923
+#: app/configurator/components/chart-options-selector.tsx:965
 msgid "controls.section.imputation.explanation"
 msgstr "Per questo tipo di grafico, i valori di sostituzione devono essere assegnati ai valori mancanti. Decidi la logica di imputazione o passa a un altro tipo di grafico."
 
@@ -491,11 +495,11 @@ msgstr "Per questo tipo di grafico, i valori di sostituzione devono essere asseg
 msgid "controls.section.interactive.filters"
 msgstr "Filtri interattivi"
 
-#: app/configurator/components/chart-options-selector.tsx:364
+#: app/configurator/components/chart-options-selector.tsx:387
 msgid "controls.section.show-standard-error"
 msgstr "Mostra l'errore standard"
 
-#: app/configurator/components/chart-options-selector.tsx:560
+#: app/configurator/components/chart-options-selector.tsx:602
 msgid "controls.section.sorting"
 msgstr "Ordina"
 
@@ -515,13 +519,13 @@ msgstr "Opzioni della tabella"
 msgid "controls.section.title.warning"
 msgstr "Aggiungi un titolo o una descrizione"
 
-#: app/configurator/components/chart-configurator.tsx:572
+#: app/configurator/components/chart-configurator.tsx:576
 #: app/configurator/components/chart-type-selector.tsx:131
 #: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
 msgstr "Tipo di grafico"
 
-#: app/configurator/components/chart-options-selector.tsx:464
+#: app/configurator/components/chart-options-selector.tsx:506
 msgid "controls.select.column.layout"
 msgstr "Layout a colonne"
 
@@ -557,14 +561,14 @@ msgstr "Colore del testo"
 msgid "controls.select.columnStyle.textStyle"
 msgstr "Stile del testo"
 
-#: app/configurator/components/chart-options-selector.tsx:219
+#: app/configurator/components/chart-options-selector.tsx:223
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:262
 msgid "controls.select.dimension"
 msgstr "Seleziona una dimensione"
 
-#: app/configurator/components/chart-options-selector.tsx:220
-#: app/configurator/components/chart-options-selector.tsx:650
-#: app/configurator/components/chart-options-selector.tsx:728
+#: app/configurator/components/chart-options-selector.tsx:224
+#: app/configurator/components/chart-options-selector.tsx:692
+#: app/configurator/components/chart-options-selector.tsx:770
 msgid "controls.select.measure"
 msgstr "Seleziona una misura"
 
@@ -581,7 +585,7 @@ msgstr "Pour de meilleurs résultats, ne sélectionnez pas plus de 7 valeurs dan
 msgid "controls.set-values-apply"
 msgstr "Appliquer les filtres"
 
-#: app/configurator/components/chart-options-selector.tsx:642
+#: app/configurator/components/chart-options-selector.tsx:684
 msgid "controls.size"
 msgstr "Grandezza"
 
@@ -589,12 +593,12 @@ msgstr "Grandezza"
 msgid "controls.sorting.addDimension"
 msgstr "Aggiungi una dimensione"
 
-#: app/configurator/components/chart-options-selector.tsx:512
+#: app/configurator/components/chart-options-selector.tsx:554
 msgid "controls.sorting.byAuto"
 msgstr "Automatico"
 
-#: app/configurator/components/chart-options-selector.tsx:506
-#: app/configurator/components/chart-options-selector.tsx:516
+#: app/configurator/components/chart-options-selector.tsx:548
+#: app/configurator/components/chart-options-selector.tsx:558
 msgid "controls.sorting.byDimensionLabel"
 msgstr "Nome"
 
@@ -608,7 +612,7 @@ msgstr "A → Z"
 msgid "controls.sorting.byDimensionLabel.descending"
 msgstr "Z → A"
 
-#: app/configurator/components/chart-options-selector.tsx:508
+#: app/configurator/components/chart-options-selector.tsx:550
 msgid "controls.sorting.byMeasure"
 msgstr "Misura"
 
@@ -620,7 +624,7 @@ msgstr "1 → 9"
 msgid "controls.sorting.byMeasure.descending"
 msgstr "9 → 1"
 
-#: app/configurator/components/chart-options-selector.tsx:510
+#: app/configurator/components/chart-options-selector.tsx:552
 msgid "controls.sorting.byTotalSize"
 msgstr "Grandezza totale"
 
@@ -701,11 +705,11 @@ msgstr "Cubo IRI"
 msgid "data.source"
 msgstr "Fonte di dati"
 
-#: app/components/chart-published.tsx:163
+#: app/components/chart-published.tsx:196
 msgid "data.source.notTrusted"
 msgstr "Questo grafico non utilizza una fonte di dati affidabile."
 
-#: app/configurator/components/select-dataset-step.tsx:217
+#: app/configurator/components/select-dataset-step.tsx:219
 msgid "dataset-preview.back-to-results"
 msgstr "Torna ai set di dati"
 
@@ -721,7 +725,7 @@ msgstr "Set di dati"
 msgid "dataset.footnotes.updated"
 msgstr "Ultimo aggiornamento"
 
-#: app/components/chart-published.tsx:172
+#: app/components/chart-published.tsx:205
 msgid "dataset.hasImputedValues"
 msgstr "In questo set di dati mancano alcuni dati. Questi sono stati interpolati per colmare le lacune.."
 
@@ -766,13 +770,13 @@ msgstr "Rilevanza"
 msgid "dataset.order.title"
 msgstr "Titolo"
 
-#: app/components/chart-preview.tsx:116
-#: app/components/chart-published.tsx:141
+#: app/components/chart-preview.tsx:115
+#: app/components/chart-published.tsx:174
 #: app/configurator/components/dataset-preview.tsx:120
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Attenzione, questo set di dati è una bozza.<0/><1>Non utilizzare questo grafico per un rapporto!</1>"
 
-#: app/components/chart-published.tsx:152
+#: app/components/chart-published.tsx:185
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Attenzione, questo set di dati è scaduto.<0/><1>Non utilizzare questo grafico per un rapporto!</1>"
 
@@ -856,7 +860,7 @@ msgstr "Problema di caricamento dei dati"
 msgid "hint.how.to.share"
 msgstr "È possibile condividere questa visualizzazione copiando l'URL o incorporandola nel vostro sito Web. Puoi anche creare una nuova visualizzazione partendo da zero oppure copiando e modificando la visualizzazione sopra."
 
-#: app/components/form.tsx:292
+#: app/components/form.tsx:282
 #: app/components/hint.tsx:111
 msgid "hint.loading.data"
 msgstr "Caricamento dei dati..."
@@ -885,11 +889,11 @@ msgstr "Valori negativi"
 msgid "hint.publication.success"
 msgstr "La tua visualizzazione è ora pubblicata. Condividila copiando l'URL o utilizzando le opzioni di incorporamento."
 
-#: app/charts/shared/chart-data-filters.tsx:94
+#: app/charts/shared/chart-data-filters.tsx:96
 msgid "interactive.data.filters.hide"
 msgstr "Nascondi i filtri"
 
-#: app/charts/shared/chart-data-filters.tsx:96
+#: app/charts/shared/chart-data-filters.tsx:98
 msgid "interactive.data.filters.show"
 msgstr "Mostra i filtri"
 
@@ -955,7 +959,7 @@ msgstr "visualize.admin.ch"
 msgid "select.controls.filters.search"
 msgstr "Cerca"
 
-#: app/components/metadata-panel.tsx:329
+#: app/components/metadata-panel.tsx:436
 msgid "select.controls.metadata.search"
 msgstr "Salta a..."
 

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -304,6 +304,7 @@ export const getCubeDimensionValuesWithMetadata = async ({
             scaleType === "Nominal" || scaleType === "Ordinal"
               ? schema.color
               : null,
+          alternateName: schema.alternateName,
         },
       }),
       dimensionIsVersioned(dimension)
@@ -311,20 +312,20 @@ export const getCubeDimensionValuesWithMetadata = async ({
         : [],
     ]);
 
-    const identifiersLookup = new Map(
-      literals.map(({ iri, identifier }) => [iri.value, identifier?.value])
+    const lookup = new Map(
+      literals.map(({ iri, alternateName, identifier, position, color }) => [
+        iri.value,
+        {
+          alternateName: alternateName?.value,
+          identifier: identifier?.value,
+          position: position?.value,
+          color: color?.value,
+        },
+      ])
     );
 
     const labelsLookup = new Map(
       labels.map(({ iri, label }) => [iri.value, label?.value])
-    );
-
-    const positionsLookup = new Map(
-      literals.map(({ iri, position }) => [iri.value, position?.value])
-    );
-
-    const colorsLookup = new Map(
-      literals.map(({ iri, color }) => [iri.value, color?.value])
     );
 
     const unversionedLookup = new Map(
@@ -332,14 +333,18 @@ export const getCubeDimensionValuesWithMetadata = async ({
     );
 
     namedNodes.forEach((iri) => {
-      const position = positionsLookup.get(iri.value);
+      const lookupValue = lookup.get(iri.value);
 
       result.push({
         value: unversionedLookup.get(iri.value) ?? iri.value,
         label: labelsLookup.get(iri.value) ?? "",
-        position: position !== undefined ? parseInt(position, 10) : undefined,
-        identifier: identifiersLookup.get(iri.value) ?? undefined,
-        color: colorsLookup.get(iri.value) ?? undefined,
+        position:
+          lookupValue?.position !== undefined
+            ? parseInt(lookupValue.position, 10)
+            : undefined,
+        identifier: lookupValue?.identifier,
+        color: lookupValue?.color,
+        alternateName: lookupValue?.alternateName,
       });
     });
   } else if (literals.length > 0) {

--- a/app/utils/sorting-values.ts
+++ b/app/utils/sorting-values.ts
@@ -33,16 +33,25 @@ export const makeDimensionValueSorters = (
       | undefined;
     sumsBySegment?: Record<string, number | null>;
     measureBySegment?: Record<string, number | null>;
+    useAbbreviations?: boolean;
   } = {}
 ): ((label: DimensionValue["label"]) => string | undefined | number)[] => {
-  const { sorting, sumsBySegment, measureBySegment } = options;
+  const { sorting, sumsBySegment, measureBySegment, useAbbreviations } =
+    options;
   const sortingType = sorting?.sortingType;
 
   if (!dimension) {
     return [];
   }
+
+  const values = useAbbreviations
+    ? (dimension.values as DimensionValue[]).map((d) => ({
+        ...d,
+        label: d.alternateName ?? d.label,
+      }))
+    : (dimension.values as DimensionValue[]);
   const valuesByLabel = new Map<string, DimensionValue>(
-    dimension.values.map((v) => [v.label, v])
+    values.map((v) => [v.label, v])
   );
 
   const getLabel = (label?: string) => label;

--- a/e2e/abbreviations.spec.ts
+++ b/e2e/abbreviations.spec.ts
@@ -1,0 +1,68 @@
+import { expect, sleep, test } from "./common";
+
+test("it should be possible to enable abbreviations", async ({
+  actions,
+  selectors,
+}) => {
+  await actions.chart.createFrom(
+    "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/6",
+    "Prod"
+  );
+
+  await actions.editor.selectActiveField("Horizontal Axis");
+
+  let checkbox = await selectors.edition.useAbbreviationsCheckbox();
+
+  expect(await checkbox.isDisabled()).toEqual(true);
+
+  await (
+    await selectors.panels.drawer().within().findByText("Jahr der Vergütung")
+  ).click();
+
+  await actions.mui.selectOption("Kanton");
+
+  // Wait for the data to load.
+  await selectors.chart.loaded();
+  await selectors.edition.filtersLoaded();
+
+  expect(await checkbox.isDisabled()).toEqual(false);
+
+  await checkbox.click();
+
+  await sleep(5_000);
+
+  const xAxis = await selectors.chart.axisWidthBand();
+  const ticks = (await xAxis.textContent()) as string;
+  expect([ticks.slice(0, 2), ticks.slice(-2)]).toEqual(["ZH", "NE"]);
+
+  await (await selectors.panels.drawer().within().findByText("Kanton")).click();
+
+  await actions.mui.selectOption("Jahr der Vergütung");
+
+  await sleep(5_000);
+
+  await actions.drawer.close();
+
+  await actions.editor.selectActiveField("Color");
+
+  await (await selectors.panels.drawer().within().findByText("None")).click();
+
+  await actions.mui.selectOption("Kanton");
+
+  checkbox = await selectors.edition.useAbbreviationsCheckbox();
+  await checkbox.click();
+
+  // Wait for the data to load.
+  await selectors.chart.loaded();
+  await selectors.edition.filtersLoaded();
+  await selectors.chart.colorLegend(undefined, { setTimeout: 5_000 });
+
+  const legendItems = await (
+    await selectors.chart.colorLegendItems()
+  ).allInnerTexts();
+
+  expect([legendItems[0], legendItems[legendItems.length - 1]]).toEqual([
+    "ZH",
+    "JU",
+  ]);
+});

--- a/e2e/actions.ts
+++ b/e2e/actions.ts
@@ -80,6 +80,9 @@ export const createActions = ({
       within,
     }),
   },
+  drawer: {
+    close: async () => await screen.locator('text="Back to main"').click(),
+  },
 });
 
 export type Actions = ReturnType<typeof createActions>;

--- a/e2e/filters.spec.ts
+++ b/e2e/filters.spec.ts
@@ -17,15 +17,9 @@ describe("Filters", () => {
     const labels = filters.locator("label[for^=select-single-filter]");
 
     const texts = await labels.allTextContents();
-    expect(texts).toEqual([
-      // --- Hierarchy dimensions
-      "1. Production region",
-      "2. Stand structure",
-      // ---
-      "3. Inventory",
-      "4. Evaluation type",
-      "5. Reference area",
-    ]);
+    // Hierarchical dimensions should come first.
+    expect(texts[0]).toEqual("1. Production region");
+    expect(texts[1]).toEqual("2. Stand structure");
 
     const productionRegionFilter = selectors.edition.dataFilterInput(
       "1. Production region"

--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -53,12 +53,18 @@ export const createSelectors = ({ screen, page, within }: Ctx) => {
         }),
       dataFilterInput: (label: string) =>
         page.locator(`div[role="button"]:has-text("${label}")`),
+      useAbbreviationsCheckbox: () =>
+        screen
+          .getByTestId("panel-drawer")
+          .within()
+          .findByText("Use abbreviations"),
     },
     published: {
       interactiveFilters: () =>
         screen.getByTestId("published-chart-interactive-filters"),
     },
     chart: {
+      axisWidthBand: async () => screen.findByTestId("axis-width-band"),
       colorLegend: (options?, waitForOptions?) =>
         screen.findByTestId("colorLegend", options, waitForOptions),
       colorLegendItems: async () =>

--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -46,7 +46,7 @@ export const createSelectors = ({ screen, page, within }: Ctx) => {
         page.locator(`[data-value="${value}"]`),
       chartTypeSelector: () => screen.findByTestId("chart-type-selector"),
       filtersLoaded: () =>
-        screen.findByText("Selected filters", undefined, { timeout: 5000 }),
+        screen.findByText("Selected filters", undefined, { timeout: 10_000 }),
       controlSection: (title: string) =>
         page.locator("[data-testid=controlSection]", {
           has: page.locator(`h5:text-is("${title}")`),

--- a/e2e/sorting.spec.ts
+++ b/e2e/sorting.spec.ts
@@ -76,7 +76,7 @@ test("Segment sorting", async ({
 
     await actions.mui.selectOption("Automatic");
 
-    await page.locator('text="Back to main"').click();
+    await actions.drawer.close();
   }
 });
 


### PR DESCRIPTION
Closes #903.

This PR adds an ability to display abbreviations instead of full labels for supported dimensions (when `schema:alternateName` property is defined for dimension values).

**Supported dimensions**: all except `NumericalMeasure` and `TemporalDimension`.

**Color segmentation**: Area, Column, Line, Map, Pie, Scatterplot
**X**: Column

- [ ] **To clarify**: should the button stay visible, but disabled, or should it not be shown at all?

### How to test
1. Open [Einmalvergütung für Photovoltaikanlagen dataset](https://visualization-tool-git-feat-use-abbreviations-ixt1.vercel.app/en/browse?previous=%7B%22includeDrafts%22%3Afalse%7D&dataset=https%3A%2F%2Fenergy.ld.admin.ch%2Fsfoe%2Fbfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen%2F6&dataSource=Prod).
2. Create a chart.
3. Add color segmentation (by Kanton).
4. See that an "Use abbreviations" checkbox is visible below dimension select element.
5. It should be possible to toggle abbreviations.
6. Follow the same logic for [Bathing water quality dataset](https://visualization-tool-git-feat-use-abbreviations-ixt1.vercel.app/en/browse?dataset=https%3A%2F%2Fenvironment.ld.admin.ch%2Ffoen%2Fubd0104%2F6&dataSource=Prod), but there see that the button is disabled, because no abbreviations exist for the dimensions in this dataset.