### PR TITLE
Save draft config

### DIFF
--- a/app/components/boldify.tsx
+++ b/app/components/boldify.tsx
@@ -1,0 +1,19 @@
+/**
+ * Uses markdown syntax for bold
+ *
+ * @example
+ * <Boldify>I am *bold*</Boldify>
+ */
+export const Boldify = ({ children }: { children: string }) => {
+  if (typeof children === "string") {
+    return (
+      <>
+        {children.split(/(\*.*?\*)/g).map((m) => {
+          return m.startsWith("*") ? <strong>{m.slice(1, -1)}</strong> : m;
+        })}
+      </>
+    );
+  } else {
+    return children;
+  }
+};

--- a/app/components/chart-selection-tabs.tsx
+++ b/app/components/chart-selection-tabs.tsx
@@ -233,6 +233,10 @@ const ShareChartEditionButton = () => {
     close();
   });
 
+  if (!key) {
+    return null;
+  }
+
   return (
     <>
       <Button

--- a/app/configurator/config-types.ts
+++ b/app/configurator/config-types.ts
@@ -835,12 +835,18 @@ const ConfiguratorStateConfiguringChart = t.intersection([
     state: t.literal("CONFIGURING_CHART"),
   }),
   Config,
+  t.partial({
+    key: t.string,
+  }),
 ]);
 const ConfiguratorStatePublishing = t.intersection([
   t.type({
     state: t.literal("PUBLISHING"),
   }),
   Config,
+  t.partial({
+    key: t.string,
+  }),
 ]);
 
 export type ConfiguratorStateSelectingDataSet = t.TypeOf<

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -17,12 +17,10 @@ import {
   applyTableDimensionToFilters,
   deriveFiltersFromFields,
   getFiltersByMappingStatus,
-  getLocalStorageKey,
   handleChartFieldChanged,
   handleChartOptionChanged,
   initChartStateFromChart,
   initChartStateFromCube,
-  initChartStateFromLocalStorage,
   moveFilterField,
   updateColorMapping,
 } from "@/configurator/configurator-state";
@@ -111,27 +109,6 @@ describe("initChartStateFromChart", () => {
     });
     const state = await initChartStateFromChart("abcde");
     expect(state).toEqual(undefined);
