### PR TITLE
Multiple hierarchy root handling

### DIFF
--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -30,8 +30,8 @@ import {
 import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import { HierarchyValue } from "@/graphql/resolver-types";
 import { getDefaultCategoricalPaletteName } from "@/palettes";
+import { bfs } from "@/utils/bfs";
 import { CHART_CONFIG_VERSION } from "@/utils/chart-config/versioning";
-import { dfs } from "@/utils/dfs";
 import { isMultiHierarchyNode } from "@/utils/hierarchy";
 
 import { mapValueIrisToColor } from "../configurator/components/ui-helpers";
@@ -136,10 +136,10 @@ export const DEFAULT_SORTING: SortingOption = {
 const findBottommostLayers = (dimension: DataCubeMetadata["dimensions"][0]) => {
   const leaves = [] as HierarchyValue[];
   let hasSeenMultiHierarchyNode = false;
-  dfs(dimension?.hierarchy as HierarchyValue[], (node) => {
+  bfs(dimension?.hierarchy as HierarchyValue[], (node) => {
     if (isMultiHierarchyNode(node)) {
       if (hasSeenMultiHierarchyNode) {
-        return dfs.IGNORE;
+        return bfs.IGNORE;
       } else {
         hasSeenMultiHierarchyNode = true;
       }

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -30,8 +30,9 @@ import {
 import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import { HierarchyValue } from "@/graphql/resolver-types";
 import { getDefaultCategoricalPaletteName } from "@/palettes";
-import { visitHierarchy } from "@/rdf/tree-utils";
 import { CHART_CONFIG_VERSION } from "@/utils/chart-config/versioning";
+import { dfs } from "@/utils/dfs";
+import { isMultiHierarchyNode } from "@/utils/hierarchy";
 
 import { mapValueIrisToColor } from "../configurator/components/ui-helpers";
 import {
@@ -129,9 +130,20 @@ export const DEFAULT_SORTING: SortingOption = {
   sortingOrder: "asc",
 };
 
+/**
+ * Finds bottomost layer for the first hierarchy
+ */
 const findBottommostLayers = (dimension: DataCubeMetadata["dimensions"][0]) => {
   const leaves = [] as HierarchyValue[];
-  visitHierarchy(dimension?.hierarchy as HierarchyValue[], (node) => {
+  let hasSeenMultiHierarchyNode = false;
+  dfs(dimension?.hierarchy as HierarchyValue[], (node) => {
+    if (isMultiHierarchyNode(node)) {
+      if (hasSeenMultiHierarchyNode) {
+        return dfs.IGNORE;
+      } else {
+        hasSeenMultiHierarchyNode = true;
+      }
+    }
     if ((!node.children || node.children.length === 0) && node.hasValue) {
       leaves.push(node);
     }

--- a/app/charts/shared/legend-color-helpers.ts
+++ b/app/charts/shared/legend-color-helpers.ts
@@ -10,6 +10,7 @@ export const getLegendGroups = ({
   hierarchy,
   sort,
   useAbbreviations,
+  labelIris,
 }: {
   title?: string;
   labels: string[];
@@ -17,6 +18,7 @@ export const getLegendGroups = ({
   hierarchy?: HierarchyValue[] | null;
   sort: boolean;
   useAbbreviations: boolean;
+  labelIris?: Record<string, any>;
 }) => {
   const groupsMap = new Map<HierarchyValue[], string[]>();
 
@@ -24,6 +26,7 @@ export const getLegendGroups = ({
     groupsMap.set(title ? [{ label: title } as HierarchyValue] : [], labels);
   } else {
     const labelSet = new Set(labels);
+
     const emptyParents: HierarchyValue[] = [];
 
     dfs(hierarchy, (node, { parents: _parents }) => {
@@ -32,6 +35,10 @@ export const getLegendGroups = ({
       );
 
       if (!labelSet.has(label)) {
+        return;
+      }
+
+      if (labelIris && !labelIris?.[node.value]) {
         return;
       }
 

--- a/app/charts/shared/legend-color-helpers.ts
+++ b/app/charts/shared/legend-color-helpers.ts
@@ -1,7 +1,7 @@
 import { ascending } from "d3";
 
 import { HierarchyValue } from "@/graphql/resolver-types";
-import { dfs } from "@/utils/dfs";
+import { bfs } from "@/utils/bfs";
 
 export const getLegendGroups = ({
   title,
@@ -29,7 +29,7 @@ export const getLegendGroups = ({
 
     const emptyParents: HierarchyValue[] = [];
 
-    dfs(hierarchy, (node, { parents: _parents }) => {
+    bfs(hierarchy, (node, { parents: _parents }) => {
       const label = getLabel(
         useAbbreviations ? node.alternateName || node.label : node.label
       );

--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -59,6 +59,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
   },
   groupHeader: {
     marginBottom: theme.spacing(1),
+    flexWrap: "wrap",
   },
 }));
 

--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -297,6 +297,7 @@ const LegendColorContent = ({
       {groups
         ? groups.map(([g, colorValues]) => {
             const headerLabelsArray = g.map((n) => n.label);
+            let chevronKey = 0;
             return (
               <div
                 className={classes.legendGroup}
@@ -312,7 +313,7 @@ const LegendColorContent = ({
                   >
                     {interlace(
                       g.map((n) => n.label),
-                      <SvgIcChevronRight />
+                      <SvgIcChevronRight key={chevronKey++} />
                     )}
                   </Typography>
                 ) : null}

--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -151,6 +151,12 @@ const useLegendGroups = ({
       : null
   ) as GenericSegmentField | null | undefined;
 
+  const segmentFilters = segmentField?.componentIri
+    ? configState.chartConfig.filters[segmentField.componentIri]
+    : null;
+  const segmentValues =
+    segmentFilters?.type === "multi" ? segmentFilters.values : {};
+
   const { dataSet: dataset, dataSource } = configState;
   const segmentDimension = useDimension({
     dataset,
@@ -180,8 +186,9 @@ const useLegendGroups = ({
       hierarchy,
       sort: !!(segmentField && "sorting" in segmentField),
       useAbbreviations: segmentField?.useAbbreviations ?? false,
+      labelIris: segmentValues,
     });
-  }, [title, labels, getLabel, hierarchy, segmentField]);
+  }, [title, labels, getLabel, hierarchy, segmentField, segmentValues]);
 
   return groups;
 };

--- a/app/configurator/components/use-hierarchy-parents.tsx
+++ b/app/configurator/components/use-hierarchy-parents.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/graphql/query-hooks";
 import { HierarchyValue } from "@/graphql/resolver-types";
 import { DataCubeMetadata } from "@/graphql/types";
-import { dfs } from "@/utils/dfs";
+import { bfs } from "@/utils/bfs";
 
 type NN<T> = NonNullable<T>;
 export type DimensionHierarchyQueryHierarchy = NN<
@@ -23,7 +23,7 @@ export type HierarchyParents = [
 ][];
 
 export const groupByParents = (hierarchy: DimensionHierarchyQueryHierarchy) => {
-  const allHierarchyValues = dfs(hierarchy, (node, { depth, parents }) => ({
+  const allHierarchyValues = bfs(hierarchy, (node, { depth, parents }) => ({
     node,
     parents,
     depth,
@@ -95,7 +95,7 @@ export const hierarchyToGraphviz = (
   hierarchy: DimensionHierarchyQueryHierarchy
 ) => {
   const lines = [] as string[];
-  dfs(hierarchy, (node, { parents }) => {
+  bfs(hierarchy, (node, { parents }) => {
     lines.push(`"${node.value}"[label="${node.label.replace(/"/g, "")}"]`);
     if (parents.length > 0) {
       const parent = parents[parents.length - 1];

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -29,6 +29,7 @@ import {
 import { HierarchyValue } from "@/graphql/resolver-types";
 import { useLocale } from "@/locales/use-locale";
 import { dfs } from "@/utils/dfs";
+import { isMultiHierarchyNode } from "@/utils/hierarchy";
 import useEvent from "@/utils/use-event";
 
 export type Option = {
@@ -46,10 +47,22 @@ export type FieldProps = Pick<
   "onChange" | "id" | "name" | "value" | "checked" | "type"
 >;
 
-const getLeaves = (tree: HierarchyValue[], limit?: number) => {
+const getLeaves = (
+  tree: HierarchyValue[],
+  {
+    limit,
+    ignoreNode,
+  }: {
+    limit?: number;
+    ignoreNode: (hv: HierarchyValue) => boolean;
+  }
+) => {
   const leaves = tree ? ([] as HierarchyValue[]) : undefined;
   if (tree && leaves) {
     dfs(tree, (node) => {
+      if (ignoreNode && ignoreNode(node)) {
+        return dfs.IGNORE;
+      }
       if (
         (!node.children || node.children.length === 0) &&
         node.hasValue &&
@@ -105,7 +118,23 @@ export const useChartFieldField = ({
         .toPromise();
       const tree = hierarchyData?.dataCubeByIri?.dimensionByIri
         ?.hierarchy as HierarchyValue[];
-      const leaves = getLeaves(tree);
+
+      let hasSeenMultiHierarchyNode = false;
+      const leaves = getLeaves(tree, {
+        ignoreNode: (hv) => {
+          if (isMultiHierarchyNode(hv)) {
+            if (hasSeenMultiHierarchyNode) {
+              return true;
+            } else {
+              hasSeenMultiHierarchyNode = true;
+              return false;
+            }
+          } else {
+            // normal node
+            return false;
+          }
+        },
+      });
 
       if (!unmountedRef.current) {
         dispatch({

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -119,6 +119,10 @@ export const useChartFieldField = ({
       const tree = hierarchyData?.dataCubeByIri?.dimensionByIri
         ?.hierarchy as HierarchyValue[];
 
+      /**
+       * When there are multiple hierarchies, we only want to select leaves from
+       * the first hierarchy.
+       */
       let hasSeenMultiHierarchyNode = false;
       const leaves = getLeaves(tree, {
         ignoreNode: (hv) => {

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -28,7 +28,7 @@ import {
 } from "@/graphql/query-hooks";
 import { HierarchyValue } from "@/graphql/resolver-types";
 import { useLocale } from "@/locales/use-locale";
-import { dfs } from "@/utils/dfs";
+import { bfs } from "@/utils/bfs";
 import { isMultiHierarchyNode } from "@/utils/hierarchy";
 import useEvent from "@/utils/use-event";
 
@@ -59,9 +59,9 @@ const getLeaves = (
 ) => {
   const leaves = tree ? ([] as HierarchyValue[]) : undefined;
   if (tree && leaves) {
-    dfs(tree, (node) => {
+    bfs(tree, (node) => {
       if (ignoreNode && ignoreNode(node)) {
-        return dfs.IGNORE;
+        return bfs.IGNORE;
       }
       if (
         (!node.children || node.children.length === 0) &&

--- a/app/domain/data.ts
+++ b/app/domain/data.ts
@@ -1,4 +1,4 @@
-import { Literal, NamedNode } from "rdf-js";
+import { Literal, NamedNode, Term } from "rdf-js";
 
 import { ComponentType } from "@/configurator/config-types";
 
@@ -71,7 +71,7 @@ export type GeoData = {
 };
 
 const xmlSchema = "http://www.w3.org/2001/XMLSchema#";
-const parseRDFLiteral = (value: Literal): ObservationValue => {
+export const parseRDFLiteral = (value: Literal): ObservationValue => {
   const v = value.value;
   const dt = value.datatype.value.replace(xmlSchema, "");
   switch (dt) {
@@ -106,6 +106,16 @@ const parseRDFLiteral = (value: Literal): ObservationValue => {
     default:
       return v;
   }
+};
+
+export const parseTerm = (term?: Term) => {
+  if (!term) {
+    return;
+  }
+  if (term.termType !== "Literal") {
+    return term.value;
+  }
+  return parseRDFLiteral(term);
 };
 
 /**

--- a/app/gql-flamegraph/devtool.tsx
+++ b/app/gql-flamegraph/devtool.tsx
@@ -332,9 +332,14 @@ function GqlDebug() {
     };
     const handleResult = (result: OperationResult) => {
       opsEndMapRef.current.set(result.operation.key, Date.now());
-      setResults((results) =>
-        uniqBy([...results, result], (x) => x.operation.key)
-      );
+      // Calls setState out of band since handleResult can be called while
+      // rendering a component. setState cannot be called while rendering
+      // a component.
+      setTimeout(() => {
+        setResults((results) =>
+          uniqBy([...results, result], (x) => x.operation.key)
+        );
+      }, 0);
     };
     urqlEE.on("urql-received-operation", handleOperation);
     urqlEE.on("urql-received-result", handleResult);

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -22,6 +22,8 @@ export type Scalars = {
   GeoShapes: any;
   Observation: Observation;
   RawObservation: RawObservation;
+  ValueIdentifier: any;
+  ValuePosition: any;
 };
 
 export type DataCube = {
@@ -223,8 +225,8 @@ export type HierarchyValue = {
   value: Scalars['String'];
   label: Scalars['String'];
   alternateName?: Maybe<Scalars['String']>;
-  position?: Maybe<Scalars['String']>;
-  identifier?: Maybe<Scalars['String']>;
+  position?: Maybe<Scalars['ValuePosition']>;
+  identifier?: Maybe<Scalars['ValueIdentifier']>;
   dimensionIri: Scalars['String'];
   depth: Scalars['Int'];
   children?: Maybe<Array<HierarchyValue>>;
@@ -492,6 +494,8 @@ export enum TimeUnit {
   Minute = 'Minute',
   Second = 'Second'
 }
+
+
 
 export type DataCubesQueryVariables = Exact<{
   sourceType: Scalars['String'];
@@ -936,7 +940,7 @@ export type SubthemesQueryVariables = Exact<{
 
 export type SubthemesQuery = { __typename: 'Query', subthemes: Array<{ __typename: 'DataCubeTheme', label?: Maybe<string>, iri: string }> };
 
-export type HierarchyValueFieldsFragment = { __typename: 'HierarchyValue', value: string, dimensionIri: string, depth: number, label: string, alternateName?: Maybe<string>, hasValue?: Maybe<boolean>, position?: Maybe<string>, identifier?: Maybe<string> };
+export type HierarchyValueFieldsFragment = { __typename: 'HierarchyValue', value: string, dimensionIri: string, depth: number, label: string, alternateName?: Maybe<string>, hasValue?: Maybe<boolean>, position?: Maybe<any>, identifier?: Maybe<any> };
 
 export type DimensionHierarchyQueryVariables = Exact<{
   sourceType: Scalars['String'];

--- a/app/graphql/resolver-types.ts
+++ b/app/graphql/resolver-types.ts
@@ -24,6 +24,8 @@ export type Scalars = {
   GeoShapes: any;
   Observation: Observation;
   RawObservation: RawObservation;
+  ValueIdentifier: any;
+  ValuePosition: any;
 };
 
 export type DataCube = {
@@ -225,8 +227,8 @@ export type HierarchyValue = {
   value: Scalars['String'];
   label: Scalars['String'];
   alternateName?: Maybe<Scalars['String']>;
-  position?: Maybe<Scalars['String']>;
-  identifier?: Maybe<Scalars['String']>;
+  position?: Maybe<Scalars['ValuePosition']>;
+  identifier?: Maybe<Scalars['ValueIdentifier']>;
   dimensionIri: Scalars['String'];
   depth: Scalars['Int'];
   children?: Maybe<Array<HierarchyValue>>;
@@ -495,6 +497,8 @@ export enum TimeUnit {
   Second = 'Second'
 }
 
+
+
 export type WithIndex<TObject> = TObject & Record<string, any>;
 export type ResolversObject<TObject> = WithIndex<TObject>;
 
@@ -595,6 +599,8 @@ export type ResolversTypes = ResolversObject<{
   RelatedDimension: ResolverTypeWrapper<RelatedDimension>;
   TemporalDimension: ResolverTypeWrapper<ResolvedDimension>;
   TimeUnit: TimeUnit;
+  ValueIdentifier: ResolverTypeWrapper<Scalars['ValueIdentifier']>;
+  ValuePosition: ResolverTypeWrapper<Scalars['ValuePosition']>;
 }>;
 
 /** Mapping between all available schema types and the resolvers parents */
@@ -630,6 +636,8 @@ export type ResolversParentTypes = ResolversObject<{
   RawObservation: Scalars['RawObservation'];
   RelatedDimension: RelatedDimension;
   TemporalDimension: ResolvedDimension;
+  ValueIdentifier: Scalars['ValueIdentifier'];
+  ValuePosition: Scalars['ValuePosition'];
 }>;
 
 export type DataCubeResolvers<ContextType = GraphQLContext, ParentType extends ResolversParentTypes['DataCube'] = ResolversParentTypes['DataCube']> = ResolversObject<{
@@ -760,8 +768,8 @@ export type HierarchyValueResolvers<ContextType = GraphQLContext, ParentType ext
   value?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   alternateName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  position?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  identifier?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  position?: Resolver<Maybe<ResolversTypes['ValuePosition']>, ParentType, ContextType>;
+  identifier?: Resolver<Maybe<ResolversTypes['ValueIdentifier']>, ParentType, ContextType>;
   dimensionIri?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   depth?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
   children?: Resolver<Maybe<Array<ResolversTypes['HierarchyValue']>>, ParentType, ContextType>;
@@ -898,6 +906,14 @@ export type TemporalDimensionResolvers<ContextType = GraphQLContext, ParentType 
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export interface ValueIdentifierScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['ValueIdentifier'], any> {
+  name: 'ValueIdentifier';
+}
+
+export interface ValuePositionScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['ValuePosition'], any> {
+  name: 'ValuePosition';
+}
+
 export type Resolvers<ContextType = GraphQLContext> = ResolversObject<{
   DataCube?: DataCubeResolvers<ContextType>;
   DataCubeOrganization?: DataCubeOrganizationResolvers<ContextType>;
@@ -925,6 +941,8 @@ export type Resolvers<ContextType = GraphQLContext> = ResolversObject<{
   RawObservation?: GraphQLScalarType;
   RelatedDimension?: RelatedDimensionResolvers<ContextType>;
   TemporalDimension?: TemporalDimensionResolvers<ContextType>;
+  ValueIdentifier?: GraphQLScalarType;
+  ValuePosition?: GraphQLScalarType;
 }>;
 
 

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -4,6 +4,8 @@ scalar FilterValue
 scalar RawObservation
 scalar Filters
 scalar GeoShapes
+scalar ValueIdentifier
+scalar ValuePosition
 
 type ObservationsQuery {
   "Observations with their values parsed to native JS types"
@@ -63,8 +65,8 @@ type HierarchyValue {
   value: String!
   label: String!
   alternateName: String
-  position: String
-  identifier: String
+  position: ValuePosition
+  identifier: ValueIdentifier
   dimensionIri: String!
   depth: Int!
   children: [HierarchyValue!]

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -171,22 +171,26 @@ export const createCubeDimensionValuesLoader =
     const result: DimensionValue[][] = [];
 
     for (const dimension of dimensions) {
-      const dimensionValues = await getCubeDimensionValues(
+      const dimensionValues = await getCubeDimensionValues({
         sparqlClient,
-        dimension,
-        filters
-      );
+        rdimension: dimension,
+        filters,
+      });
       result.push(dimensionValues);
     }
 
     return result;
   };
 
-export const getCubeDimensionValues = async (
-  sparqlClient: ParsingClient,
-  rdimension: ResolvedDimension,
-  filters?: Filters
-): Promise<DimensionValue[]> => {
+export const getCubeDimensionValues = async ({
+  sparqlClient,
+  rdimension,
+  filters,
+}: {
+  sparqlClient: ParsingClient;
+  rdimension: ResolvedDimension;
+  filters?: Filters;
+}): Promise<DimensionValue[]> => {
   const { dimension, cube, locale, data } = rdimension;
 
   if (
@@ -315,7 +319,12 @@ export const getCubeDimensionValuesWithMetadata = async ({
   if (namedNodes.length > 0) {
     const scaleType = getScaleType(dimension);
     const [labels, descriptions, literals, unversioned] = await Promise.all([
-      loadResourceLabels({ ids: namedNodes, locale, sparqlClient }),
+      loadResourceLabels({
+        ids: namedNodes,
+        locale,
+        sparqlClient,
+        labelTerm: schema.name,
+      }),
       scaleType === "Ordinal" || scaleType === "Nominal"
         ? loadResourceLabels({
             ids: namedNodes,

--- a/app/rdf/query-dimension-values.ts
+++ b/app/rdf/query-dimension-values.ts
@@ -211,7 +211,9 @@ export const loadMinMaxDimensionValues = async ({
       operation: "postUrlencoded",
     })) as unknown as MinMaxResult[];
   } catch {
-    console.warn(`Failed to fetch min max dimension values for ${datasetIri}.`);
+    console.warn(
+      `Failed to fetch min max dimension values for ${datasetIri}, ${dimensionIri}.`
+    );
   } finally {
     return result[0];
   }

--- a/app/rdf/query-hierarchies.ts
+++ b/app/rdf/query-hierarchies.ts
@@ -159,9 +159,5 @@ export const queryHierarchy = async (
         } as HierarchyValue)
     );
 
-  fs.writeFileSync(
-    "/tmp/a.json",
-    JSON.stringify([...prunedTree, ...additionalTreeValues])
-  );
   return [...prunedTree, ...additionalTreeValues];
 };

--- a/app/rdf/query-hierarchies.ts
+++ b/app/rdf/query-hierarchies.ts
@@ -64,7 +64,7 @@ const findHierarchiesForDimension = (cube: Cube, dimensionIri: string) => {
       .has(ns.cubeMeta.inHierarchy)
       .out(ns.cubeMeta.inHierarchy)
       .toArray(),
-    (x) => x.value
+    (x) => x.out(ns.schema.name).value
   );
   if (newHierarchies) {
     return newHierarchies;

--- a/app/rdf/query-hierarchies.ts
+++ b/app/rdf/query-hierarchies.ts
@@ -114,8 +114,7 @@ export const queryHierarchy = async (
     hierarchies?.map(async (h) => ({
       // @ts-ignore
       nodes: (await getHierarchy(h).execute(sparqlClientStream, rdf)) || [],
-      hierarchyName: h.out(ns.cubeMeta.nextInHierarchy).out(ns.schema.name)
-        .value,
+      hierarchyName: getName(h.out(ns.cubeMeta.nextInHierarchy), locale),
     }))
   );
 

--- a/app/rdf/query-hierarchies.ts
+++ b/app/rdf/query-hierarchies.ts
@@ -1,5 +1,3 @@
-import fs from "fs";
-
 import {
   getHierarchy,
   HierarchyNode,
@@ -116,7 +114,8 @@ export const queryHierarchy = async (
     hierarchies?.map(async (h) => ({
       // @ts-ignore
       nodes: (await getHierarchy(h).execute(sparqlClientStream, rdf)) || [],
-      hierarchyName: h.out(ns.schema.name).value,
+      hierarchyName: h.out(ns.cubeMeta.nextInHierarchy).out(ns.schema.name)
+        .value,
     }))
   );
 

--- a/app/rdf/query-hierarchies.ts
+++ b/app/rdf/query-hierarchies.ts
@@ -3,7 +3,6 @@ import {
   HierarchyNode,
 } from "@zazuko/cube-hierarchy-query/index";
 import { AnyPointer } from "clownface";
-import { isGraphPointer } from "is-graph-pointer";
 import uniqBy from "lodash/uniqBy";
 import { Cube } from "rdf-cube-view-query";
 import rdf from "rdf-ext";
@@ -93,8 +92,7 @@ export const queryHierarchy = async (
     rdimension.data.iri
   );
 
-  // @ts-ignore
-  if (!isGraphPointer(hierarchies[0])) {
+  if (hierarchies.length === 0) {
     return null;
   }
   const dimensionValuesWithLabels = await getCubeDimensionValuesWithMetadata({

--- a/app/rdf/query-hierarchies.ts
+++ b/app/rdf/query-hierarchies.ts
@@ -71,7 +71,7 @@ const findHierarchiesForDimension = (cube: Cube, dimensionIri: string) => {
       .has(ns.cubeMeta.inHierarchy)
       .out(ns.cubeMeta.inHierarchy)
       .toArray(),
-    (x) => x.out(ns.schema.name).value
+    (x) => x.value
   );
   if (newHierarchies) {
     return newHierarchies;
@@ -83,7 +83,6 @@ const findHierarchiesForDimension = (cube: Cube, dimensionIri: string) => {
     .out(ns.cubeMeta.hasHierarchy)
     .toArray();
   if (legacyHierarchies) {
-    console.log("legacy");
     return legacyHierarchies;
   }
   return [];

--- a/app/rdf/query-labels.ts
+++ b/app/rdf/query-labels.ts
@@ -1,4 +1,3 @@
-import { schema } from "@tpluscode/rdf-ns-builders";
 import { sparql } from "@tpluscode/rdf-string";
 import { TemplateResult } from "@tpluscode/rdf-string/lib/TemplateResult";
 import { SELECT } from "@tpluscode/sparql-builder";
@@ -59,12 +58,12 @@ const buildResourceLabelsQuery = (
 export async function loadResourceLabels({
   ids,
   locale,
-  labelTerm = schema.name,
+  labelTerm,
   sparqlClient,
 }: {
   ids: NamedNode[];
   locale: string;
-  labelTerm?: NamedNode;
+  labelTerm: NamedNode;
   sparqlClient: ParsingClient;
 }): Promise<ResourceLabel[]> {
   const localesFilter = makeLocalesFilter("?iri", labelTerm, "?label", locale);

--- a/app/rdf/tree-utils.spec.ts
+++ b/app/rdf/tree-utils.spec.ts
@@ -1,6 +1,8 @@
 import { HierarchyValue } from "@/graphql/query-hooks";
 
-import { pruneTree, mapTree } from "./tree-utils";
+import multipleRootHierarchy from "../test/__fixtures/data/multiple-root-hierarchy.json";
+
+import { pruneTree, mapTree, regroupTrees } from "./tree-utils";
 
 // Country > Canton > Municipality
 // Countries have no value
@@ -74,6 +76,17 @@ describe("filterTree", () => {
           },
         ],
       },
+    ]);
+  });
+});
+
+describe("multiple hierarchy handling", () => {
+  it("should regroup trees", () => {
+    const tree = regroupTrees(multipleRootHierarchy);
+    expect(tree[0].children?.map((x) => x.value)).toEqual([
+      "Switzerland - Canton",
+      "Switzerland - Protection Region - Economic Region",
+      "Switzerland - Production Region - Economic Region",
     ]);
   });
 });

--- a/app/rdf/tree-utils.ts
+++ b/app/rdf/tree-utils.ts
@@ -2,7 +2,7 @@ import orderBy from "lodash/orderBy";
 import sortBy from "lodash/sortBy";
 
 import { HierarchyValue } from "@/graphql/resolver-types";
-import { dfs } from "@/utils/dfs";
+import { bfs } from "@/utils/bfs";
 
 export const mapTree = <T extends { children?: T[] | null }>(
   tree: T[],
@@ -124,7 +124,7 @@ export const makeTreeFromValues = (
 
 export const getOptionsFromTree = (tree: HierarchyValue[]) => {
   return sortBy(
-    dfs(tree, (node, { parents }) => ({
+    bfs(tree, (node, { parents }) => ({
       ...node,
       parents,
     })),
@@ -138,7 +138,7 @@ export const joinParents = (parents?: HierarchyValue[]) => {
 
 export const flattenTree = (tree: HierarchyValue[]) => {
   const res: HierarchyValue[] = [];
-  dfs(tree, (x) => res.push(x));
+  bfs(tree, (x) => res.push(x));
   return res;
 };
 

--- a/app/rdf/tree-utils.ts
+++ b/app/rdf/tree-utils.ts
@@ -141,3 +141,32 @@ export const flattenTree = (tree: HierarchyValue[]) => {
   dfs(tree, (x) => res.push(x));
   return res;
 };
+
+export const regroupTrees = (
+  trees: (HierarchyValue & { hierarchyName?: string })[][]
+): HierarchyValue[] => {
+  if (trees.length < 2) {
+    return trees[0];
+  } else {
+    // We have multiple hierarchies
+    const roots = new Set(trees.map((x) => x[0].value));
+    if (roots.size > 1) {
+      throw new Error(
+        "Cannot have multiple hierarchies not sharing the same root"
+      );
+    }
+    return [
+      {
+        ...trees[0][0],
+        children: trees.map((t) => ({
+          value: t[0].hierarchyName!,
+          hasValue: false,
+          children: t[0].children,
+          dimensionIri: t[0].dimensionIri,
+          label: t[0].hierarchyName!,
+          depth: -1,
+        })),
+      },
+    ];
+  }
+};

--- a/app/test/__fixtures/data/forest-area-by-production-region.json
+++ b/app/test/__fixtures/data/forest-area-by-production-region.json
@@ -170,7 +170,7 @@
               "label": "Southern Alps"
             },
             {
-              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/Switzerland",
+              "value": "https://ld.admin.ch/country/CHE",
               "label": "Switzerland"
             }
           ],

--- a/app/test/__fixtures/data/multiple-root-hierarchy.json
+++ b/app/test/__fixtures/data/multiple-root-hierarchy.json
@@ -2,7 +2,7 @@
   [
     {
       "label": "Switzerland",
-      "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/Switzerland",
+      "value": "https://ld.admin.ch/country/CHE",
       "children": [
         {
           "label": "ZH",
@@ -290,7 +290,7 @@
   [
     {
       "label": "Switzerland",
-      "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/Switzerland",
+      "value": "https://ld.admin.ch/country/CHE",
       "children": [
         {
           "label": "-",
@@ -678,7 +678,7 @@
   [
     {
       "label": "Switzerland",
-      "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/Switzerland",
+      "value": "https://ld.admin.ch/country/CHE",
       "children": [
         {
           "label": "-",

--- a/app/test/__fixtures/data/multiple-root-hierarchy.json
+++ b/app/test/__fixtures/data/multiple-root-hierarchy.json
@@ -1,0 +1,1065 @@
+[
+  [
+    {
+      "label": "Switzerland",
+      "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/Switzerland",
+      "children": [
+        {
+          "label": "ZH",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/1",
+          "children": [],
+          "identifier": "1",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "FR",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/10",
+          "children": [],
+          "identifier": "10",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "SO",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/11",
+          "children": [],
+          "identifier": "11",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "BL/BS",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/13",
+          "children": [],
+          "identifier": "13",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "SH",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/14",
+          "children": [],
+          "identifier": "14",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "AR",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/15",
+          "children": [],
+          "identifier": "15",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "AI",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/16",
+          "children": [],
+          "identifier": "16",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "SG",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/17",
+          "children": [],
+          "identifier": "17",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "GR",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/18",
+          "children": [],
+          "identifier": "18",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "AG",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/19",
+          "children": [],
+          "identifier": "19",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "BE",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/2",
+          "children": [],
+          "identifier": "2",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "TG",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/20",
+          "children": [],
+          "identifier": "20",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "TI",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/21",
+          "children": [],
+          "identifier": "21",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "VS",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/23",
+          "children": [],
+          "identifier": "23",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "NE",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/24",
+          "children": [],
+          "identifier": "24",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "GE",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/25",
+          "children": [],
+          "identifier": "25",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "JU",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/26",
+          "children": [],
+          "identifier": "26",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "LU",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/3",
+          "children": [],
+          "identifier": "3",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "UR",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/4",
+          "children": [],
+          "identifier": "4",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "SZ",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/5",
+          "children": [],
+          "identifier": "5",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "OW",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/6",
+          "children": [],
+          "identifier": "6",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "NW",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/7",
+          "children": [],
+          "identifier": "7",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "GL",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/8",
+          "children": [],
+          "identifier": "8",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "ZG",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/9",
+          "children": [],
+          "identifier": "9",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/-1",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/1",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/2",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/3",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/4",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/5",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Schureg/1",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Schureg/2",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Schureg/3",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Schureg/4",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Schureg/5",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Schureg/6",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        }
+      ],
+      "identifier": "0",
+      "depth": 0,
+      "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference",
+      "hierarchyName": "Switzerland - Canton"
+    }
+  ],
+  [
+    {
+      "label": "Switzerland",
+      "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/Switzerland",
+      "children": [
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/1",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/10",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/11",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/13",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/14",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/15",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/16",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/17",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/18",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/19",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/2",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/20",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/21",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/23",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/24",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/25",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/26",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/3",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/4",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/5",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/6",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/7",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/8",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/9",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/-1",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/1",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/2",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/3",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/4",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/5",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "Jura + Plateau",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Schureg/1",
+          "children": [
+            {
+              "label": "Western Jura",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/1",
+              "children": [],
+              "identifier": "1",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            },
+            {
+              "label": "Eastern Jura",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/2",
+              "children": [],
+              "identifier": "2",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            },
+            {
+              "label": "Western Plateau",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/3",
+              "children": [],
+              "identifier": "3",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            },
+            {
+              "label": "Central Plateau",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/4",
+              "children": [],
+              "identifier": "4",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            },
+            {
+              "label": "Eastern Plateau",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/5",
+              "children": [],
+              "identifier": "5",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            }
+          ],
+          "identifier": "1",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "Northwestern Alps",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Schureg/2",
+          "children": [
+            {
+              "label": "Western Pre-Alps",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/6",
+              "children": [],
+              "identifier": "6",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            },
+            {
+              "label": "Central Pre-Alps",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/7",
+              "children": [],
+              "identifier": "7",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            },
+            {
+              "label": "Northwestern Alps",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/9",
+              "children": [],
+              "identifier": "9",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            }
+          ],
+          "identifier": "2",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "Northeastern Alps",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Schureg/3",
+          "children": [
+            {
+              "label": "Central Alps",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/10",
+              "children": [],
+              "identifier": "10",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            },
+            {
+              "label": "Northeastern Alps",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/11",
+              "children": [],
+              "identifier": "11",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            },
+            {
+              "label": "Eastern Pre-Alps",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/8",
+              "children": [],
+              "identifier": "8",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            }
+          ],
+          "identifier": "3",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "Southwestern Alps ",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Schureg/4",
+          "children": [
+            {
+              "label": "Southwestern Alps",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/12",
+              "children": [],
+              "identifier": "12",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            }
+          ],
+          "identifier": "4",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "Southeastern Alps",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Schureg/5",
+          "children": [
+            {
+              "label": "Southeastern Alps",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/13",
+              "children": [],
+              "identifier": "13",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            }
+          ],
+          "identifier": "5",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "Southern Alps",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Schureg/6",
+          "children": [
+            {
+              "label": "Southern Alps",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/14",
+              "children": [],
+              "identifier": "14",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            }
+          ],
+          "identifier": "6",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        }
+      ],
+      "identifier": "0",
+      "depth": 0,
+      "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference",
+      "hierarchyName": "Switzerland - Protection Region - Economic Region"
+    }
+  ],
+  [
+    {
+      "label": "Switzerland",
+      "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/Switzerland",
+      "children": [
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/1",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/10",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/11",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/13",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/14",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/15",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/16",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/17",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/18",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/19",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/2",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/20",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/21",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/23",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/24",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/25",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/26",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/3",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/4",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/5",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/6",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/7",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/8",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Ktbsl/9",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "N/a",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/-1",
+          "children": [],
+          "identifier": "99",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "Jura",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/1",
+          "children": [
+            {
+              "label": "Western Jura",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/1",
+              "children": [],
+              "identifier": "1",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            },
+            {
+              "label": "Eastern Jura",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/2",
+              "children": [],
+              "identifier": "2",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            }
+          ],
+          "identifier": "1",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "Plateau",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/2",
+          "children": [
+            {
+              "label": "Western Plateau",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/3",
+              "children": [],
+              "identifier": "3",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            },
+            {
+              "label": "Central Plateau",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/4",
+              "children": [],
+              "identifier": "4",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            },
+            {
+              "label": "Eastern Plateau",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/5",
+              "children": [],
+              "identifier": "5",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            }
+          ],
+          "identifier": "2",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "Pre-Alps",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/3",
+          "children": [
+            {
+              "label": "Western Pre-Alps",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/6",
+              "children": [],
+              "identifier": "6",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            },
+            {
+              "label": "Central Pre-Alps",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/7",
+              "children": [],
+              "identifier": "7",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            },
+            {
+              "label": "Eastern Pre-Alps",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/8",
+              "children": [],
+              "identifier": "8",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            }
+          ],
+          "identifier": "3",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "Alps",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/4",
+          "children": [
+            {
+              "label": "Central Alps",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/10",
+              "children": [],
+              "identifier": "10",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            },
+            {
+              "label": "Northeastern Alps",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/11",
+              "children": [],
+              "identifier": "11",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            },
+            {
+              "label": "Southwestern Alps",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/12",
+              "children": [],
+              "identifier": "12",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            },
+            {
+              "label": "Southeastern Alps",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/13",
+              "children": [],
+              "identifier": "13",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            },
+            {
+              "label": "Northwestern Alps",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/9",
+              "children": [],
+              "identifier": "9",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            }
+          ],
+          "identifier": "4",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "Southern Alps",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/5",
+          "children": [
+            {
+              "label": "Southern Alps",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Wiregr0704/14",
+              "children": [],
+              "identifier": "14",
+              "depth": 2,
+              "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+            }
+          ],
+          "identifier": "5",
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Schureg/1",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Schureg/2",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Schureg/3",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Schureg/4",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Schureg/5",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        },
+        {
+          "label": "-",
+          "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Schureg/6",
+          "children": [],
+          "depth": 1,
+          "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference"
+        }
+      ],
+      "identifier": "0",
+      "depth": 0,
+      "dimensionIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference",
+      "hierarchyName": "Switzerland - Production Region - Economic Region"
+    }
+  ]
+]

--- a/app/utils/bfs.ts
+++ b/app/utils/bfs.ts
@@ -2,7 +2,12 @@ import { HierarchyValue } from "@/graphql/resolver-types";
 
 export const IGNORE = {};
 
-export const dfs = function <T extends unknown>(
+/**
+ * TODO check if can be deduplicated with visitHierarchy
+ * ⚠️ visitHierarchy is a depth-first-search while we have
+ * a bread-first-search here.
+ */
+export const bfs = function <T extends unknown>(
   tree: HierarchyValue[],
   visitor: (
     node: HierarchyValue,
@@ -21,7 +26,7 @@ export const dfs = function <T extends unknown>(
     const popped = q.shift()!;
     const { node, depth, parents } = popped;
     const visitResult = visitor(node, { depth, parents });
-    if (visitResult === dfs.IGNORE) {
+    if (visitResult === bfs.IGNORE) {
       continue;
     }
     res.push(visitResult);
@@ -40,4 +45,4 @@ export const dfs = function <T extends unknown>(
  * if the concerned nodes and its children should be ignored
  * by the DFS.
  */
-dfs.IGNORE = IGNORE;
+bfs.IGNORE = IGNORE;

--- a/app/utils/dfs.ts
+++ b/app/utils/dfs.ts
@@ -1,5 +1,7 @@
 import { HierarchyValue } from "@/graphql/resolver-types";
 
+export const IGNORE = {};
+
 export const dfs = function <T extends unknown>(
   tree: HierarchyValue[],
   visitor: (
@@ -16,9 +18,13 @@ export const dfs = function <T extends unknown>(
   ].reverse();
   const res = [];
   while (q.length > 0) {
-    const popped = q.pop()!;
+    const popped = q.shift()!;
     const { node, depth, parents } = popped;
-    res.push(visitor(node, { depth, parents }));
+    const visitResult = visitor(node, { depth, parents });
+    if (visitResult === dfs.IGNORE) {
+      continue;
+    }
+    res.push(visitResult);
     const childrenParents = [...parents, node];
     if (node?.children && node.children.length > 0) {
       for (let child of node.children) {
@@ -28,3 +34,10 @@ export const dfs = function <T extends unknown>(
   }
   return res;
 };
+
+/**
+ * Sentinel value meant to be returned from visitor callbacks
+ * if the concerned nodes and its children should be ignored
+ * by the DFS.
+ */
+dfs.IGNORE = IGNORE;

--- a/app/utils/hierarchy.ts
+++ b/app/utils/hierarchy.ts
@@ -65,3 +65,8 @@ export const hierarchyToOptions = (
   };
   return sortHierarchy(hierarchy).map(transform).filter(truthy);
 };
+
+export const isMultiHierarchyNode = (hv: HierarchyValue) => {
+  // A bit hackish but should be fine for now
+  return hv.depth === -1;
+};

--- a/e2e/abbreviations.spec.ts
+++ b/e2e/abbreviations.spec.ts
@@ -4,6 +4,7 @@ test("it should be possible to enable abbreviations for colors & x field (column
   actions,
   selectors,
 }) => {
+  test.slow();
   await actions.chart.createFrom(
     "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/6",
     "Prod"

--- a/e2e/filters.spec.ts
+++ b/e2e/filters.spec.ts
@@ -29,7 +29,7 @@ describe("Filters", () => {
       .locator("input[name^=select-single-filter]")
       .inputValue();
     expect(productionRegionFilterValue).toEqual(
-      "https://environment.ld.admin.ch/foen/nfi/UnitOfReference/Prodreg/Switzerland"
+      "https://ld.admin.ch/country/CHE"
     );
 
     const standStructureFilter =

--- a/e2e/query-hierarchies.spec.ts
+++ b/e2e/query-hierarchies.spec.ts
@@ -1,0 +1,170 @@
+import gql from "graphql-tag";
+import { createClient } from "urql";
+
+import { describe, test, expect } from "./common";
+
+/**
+ * Had to copy graphql definitions from graphql/query-hooks
+ * due to problem importing rdf-js if we import the definitions
+ * from graphql/query-hooks. Please keep the definitions below
+ * in sync with graphql/query-hooks.
+ */
+export const HierarchyValueFieldsFragmentDoc = gql`
+  fragment hierarchyValueFields on HierarchyValue {
+    value
+    dimensionIri
+    depth
+    label
+    alternateName
+    hasValue
+    position
+    identifier
+  }
+`;
+
+export const HierarchyMetadataFragmentDoc = gql`
+  fragment hierarchyMetadata on Dimension {
+    hierarchy(sourceType: $sourceType, sourceUrl: $sourceUrl) {
+      ...hierarchyValueFields
+      children {
+        ...hierarchyValueFields
+        children {
+          ...hierarchyValueFields
+          children {
+            ...hierarchyValueFields
+            children {
+              ...hierarchyValueFields
+              children {
+                ...hierarchyValueFields
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  ${HierarchyValueFieldsFragmentDoc}
+`;
+
+export const DimensionHierarchyDocument = gql`
+  query DimensionHierarchy(
+    $sourceType: String!
+    $sourceUrl: String!
+    $locale: String!
+    $cubeIri: String!
+    $dimensionIri: String!
+  ) {
+    dataCubeByIri(
+      iri: $cubeIri
+      sourceType: $sourceType
+      sourceUrl: $sourceUrl
+      locale: $locale
+    ) {
+      dimensionByIri(
+        iri: $dimensionIri
+        sourceType: $sourceType
+        sourceUrl: $sourceUrl
+      ) {
+        ...hierarchyMetadata
+      }
+    }
+  }
+  ${HierarchyMetadataFragmentDoc}
+`;
+
+const cubeIris = {
+  "C-96-r":
+    "https://environment.ld.admin.ch/foen/nfi/C-96-r-multilingual/cube/1",
+  "C-96-r-multilingual":
+    "https://environment.ld.admin.ch/foen/nfi/C-96-r-multilingual/cube/1",
+  "C-96": "https://environment.ld.admin.ch/foen/nfi/C-96/cube/1",
+  "C-96-multilingual":
+    "https://environment.ld.admin.ch/foen/nfi/C-96-multilingual/cube/1",
+};
+
+const runTest = async ({
+  cubeIri,
+  locale,
+  expected,
+}: {
+  cubeIri: string;
+  locale: string;
+  expected: { root: string; children: string[] };
+}) => {
+  const client = createClient({
+    url: "http://localhost:3000/api/graphql",
+  });
+  const res = await client
+    .query(DimensionHierarchyDocument, {
+      cubeIri: cubeIri,
+      sourceUrl: "https://int.lindas.admin.ch/query",
+      sourceType: "sparql",
+      dimensionIri: "https://environment.ld.admin.ch/foen/nfi/unitOfReference",
+      locale,
+    })
+    .toPromise();
+  const dimension = res.data.dataCubeByIri.dimensionByIri;
+  const {
+    hierarchy: [{ label, children }],
+  } = dimension;
+  expect(label).toBe(expected.root);
+  expect(children.map((x) => x.label)).toEqual(expected.children);
+};
+
+describe("multi root hierarchy retrieval", () => {
+  test("should work for C-96-r", async () => {
+    await runTest({
+      cubeIri: cubeIris["C-96-r"],
+      locale: "de",
+      expected: {
+        root: "Schweiz",
+        children: [
+          "Kanton",
+          "Produktionsregion - Wirtschaftsregion",
+          "Schutzwaldregion - Wirtschaftsregion",
+        ],
+      },
+    });
+  });
+
+  test("should work for C-96-r-multilingual", async ({}) => {
+    await runTest({
+      cubeIri: cubeIris["C-96-r-multilingual"],
+      locale: "en",
+      expected: {
+        root: "Switzerland",
+        children: [
+          "Canton",
+          "Production region - Economic region",
+          "Protection Forest region - Economic region",
+        ],
+      },
+    });
+  });
+
+  test("should work for C-96", async () => {
+    await runTest({
+      cubeIri: cubeIris["C-96"],
+      locale: "en",
+      expected: {
+        root: "Switzerland",
+        children: [
+          "Canton",
+          "Production Region - Economic Region",
+          "Protection Region - Economic Region",
+        ],
+      },
+    });
+  });
+
+  test("should work for C-96-multilingual", async () => {
+    await runTest({
+      cubeIri: cubeIris["C-96-multilingual"],
+      locale: "en",
+      expected: {
+        root: "Switzerland",
+        children: ["Canton", "Production region", "Protection Forest region"],
+      },
+    });
+  });
+});

--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -66,8 +66,10 @@ export const createSelectors = ({ screen, page, within }: Ctx) => {
     },
     chart: {
       axisWidthBand: async () => screen.findByTestId("axis-width-band"),
-      colorLegend: (options?, waitForOptions?) =>
-        screen.findByTestId("colorLegend", options, waitForOptions),
+      colorLegend: (
+        options?,
+        waitForOptions?: Parameters<typeof screen.findByTestId>[2]
+      ) => screen.findByTestId("colorLegend", options, waitForOptions),
       colorLegendItems: async () =>
         (await selectors.chart.colorLegend()).locator("div"),
       loaded: async (options: { timeout?: number } = {}) => {

--- a/e2e/sorting.spec.ts
+++ b/e2e/sorting.spec.ts
@@ -103,7 +103,7 @@ test("Segment sorting with hierarchy", async ({
   await selectors.chart.loaded();
 
   await selectors.edition.filtersLoaded();
-  await selectors.chart.colorLegend(undefined, { setTimeout: 5_000 });
+  await selectors.chart.colorLegend(undefined, { timeout: 30_000 });
 
   await within(await selectors.chart.colorLegend()).findByText(
     "Southern Alps",

--- a/e2e/tooltip.spec.ts
+++ b/e2e/tooltip.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "./common";
 
 test("tooltip content", async ({ actions, selectors, within, page }) => {
+  test.slow();
   await actions.chart.createFrom(
     "https://environment.ld.admin.ch/foen/ubd000502_sad_01/6",
     "Int"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15251,9 +15251,9 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript@^4.3.4:
-  version "4.3.4"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.3.4.tgz"
-  integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
+  version "4.9.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.4.tgz#a2a3d2756c079abda241d75f149df9d561091e78"
+  integrity sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Handle multiple root hierarchy on the server by transforming the tree

```
Switzerland (hierarchy: cantons)
  Zurich, Appenzell, Schwiz....
Switzerland (hierarchy: production region)
  Jura, Plateau ...
Switzerland (hierarchy: protection region)
  Jura + Plateau, Southwestern alps
```

We notice that it is the same root (Switzerland) for the 3 hierarchies, so we transform the tree into

```
Switzerland (hierarchy: cantons)
  Cantons
    Zurich, Appenzell, Schwiz....
  Production region
    Jura, Plateau ...
  Protection region
    Jura + Plateau, Southwestern alps
```

This way, the front-end does not have to know about those multiple roots.

Putting this PR in draft as I'd like to see with Thomas Bettler if the hierarchy is correct as I see multiple hierarchy nodes with "-".

Should fix https://github.com/visualize-admin/visualization-tool/issues/936

How to test:

- Use this dataset : https://visualization-tool-git-feat-multiple-hierarchy-roots-ixt1.vercel.app/en/browse?dataset=https%3A%2F%2Fenvironment.ld.admin.ch%2Ffoen%2Fnfi%2FC-96-r%2Fcube%2F1&dataSource=Int
- Select NFI4 as inventory filter otherwise no data is shown on the chart (?)
- In the Region filter, you can see the multiple roots