### PR TITLE
feat: Metadata panel enhancements

### DIFF
--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -40,11 +40,7 @@ import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { Observer, useWidth } from "@/charts/shared/use-width";
 import { AreaFields } from "@/configurator";
-import {
-  DimensionValue,
-  isTemporalDimension,
-  Observation,
-} from "@/domain/data";
+import { isTemporalDimension, Observation } from "@/domain/data";
 import {
   useFormatNumber,
   formatNumberWithUnit,
@@ -130,7 +126,7 @@ const useAreasState = (
   });
 
   const segmentsByValue = useMemo(() => {
-    const values = (segmentDimension?.values || []) as DimensionValue[];
+    const values = segmentDimension?.values || [];
 
     return new Map(values.map((d) => [d.value, d]));
   }, [segmentDimension?.values]);

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -5,7 +5,6 @@ import { AreaChart } from "@/charts/area/areas-state";
 import { AxisHeightLinear } from "@/charts/shared/axis-height-linear";
 import { AxisTime, AxisTimeDomain } from "@/charts/shared/axis-width-time";
 import { BrushTime } from "@/charts/shared/brush";
-import { QueryFilters } from "@/charts/shared/chart-helpers";
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { Ruler } from "@/charts/shared/interaction/ruler";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
@@ -16,7 +15,8 @@ import {
   AreaFields,
   DataSource,
   InteractiveFiltersConfig,
-} from "@/configurator";
+  QueryFilters,
+} from "@/configurator/config-types";
 import { Observation } from "@/domain/data";
 import {
   DimensionMetadataFragment,

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -23,10 +23,9 @@ import {
   ColumnConfig,
   ColumnFields,
   DataSource,
-  Filters,
-  FilterValueSingle,
   InteractiveFiltersConfig,
-} from "@/configurator";
+  QueryFilters,
+} from "@/configurator/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import { Observation } from "@/domain/data";
 import {
@@ -46,7 +45,7 @@ export const ChartColumnsVisualization = ({
   dataSetIri: string;
   dataSource: DataSource;
   chartConfig: ColumnConfig;
-  queryFilters: Filters | FilterValueSingle;
+  queryFilters: QueryFilters;
 }) => {
   const locale = useLocale();
   const [queryResp] = useDataCubeObservationsQuery({

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -47,11 +47,7 @@ import {
   useErrorMeasure,
   useErrorRange,
 } from "@/configurator/components/ui-helpers";
-import {
-  DimensionValue,
-  isTemporalDimension,
-  Observation,
-} from "@/domain/data";
+import { isTemporalDimension, Observation } from "@/domain/data";
 import { useFormatNumber, formatNumberWithUnit } from "@/formatters";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 import { getPalette } from "@/palettes";
@@ -138,7 +134,7 @@ const useGroupedColumnsState = (
   });
 
   const segmentsByValue = useMemo(() => {
-    const values = (segmentDimension?.values || []) as DimensionValue[];
+    const values = segmentDimension?.values || [];
 
     return new Map(values.map((d) => [d.value, d]));
   }, [segmentDimension?.values]);

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -47,11 +47,7 @@ import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { Observer, useWidth } from "@/charts/shared/use-width";
 import { ColumnFields, SortingOrder, SortingType } from "@/configurator";
-import {
-  DimensionValue,
-  isTemporalDimension,
-  Observation,
-} from "@/domain/data";
+import { isTemporalDimension, Observation } from "@/domain/data";
 import { formatNumberWithUnit, useFormatNumber } from "@/formatters";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 import { getPalette } from "@/palettes";
@@ -138,7 +134,7 @@ const useColumnsStackedState = (
   });
 
   const segmentsByValue = useMemo(() => {
-    const values = (segmentDimension?.values || []) as DimensionValue[];
+    const values = segmentDimension?.values || [];
 
     return new Map(values.map((d) => [d.value, d]));
   }, [segmentDimension?.values]);

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -13,12 +13,11 @@ import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import {
   DataSource,
-  Filters,
-  FilterValueSingle,
   InteractiveFiltersConfig,
   LineConfig,
   LineFields,
-} from "@/configurator";
+  QueryFilters,
+} from "@/configurator/config-types";
 import { Observation } from "@/domain/data";
 import {
   DimensionMetadataFragment,
@@ -37,7 +36,7 @@ export const ChartLinesVisualization = ({
   dataSetIri: string;
   dataSource: DataSource;
   chartConfig: LineConfig;
-  queryFilters: Filters | FilterValueSingle;
+  queryFilters: QueryFilters;
 }) => {
   const locale = useLocale();
   const [queryResp] = useDataCubeObservationsQuery({

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -33,11 +33,7 @@ import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { Observer, useWidth } from "@/charts/shared/use-width";
 import { LineFields } from "@/configurator";
-import {
-  DimensionValue,
-  isTemporalDimension,
-  Observation,
-} from "@/domain/data";
+import { isTemporalDimension, Observation } from "@/domain/data";
 import {
   useFormatNumber,
   formatNumberWithUnit,
@@ -125,7 +121,7 @@ const useLinesState = (
   });
 
   const segmentsByValue = useMemo(() => {
-    const values = (segmentDimension?.values || []) as DimensionValue[];
+    const values = segmentDimension?.values || [];
 
     return new Map(values.map((d) => [d.value, d]));
   }, [segmentDimension?.values]);

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -7,9 +7,14 @@ import { MapComponent } from "@/charts/map/map";
 import { MapLegend } from "@/charts/map/map-legend";
 import { MapChart } from "@/charts/map/map-state";
 import { MapTooltip } from "@/charts/map/map-tooltip";
-import { QueryFilters } from "@/charts/shared/chart-helpers";
 import { ChartContainer } from "@/charts/shared/containers";
-import { BaseLayer, DataSource, MapConfig, MapFields } from "@/configurator";
+import {
+  BaseLayer,
+  DataSource,
+  MapConfig,
+  MapFields,
+  QueryFilters,
+} from "@/configurator/config-types";
 import {
   AreaLayer,
   GeoData,

--- a/app/charts/map/map-state.tsx
+++ b/app/charts/map/map-state.tsx
@@ -44,7 +44,6 @@ import {
   NumericalColorField,
 } from "@/configurator/config-types";
 import {
-  DimensionValue,
   findRelatedErrorDimension,
   GeoData,
   isGeoShapesDimension,
@@ -181,13 +180,12 @@ const getCategoricalColors = (
   const component = [...dimensions, ...measures].find(
     (d) => d.iri === color.componentIri
   ) as DimensionMetadataFragment;
-  const values = component.values as DimensionValue[];
-  const valuesByLabel = keyBy(values, (d) => d.label);
+  const valuesByLabel = keyBy(component.values, (d) => d.label);
   const valuesByAbbreviationOrLabel = keyBy(
-    values,
+    component.values,
     color.useAbbreviations ? (d) => d.alternateName ?? d.label : (d) => d.label
   );
-  const domain: string[] = values.map((d) => `${d.value}`) || [];
+  const domain: string[] = component.values.map((d) => `${d.value}`) || [];
   const rgbColorMapping = mapValues(color.colorMapping, (d) =>
     colorToRgbArray(d)
   );

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -16,12 +16,11 @@ import {
 } from "@/components/hint";
 import {
   DataSource,
-  Filters,
-  FilterValueSingle,
   InteractiveFiltersConfig,
   PieConfig,
   PieFields,
-} from "@/configurator";
+  QueryFilters,
+} from "@/configurator/config-types";
 import { Observation } from "@/domain/data";
 import {
   DimensionMetadataFragment,
@@ -38,7 +37,7 @@ export const ChartPieVisualization = ({
   dataSetIri: string;
   dataSource: DataSource;
   chartConfig: PieConfig;
-  queryFilters: Filters | FilterValueSingle;
+  queryFilters: QueryFilters;
 }) => {
   const locale = useLocale();
   const [{ data, fetching, error }] = useDataCubeObservationsQuery({

--- a/app/charts/pie/pie-state.tsx
+++ b/app/charts/pie/pie-state.tsx
@@ -23,7 +23,7 @@ import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { Observer, useWidth } from "@/charts/shared/use-width";
 import { PieFields } from "@/configurator";
-import { DimensionValue, Observation } from "@/domain/data";
+import { Observation } from "@/domain/data";
 import { formatNumberWithUnit, useFormatNumber } from "@/formatters";
 import { getPalette } from "@/palettes";
 import {
@@ -85,7 +85,7 @@ const usePieState = (
   });
 
   const segmentsByValue = useMemo(() => {
-    const values = (segmentDimension?.values || []) as DimensionValue[];
+    const values = segmentDimension?.values || [];
 
     return new Map(values.map((d) => [d.value, d]));
   }, [segmentDimension?.values]);

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -16,12 +16,11 @@ import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionVoronoi } from "@/charts/shared/overlay-voronoi";
 import {
   DataSource,
-  Filters,
-  FilterValueSingle,
   InteractiveFiltersConfig,
+  QueryFilters,
   ScatterPlotConfig,
   ScatterPlotFields,
-} from "@/configurator";
+} from "@/configurator/config-types";
 import { Observation } from "@/domain/data";
 import {
   DimensionMetadataFragment,
@@ -40,7 +39,7 @@ export const ChartScatterplotVisualization = ({
   dataSetIri: string;
   dataSource: DataSource;
   chartConfig: ScatterPlotConfig;
-  queryFilters: Filters | FilterValueSingle;
+  queryFilters: QueryFilters;
 }) => {
   const locale = useLocale();
   const [queryResp] = useDataCubeObservationsQuery({

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -25,7 +25,7 @@ import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { Observer, useWidth } from "@/charts/shared/use-width";
 import { ScatterPlotFields } from "@/configurator";
 import { mkNumber } from "@/configurator/components/ui-helpers";
-import { DimensionValue, Observation } from "@/domain/data";
+import { Observation } from "@/domain/data";
 import { useFormatNumber } from "@/formatters";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 import { getPalette } from "@/palettes";
@@ -84,7 +84,7 @@ const useScatterplotState = ({
   });
 
   const segmentsByValue = useMemo(() => {
-    const values = (segmentDimension?.values || []) as DimensionValue[];
+    const values = segmentDimension?.values || [];
 
     return new Map(values.map((d) => [d.value, d]));
   }, [segmentDimension?.values]);

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -304,6 +304,7 @@ const DataFilterHierarchyDimension = ({
     if (hierarchy) {
       opts = hierarchyToOptions(hierarchy);
     } else {
+      // @ts-ignore
       opts = dimensionValues;
     }
     if (!isKeyDimension) {
@@ -351,8 +352,8 @@ const DataFilterTemporalDimension = ({
   const timeIntervalWithProps = React.useMemo(
     () =>
       getTimeIntervalWithProps(
-        options[0].value,
-        options[1].value,
+        options[0].value as string,
+        options[1].value as string,
         timeUnit,
         timeFormat,
         formatLocale

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -16,17 +16,15 @@ import {
   ChartConfig,
   ChartType,
   Filters,
-  FilterValueSingle,
   ImputationType,
   InteractiveFiltersConfig,
   isAreaConfig,
+  QueryFilters,
 } from "@/configurator/config-types";
 import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import { Observation } from "@/domain/data";
 import { truthy } from "@/domain/types";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
-
-export type QueryFilters = Filters | FilterValueSingle;
 
 // Prepare filters used in data query:
 // - merges publisher data filters and interactive data filters (user-defined),

--- a/app/charts/shared/colors.tsx
+++ b/app/charts/shared/colors.tsx
@@ -1,6 +1,5 @@
 import { color, RGBColor } from "d3";
 
-import { DimensionValue } from "@/domain/data";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 
 export const colorToRgbArray = (_color: string, opacity?: number): number[] => {
@@ -25,7 +24,5 @@ export const rgbArrayToHex = (rgbArray: number[]): string => {
 export const hasDimensionColors = (
   d?: DimensionMetadataFragment
 ): d is DimensionMetadataFragment => {
-  return !!(d?.values as DimensionValue[] | undefined)?.some(
-    (d) => d.color !== undefined
-  );
+  return !!d?.values?.some((d) => d.color !== undefined);
 };

--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -15,7 +15,7 @@ import {
   isSegmentInConfig,
   useReadOnlyConfiguratorState,
 } from "@/configurator";
-import { DimensionValue, Observation } from "@/domain/data";
+import { Observation } from "@/domain/data";
 import {
   DimensionMetadataFragment,
   useDataCubeMetadataWithComponentValuesQuery,
@@ -209,19 +209,20 @@ export const MapLegendColor = memo(function LegendColor({
   getColor: (d: Observation) => number[];
   useAbbreviations: boolean;
 }) {
-  const values = component.values as DimensionValue[];
-  const sortedValues = values.sort((a, b) => a.label.localeCompare(b.label));
+  const sortedValues = component.values.sort((a, b) =>
+    a.label.localeCompare(b.label)
+  );
   const groups = useLegendGroups({
     labels: sortedValues.map((d) => `${d.value}`),
     title: component.label,
   });
   const getLabel = useAbbreviations
     ? (d: string) => {
-        const v = values.find((v) => v.value === d);
+        const v = component.values.find((v) => v.value === d);
         return (v?.alternateName || v?.label) as string;
       }
     : (d: string) => {
-        return values.find((v) => v.value === d)?.label as string;
+        return component.values.find((v) => v.value === d)?.label as string;
       };
 
   return (

--- a/app/charts/shared/use-abbreviations.tsx
+++ b/app/charts/shared/use-abbreviations.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { DimensionValue, Observation } from "@/domain/data";
+import { Observation } from "@/domain/data";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 
 export const useMaybeAbbreviations = ({
@@ -11,7 +11,7 @@ export const useMaybeAbbreviations = ({
   dimension: DimensionMetadataFragment | undefined;
 }) => {
   const { labelLookup, abbreviationOrLabelLookup } = React.useMemo(() => {
-    const values: DimensionValue[] = dimension?.values ?? [];
+    const values = dimension?.values ?? [];
 
     const labelLookup = new Map(values.map((d) => [d.label, d]));
     const abbreviationOrLabelLookup = new Map(

--- a/app/charts/table/table-content.tsx
+++ b/app/charts/table/table-content.tsx
@@ -4,7 +4,7 @@ import clsx from "clsx";
 import React, { useMemo, useContext } from "react";
 import { HeaderGroup } from "react-table";
 
-import { MaybeTooltip } from "@/utils/maybe-tooltip";
+import { OpenMetadataPanelWrapper } from "@/components/metadata-panel";
 
 import Flex from "../../components/flex";
 import { Observation } from "../../domain/data";
@@ -87,7 +87,7 @@ export const TableContent = ({ children }: { children: React.ReactNode }) => {
             // eslint-disable-next-line react/jsx-key
             <Box {...headerGroup.getHeaderGroupProps()}>
               {headerGroup.headers.map((column) => {
-                const { columnComponentType, description } =
+                const { dim, columnComponentType } =
                   tableColumnsMeta[column.id];
                 // We assume that the customSortCount items are at the beginning of the sorted array, so any item with a lower index must be a custom sorted one
                 const isCustomSorted = column.sortedIndex < customSortCount;
@@ -107,17 +107,11 @@ export const TableContent = ({ children }: { children: React.ReactNode }) => {
                       active={isCustomSorted}
                       direction={column.isSortedDesc ? "desc" : "asc"}
                     >
-                      <MaybeTooltip text={description}>
-                        <span
-                          style={{
-                            textDecoration: description
-                              ? "underline"
-                              : undefined,
-                          }}
-                        >
+                      <OpenMetadataPanelWrapper dim={dim}>
+                        <span style={{ fontWeight: "bold" }}>
                           {column.render("Header")}
                         </span>
-                      </MaybeTooltip>
+                      </OpenMetadataPanelWrapper>
                     </TableSortLabel>
                   </Flex>
                 );

--- a/app/charts/table/table-state.tsx
+++ b/app/charts/table/table-state.tsx
@@ -36,12 +36,14 @@ import {
 } from "@/configurator/components/ui-helpers";
 import { Observation } from "@/domain/data";
 import { useFormatNumber, useDimensionFormatters } from "@/formatters";
+import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 import { getColorInterpolator } from "@/palettes";
 import { useTheme } from "@/themes";
 import { estimateTextWidth } from "@/utils/estimate-text-width";
 import { makeDimensionValueSorters } from "@/utils/sorting-values";
 
 export type MKColumnMeta<T> = {
+  dim: DimensionMetadataFragment;
   iri: string;
   slugifiedIri: string;
   description?: string;
@@ -293,6 +295,7 @@ const useTableState = ({
         const formatter = formatters[iri];
         const cellFormatter = (x: Cell<Observation>) => formatter(x.value);
         const common = {
+          dim: allColumnsByIri[iri],
           iri,
           slugifiedIri,
           columnComponentType,

--- a/app/components/data-download.tsx
+++ b/app/components/data-download.tsx
@@ -26,12 +26,11 @@ import React, {
 } from "react";
 import { OperationResult, useClient } from "urql";
 
-import { QueryFilters } from "@/charts/shared/chart-helpers";
-import { DataSource } from "@/configurator";
 import { getSortedColumns } from "@/configurator/components/datatable";
+import { DataSource, QueryFilters } from "@/configurator/config-types";
+import { Observation } from "@/domain/data";
 import { useLocale } from "@/src";
 
-import { Observation } from "../domain/data";
 import {
   DataCubeObservationsDocument,
   DataCubeObservationsQuery,

--- a/app/components/metadata-panel.tsx
+++ b/app/components/metadata-panel.tsx
@@ -294,6 +294,7 @@ export const MetadataPanel = ({
         hideBackdrop
         ModalProps={{ container }}
         PaperProps={{ style: { position: "absolute" } }}
+        disableEnforceFocus
       >
         <Header onClose={handleToggle} />
 

--- a/app/components/metadata-panel.tsx
+++ b/app/components/metadata-panel.tsx
@@ -4,6 +4,7 @@ import {
   Autocomplete,
   Box,
   Button,
+  Divider,
   Drawer,
   IconButton,
   InputAdornment,
@@ -26,6 +27,7 @@ import { BackButton, DataSource } from "@/configurator";
 import { DataSetMetadata } from "@/configurator/components/dataset-metadata";
 import { DRAWER_WIDTH } from "@/configurator/components/drawer";
 import { MotionBox } from "@/configurator/components/presence";
+import { DimensionValue } from "@/domain/data";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 import { getDimensionIconName, Icon } from "@/icons";
 import SvgIcArrowRight from "@/icons/components/IcArrowRight";
@@ -547,23 +549,8 @@ const TabPanelDataDimension = ({
             component={Flex}
             {...animationProps}
           >
-            {dim.values.map((d) => (
-              <React.Fragment key={d.value}>
-                <Typography variant="body2" {...animationProps}>
-                  {d.label}{" "}
-                  {d.alternateName ? (
-                    <span style={{ fontStyle: "italic" }}>
-                      ({d.alternateName})
-                    </span>
-                  ) : (
-                    ""
-                  )}
-                </Typography>
-                {d.description ? (
-                  <Typography variant="caption">{d.description}</Typography>
-                ) : null}
-              </React.Fragment>
-            ))}
+            <Divider />
+            <DimensionValues dim={dim} />
           </MotionBox>
         )}
       </AnimatePresence>
@@ -581,5 +568,56 @@ const TabPanelDataDimension = ({
         </Button>
       )}
     </div>
+  );
+};
+
+const DimensionValues = ({ dim }: { dim: DimensionMetadataFragment }) => {
+  switch (dim.__typename) {
+    case "NominalDimension":
+    case "OrdinalDimension":
+    case "OrdinalMeasure":
+    case "GeoCoordinatesDimension":
+    case "GeoShapesDimension":
+      return <DimensionValuesNominal values={dim.values} />;
+    case "NumericalMeasure":
+    case "TemporalDimension":
+      return <DimensionValuesNumeric values={dim.values} />;
+    default:
+      const _exhaustiveCheck: never = dim;
+      return _exhaustiveCheck;
+  }
+};
+
+const DimensionValuesNominal = ({ values }: { values: DimensionValue[] }) => {
+  return (
+    <>
+      {values.map((d) => (
+        <React.Fragment key={d.value}>
+          <Typography variant="body2" {...animationProps}>
+            {d.label}{" "}
+            {d.alternateName ? (
+              <span style={{ fontStyle: "italic" }}>({d.alternateName})</span>
+            ) : (
+              ""
+            )}
+          </Typography>
+          {d.description ? (
+            <Typography variant="caption">{d.description}</Typography>
+          ) : null}
+        </React.Fragment>
+      ))}
+    </>
+  );
+};
+
+const DimensionValuesNumeric = ({ values }: { values: DimensionValue[] }) => {
+  const min = values[0];
+  const max = values[values.length - 1];
+
+  return (
+    <>
+      <Typography variant="body2">Min: {min.value}</Typography>
+      <Typography variant="body2">Max: {max.value}</Typography>
+    </>
   );
 };

--- a/app/components/metadata-panel.tsx
+++ b/app/components/metadata-panel.tsx
@@ -127,9 +127,6 @@ const useOtherStyles = makeStyles<Theme>((theme) => {
       marginTop: theme.spacing(6),
       marginBottom: theme.spacing(4),
     },
-    content: {
-      padding: theme.spacing(4),
-    },
     tabList: {
       height: 40,
       minHeight: 40,
@@ -148,7 +145,17 @@ const useOtherStyles = makeStyles<Theme>((theme) => {
       flexDirection: "column",
       gap: theme.spacing(4),
     },
-    icon: {
+    dimensionButton: {
+      textAlign: "left",
+      minHeight: 0,
+      padding: 0,
+      color: theme.palette.grey[700],
+
+      "& > svg": {
+        marginLeft: 0,
+      },
+    },
+    dimensionIcon: {
       display: "inline",
       marginLeft: -2,
       marginTop: -3,
@@ -328,8 +335,6 @@ export const MetadataPanel = ({
             ) : null}
           </AnimatePresence>
         </TabContext>
-
-        <Content />
       </Drawer>
     </>
   );
@@ -359,12 +364,6 @@ const Header = ({ onClose }: { onClose: () => void }) => {
       </IconButton>
     </div>
   );
-};
-
-const Content = () => {
-  const classes = useOtherStyles();
-
-  return <div className={classes.content}></div>;
 };
 
 const TabPanelGeneral = ({
@@ -494,9 +493,17 @@ const TabPanelDataDimension = ({
   expandable: boolean;
 }) => {
   const classes = useOtherStyles();
+  const selectedDimension = useMetadataPanelStore(
+    (state) => state.selectedDimension
+  );
   const { setSelectedDimension } = useMetadataPanelStoreActions();
   const { description, showExpandButton } = React.useMemo(() => {
-    if (expandable && dim.description && dim.description.length > 180) {
+    if (
+      expandable &&
+      dim.description &&
+      dim.description.length > 180 &&
+      !(selectedDimension && selectedDimension.iri === dim.iri)
+    ) {
       return {
         description: dim.description.slice(0, 180) + "…",
         showExpandButton: true,
@@ -507,26 +514,44 @@ const TabPanelDataDimension = ({
       description: dim.description,
       showExpandButton: false,
     };
-  }, [dim.description, expandable]);
+  }, [dim.description, expandable, dim.iri, selectedDimension]);
   const iconName = React.useMemo(() => {
     return getDimensionIconName(dim.__typename);
   }, [dim.__typename]);
 
+  const handleClick = React.useCallback(() => {
+    if (expandable) {
+      setSelectedDimension(dim);
+    }
+  }, [expandable, dim, setSelectedDimension]);
+
   return (
     <div>
       <Flex>
-        <Icon className={classes.icon} name={iconName} />
-        <Typography variant="body2" fontWeight="bold">
-          {dim.label}
-        </Typography>
+        <Button
+          className={classes.dimensionButton}
+          variant="text"
+          size="small"
+          onClick={handleClick}
+          sx={{
+            ":hover": { color: expandable ? "primary.main" : "grey.800" },
+            cursor: expandable ? "pointer" : "default",
+          }}
+        >
+          <Icon className={classes.dimensionIcon} name={iconName} />
+          <Typography variant="body2" fontWeight="bold">
+            {dim.label}
+          </Typography>
+        </Button>
       </Flex>
       {description && <Typography variant="body2">{description}</Typography>}
+
       {showExpandButton && (
         <Button
           component="a"
           variant="text"
           size="small"
-          onClick={() => setSelectedDimension(dim)}
+          onClick={handleClick}
           endIcon={<SvgIcArrowRight />}
           sx={{ p: 0 }}
         >

--- a/app/components/metadata-panel.tsx
+++ b/app/components/metadata-panel.tsx
@@ -229,7 +229,8 @@ export const OpenMetadataPanelWrapper = ({
 }) => {
   const classes = useOtherStyles();
   const { openDimension } = useMetadataPanelStoreActions();
-  const handleClick = useEvent(() => {
+  const handleClick = useEvent((e: React.MouseEvent) => {
+    e.stopPropagation();
     openDimension(dim);
   });
 

--- a/app/components/metadata-panel.tsx
+++ b/app/components/metadata-panel.tsx
@@ -286,6 +286,7 @@ export const MetadataPanel = ({
       <ToggleButton onClick={handleToggle} />
 
       <Drawer
+        data-testid="panel-metadata"
         className={drawerClasses.root}
         open={open}
         anchor="left"
@@ -344,7 +345,13 @@ export const MetadataPanel = ({
 
 const ToggleButton = ({ onClick }: { onClick: () => void }) => {
   return (
-    <Button component="a" variant="text" size="small" onClick={onClick}>
+    <Button
+      data-testid="panel-metadata-toggle"
+      component="a"
+      variant="text"
+      size="small"
+      onClick={onClick}
+    >
       <Typography variant="body2">
         <Trans id="controls.metadata-panel.metadata">Metadata</Trans>
       </Typography>

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -143,8 +143,8 @@ const DataFilterSelectGeneric = ({
     } else if (dimension.timeUnit === "Month") {
       return <DataFilterSelect {...sharedProps} />;
     } else {
-      const from = values[0].value;
-      const to = values[values.length - 1]?.value || from;
+      const from = `${values[0].value}`;
+      const to = `${values[values.length - 1]?.value || from}`;
 
       return (
         <DataFilterSelectTime
@@ -353,7 +353,7 @@ const useFilterReorder = ({
       type: "CHART_CONFIG_FILTER_SET_SINGLE",
       value: {
         dimensionIri: dimension.iri,
-        value: filterValue.value,
+        value: `${filterValue.value}`,
       },
     });
   });

--- a/app/configurator/components/chart-controls/color-palette.tsx
+++ b/app/configurator/components/chart-controls/color-palette.tsx
@@ -20,7 +20,7 @@ import {
   useConfiguratorState,
 } from "@/configurator";
 import { mapValueIrisToColor } from "@/configurator/components/ui-helpers";
-import { DimensionValue, isNumericalMeasure } from "@/domain/data";
+import { isNumericalMeasure } from "@/domain/data";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 import {
   categoricalPalettes,
@@ -64,9 +64,7 @@ export const ColorPalette = ({
   const defaultPalette =
     hasColors && component
       ? getDefaultCategoricalPalette(
-          (component.values as DimensionValue[])
-            .map((d) => d.color)
-            .filter(Boolean) as string[]
+          component.values.map((d) => d.color).filter(Boolean) as string[]
         )
       : null;
 

--- a/app/configurator/components/datatable.tsx
+++ b/app/configurator/components/datatable.tsx
@@ -16,6 +16,7 @@ import { useMemo, useRef, useState } from "react";
 
 import { useQueryFilters } from "@/charts/shared/chart-helpers";
 import { Loading } from "@/components/hint";
+import { OpenMetadataPanelWrapper } from "@/components/metadata-panel";
 import { ChartConfig, DataSource } from "@/configurator/config-types";
 import { isNumericalMeasure, Observation } from "@/domain/data";
 import { useDimensionFormatters } from "@/formatters";
@@ -29,19 +30,28 @@ import { useLocale } from "@/locales/use-locale";
 const DimensionLabel = ({
   dimension,
   tooltipProps,
+  linkToMetadataPanel,
 }: {
   dimension: DimensionMetadataFragment;
   tooltipProps?: Omit<TooltipProps, "title" | "children">;
+  linkToMetadataPanel: boolean;
 }) => {
   const label = dimension.unit
     ? `${dimension.label} (${dimension.unit})`
     : dimension.label;
-  return dimension.description ? (
+
+  return linkToMetadataPanel ? (
+    <OpenMetadataPanelWrapper dim={dimension}>
+      <span style={{ fontWeight: "bold" }}>{label}</span>
+    </OpenMetadataPanelWrapper>
+  ) : dimension.description ? (
     <Tooltip title={dimension.description} arrow {...tooltipProps}>
-      <span style={{ textDecoration: "underline" }}>{label}</span>
+      <span style={{ fontWeight: "bold", textDecoration: "underline" }}>
+        {label}
+      </span>
     </Tooltip>
   ) : (
-    <>{label}</>
+    <span style={{ fontWeight: "bold" }}>{label}</span>
   );
 };
 
@@ -49,10 +59,12 @@ export const PreviewTable = ({
   title,
   headers,
   observations,
+  linkToMetadataPanel,
 }: {
   title: string;
   headers: DimensionMetadataFragment[];
   observations: Observation[];
+  linkToMetadataPanel: boolean;
 }) => {
   const [sortBy, setSortBy] = useState<DimensionMetadataFragment>();
   const [sortDirection, setSortDirection] = useState<"asc" | "desc">();
@@ -127,7 +139,11 @@ export const PreviewTable = ({
                       },
                     }}
                   >
-                    <DimensionLabel dimension={d} tooltipProps={tooltipProps} />
+                    <DimensionLabel
+                      dimension={d}
+                      tooltipProps={tooltipProps}
+                      linkToMetadataPanel={linkToMetadataPanel}
+                    />
                   </TableSortLabel>
                 </TableCell>
               );
@@ -196,6 +212,7 @@ export const DataSetPreviewTable = ({
         title={title}
         headers={headers}
         observations={observations}
+        linkToMetadataPanel={false}
       />
     );
   } else {
@@ -245,6 +262,7 @@ export const DataSetTable = ({
           title={data.dataCubeByIri.title}
           headers={headers}
           observations={data.dataCubeByIri.observations.data}
+          linkToMetadataPanel={true}
         />
       </Box>
     );

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -56,6 +56,7 @@ import {
   useConfiguratorState,
 } from "@/configurator/configurator-state";
 import { FIELD_VALUE_NONE } from "@/configurator/constants";
+import { DimensionValue } from "@/domain/data";
 import { truthy } from "@/domain/types";
 import { useTimeFormatLocale } from "@/formatters";
 import { DimensionMetadataFragment, TimeUnit } from "@/graphql/query-hooks";
@@ -175,7 +176,7 @@ export const DataFilterSelect = ({
 
   const sortedValues = useMemo(() => {
     const sorters = makeDimensionValueSorters(dimension);
-    const sortedValues = orderBy(dimension.values, sorters);
+    const sortedValues = orderBy(dimension.values, sorters) as DimensionValue[];
 
     return sortedValues;
   }, [dimension]);
@@ -289,7 +290,7 @@ export const DataFilterSelectDay = ({
         .filter((x) => x.value !== FIELD_VALUE_NONE)
         .map((x) => {
           try {
-            return x.value;
+            return x.value as string;
           } catch (e) {
             console.warn(`Bad value ${x.value}`);
             return;

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -922,6 +922,8 @@ export const DimensionValuesMultiFilter = ({
         <MultiFilterContent
           field={field}
           colorComponent={colorComponent}
+          // FIXME: types
+          // @ts-ignore
           tree={
             hierarchyTree && hierarchyTree.length > 0
               ? hierarchyTree
@@ -987,8 +989,10 @@ export const TimeFilter = ({
     const parse = formatLocale.parse(timeFormat);
     const formatDateValue = formatLocale.format(timeFormat);
 
-    const from = parse(dimension.values[0].value);
-    const to = parse(dimension.values[dimension.values.length - 1].value);
+    const from = parse(dimension.values[0].value as string);
+    const to = parse(
+      dimension.values[dimension.values.length - 1].value as string
+    );
 
     if (!from || !to) {
       return null;
@@ -1044,9 +1048,9 @@ export const DimensionValuesSingleFilter = ({
   const dimension = data?.dataCubeByIri?.dimensionByIri;
 
   const sortedDimensionValues = useMemo(() => {
-    return dimension?.values
-      ? [...dimension.values].sort(valueComparator(locale))
-      : [];
+    const values = dimension?.values ?? [];
+
+    return [...values].sort(valueComparator(locale));
   }, [dimension?.values, locale]);
 
   if (dimension) {
@@ -1058,7 +1062,7 @@ export const DimensionValuesSingleFilter = ({
               key={dv.value}
               dimensionIri={dimensionIri}
               label={dv.label}
-              value={dv.value}
+              value={`${dv.value}`}
             />
           );
         })}

--- a/app/configurator/components/ui-helpers.ts
+++ b/app/configurator/components/ui-helpers.ts
@@ -254,9 +254,7 @@ export const canUseAbbreviations = (d?: DimensionMetadataFragment): boolean => {
       return false;
   }
 
-  const anyAbbreviationsPresent = !!(d.values as DimensionValue[]).find(
-    (d) => d.alternateName
-  );
+  const anyAbbreviationsPresent = !!d.values.find((d) => d.alternateName);
 
   return anyAbbreviationsPresent;
 };

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -521,13 +521,14 @@ export const MultiFilterContextProvider = ({
     : null;
 
   const allValues = useMemo(() => {
-    return dimensionData?.values.map((d) => d.value) ?? [];
+    return dimensionData?.values.map((d) => `${d.value}`) ?? [];
   }, [dimensionData?.values]);
 
   const activeKeys: Set<string> = useMemo(() => {
     if (!dimensionData) {
       return new Set();
     }
+
     const activeKeys = activeFilter
       ? activeFilter.type === "single"
         ? [String(activeFilter.value)]

--- a/app/configurator/config-types.ts
+++ b/app/configurator/config-types.ts
@@ -63,6 +63,8 @@ const Filters = t.record(t.string, FilterValue, "Filters");
 
 export type Filters = t.TypeOf<typeof Filters>;
 
+export type QueryFilters = Filters | FilterValueSingle;
+
 // Meta
 const Title = t.type({
   de: t.string,

--- a/app/configurator/interactive-filters/editor-time-brush.tsx
+++ b/app/configurator/interactive-filters/editor-time-brush.tsx
@@ -11,6 +11,7 @@ import {
   useConfiguratorState,
 } from "@/configurator/configurator-state";
 import { updateInteractiveTimeRangeFilter } from "@/configurator/interactive-filters/interactive-filters-config-state";
+import { DimensionValue } from "@/domain/data";
 import { useFormatFullDateAuto } from "@/formatters";
 import { useTheme } from "@/themes";
 import { useResizeObserver } from "@/utils/use-resize-observer";
@@ -29,11 +30,7 @@ export const EditorBrush = ({
   disabled,
 }: {
   timeExtent: Date[];
-  timeDataPoints?: {
-    __typename: "DimensionValue";
-    value: string;
-    label: string;
-  }[];
+  timeDataPoints?: DimensionValue[];
   disabled: boolean;
 }) => {
   const [resizeRef, width] = useResizeObserver<HTMLDivElement>();
@@ -52,7 +49,9 @@ export const EditorBrush = ({
   const getClosestDimensionValue = useCallback(
     (date: Date): Date => {
       if (timeDataPoints) {
-        const dimensionValues = timeDataPoints.map((d) => parseDate(d.value));
+        const dimensionValues = timeDataPoints.map((d) =>
+          parseDate(d.value as string)
+        );
 
         const bisectDateLeft = bisector(
           (dvs: Date, date: Date) => dvs.getTime() - date.getTime()

--- a/app/configurator/table/table-chart-options.tsx
+++ b/app/configurator/table/table-chart-options.tsx
@@ -350,11 +350,11 @@ export const TableColumnOptions = ({
               <DataFilterSelectTime
                 dimension={component}
                 label={component.label}
-                from={component.values[0].value}
-                to={
-                  component.values[component.values.length - 1]?.value ||
+                from={`${component.values[0].value}`}
+                to={`${
+                  component.values[component.values.length - 1]?.value ??
                   component.values[0].value
-                }
+                }`}
                 timeUnit={component.timeUnit}
                 timeFormat={component.timeFormat}
                 disabled={false}

--- a/app/docs/fixtures.ts
+++ b/app/docs/fixtures.ts
@@ -495,10 +495,10 @@ export const tableDimensions = [
     iri: "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/0",
     label: "Jahr",
     values: [
-      { value: "2015", label: "2015", __typename: "DimensionValue" },
-      { value: "2016", label: "2016", __typename: "DimensionValue" },
-      { value: "2017", label: "2017", __typename: "DimensionValue" },
-      { value: "2018", label: "2018", __typename: "DimensionValue" },
+      { value: "2015", label: "2015" },
+      { value: "2016", label: "2016" },
+      { value: "2017", label: "2017" },
+      { value: "2018", label: "2018" },
     ],
     __typename: "TemporalDimension",
   },
@@ -510,37 +510,31 @@ export const tableDimensions = [
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/1/0",
         label: "Schweiz",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/1/1",
         label: "Jura",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/1/2",
         label: "Mittelland",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/1/3",
         label: "Voralpen",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/1/4",
         label: "Alpen",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/1/5",
         label: "Alpen-Südseite",
-        __typename: "DimensionValue",
       },
     ],
     __typename: "NominalDimension",
@@ -553,163 +547,136 @@ export const tableDimensions = [
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/0",
         label: "Schweiz",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/1",
         label: "Zürich",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/2",
         label: "Bern / Berne",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/3",
         label: "Luzern",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/4",
         label: "Uri",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/5",
         label: "Schwyz",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/6",
         label: "Obwalden",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/7",
         label: "Nidwalden",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/8",
         label: "Glarus",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/9",
         label: "Zug",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/10",
         label: "Fribourg / Freiburg",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/11",
         label: "Solothurn",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/12",
         label: "Basel-Stadt",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/13",
         label: "Basel-Landschaft",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/14",
         label: "Schaffhausen",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/15",
         label: "Appenzell Ausserrhoden",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/16",
         label: "Appenzell Innerrhoden",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/17",
         label: "St. Gallen",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/18",
         label: "Graubünden / Grigioni / Grischun",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/19",
         label: "Aargau",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/20",
         label: "Thurgau",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/21",
         label: "Ticino",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/22",
         label: "Vaud",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/23",
         label: "Valais / Wallis",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/24",
         label: "Neuchâtel",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/25",
         label: "Genève",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2/26",
         label: "Jura",
-        __typename: "DimensionValue",
       },
     ],
     __typename: "NominalDimension",
@@ -722,37 +689,31 @@ export const tableDimensions = [
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/3/0",
         label: "Grössenklasse - Total",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/3/1",
         label: "150 - 249 ha",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/3/2",
         label: "250 - 499 ha",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/3/3",
         label: "500 - 999 ha",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/3/4",
         label: "1000 - 1999 ha",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/3/5",
         label: ">= 2000 ha",
-        __typename: "DimensionValue",
       },
     ],
     __typename: "NominalDimension",
@@ -765,61 +726,51 @@ export const tableDimensions = [
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/4/0",
         label: "Steuerhoheit - Total",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/4/1",
         label: "Mit Steuerhoheit - Total",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/4/2",
         label: ">>Bund",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/4/3",
         label: ">>Kantone",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/4/4",
         label: ">>Gemeinden",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/4/5",
         label: "Ohne Steuerhoheit - Total",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/4/6",
         label: ">>Bürger- Burgergemeinden",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/4/7",
         label: ">>übrige öffentliche ohne Steuerhoheit",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/4/8",
         label: ">>Private",
-        __typename: "DimensionValue",
       },
       {
         value:
           "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/4/9",
         label: "Gemischte (mit/ohne) - Total",
-        __typename: "DimensionValue",
       },
     ],
     __typename: "NominalDimension",

--- a/app/domain/data.ts
+++ b/app/domain/data.ts
@@ -23,6 +23,7 @@ export type ObservationValue = string | number | null;
 export type DimensionValue = {
   value: string | number;
   label: string;
+  description?: string;
   position?: number;
   color?: string;
   identifier?: string;

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -1,3 +1,7 @@
+import { DimensionValue } from '../domain/data';
+import { QueryFilters } from '../configurator';
+import { Observation } from '../domain/data';
+import { RawObservation } from '../domain/data';
 import gql from 'graphql-tag';
 import * as Urql from 'urql';
 export type Maybe<T> = T | null;
@@ -12,12 +16,12 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
-  DimensionValue: any;
+  DimensionValue: DimensionValue;
   FilterValue: any;
-  Filters: any;
+  Filters: QueryFilters;
   GeoShapes: any;
-  Observation: any;
-  RawObservation: any;
+  Observation: Observation;
+  RawObservation: RawObservation;
 };
 
 export type DataCube = {
@@ -502,37 +506,37 @@ export type DataCubesQueryVariables = Exact<{
 export type DataCubesQuery = { __typename: 'Query', dataCubes: Array<{ __typename: 'DataCubeResult', highlightedTitle?: Maybe<string>, highlightedDescription?: Maybe<string>, dataCube: { __typename: 'DataCube', iri: string, title: string, workExamples?: Maybe<Array<Maybe<string>>>, description?: Maybe<string>, publicationStatus: DataCubePublicationStatus, datePublished?: Maybe<string>, creator?: Maybe<{ __typename: 'DataCubeOrganization', iri: string, label?: Maybe<string> }>, themes: Array<{ __typename: 'DataCubeTheme', iri: string, label?: Maybe<string> }> } }> };
 
 type DimensionMetadata_GeoCoordinatesDimension_Fragment = (
-  { __typename: 'GeoCoordinatesDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'GeoCoordinatesDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_GeoCoordinatesDimension_Fragment
 );
 
 type DimensionMetadata_GeoShapesDimension_Fragment = (
-  { __typename: 'GeoShapesDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'GeoShapesDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_GeoShapesDimension_Fragment
 );
 
 type DimensionMetadata_NominalDimension_Fragment = (
-  { __typename: 'NominalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'NominalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_NominalDimension_Fragment
 );
 
 type DimensionMetadata_NumericalMeasure_Fragment = (
-  { __typename: 'NumericalMeasure', isCurrency?: Maybe<boolean>, currencyExponent?: Maybe<number>, resolution?: Maybe<number>, isDecimal?: Maybe<boolean>, iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'NumericalMeasure', isCurrency?: Maybe<boolean>, currencyExponent?: Maybe<number>, resolution?: Maybe<number>, isDecimal?: Maybe<boolean>, iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_NumericalMeasure_Fragment
 );
 
 type DimensionMetadata_OrdinalDimension_Fragment = (
-  { __typename: 'OrdinalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'OrdinalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_OrdinalDimension_Fragment
 );
 
 type DimensionMetadata_OrdinalMeasure_Fragment = (
-  { __typename: 'OrdinalMeasure', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'OrdinalMeasure', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_OrdinalMeasure_Fragment
 );
 
 type DimensionMetadata_TemporalDimension_Fragment = (
-  { __typename: 'TemporalDimension', timeUnit: TimeUnit, timeFormat: string, iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<any>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'TemporalDimension', timeUnit: TimeUnit, timeFormat: string, iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_TemporalDimension_Fragment
 );
 
@@ -575,7 +579,7 @@ export type DataCubePreviewQuery = { __typename: 'Query', dataCubeByIri?: Maybe<
     ) | (
       { __typename: 'OrdinalMeasure' }
       & DimensionMetadata_OrdinalMeasure_Fragment
-    )>, observations: { __typename: 'ObservationsQuery', data: Array<any>, sparql: string, sparqlEditorUrl?: Maybe<string> } }> };
+    )>, observations: { __typename: 'ObservationsQuery', data: Array<Observation>, sparql: string, sparqlEditorUrl?: Maybe<string> } }> };
 
 export type DataCubeMetadataQueryVariables = Exact<{
   iri: Scalars['String'];
@@ -891,7 +895,7 @@ export type DataCubeObservationsQuery = { __typename: 'Query', dataCubeByIri?: M
     ) | (
       { __typename: 'OrdinalMeasure' }
       & DimensionMetadata_OrdinalMeasure_Fragment
-    )>, observations: { __typename: 'ObservationsQuery', data: Array<any>, sparqlEditorUrl?: Maybe<string> } }> };
+    )>, observations: { __typename: 'ObservationsQuery', data: Array<Observation>, sparqlEditorUrl?: Maybe<string> } }> };
 
 export type PossibleFiltersQueryVariables = Exact<{
   iri: Scalars['String'];

--- a/app/graphql/resolvers/index.ts
+++ b/app/graphql/resolvers/index.ts
@@ -2,12 +2,7 @@ import { GraphQLJSONObject } from "graphql-type-json";
 import { topology } from "topojson-server";
 import { parse as parseWKT } from "wellknown";
 
-import {
-  DimensionValue,
-  GeoFeature,
-  GeoProperties,
-  GeoShapes,
-} from "@/domain/data";
+import { GeoFeature, GeoProperties, GeoShapes } from "@/domain/data";
 import {
   DataCubeResolvers,
   QueryResolvers,
@@ -222,9 +217,7 @@ export const resolvers: Resolvers = {
     ...mkDimensionResolvers("GeoShapesDimension"),
     geoShapes: async (parent, _, { setup }, info) => {
       const { loaders } = await setup(info);
-      const dimValues = (await loaders.dimensionValues.load(
-        parent
-      )) as DimensionValue[];
+      const dimValues = await loaders.dimensionValues.load(parent);
       const dimIris = dimValues.map((d) => `${d.value}`) as string[];
       const shapes = (await loaders.geoShapes.loadMany(
         dimIris

--- a/app/graphql/resolvers/rdf.ts
+++ b/app/graphql/resolvers/rdf.ts
@@ -306,7 +306,7 @@ export const dimensionValues: NonNullable<
   const { loaders, sparqlClient } = await setup(info);
   // Different loader if we have filters or not
   const loader = getDimensionValuesLoader(sparqlClient, loaders, filters);
-  const values: Array<DimensionValue> = await loader.load(parent);
+  const values: DimensionValue[] = await loader.load(parent);
 
   return values.sort((a, b) =>
     ascending(

--- a/app/graphql/resolvers/sql.ts
+++ b/app/graphql/resolvers/sql.ts
@@ -1,7 +1,7 @@
 import max from "lodash/max";
 import min from "lodash/min";
 
-import { QueryFilters } from "@/charts/shared/chart-helpers";
+import { QueryFilters } from "@/configurator/config-types";
 import { DimensionValue, Observation } from "@/domain/data";
 import { SQL_ENDPOINT } from "@/domain/env";
 import {

--- a/app/pages/_pivot.tsx
+++ b/app/pages/_pivot.tsx
@@ -273,6 +273,7 @@ const PivotTable = ({ dataset }: { dataset: typeof datasets[string] }) => {
           const pivotValueAttr = `${pivotDimension.iri}/${
             item[pivotDimension.iri]
           }`;
+          // @ts-ignore
           row[pivotValueAttr] = Object.fromEntries(
             measures.map((m) => [m.iri, item[m.iri]])
           );

--- a/app/utils/sorting-values.ts
+++ b/app/utils/sorting-values.ts
@@ -35,7 +35,7 @@ export const makeDimensionValueSorters = (
     measureBySegment?: Record<string, number | null>;
     useAbbreviations?: boolean;
   } = {}
-): ((label: DimensionValue["label"]) => string | undefined | number)[] => {
+): ((label: string) => string | undefined | number)[] => {
   const { sorting, sumsBySegment, measureBySegment, useAbbreviations } =
     options;
   const sortingType = sorting?.sortingType;
@@ -45,11 +45,11 @@ export const makeDimensionValueSorters = (
   }
 
   const values = useAbbreviations
-    ? (dimension.values as DimensionValue[]).map((d) => ({
+    ? dimension.values.map((d) => ({
         ...d,
         label: d.alternateName ?? d.label,
       }))
-    : (dimension.values as DimensionValue[]);
+    : dimension.values;
   const valuesByLabel = new Map<string, DimensionValue>(
     values.map((v) => [v.label, v])
   );
@@ -70,9 +70,7 @@ export const makeDimensionValueSorters = (
   const getMeasure = (label?: string) =>
     label ? measureBySegment?.[label] ?? Infinity : Infinity;
 
-  let sorters: ((
-    dv: DimensionValue["label"]
-  ) => string | undefined | number)[] = [];
+  let sorters: ((dv: string) => string | undefined | number)[] = [];
 
   const defaultSorters = [getPosition, getIdentifier, getLabel];
 
@@ -101,7 +99,7 @@ export const makeDimensionValueSorters = (
 interface Value {
   label: string;
   position?: number;
-  identifier?: number;
+  identifier?: number | string;
 }
 
 export const valueComparator = (locale: string) => (a: Value, b: Value) => {

--- a/codegen.yml
+++ b/codegen.yml
@@ -13,6 +13,13 @@ generates:
       withComponent: false
       withHooks: true
       contextType: ./context#GraphQLContext
+      scalars:
+        Observation: "../domain/data#Observation"
+        ObservationValue: "../domain/data#ObservationValue"
+        DimensionValue: "../domain/data#DimensionValue"
+        RawObservation: "../domain/data#RawObservation"
+        Filters: "../configurator#QueryFilters"
+        GeoShape: "../domain/data#GeoShape"
   app/graphql/resolver-types.ts:
     plugins:
       - "typescript"

--- a/e2e/actions.ts
+++ b/e2e/actions.ts
@@ -80,6 +80,12 @@ export const createActions = ({
       within,
     }),
   },
+  metadataPanel: {
+    toggle: async () => {
+      const toggleButton = await screen.findByTestId("panel-metadata-toggle");
+      await toggleButton.click();
+    },
+  },
   drawer: {
     close: async () => await screen.locator('text="Back to main"').click(),
   },

--- a/e2e/metadata-panel.spec.ts
+++ b/e2e/metadata-panel.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "./common";
+
+test("it should be possible to open a metadata panel by clicking on elements in the editor", async ({
+  actions,
+  selectors,
+}) => {
+  await actions.chart.createFrom(
+    "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/6",
+    "Prod"
+  );
+
+  const checkKantonDescription = async () => {
+    const kantonDimensionDescription = await selectors.panels
+      .metadata()
+      .within()
+      .findByText("Kanton, in welchem die geförderten Anlagen stehen");
+
+    expect(kantonDimensionDescription).toBeDefined();
+  };
+
+  const chartFilters = await selectors.edition.chartFilters();
+
+  await chartFilters.locator("button >> text='Kanton'").click();
+
+  await checkKantonDescription();
+
+  await actions.metadataPanel.toggle();
+
+  const configFilters = await selectors.edition.configFilters();
+
+  await configFilters.locator("button >> text='1. Kanton'").click();
+
+  await checkKantonDescription();
+});

--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -34,6 +34,7 @@ export const createSelectors = ({ screen, page, within }: Ctx) => {
       left: () => screen.getByTestId("panel-left"),
       drawer: () => screen.getByTestId("panel-drawer"),
       middle: () => screen.getByTestId("panel-middle"),
+      metadata: () => screen.getByTestId("panel-metadata"),
     },
     edition: {
       configFilters: () =>


### PR DESCRIPTION
Closes #917.

- Table headers now point to metadata panel, the tooltip is only present for dataset preview before user starts creating a chart
- Fixed a focus issue on homepage (focus is not enforced to last opened panel)
- E2E test for opening the panel when clicking on elements inside the editor

cc: @AnninaWalker 