-  });
-});
-
-describe("initChartFromLocalStorage", () => {
-  it("should initialize from localStorage if valid", async () => {
-    localStorage.setItem(
-      getLocalStorageKey("viz1234"),
-      JSON.stringify({ state: "CONFIGURING_CHART", ...fakeVizFixture })
-    );
-    const state = await initChartStateFromLocalStorage("viz1234");
-    expect(state).not.toBeUndefined();
-  });
-
-  it("should return undefined and remove key from localStorage if invalid", async () => {
-    jest.spyOn(console, "warn").mockImplementation(() => {});
-    jest.spyOn(console, "error").mockImplementation(() => {});
-
-    localStorage.setItem(getLocalStorageKey("viz1234"), "abcde");
-    const state = await initChartStateFromLocalStorage("viz1234");
-    expect(state).toBeUndefined();
-    expect(localStorage.getItem(getLocalStorageKey("viz1234"))).toBe(null);
   });
 });
 

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -1501,7 +1501,7 @@ const ConfiguratorStateProviderInternal = ({
   const locale = useLocale();
   const stateAndDispatch = useImmerReducer(reducer, initialState);
   const [state, dispatch] = stateAndDispatch;
-  const { asPath, push, replace, query } = useRouter();
+  const { push, replace, query } = useRouter();
   const client = useClient();
 
   // Re-initialize state on page load
@@ -1616,7 +1616,7 @@ const ConfiguratorStateProviderInternal = ({
       }
     };
     run();
-  }, [state, dispatch, chartId, push, asPath, locale, query.from, replace]);
+  }, [dispatch, push, replace, state]);
 
   return (
     <ConfiguratorStateContext.Provider value={stateAndDispatch}>

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -257,10 +257,6 @@ export type ConfiguratorStateAction =
 export type ActionType<ConfiguratorStateAction> =
   ConfiguratorStateAction[keyof ConfiguratorStateAction];
 
-const LOCALSTORAGE_PREFIX = "vizualize-configurator-state";
-export const getLocalStorageKey = (chartId: string) =>
-  `${LOCALSTORAGE_PREFIX}:${chartId}`;
-
 const getStateWithCurrentDataSource = (state: ConfiguratorState) => {
   const dataSource = getDataSourceFromLocalStorage();
 

--- a/app/db/config.ts
+++ b/app/db/config.ts
@@ -22,15 +22,44 @@ type PublishedConfig = Omit<ConfigType, "activeField">;
 export const createConfig = async ({
   data,
   userId,
+  isDraft,
 }: {
   data: Prisma.ConfigCreateInput["data"];
   userId?: User["id"] | undefined;
+  isDraft?: boolean;
 }): Promise<{ key: string }> => {
   const result = await prisma.config.create({
     data: {
       key: createChartId(),
       data: data,
       user_id: userId,
+      is_draft: isDraft,
+    },
+  });
+
+  return result;
+};
+
+/**
+ * Updates a config in the DB.
+ *
+ * @param data Data to be stored as configuration
+ */
+export const updateConfig = async (
+  key: string,
+  data: Exclude<Prisma.ConfigUpdateInput["data"], undefined>,
+  userId?: User["id"] | undefined
+): Promise<{ key: string }> => {
+  // data
+  const result = await prisma.config.update({
+    where: {
+      key,
+    },
+    data: {
+      key,
+      data: data,
+      user_id: userId,
+      updated_at: new Date(),
     },
   });
 

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -1016,6 +1016,26 @@ msgstr "Suche"
 msgid "select.controls.metadata.search"
 msgstr "Springen zu..."
 
+#: app/components/chart-selection-tabs.tsx:244
+msgstr "share-creation.button"
+msgstr "Teilen"
+
+#: app/components/chart-selection-tabs.tsx:293
+msgstr "share-creation.popover.share-copy.caption"
+msgstr "Die andere Person wird das Diagramm *nicht* bearbeiten können"
+
+#: app/components/chart-selection-tabs.tsx:266
+msgstr "share-creation.popover.share-copy.title"
+msgstr "Eine Kopie teilen"
+
+#: app/components/chart-selection-tabs.tsx:276
+msgstr "share-creation.popover.share-with-editing-rights.caption"
+msgstr "Die andere Person *wird* das Diagramm bearbeiten können"
+
+#: app/components/chart-selection-tabs.tsx:262
+msgstr "share-creation.popover.title"
+msgstr "Erstellungsadresse teilen"
+
 #: app/configurator/components/chart-controls/drag-and-drop-tab.tsx:101
 msgid "table.column.no"
 msgstr "Spalte {0}"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -1016,6 +1016,26 @@ msgstr "Search"
 msgid "select.controls.metadata.search"
 msgstr "Jump to..."
 
+#: app/components/chart-selection-tabs.tsx:244
+msgid "share-creation.button"
+msgstr "Share"
+
+#: app/components/chart-selection-tabs.tsx:293
+msgid "share-creation.popover.share-copy.caption"
+msgstr "The other person *will be able* to overwrite your chart settings."
+
+#: app/components/chart-selection-tabs.tsx:266
+msgid "share-creation.popover.share-copy.title"
+msgstr "Share a copy"
+
+#: app/components/chart-selection-tabs.tsx:276
+msgid "share-creation.popover.share-with-editing-rights.caption"
+msgstr "The other person *will not be able* to overwrite your chart settings."
+
+#: app/components/chart-selection-tabs.tsx:262
+msgid "share-creation.popover.title"
+msgstr "Share creation URL"
+
 #: app/configurator/components/chart-controls/drag-and-drop-tab.tsx:101
 msgid "table.column.no"
 msgstr "Column {0}"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -1016,6 +1016,26 @@ msgstr "Chercher"
 msgid "select.controls.metadata.search"
 msgstr "Sauter à..."
 
+#: app/components/chart-selection-tabs.tsx:244
+msgid "share-creation.button"
+msgstr "Partager"
+
+#: app/components/chart-selection-tabs.tsx:293
+msgid "share-creation.popover.share-copy.caption"
+msgstr "L'autre personne *ne pourra pas* éditer le graphique"
+
+#: app/components/chart-selection-tabs.tsx:266
+msgid "share-creation.popover.share-copy.title"
+msgstr "Partager une copie"
+
+#: app/components/chart-selection-tabs.tsx:276
+msgid "share-creation.popover.share-with-editing-rights.caption"
+msgstr "L'autre personne *pourra* éditer le graphique"
+
+#: app/components/chart-selection-tabs.tsx:262
+msgid "share-creation.popover.title"
+msgstr "Partager l'adresse de création"
+
 #: app/configurator/components/chart-controls/drag-and-drop-tab.tsx:101
 msgid "table.column.no"
 msgstr "Colonne {0}"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -1016,6 +1016,26 @@ msgstr "Cerca"
 msgid "select.controls.metadata.search"
 msgstr "Salta a..."
 
+#: app/components/chart-selection-tabs.tsx:244
+msgstr "share-creation.button"
+msgstr "Condividi"
+
+#: app/components/chart-selection-tabs.tsx:293
+msgstr "share-creation.popover.share-copy.caption"
+msgstr "L'altra persona *non sarà* in grado di modificare il grafico"
+
+#: app/components/chart-selection-tabs.tsx:266
+msgstr "share-creation.popover.share-copy.title"
+msgstr "Condividi una copia"
+
+#: app/components/chart-selection-tabs.tsx:276
+msgstr "share-creation.popover.share-with-editing-rights.caption"
+msgstr "L'altra persona *sarà* in grado di modificare il grafico"
+
+#: app/components/chart-selection-tabs.tsx:262
+msgstr "share-creation.popover.title"
+msgstr "Condividi indirizzo di creazione"
+
 #: app/configurator/components/chart-controls/drag-and-drop-tab.tsx:101
 msgid "table.column.no"
 msgstr "Colonna {0}"

--- a/app/pages/api/config.ts
+++ b/app/pages/api/config.ts
@@ -8,8 +8,9 @@ const route = api({
   POST: async ({ req, res }) => {
     const session = await getServerSideSession(req, res);
     const userId = session?.user?.id;
-    const { data } = req.body;
+    const { data, isDraft } = req.body;
     const result = await createConfig({
+      isDraft,
       data,
       userId,
     });

--- a/app/pages/api/config/[key].ts
+++ b/app/pages/api/config/[key].ts
@@ -1,6 +1,6 @@
 import { NextkitError } from "nextkit";
 
-import { getConfig } from "../../../db/config";
+import { getConfig, updateConfig } from "../../../db/config";
 import { api } from "../../../server/nextkit";
 
 const route = api({
@@ -10,6 +10,26 @@ const route = api({
       return result;
     } else {
       throw new NextkitError(404, "Not found");
+    }
+  },
+  PATCH: async ({ req }) => {
+    const key = req.query.key as string;
+    const existing = await getConfig(key);
+
+    if (existing) {
+      if (!existing?.is_draft) {
+        throw new NextkitError(401, "Cannot edit non draft config");
+      }
+    } else {
+      throw new NextkitError(404, "Config not found");
+    }
+
+    const result = updateConfig(key, req.body);
+
+    if (result) {
+      return result;
+    } else {
+      throw new NextkitError(401, "Could not edit chart");
     }
   },
 });

--- a/app/pages/create/[chartId].tsx
+++ b/app/pages/create/[chartId].tsx
@@ -8,16 +8,35 @@ import {
   MetadataPanelStoreContext,
 } from "@/components/metadata-panel";
 import { Configurator, EditorConfiguratorStateProvider } from "@/configurator";
+import { getConfig } from "@/db/config";
 
 type PageProps = {
   locale: string;
   chartId: string;
 };
 
-export const getServerSideProps: GetServerSideProps<PageProps> = async ({
+export const getServerSideProps: GetServerSideProps<PageProps | {}> = async ({
   params,
   locale,
+  query,
+  res,
 }) => {
+  const config = await getConfig(query.chartId as string);
+
+  if (!config) {
+    res.statusCode = 404;
+    return { props: { chartId: undefined } };
+  }
+
+  if (!config.is_draft) {
+    return {
+      props: {},
+      redirect: {
+        destination: `/v/${query.chartId}`,
+      },
+    };
+  }
+
   return {
     props: {
       locale: locale!,

--- a/app/pages/embed/[chartId].tsx
+++ b/app/pages/embed/[chartId].tsx
@@ -26,7 +26,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
 }) => {
   const config = await getConfig(query.chartId as string);
 
-  if (config && config.data) {
+  if (config && config.data && !config.is_draft) {
     // TODO validate configuration
     return { props: serializeProps({ status: "found", config }) };
   }

--- a/app/pages/v/[chartId].tsx
+++ b/app/pages/v/[chartId].tsx
@@ -37,7 +37,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
 }) => {
   const config = await getConfig(query.chartId as string);
 
-  if (config && config.data) {
+  if (config && config.data && !config.is_draft) {
     // TODO validate configuration
     return { props: serializeProps({ status: "found", config }) };
   }

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -12,6 +12,8 @@ model Config {
   key        String   @unique @db.Char(12)
   data       Json
   created_at DateTime @default(now()) @db.Timestamp(6)
+  updated_at DateTime @default(now()) @db.Timestamp(6)
+  is_draft   Boolean  @default(false)
 
   user    User? @relation(fields: [user_id], references: [id])
   user_id Int?

--- a/app/utils/chart-config/api.ts
+++ b/app/utils/chart-config/api.ts
@@ -9,7 +9,9 @@ import { apiFetch } from "../api";
 import type apiConfigs from "../../pages/api/config";
 import type apiConfig from "../../pages/api/config/[key]";
 
-export const createConfig = async (state: ConfiguratorStatePublishing) => {
+export const createChartConfigFromConfiguratorState = async (
+  state: ConfiguratorStateConfiguringChart
+) => {
   return apiFetch<InferAPIResponse<typeof apiConfigs, "POST">>("/api/config", {
     method: "POST",
     data: {
@@ -32,7 +34,8 @@ export const fetchChartConfig = async (chartId: string) => {
 
 export const updateChartConfigFromConfiguratorState = async (
   key: string,
-  state: ConfiguratorStateConfiguringChart | ConfiguratorStatePublishing
+  state: ConfiguratorStateConfiguringChart | ConfiguratorStatePublishing,
+  isDraft: boolean
 ) => {
   return apiFetch<InferAPIResponse<typeof apiConfig, "PATCH">>(
     `/api/config/${key}`,
@@ -43,6 +46,7 @@ export const updateChartConfigFromConfiguratorState = async (
         dataSource: state.dataSource,
         meta: state.meta,
         chartConfig: state.chartConfig,
+        isDraft,
       },
     }
   );

--- a/app/utils/chart-config/api.ts
+++ b/app/utils/chart-config/api.ts
@@ -1,6 +1,9 @@
 import { InferAPIResponse } from "nextkit";
 
-import { ConfiguratorStatePublishing } from "../../configurator/config-types";
+import {
+  ConfiguratorStateConfiguringChart,
+  ConfiguratorStatePublishing,
+} from "../../configurator/config-types";
 import { apiFetch } from "../api";
 
 import type apiConfigs from "../../pages/api/config";
@@ -10,6 +13,7 @@ export const createConfig = async (state: ConfiguratorStatePublishing) => {
   return apiFetch<InferAPIResponse<typeof apiConfigs, "POST">>("/api/config", {
     method: "POST",
     data: {
+      isDraft: true,
       data: {
         dataSet: state.dataSet,
         dataSource: state.dataSource,
@@ -23,5 +27,23 @@ export const createConfig = async (state: ConfiguratorStatePublishing) => {
 export const fetchChartConfig = async (chartId: string) => {
   return await apiFetch<InferAPIResponse<typeof apiConfig, "GET">>(
     `/api/config/${chartId}`
+  );
+};
+
+export const updateChartConfigFromConfiguratorState = async (
+  key: string,
+  state: ConfiguratorStateConfiguringChart | ConfiguratorStatePublishing
+) => {
+  return apiFetch<InferAPIResponse<typeof apiConfig, "PATCH">>(
+    `/api/config/${key}`,
+    {
+      method: "PATCH",
+      data: {
+        dataSet: state.dataSet,
+        dataSource: state.dataSource,
+        meta: state.meta,
+        chartConfig: state.chartConfig,
+      },
+    }
   );
 };


### PR DESCRIPTION
Instead of saving the chart locally while it has not been published, we save it to the database.
This lets us share the creation link before the chart is published.
While a chart is not published, it is in draft

- [x] Ability to update a chart
- [x] Chart is auto saved when it changes 
- [x] Share button next to publish to get either a URL bringing the person to a copy of chart, or to the chart with edit rights
- [x] Chart in draft should not be viewable or embeddable
- [x] When changing the chart title and re-opening the page, some letters are removed
- [ ] Clean up of draft charts that have not been updated in a while