### PR TITLE
Embed options

### DIFF
--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -122,6 +122,7 @@ const useDimension = ({
   }, [cubeMetadata?.dataCubeByIri?.dimensions, dimensionIri]);
 };
 
+const emptyObj = {};
 const useLegendGroups = ({
   title,
   labels,
@@ -155,7 +156,7 @@ const useLegendGroups = ({
     ? configState.chartConfig.filters[segmentField.componentIri]
     : null;
   const segmentValues =
-    segmentFilters?.type === "multi" ? segmentFilters.values : {};
+    segmentFilters?.type === "multi" ? segmentFilters.values : emptyObj;
 
   const { dataSet: dataset, dataSource } = configState;
   const segmentDimension = useDimension({

--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -57,12 +57,28 @@ export const ChartFootnotes = ({
   chartConfig,
   configKey,
   onToggleTableView,
+  showDownload,
+  showTableSwitch,
+  showSparqlQuery,
+  visualizeLinkText,
+  showLandingPage,
+  showSource,
+  showDatasetTitle,
+  showDatePublished,
 }: {
   dataSetIri: string;
   dataSource: DataSource;
   chartConfig: ChartConfig;
   configKey?: string;
   onToggleTableView: () => void;
+  showDownload?: boolean;
+  showLandingPage?: boolean;
+  showTableSwitch?: boolean;
+  showSparqlQuery?: boolean;
+  showSource?: boolean;
+  showDatasetTitle?: boolean;
+  showDatePublished?: boolean;
+  visualizeLinkText?: JSX.Element;
 }) => {
   const classes = useFootnotesStyles({ useMarginTop: true });
   const locale = useLocale();
@@ -112,26 +128,28 @@ export const ChartFootnotes = ({
 
     return (
       <Box sx={{ mt: 2 }}>
-        <Typography component="span" variant="caption" color="grey.600">
-          <strong>
-            <Trans id="dataset.footnotes.dataset">Dataset</Trans>
-          </strong>
-          <Trans id="typography.colon">: </Trans>
-          {cubeLink ? (
-            <Link target="_blank" href={cubeLink} rel="noreferrer">
-              {dataCubeByIri.title}{" "}
-              <Icon
-                name="linkExternal"
-                size="1em"
-                style={{ display: "inline" }}
-              />
-            </Link>
-          ) : (
-            dataCubeByIri.title
-          )}
-        </Typography>
+        {showDatasetTitle !== false ? (
+          <Typography component="span" variant="caption" color="grey.600">
+            <strong>
+              <Trans id="dataset.footnotes.dataset">Dataset</Trans>
+            </strong>
+            <Trans id="typography.colon">: </Trans>
+            {cubeLink ? (
+              <Link target="_blank" href={cubeLink} rel="noreferrer">
+                {dataCubeByIri.title}{" "}
+                <Icon
+                  name="linkExternal"
+                  size="1em"
+                  style={{ display: "inline" }}
+                />
+              </Link>
+            ) : (
+              dataCubeByIri.title
+            )}
+          </Typography>
+        ) : null}
 
-        {dataCubeByIri.dateModified ? (
+        {dataCubeByIri.dateModified && showDatePublished !== false ? (
           <Typography component="span" variant="caption" color="grey.600">
             ,&nbsp;
             <strong>
@@ -144,53 +162,65 @@ export const ChartFootnotes = ({
           </Typography>
         ) : null}
 
-        <Typography component="div" variant="caption" color="grey.600">
-          <strong>
-            <Trans id="metadata.source">Source</Trans>
-          </strong>
-          <Trans id="typography.colon">: </Trans>
-          {dataCubeByIri.publisher && (
-            <Box
-              component="span"
-              sx={{ "> a": { color: "grey.600" } }}
-              dangerouslySetInnerHTML={{ __html: dataCubeByIri.publisher }}
-            ></Box>
-          )}
-        </Typography>
+        {showSource !== false ? (
+          <Typography component="div" variant="caption" color="grey.600">
+            <strong>
+              <Trans id="metadata.source">Source</Trans>
+            </strong>
+            <Trans id="typography.colon">: </Trans>
+            {dataCubeByIri.publisher && (
+              <Box
+                component="span"
+                sx={{ "> a": { color: "grey.600" } }}
+                dangerouslySetInnerHTML={{ __html: dataCubeByIri.publisher }}
+              ></Box>
+            )}
+          </Typography>
+        ) : null}
 
         <Box className={classes.actions}>
-          <DataDownloadMenu
-            dataSetIri={dataSetIri}
-            dataSource={dataSource}
-            title={dataCubeByIri.title}
-            filters={filters}
-          />
-          {chartConfig.chartType !== "table" && (
-            <Button
-              component="a"
-              color="primary"
-              variant="text"
-              size="small"
-              startIcon={
-                <Icon
-                  name={
-                    isTablePreview
-                      ? getChartIcon(chartConfig.chartType)
-                      : "table"
+          {showDownload !== false ? (
+            <DataDownloadMenu
+              dataSetIri={dataSetIri}
+              dataSource={dataSource}
+              title={dataCubeByIri.title}
+              filters={filters}
+            />
+          ) : null}
+          {showTableSwitch !== false ? (
+            <>
+              {chartConfig.chartType !== "table" && (
+                <Button
+                  component="a"
+                  color="primary"
+                  variant="text"
+                  size="small"
+                  startIcon={
+                    <Icon
+                      name={
+                        isTablePreview
+                          ? getChartIcon(chartConfig.chartType)
+                          : "table"
+                      }
+                    />
                   }
-                />
-              }
-              onClick={onToggleTableView}
-              sx={{ p: 0, typography: "caption" }}
-            >
-              {isTablePreview ? (
-                <Trans id="metadata.switch.chart">Switch to chart view</Trans>
-              ) : (
-                <Trans id="metadata.switch.table">Switch to table view</Trans>
+                  onClick={onToggleTableView}
+                  sx={{ p: 0, typography: "caption" }}
+                >
+                  {isTablePreview ? (
+                    <Trans id="metadata.switch.chart">
+                      Switch to chart view
+                    </Trans>
+                  ) : (
+                    <Trans id="metadata.switch.table">
+                      Switch to table view
+                    </Trans>
+                  )}
+                </Button>
               )}
-            </Button>
-          )}
-          {dataCubeByIri.landingPage && (
+            </>
+          ) : null}
+          {dataCubeByIri.landingPage && showLandingPage !== false && (
             <Button
               variant="text"
               component="a"
@@ -206,7 +236,7 @@ export const ChartFootnotes = ({
               </Trans>
             </Button>
           )}
-          {sparqlEditorUrl && (
+          {sparqlEditorUrl && showSparqlQuery !== false && (
             <RunSparqlQuery url={sparqlEditorUrl as string} />
           )}
           {configKey && shareUrl && (
@@ -220,9 +250,11 @@ export const ChartFootnotes = ({
               target="_blank"
               rel="noopener noreferrer"
             >
-              <Trans id="metadata.link.created.with.visualize">
-                Created with visualize.admin.ch
-              </Trans>
+              {visualizeLinkText ?? (
+                <Trans id="metadata.link.created.with.visualize">
+                  Created with visualize.admin.ch
+                </Trans>
+              )}
             </Button>
           )}
         </Box>

--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/graphql/query-hooks";
 import { getChartIcon, Icon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
+import { useEmbedOptions } from "@/utils/embed";
 import { makeOpenDataLink } from "@/utils/opendata";
 
 import { useQueryFilters } from "../charts/shared/chart-helpers";
@@ -57,27 +58,13 @@ export const ChartFootnotes = ({
   chartConfig,
   configKey,
   onToggleTableView,
-  showDownload,
-  showTableSwitch,
-  showSparqlQuery,
   visualizeLinkText,
-  showLandingPage,
-  showSource,
-  showDatasetTitle,
-  showDatePublished,
 }: {
   dataSetIri: string;
   dataSource: DataSource;
   chartConfig: ChartConfig;
   configKey?: string;
   onToggleTableView: () => void;
-  showDownload?: boolean;
-  showLandingPage?: boolean;
-  showTableSwitch?: boolean;
-  showSparqlQuery?: boolean;
-  showSource?: boolean;
-  showDatasetTitle?: boolean;
-  showDatePublished?: boolean;
   visualizeLinkText?: JSX.Element;
 }) => {
   const classes = useFootnotesStyles({ useMarginTop: true });
@@ -122,6 +109,18 @@ export const ChartFootnotes = ({
   const cubeLink = useMemo(() => {
     return makeOpenDataLink(locale, data?.dataCubeByIri);
   }, [locale, data?.dataCubeByIri]);
+
+  const [
+    {
+      showDownload,
+      showLandingPage,
+      showTableSwitch,
+      showSparqlQuery,
+      showDatePublished,
+      showSource,
+      showDatasetTitle,
+    },
+  ] = useEmbedOptions();
 
   if (data?.dataCubeByIri) {
     const { dataCubeByIri } = data;

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -47,6 +47,8 @@ import { DataCubePublicationStatus } from "@/graphql/resolver-types";
 import { useLocale } from "@/locales/use-locale";
 import useEvent from "@/utils/use-event";
 
+import { useEmbedOptions } from "../utils/embed";
+
 export const ChartPublished = ({
   dataSet,
   dataSource,
@@ -87,6 +89,16 @@ const useStyles = makeStyles<Theme, { shrink: boolean }>((theme) => ({
     transition: "padding 0.25s ease",
   },
 }));
+
+export type EmbedOptions = {
+  showDownload?: boolean;
+  showLandingPage?: boolean;
+  showTableSwitch?: boolean;
+  showSparqlQuery?: boolean;
+  showDatePublished?: boolean;
+  showSource?: boolean;
+  showDatasetTitle?: boolean;
+};
 
 export const ChartPublishedInner = ({
   dataSet,
@@ -163,6 +175,7 @@ export const ChartPublishedInner = ({
     ];
   }, [metaData?.dataCubeByIri?.dimensions, metaData?.dataCubeByIri?.measures]);
 
+  const [embedOptions] = useEmbedOptions();
   return (
     <MetadataPanelStoreContext.Provider value={metadataPanelStore}>
       <Box className={classes.root} ref={rootRef}>
@@ -260,6 +273,20 @@ export const ChartPublishedInner = ({
               chartConfig={chartConfig}
               configKey={configKey}
               onToggleTableView={handleToggleTableView}
+              showDownload={embedOptions.showDownload}
+              showLandingPage={embedOptions.showLandingPage}
+              showTableSwitch={embedOptions.showTableSwitch}
+              showSparqlQuery={embedOptions.showSparqlQuery}
+              showDatePublished={embedOptions.showDatePublished}
+              showSource={embedOptions.showSource}
+              showDatasetTitle={embedOptions.showDatasetTitle}
+              visualizeLinkText={
+                embedOptions.showDownload === false ? (
+                  <Trans id="metadata.link.created.with.visualize.alternate">
+                    More information
+                  </Trans>
+                ) : undefined
+              }
             />
           </InteractiveFiltersProvider>
         </ChartErrorBoundary>

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -45,9 +45,8 @@ import {
 } from "@/graphql/query-hooks";
 import { DataCubePublicationStatus } from "@/graphql/resolver-types";
 import { useLocale } from "@/locales/use-locale";
+import { useEmbedOptions } from "@/utils/embed";
 import useEvent from "@/utils/use-event";
-
-import { useEmbedOptions } from "../utils/embed";
 
 export const ChartPublished = ({
   dataSet,
@@ -89,16 +88,6 @@ const useStyles = makeStyles<Theme, { shrink: boolean }>((theme) => ({
     transition: "padding 0.25s ease",
   },
 }));
-
-export type EmbedOptions = {
-  showDownload?: boolean;
-  showLandingPage?: boolean;
-  showTableSwitch?: boolean;
-  showSparqlQuery?: boolean;
-  showDatePublished?: boolean;
-  showSource?: boolean;
-  showDatasetTitle?: boolean;
-};
 
 export const ChartPublishedInner = ({
   dataSet,
@@ -175,7 +164,8 @@ export const ChartPublishedInner = ({
     ];
   }, [metaData?.dataCubeByIri?.dimensions, metaData?.dataCubeByIri?.measures]);
 
-  const [embedOptions] = useEmbedOptions();
+  const [{ showDownload }] = useEmbedOptions();
+
   return (
     <MetadataPanelStoreContext.Provider value={metadataPanelStore}>
       <Box className={classes.root} ref={rootRef}>
@@ -273,15 +263,8 @@ export const ChartPublishedInner = ({
               chartConfig={chartConfig}
               configKey={configKey}
               onToggleTableView={handleToggleTableView}
-              showDownload={embedOptions.showDownload}
-              showLandingPage={embedOptions.showLandingPage}
-              showTableSwitch={embedOptions.showTableSwitch}
-              showSparqlQuery={embedOptions.showSparqlQuery}
-              showDatePublished={embedOptions.showDatePublished}
-              showSource={embedOptions.showSource}
-              showDatasetTitle={embedOptions.showDatasetTitle}
               visualizeLinkText={
-                embedOptions.showDownload === false ? (
+                showDownload === false ? (
                   <Trans id="metadata.link.created.with.visualize.alternate">
                     More information
                   </Trans>

--- a/app/components/metadata-panel.tsx
+++ b/app/components/metadata-panel.tsx
@@ -31,6 +31,7 @@ import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 import { Icon } from "@/icons";
 import SvgIcArrowRight from "@/icons/components/IcArrowRight";
 import SvgIcClose from "@/icons/components/IcClose";
+import { useEmbedOptions } from "@/utils/embed";
 import useEvent from "@/utils/use-event";
 
 import Flex from "./flex";
@@ -239,6 +240,11 @@ export const OpenMetadataPanelWrapper = ({
     openDimension(dim);
   });
 
+  const [embedOptions] = useEmbedOptions();
+  if (embedOptions.showMetadata === false) {
+    return <>{children}</>;
+  }
+
   return (
     <Button
       className={classes.openDimension}
@@ -282,6 +288,12 @@ export const MetadataPanel = ({
     setOpen(false);
     reset();
   }, [router.pathname, setOpen, reset]);
+
+  const [embedOptions] = useEmbedOptions();
+
+  if (embedOptions.showMetadata === false) {
+    return null;
+  }
 
   return (
     <>

--- a/app/components/publish-actions.tsx
+++ b/app/components/publish-actions.tsx
@@ -103,7 +103,6 @@ export const Share = ({ configKey, locale }: EmbedShareProps) => {
               setAnchorEl(ev.target as HTMLElement);
             }}
             startIcon={<Icon name="linkExternal" size={16} />}
-            variant="outlined"
           >
             <Trans id="button.share">Share</Trans>
           </Button>
@@ -286,11 +285,11 @@ export const Embed = ({ configKey, locale }: EmbedShareProps) => {
                         Standard
                       </Trans>
                     </Typography>
-                    {/* <Typography variant="caption" display="block">
+                    <Typography variant="caption" display="block">
                       <Trans id="publication.embed.style.standard.caption">
-                        Chart, download the data links, attribution etc...
+                        Provides metadata and download links for the dataset
                       </Trans>
-                    </Typography> */}
+                    </Typography>
                   </div>
                 }
                 disableTypography
@@ -306,11 +305,12 @@ export const Embed = ({ configKey, locale }: EmbedShareProps) => {
                         Minimal
                       </Trans>
                     </Typography>
-                    {/* <Typography variant="caption" display="block">
+                    <Typography variant="caption" display="block">
                       <Trans id="publication.embed.style.minimal.caption">
-                        Only the chart and a link for more information.
+                        Chart only with link to full information on
+                        visualize.admin.ch.
                       </Trans>
-                    </Typography> */}
+                    </Typography>
                   </div>
                 }
                 disableTypography

--- a/app/components/publish-actions.tsx
+++ b/app/components/publish-actions.tsx
@@ -102,8 +102,8 @@ export const Share = ({ configKey, locale }: EmbedShareProps) => {
             onClick={(ev) => {
               setAnchorEl(ev.target as HTMLElement);
             }}
-            size="large"
-            startIcon={<Icon name="linkExternal" />}
+            startIcon={<Icon name="linkExternal" size={16} />}
+            variant="outlined"
           >
             <Trans id="button.share">Share</Trans>
           </Button>
@@ -199,9 +199,7 @@ export const Embed = ({ configKey, locale }: EmbedShareProps) => {
   const [embedIframeUrl, setEmbedIframeUrl] = useState("");
   const [embedAEMUrl, setEmbedAEMUrl] = useState("");
   const [embedOptions, setEmbedOptions] = useEmbedOptions();
-  console.log([embedOptions, setEmbedOptions]);
   const handleChange: RadioGroupProps["onChange"] = (_ev, value) => {
-    console.log(setEmbedOptions);
     if (value === "minimal") {
       setEmbedOptions({
         showDatasetTitle: false,
@@ -253,8 +251,7 @@ export const Embed = ({ configKey, locale }: EmbedShareProps) => {
       }}
       renderTrigger={(setAnchorEl) => (
         <Button
-          startIcon={<Icon name="embed" />}
-          size="large"
+          startIcon={<Icon name="embed" size={16} />}
           variant="contained"
           color="primary"
           onClick={(ev) => setAnchorEl(ev.currentTarget)}

--- a/app/components/publish-actions.tsx
+++ b/app/components/publish-actions.tsx
@@ -9,6 +9,7 @@ import {
   Input,
   Link,
   Popover,
+  PopoverProps,
   Radio,
   RadioGroup,
   RadioGroupProps,
@@ -49,14 +50,16 @@ export const PublishActions = ({
   );
 };
 
-const PopUp = ({
+const TriggeredPopover = ({
   children,
   renderTrigger,
+  popoverProps,
 }: {
   children: ReactNode;
   renderTrigger: (
     setAnchorEl: (el: HTMLElement | undefined) => void
   ) => React.ReactNode;
+  popoverProps: Omit<PopoverProps, "open" | "anchorEl" | "onClose">;
 }) => {
   const [anchorEl, setAnchorEl] = useState<Element | undefined>();
 
@@ -66,17 +69,10 @@ const PopUp = ({
       <Popover
         open={!!anchorEl}
         anchorEl={anchorEl}
-        anchorOrigin={{
-          vertical: 48,
-          horizontal: "left",
-        }}
-        transformOrigin={{
-          vertical: "top",
-          horizontal: "left",
-        }}
+        {...popoverProps}
         onClose={() => setAnchorEl(undefined)}
       >
-        <Box m={4}>{children}</Box>
+        {children}
       </Popover>
     </>
   );
@@ -89,7 +85,17 @@ export const Share = ({ configKey, locale }: EmbedShareProps) => {
     setShareUrl(`${window.location.origin}/${locale}/v/${configKey}`);
   }, [configKey, locale]);
   return (
-    <PopUp
+    <TriggeredPopover
+      popoverProps={{
+        anchorOrigin: {
+          vertical: "bottom",
+          horizontal: "right",
+        },
+        transformOrigin: {
+          vertical: -4,
+          horizontal: "right",
+        },
+      }}
       renderTrigger={(setAnchorEl) => {
         return (
           <Button
@@ -104,7 +110,7 @@ export const Share = ({ configKey, locale }: EmbedShareProps) => {
         );
       }}
     >
-      <>
+      <Box m={4}>
         <Flex
           sx={{
             justifyContent: "space-between",
@@ -179,8 +185,8 @@ export const Share = ({ configKey, locale }: EmbedShareProps) => {
             {/* <Icon name="share"></Icon> */}
           </Box>
         </Box>
-      </>
-    </PopUp>
+      </Box>
+    </TriggeredPopover>
   );
 };
 
@@ -234,7 +240,17 @@ export const Embed = ({ configKey, locale }: EmbedShareProps) => {
   }, [configKey, locale, embedOptions]);
 
   return (
-    <PopUp
+    <TriggeredPopover
+      popoverProps={{
+        anchorOrigin: {
+          vertical: "bottom",
+          horizontal: "right",
+        },
+        transformOrigin: {
+          vertical: -4,
+          horizontal: "right",
+        },
+      }}
       renderTrigger={(setAnchorEl) => (
         <Button
           startIcon={<Icon name="embed" />}
@@ -247,7 +263,7 @@ export const Embed = ({ configKey, locale }: EmbedShareProps) => {
         </Button>
       )}
     >
-      <Box sx={{ "& > * + *": { mt: 4 } }}>
+      <Box m={4} sx={{ "& > * + *": { mt: 4 } }}>
         <div>
           <FormControl>
             <Typography variant="h5" gutterBottom>
@@ -336,7 +352,7 @@ export const Embed = ({ configKey, locale }: EmbedShareProps) => {
           <CopyToClipboardTextInput iFrameCode={embedAEMUrl} />
         </div>
       </Box>
-    </PopUp>
+    </TriggeredPopover>
   );
 };
 

--- a/app/components/publish-actions.tsx
+++ b/app/components/publish-actions.tsx
@@ -193,13 +193,16 @@ export const Embed = ({ configKey, locale }: EmbedShareProps) => {
   const [embedIframeUrl, setEmbedIframeUrl] = useState("");
   const [embedAEMUrl, setEmbedAEMUrl] = useState("");
   const [embedOptions, setEmbedOptions] = useEmbedOptions();
+  console.log([embedOptions, setEmbedOptions]);
   const handleChange: RadioGroupProps["onChange"] = (_ev, value) => {
+    console.log(setEmbedOptions);
     if (value === "minimal") {
       setEmbedOptions({
         showDatasetTitle: false,
         showDownload: false,
         showLandingPage: false,
-        showSource: false,
+        showSource: true,
+        showMetadata: false,
         showSparqlQuery: false,
         showDatePublished: false,
         showTableSwitch: false,
@@ -213,6 +216,7 @@ export const Embed = ({ configKey, locale }: EmbedShareProps) => {
         showSparqlQuery: true,
         showDatePublished: true,
         showTableSwitch: true,
+        showMetadata: true,
       });
     }
   };

--- a/app/components/publish-actions.tsx
+++ b/app/components/publish-actions.tsx
@@ -267,11 +267,11 @@ export const Embed = ({ configKey, locale }: EmbedShareProps) => {
                         Standard
                       </Trans>
                     </Typography>
-                    <Typography variant="caption" display="block">
+                    {/* <Typography variant="caption" display="block">
                       <Trans id="publication.embed.style.standard.caption">
                         Chart, download the data links, attribution etc...
                       </Trans>
-                    </Typography>
+                    </Typography> */}
                   </div>
                 }
                 disableTypography
@@ -287,11 +287,11 @@ export const Embed = ({ configKey, locale }: EmbedShareProps) => {
                         Minimal
                       </Trans>
                     </Typography>
-                    <Typography variant="caption" display="block">
+                    {/* <Typography variant="caption" display="block">
                       <Trans id="publication.embed.style.minimal.caption">
                         Only the chart and a link for more information.
                       </Trans>
-                    </Typography>
+                    </Typography> */}
                   </div>
                 }
                 disableTypography
@@ -305,7 +305,7 @@ export const Embed = ({ configKey, locale }: EmbedShareProps) => {
           </Typography>
           <Typography variant="caption">
             <Trans id="publication.embed.iframe.caption">
-              Use this link to insert this visualization into other webpages.
+              Use this link to embed the chart into other webpages.
             </Trans>
           </Typography>
 
@@ -322,8 +322,8 @@ export const Embed = ({ configKey, locale }: EmbedShareProps) => {
           </Typography>
           <Typography variant="caption">
             <Trans id="publication.embed.AEM.caption">
-              Use this link to insert this visualization into Adobe Experience
-              Manager assets.
+              Use this link to embed the chart into Adobe Experience Manager
+              assets.
             </Trans>
           </Typography>
 

--- a/app/components/publish-actions.tsx
+++ b/app/components/publish-actions.tsx
@@ -216,6 +216,8 @@ export const Embed = ({ configKey, locale }: EmbedShareProps) => {
       });
     }
   };
+  const isMinimal = embedOptions.showDatasetTitle === false;
+  const iFrameHeight = isMinimal ? "560px" : "640px";
 
   useEffect(() => {
     const embedOptionsParam = encodeURIComponent(JSON.stringify(embedOptions));
@@ -310,7 +312,7 @@ export const Embed = ({ configKey, locale }: EmbedShareProps) => {
           </Typography>
 
           <CopyToClipboardTextInput
-            iFrameCode={`<iframe src="${embedIframeUrl}" style="border:0px #ffffff none;" name="visualize.admin.ch" scrolling="no" frameborder="1" marginheight="0px" marginwidth="0px" height="400px" width="600px" allowfullscreen></iframe>`}
+            iFrameCode={`<iframe src="${embedIframeUrl}" style="border:0px #ffffff none;" name="visualize.admin.ch" scrolling="no" frameborder="1" marginheight="0px" marginwidth="0px" height="${iFrameHeight}" width="600px" allowfullscreen></iframe>`}
           />
         </div>
 

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -66,7 +66,7 @@ msgstr "Erkunden Sie die vom LINDAS Linked Data Service bereitgestellten Datens�
 msgid "button.back"
 msgstr "Zurück"
 
-#: app/pages/v/[chartId].tsx:154
+#: app/pages/v/[chartId].tsx:166
 msgid "button.copy.visualization"
 msgstr "Diese Visualisierung kopieren und editieren"
 
@@ -103,7 +103,7 @@ msgstr "Kopieren"
 msgid "button.hint.copied"
 msgstr "Kopiert!"
 
-#: app/pages/v/[chartId].tsx:139
+#: app/pages/v/[chartId].tsx:151
 msgid "button.new.visualization"
 msgstr "Neue Visualisierung erstellen"
 
@@ -865,7 +865,7 @@ msgstr "Es gab ein Problem beim Laden der Koordinaten aus den geografischen Dime
 msgid "hint.coordinatesloadingerror.title"
 msgstr "Koordinaten-Ladefehler"
 
-#: app/pages/v/[chartId].tsx:117
+#: app/pages/v/[chartId].tsx:128
 msgid "hint.create.your.own.chart"
 msgstr "Kopieren Sie diese Visualisierung oder erstellen Sie eine neue Visualisierung mit Swiss Open Government Data."
 
@@ -881,7 +881,7 @@ msgstr "Weitere Informationen finden Sie auf der Statusseite"
 msgid "hint.dataloadingerror.title"
 msgstr "Daten-Ladefehler"
 
-#: app/pages/v/[chartId].tsx:111
+#: app/pages/v/[chartId].tsx:122
 msgid "hint.how.to.share"
 msgstr "Sie können diese Visualisierung teilen oder sie einbetten. Zudem können Sie eine neue Visualisierung erstellen oder die gezeigte Visualisierung kopieren."
 
@@ -931,6 +931,10 @@ msgstr "Logo der Schweizerischen Eidgenossenschaft"
 msgid "metadata.link.created.with.visualize"
 msgstr "Erstellt mit visualize.admin.ch"
 
+#: app/components/chart-published.tsx:285
+msgid "metadata.link.created.with.visualize.alternate"
+msgstr "Mehr Informationen"
+
 #: app/components/chart-footnotes.tsx:168
 msgid "metadata.source"
 msgstr "Quelle"
@@ -964,16 +968,16 @@ msgid "publication.embed.style.minimal"
 msgstr "Minimale"
 
 #: app/components/publish-actions.tsx:291
-msgid "publication.embed.style.minimal.caption"
-msgstr ""
+#~ msgid "publication.embed.style.minimal.caption"
+#~ msgstr ""
 
 #: app/components/publish-actions.tsx:266
 msgid "publication.embed.style.standard"
 msgstr "Standard"
 
 #: app/components/publish-actions.tsx:271
-msgid "publication.embed.style.standard.caption"
-msgstr ""
+#~ msgid "publication.embed.style.standard.caption"
+#~ msgstr ""
 
 #: app/components/publish-actions.tsx:117
 msgid "publication.popup.share"

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -912,7 +912,7 @@ msgstr "Negative Werte"
 
 #: app/components/hint.tsx:226
 msgid "hint.publication.success"
-msgstr "Die Visualisierung ist jetzt veröffentlicht. Sie können sie teilen oder einbetten, indem Sie die URL kopieren oder das Menü unten verwenden."
+msgstr "Die Visualisierung ist jetzt veröffentlicht. Sie können sie teilen oder einbetten, indem Sie die URL kopieren oder das Menü oben verwenden."
 
 #: app/charts/shared/chart-data-filters.tsx:96
 msgid "interactive.data.filters.hide"

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -949,7 +949,7 @@ msgstr "Einbett-Code für AEM «Externe Applikation»"
 
 #: app/components/publish-actions.tsx:324
 msgid "publication.embed.AEM.caption"
-msgstr ""
+msgstr "Verwenden Sie diesen Code, um das Diagramm in Adobe Experience Manager einzubetten"
 
 #: app/components/publish-actions.tsx:304
 msgid "publication.embed.iframe"
@@ -957,11 +957,11 @@ msgstr "Einbett-Code"
 
 #: app/components/publish-actions.tsx:307
 msgid "publication.embed.iframe.caption"
-msgstr ""
+msgstr "Verwenden Sie diesen Code, um das Diagramm auf einer Webseite einzubetten"
 
 #: app/components/publish-actions.tsx:286
 msgid "publication.embed.style.minimal"
-msgstr ""
+msgstr "Minimale"
 
 #: app/components/publish-actions.tsx:291
 msgid "publication.embed.style.minimal.caption"
@@ -969,7 +969,7 @@ msgstr ""
 
 #: app/components/publish-actions.tsx:266
 msgid "publication.embed.style.standard"
-msgstr ""
+msgstr "Standard"
 
 #: app/components/publish-actions.tsx:271
 msgid "publication.embed.style.standard.caption"

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -13,19 +13,19 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:709
+#: app/configurator/components/chart-configurator.tsx:701
 msgid "Add filter"
 msgstr "Filter hinzufügen"
 
-#: app/configurator/components/chart-configurator.tsx:682
+#: app/configurator/components/chart-configurator.tsx:674
 msgid "Drag filters to reorganize"
 msgstr "Ziehen Sie die Filter per Drag & Drop, um sie neu zu organisieren"
 
-#: app/configurator/components/chart-configurator.tsx:679
+#: app/configurator/components/chart-configurator.tsx:671
 msgid "Move filter down"
 msgstr "Filter nach unten verschieben"
 
-#: app/configurator/components/chart-configurator.tsx:676
+#: app/configurator/components/chart-configurator.tsx:668
 msgid "Move filter up"
 msgstr "Filter nach oben verschieben"
 
@@ -66,7 +66,7 @@ msgstr "Erkunden Sie die vom LINDAS Linked Data Service bereitgestellten Datens�
 msgid "button.back"
 msgstr "Zurück"
 
-#: app/pages/v/[chartId].tsx:166
+#: app/pages/v/[chartId].tsx:154
 msgid "button.copy.visualization"
 msgstr "Diese Visualisierung kopieren und editieren"
 
@@ -90,20 +90,20 @@ msgstr "Daten aus der Grafik"
 msgid "button.download.runsparqlquery.visible"
 msgstr "SPARQL-Abfrage ausführen"
 
-#: app/components/publish-actions.tsx:206
+#: app/components/publish-actions.tsx:240
 msgid "button.embed"
 msgstr "Einbetten"
 
-#: app/components/publish-actions.tsx:281
-#: app/components/publish-actions.tsx:287
+#: app/components/publish-actions.tsx:390
+#: app/components/publish-actions.tsx:396
 msgid "button.hint.click.to.copy"
 msgstr "Kopieren"
 
-#: app/components/publish-actions.tsx:311
+#: app/components/publish-actions.tsx:420
 msgid "button.hint.copied"
 msgstr "Kopiert!"
 
-#: app/pages/v/[chartId].tsx:151
+#: app/pages/v/[chartId].tsx:139
 msgid "button.new.visualization"
 msgstr "Neue Visualisierung erstellen"
 
@@ -111,7 +111,7 @@ msgstr "Neue Visualisierung erstellen"
 msgid "button.publish"
 msgstr "Diese Visualisierung veröffentlichen"
 
-#: app/components/publish-actions.tsx:96
+#: app/components/publish-actions.tsx:102
 msgid "button.share"
 msgstr "Teilen"
 
@@ -119,7 +119,7 @@ msgstr "Teilen"
 msgid "chart.map.layers.area"
 msgstr "Flächen"
 
-#: app/configurator/components/chart-configurator.tsx:762
+#: app/configurator/components/chart-configurator.tsx:754
 #: app/configurator/components/chart-options-selector.tsx:1055
 #: app/configurator/components/field-i18n.ts:31
 msgid "chart.map.layers.base"
@@ -307,8 +307,8 @@ msgstr "Beschreibung hinzufügen"
 #: app/charts/shared/chart-data-filters.tsx:249
 #: app/charts/shared/chart-data-filters.tsx:296
 #: app/configurator/components/field.tsx:167
-#: app/configurator/components/field.tsx:264
-#: app/configurator/components/field.tsx:364
+#: app/configurator/components/field.tsx:267
+#: app/configurator/components/field.tsx:367
 msgid "controls.dimensionvalue.none"
 msgstr "Kein Filter"
 
@@ -324,12 +324,12 @@ msgstr "Alle auswählen"
 msgid "controls.filter.select.none"
 msgstr "Alle abwählen"
 
-#: app/configurator/components/chart-configurator.tsx:512
+#: app/configurator/components/chart-configurator.tsx:513
 #: app/configurator/components/filters.tsx:366
 msgid "controls.filters.interactive.toggle"
 msgstr "Interaktiv"
 
-#: app/configurator/components/chart-configurator.tsx:505
+#: app/configurator/components/chart-configurator.tsx:506
 #: app/configurator/components/filters.tsx:360
 msgid "controls.filters.interactive.tooltip"
 msgstr "Erlauben Sie Benutzern, Filter zu ändern"
@@ -432,8 +432,8 @@ msgstr "Zurück zur Übersicht"
 msgid "controls.nav.back-to-preview"
 msgstr "Zurück zur Vorschau"
 
-#: app/configurator/components/field.tsx:703
-#: app/configurator/components/field.tsx:875
+#: app/configurator/components/field.tsx:706
+#: app/configurator/components/field.tsx:878
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:244
 msgid "controls.none"
 msgstr "Keine"
@@ -450,7 +450,7 @@ msgstr "Aus"
 msgid "controls.scale.type"
 msgstr "Skalierungstyp"
 
-#: app/components/form.tsx:611
+#: app/components/form.tsx:614
 msgid "controls.search.clear"
 msgstr "Suche zurücksetzen"
 
@@ -458,7 +458,7 @@ msgstr "Suche zurücksetzen"
 msgid "controls.section.additional-information"
 msgstr "Zusätzliche Informationen"
 
-#: app/configurator/components/chart-configurator.tsx:595
+#: app/configurator/components/chart-configurator.tsx:587
 msgid "controls.section.chart.options"
 msgstr "Diagramm-Einstellungen"
 
@@ -470,11 +470,11 @@ msgstr "Spalten"
 msgid "controls.section.columnstyle"
 msgstr "Spaltenstil"
 
-#: app/configurator/components/chart-configurator.tsx:613
+#: app/configurator/components/chart-configurator.tsx:605
 msgid "controls.section.data.filters"
 msgstr "Filter"
 
-#: app/configurator/components/chart-configurator.tsx:629
+#: app/configurator/components/chart-configurator.tsx:621
 msgid "controls.section.data.filters.possible-filters-error"
 msgstr "Beim Abrufen möglicher Filter ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut oder laden Sie die Seite neu."
 
@@ -532,7 +532,7 @@ msgstr "Tabellenoptionen"
 msgid "controls.section.title.warning"
 msgstr "Fügen Sie einen Titel oder eine Beschreibung hinzu"
 
-#: app/configurator/components/chart-configurator.tsx:587
+#: app/configurator/components/chart-configurator.tsx:579
 #: app/configurator/components/chart-type-selector.tsx:131
 #: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
@@ -586,10 +586,10 @@ msgid "controls.select.measure"
 msgstr "Messwert auswählen"
 
 #: app/configurator/components/field.tsx:172
-#: app/configurator/components/field.tsx:269
-#: app/configurator/components/field.tsx:369
-#: app/configurator/components/field.tsx:708
-#: app/configurator/components/field.tsx:880
+#: app/configurator/components/field.tsx:272
+#: app/configurator/components/field.tsx:372
+#: app/configurator/components/field.tsx:711
+#: app/configurator/components/field.tsx:883
 msgid "controls.select.optional"
 msgstr ""
 
@@ -726,7 +726,7 @@ msgstr "Cube IRI"
 msgid "data.source"
 msgstr "Datenquelle"
 
-#: app/components/chart-published.tsx:196
+#: app/components/chart-published.tsx:209
 msgid "data.source.notTrusted"
 msgstr "Dieses Diagramm verwendet keine vertrauenswürdige Datenquelle."
 
@@ -738,15 +738,15 @@ msgstr "Zurück zu den Datensätzen"
 msgid "dataset-preview.keywords"
 msgstr "Schlüsselwörter"
 
-#: app/components/chart-footnotes.tsx:117
+#: app/components/chart-footnotes.tsx:134
 msgid "dataset.footnotes.dataset"
 msgstr "Datensatz"
 
-#: app/components/chart-footnotes.tsx:138
+#: app/components/chart-footnotes.tsx:156
 msgid "dataset.footnotes.updated"
 msgstr "Neuestes Update"
 
-#: app/components/chart-published.tsx:205
+#: app/components/chart-published.tsx:218
 msgid "dataset.hasImputedValues"
 msgstr "Einige Daten in diesem Datensatz fehlen und wurden interpoliert, um die Lücken zu füllen."
 
@@ -766,7 +766,7 @@ msgstr "Kontaktstellen"
 msgid "dataset.metadata.furtherinformation"
 msgstr "Weitere Informationen"
 
-#: app/components/chart-footnotes.tsx:204
+#: app/components/chart-footnotes.tsx:234
 #: app/configurator/components/dataset-metadata.tsx:107
 msgid "dataset.metadata.learnmore"
 msgstr "Erfahren Sie mehr über diesen Datensatz"
@@ -792,12 +792,12 @@ msgid "dataset.order.title"
 msgstr "Titel"
 
 #: app/components/chart-preview.tsx:115
-#: app/components/chart-published.tsx:174
+#: app/components/chart-published.tsx:187
 #: app/configurator/components/dataset-preview.tsx:120
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Achtung, dieser Datensatz ist im Entwurfs-Stadium.<0/><1>Diese Grafik nicht für Berichte verwenden.</1>"
 
-#: app/components/chart-published.tsx:185
+#: app/components/chart-published.tsx:198
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Achtung, dieser Datensatz ist abgelaufen.<0/><1>Diese Grafik nicht für Berichte verwenden.</1>"
 
@@ -865,7 +865,7 @@ msgstr "Es gab ein Problem beim Laden der Koordinaten aus den geografischen Dime
 msgid "hint.coordinatesloadingerror.title"
 msgstr "Koordinaten-Ladefehler"
 
-#: app/pages/v/[chartId].tsx:128
+#: app/pages/v/[chartId].tsx:117
 msgid "hint.create.your.own.chart"
 msgstr "Kopieren Sie diese Visualisierung oder erstellen Sie eine neue Visualisierung mit Swiss Open Government Data."
 
@@ -881,11 +881,11 @@ msgstr "Weitere Informationen finden Sie auf der Statusseite"
 msgid "hint.dataloadingerror.title"
 msgstr "Daten-Ladefehler"
 
-#: app/pages/v/[chartId].tsx:122
+#: app/pages/v/[chartId].tsx:111
 msgid "hint.how.to.share"
 msgstr "Sie können diese Visualisierung teilen oder sie einbetten. Zudem können Sie eine neue Visualisierung erstellen oder die gezeigte Visualisierung kopieren."
 
-#: app/components/form.tsx:282
+#: app/components/form.tsx:285
 #: app/components/hint.tsx:111
 msgid "hint.loading.data"
 msgstr "Lade Daten …"
@@ -927,55 +927,79 @@ msgstr "Filter anzeigen"
 msgid "logo.swiss.confederation"
 msgstr "Logo der Schweizerischen Eidgenossenschaft"
 
-#: app/components/chart-footnotes.tsx:223
+#: app/components/chart-footnotes.tsx:254
 msgid "metadata.link.created.with.visualize"
 msgstr "Erstellt mit visualize.admin.ch"
 
-#: app/components/chart-footnotes.tsx:149
+#: app/components/chart-footnotes.tsx:168
 msgid "metadata.source"
 msgstr "Quelle"
 
-#: app/components/chart-footnotes.tsx:187
+#: app/components/chart-footnotes.tsx:211
 msgid "metadata.switch.chart"
 msgstr "Zur Diagrammansicht wechseln"
 
-#: app/components/chart-footnotes.tsx:189
+#: app/components/chart-footnotes.tsx:215
 msgid "metadata.switch.table"
 msgstr "Zur Tabellenansicht wechseln"
 
-#: app/components/publish-actions.tsx:218
+#: app/components/publish-actions.tsx:319
 msgid "publication.embed.AEM"
-msgstr "Einbett-Code für AEM «Externe Applikation»:"
+msgstr "Einbett-Code für AEM «Externe Applikation»"
 
-#: app/components/publish-actions.tsx:211
+#: app/components/publish-actions.tsx:324
+msgid "publication.embed.AEM.caption"
+msgstr ""
+
+#: app/components/publish-actions.tsx:304
 msgid "publication.embed.iframe"
-msgstr "Einbett-Code:"
+msgstr "Einbett-Code"
 
-#: app/components/publish-actions.tsx:111
+#: app/components/publish-actions.tsx:307
+msgid "publication.embed.iframe.caption"
+msgstr ""
+
+#: app/components/publish-actions.tsx:286
+msgid "publication.embed.style.minimal"
+msgstr ""
+
+#: app/components/publish-actions.tsx:291
+msgid "publication.embed.style.minimal.caption"
+msgstr ""
+
+#: app/components/publish-actions.tsx:266
+msgid "publication.embed.style.standard"
+msgstr ""
+
+#: app/components/publish-actions.tsx:271
+msgid "publication.embed.style.standard.caption"
+msgstr ""
+
+#: app/components/publish-actions.tsx:117
 msgid "publication.popup.share"
 msgstr "Teilen"
 
-#: app/components/publish-actions.tsx:159
+#: app/components/publish-actions.tsx:165
 msgid "publication.share.chart.url"
 msgstr "Diagramm-URL:"
 
-#: app/components/publish-actions.tsx:117
+#: app/components/publish-actions.tsx:123
 msgid "publication.share.linktitle.facebook"
 msgstr "Teilen via Facebook"
 
-#: app/components/publish-actions.tsx:137
+#: app/components/publish-actions.tsx:143
 msgid "publication.share.linktitle.mail"
 msgstr "Versenden via E-Mail"
 
-#: app/components/publish-actions.tsx:127
+#: app/components/publish-actions.tsx:133
 msgid "publication.share.linktitle.twitter"
 msgstr "Teilen via Twitter"
 
-#: app/components/publish-actions.tsx:148
+#: app/components/publish-actions.tsx:154
 msgid "publication.share.mail.body"
 msgstr "Hier ist eine Visualisierung, die ich mit visualize.admin.ch erstellt habe"
 
-#: app/components/publish-actions.tsx:143
+#: app/components/publish-actions.tsx:149
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
@@ -992,8 +1016,8 @@ msgstr "Springen zu..."
 msgid "table.column.no"
 msgstr "Spalte {0}"
 
-#: app/components/chart-footnotes.tsx:119
-#: app/components/chart-footnotes.tsx:140
-#: app/components/chart-footnotes.tsx:151
+#: app/components/chart-footnotes.tsx:136
+#: app/components/chart-footnotes.tsx:158
+#: app/components/chart-footnotes.tsx:170
 msgid "typography.colon"
 msgstr ": "

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -62,11 +62,11 @@ msgstr "Alle Datensätze"
 msgid "browse.datasets.description"
 msgstr "Erkunden Sie die vom LINDAS Linked Data Service bereitgestellten Datensätze, indem Sie entweder nach Kategorien oder Organisationen filtern oder direkt nach bestimmten Stichworten suchen. Klicken Sie auf einen Datensatz, um detailliertere Informationen zu erhalten und Ihre eigenen Visualisierungen zu erstellen."
 
-#: app/components/metadata-panel.tsx:426
+#: app/components/metadata-panel.tsx:438
 msgid "button.back"
 msgstr "Zurück"
 
-#: app/pages/v/[chartId].tsx:166
+#: app/pages/v/[chartId].tsx:165
 msgid "button.copy.visualization"
 msgstr "Diese Visualisierung kopieren und editieren"
 
@@ -90,20 +90,20 @@ msgstr "Daten aus der Grafik"
 msgid "button.download.runsparqlquery.visible"
 msgstr "SPARQL-Abfrage ausführen"
 
-#: app/components/publish-actions.tsx:240
+#: app/components/publish-actions.tsx:258
 msgid "button.embed"
 msgstr "Einbetten"
 
-#: app/components/publish-actions.tsx:390
-#: app/components/publish-actions.tsx:396
+#: app/components/publish-actions.tsx:409
+#: app/components/publish-actions.tsx:415
 msgid "button.hint.click.to.copy"
 msgstr "Kopieren"
 
-#: app/components/publish-actions.tsx:420
+#: app/components/publish-actions.tsx:439
 msgid "button.hint.copied"
 msgstr "Kopiert!"
 
-#: app/pages/v/[chartId].tsx:151
+#: app/pages/v/[chartId].tsx:155
 msgid "button.new.visualization"
 msgstr "Neue Visualisierung erstellen"
 
@@ -111,7 +111,7 @@ msgstr "Neue Visualisierung erstellen"
 msgid "button.publish"
 msgstr "Diese Visualisierung veröffentlichen"
 
-#: app/components/publish-actions.tsx:102
+#: app/components/publish-actions.tsx:107
 msgid "button.share"
 msgstr "Teilen"
 
@@ -407,20 +407,20 @@ msgstr "Italienisch"
 msgid "controls.measure"
 msgstr "Messwert"
 
-#: app/components/metadata-panel.tsx:568
+#: app/components/metadata-panel.tsx:580
 msgid "controls.metadata-panel.available-values"
 msgstr "Verfügbare Werte"
 
-#: app/components/metadata-panel.tsx:362
 #: app/components/metadata-panel.tsx:374
+#: app/components/metadata-panel.tsx:386
 msgid "controls.metadata-panel.metadata"
 msgstr "Metadata"
 
-#: app/components/metadata-panel.tsx:323
+#: app/components/metadata-panel.tsx:335
 msgid "controls.metadata-panel.section.data"
 msgstr "Daten"
 
-#: app/components/metadata-panel.tsx:313
+#: app/components/metadata-panel.tsx:325
 msgid "controls.metadata-panel.section.general"
 msgstr "Allgemeines"
 
@@ -726,7 +726,7 @@ msgstr "Cube IRI"
 msgid "data.source"
 msgstr "Datenquelle"
 
-#: app/components/chart-published.tsx:209
+#: app/components/chart-published.tsx:199
 msgid "data.source.notTrusted"
 msgstr "Dieses Diagramm verwendet keine vertrauenswürdige Datenquelle."
 
@@ -738,15 +738,15 @@ msgstr "Zurück zu den Datensätzen"
 msgid "dataset-preview.keywords"
 msgstr "Schlüsselwörter"
 
-#: app/components/chart-footnotes.tsx:134
+#: app/components/chart-footnotes.tsx:133
 msgid "dataset.footnotes.dataset"
 msgstr "Datensatz"
 
-#: app/components/chart-footnotes.tsx:156
+#: app/components/chart-footnotes.tsx:155
 msgid "dataset.footnotes.updated"
 msgstr "Neuestes Update"
 
-#: app/components/chart-published.tsx:218
+#: app/components/chart-published.tsx:208
 msgid "dataset.hasImputedValues"
 msgstr "Einige Daten in diesem Datensatz fehlen und wurden interpoliert, um die Lücken zu füllen."
 
@@ -766,7 +766,7 @@ msgstr "Kontaktstellen"
 msgid "dataset.metadata.furtherinformation"
 msgstr "Weitere Informationen"
 
-#: app/components/chart-footnotes.tsx:234
+#: app/components/chart-footnotes.tsx:233
 #: app/configurator/components/dataset-metadata.tsx:107
 msgid "dataset.metadata.learnmore"
 msgstr "Erfahren Sie mehr über diesen Datensatz"
@@ -792,12 +792,12 @@ msgid "dataset.order.title"
 msgstr "Titel"
 
 #: app/components/chart-preview.tsx:115
-#: app/components/chart-published.tsx:187
+#: app/components/chart-published.tsx:177
 #: app/configurator/components/dataset-preview.tsx:120
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Achtung, dieser Datensatz ist im Entwurfs-Stadium.<0/><1>Diese Grafik nicht für Berichte verwenden.</1>"
 
-#: app/components/chart-published.tsx:198
+#: app/components/chart-published.tsx:188
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Achtung, dieser Datensatz ist abgelaufen.<0/><1>Diese Grafik nicht für Berichte verwenden.</1>"
 
@@ -865,7 +865,7 @@ msgstr "Es gab ein Problem beim Laden der Koordinaten aus den geografischen Dime
 msgid "hint.coordinatesloadingerror.title"
 msgstr "Koordinaten-Ladefehler"
 
-#: app/pages/v/[chartId].tsx:128
+#: app/pages/v/[chartId].tsx:137
 msgid "hint.create.your.own.chart"
 msgstr "Kopieren Sie diese Visualisierung oder erstellen Sie eine neue Visualisierung mit Swiss Open Government Data."
 
@@ -881,7 +881,7 @@ msgstr "Weitere Informationen finden Sie auf der Statusseite"
 msgid "hint.dataloadingerror.title"
 msgstr "Daten-Ladefehler"
 
-#: app/pages/v/[chartId].tsx:122
+#: app/pages/v/[chartId].tsx:131
 msgid "hint.how.to.share"
 msgstr "Sie können diese Visualisierung teilen oder sie einbetten. Zudem können Sie eine neue Visualisierung erstellen oder die gezeigte Visualisierung kopieren."
 
@@ -927,83 +927,83 @@ msgstr "Filter anzeigen"
 msgid "logo.swiss.confederation"
 msgstr "Logo der Schweizerischen Eidgenossenschaft"
 
-#: app/components/chart-footnotes.tsx:254
+#: app/components/chart-footnotes.tsx:253
 msgid "metadata.link.created.with.visualize"
 msgstr "Erstellt mit visualize.admin.ch"
 
-#: app/components/chart-published.tsx:285
+#: app/components/chart-published.tsx:268
 msgid "metadata.link.created.with.visualize.alternate"
 msgstr "Mehr Informationen"
 
-#: app/components/chart-footnotes.tsx:168
+#: app/components/chart-footnotes.tsx:167
 msgid "metadata.source"
 msgstr "Quelle"
 
-#: app/components/chart-footnotes.tsx:211
+#: app/components/chart-footnotes.tsx:210
 msgid "metadata.switch.chart"
 msgstr "Zur Diagrammansicht wechseln"
 
-#: app/components/chart-footnotes.tsx:215
+#: app/components/chart-footnotes.tsx:214
 msgid "metadata.switch.table"
 msgstr "Zur Tabellenansicht wechseln"
 
-#: app/components/publish-actions.tsx:319
+#: app/components/publish-actions.tsx:338
 msgid "publication.embed.AEM"
 msgstr "Einbett-Code für AEM «Externe Applikation»"
 
-#: app/components/publish-actions.tsx:324
+#: app/components/publish-actions.tsx:343
 msgid "publication.embed.AEM.caption"
 msgstr "Verwenden Sie diesen Code, um das Diagramm in Adobe Experience Manager einzubetten"
 
-#: app/components/publish-actions.tsx:304
+#: app/components/publish-actions.tsx:323
 msgid "publication.embed.iframe"
 msgstr "Einbett-Code"
 
-#: app/components/publish-actions.tsx:307
+#: app/components/publish-actions.tsx:326
 msgid "publication.embed.iframe.caption"
 msgstr "Verwenden Sie diesen Code, um das Diagramm auf einer Webseite einzubetten"
 
-#: app/components/publish-actions.tsx:286
+#: app/components/publish-actions.tsx:304
 msgid "publication.embed.style.minimal"
 msgstr "Minimale"
 
-#: app/components/publish-actions.tsx:291
-#~ msgid "publication.embed.style.minimal.caption"
-#~ msgstr ""
+#: app/components/publish-actions.tsx:309
+msgid "publication.embed.style.minimal.caption"
+msgstr "Nur Visualisierung mit Link zu mehr Informationen auf visualize.admin.ch"
 
-#: app/components/publish-actions.tsx:266
+#: app/components/publish-actions.tsx:284
 msgid "publication.embed.style.standard"
 msgstr "Standard"
 
-#: app/components/publish-actions.tsx:271
-#~ msgid "publication.embed.style.standard.caption"
-#~ msgstr ""
+#: app/components/publish-actions.tsx:289
+msgid "publication.embed.style.standard.caption"
+msgstr "Stellt Metadata und Downloadlink für das Datenset zur Verfügung"
 
-#: app/components/publish-actions.tsx:117
+#: app/components/publish-actions.tsx:122
 msgid "publication.popup.share"
 msgstr "Teilen"
 
-#: app/components/publish-actions.tsx:165
+#: app/components/publish-actions.tsx:170
 msgid "publication.share.chart.url"
 msgstr "Diagramm-URL:"
 
-#: app/components/publish-actions.tsx:123
+#: app/components/publish-actions.tsx:128
 msgid "publication.share.linktitle.facebook"
 msgstr "Teilen via Facebook"
 
-#: app/components/publish-actions.tsx:143
+#: app/components/publish-actions.tsx:148
 msgid "publication.share.linktitle.mail"
 msgstr "Versenden via E-Mail"
 
-#: app/components/publish-actions.tsx:133
+#: app/components/publish-actions.tsx:138
 msgid "publication.share.linktitle.twitter"
 msgstr "Teilen via Twitter"
 
-#: app/components/publish-actions.tsx:154
+#: app/components/publish-actions.tsx:159
 msgid "publication.share.mail.body"
 msgstr "Hier ist eine Visualisierung, die ich mit visualize.admin.ch erstellt habe"
 
-#: app/components/publish-actions.tsx:149
+#: app/components/publish-actions.tsx:154
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
@@ -1012,7 +1012,7 @@ msgstr "visualize.admin.ch"
 msgid "select.controls.filters.search"
 msgstr "Suche"
 
-#: app/components/metadata-panel.tsx:450
+#: app/components/metadata-panel.tsx:462
 msgid "select.controls.metadata.search"
 msgstr "Springen zu..."
 
@@ -1020,8 +1020,8 @@ msgstr "Springen zu..."
 msgid "table.column.no"
 msgstr "Spalte {0}"
 
-#: app/components/chart-footnotes.tsx:136
-#: app/components/chart-footnotes.tsx:158
-#: app/components/chart-footnotes.tsx:170
+#: app/components/chart-footnotes.tsx:135
+#: app/components/chart-footnotes.tsx:157
+#: app/components/chart-footnotes.tsx:169
 msgid "typography.colon"
 msgstr ": "

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -66,7 +66,7 @@ msgstr "Explore datasets provided by the LINDAS Linked Data Service by either fi
 msgid "button.back"
 msgstr "Back"
 
-#: app/pages/v/[chartId].tsx:154
+#: app/pages/v/[chartId].tsx:166
 msgid "button.copy.visualization"
 msgstr "Copy and edit this visualization"
 
@@ -103,7 +103,7 @@ msgstr "Click to copy"
 msgid "button.hint.copied"
 msgstr "Copied!"
 
-#: app/pages/v/[chartId].tsx:139
+#: app/pages/v/[chartId].tsx:151
 msgid "button.new.visualization"
 msgstr "Create New Visualization"
 
@@ -865,7 +865,7 @@ msgstr "There was a problem with loading the coordinates from geographical dimen
 msgid "hint.coordinatesloadingerror.title"
 msgstr "Coordinates loading error"
 
-#: app/pages/v/[chartId].tsx:117
+#: app/pages/v/[chartId].tsx:128
 msgid "hint.create.your.own.chart"
 msgstr "Copy this visualization or make a new visualization using Swiss Open Government Data."
 
@@ -881,7 +881,7 @@ msgstr "Check the status page for more information"
 msgid "hint.dataloadingerror.title"
 msgstr "Data loading error"
 
-#: app/pages/v/[chartId].tsx:111
+#: app/pages/v/[chartId].tsx:122
 msgid "hint.how.to.share"
 msgstr "You can share this visualization by copying the URL or by embedding it on your own website. You can also create a new visualization from scratch or start by copying the visualization above."
 
@@ -931,6 +931,10 @@ msgstr "Logo of the Swiss Confederation"
 msgid "metadata.link.created.with.visualize"
 msgstr "Created with visualize.admin.ch"
 
+#: app/components/chart-published.tsx:285
+msgid "metadata.link.created.with.visualize.alternate"
+msgstr "More information"
+
 #: app/components/chart-footnotes.tsx:168
 msgid "metadata.source"
 msgstr "Source"
@@ -964,16 +968,16 @@ msgid "publication.embed.style.minimal"
 msgstr "Minimal"
 
 #: app/components/publish-actions.tsx:291
-msgid "publication.embed.style.minimal.caption"
-msgstr "Only the chart and a link for more information."
+#~ msgid "publication.embed.style.minimal.caption"
+#~ msgstr "Only the chart and a link for more information."
 
 #: app/components/publish-actions.tsx:266
 msgid "publication.embed.style.standard"
 msgstr "Standard"
 
 #: app/components/publish-actions.tsx:271
-msgid "publication.embed.style.standard.caption"
-msgstr "Chart, download the data links, attribution etc..."
+#~ msgid "publication.embed.style.standard.caption"
+#~ msgstr "Chart, download the data links, attribution etc..."
 
 #: app/components/publish-actions.tsx:117
 msgid "publication.popup.share"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -912,7 +912,7 @@ msgstr "Negative Values"
 
 #: app/components/hint.tsx:226
 msgid "hint.publication.success"
-msgstr "Your visualization is now published. Share it by copying the URL or use the Embed menu below."
+msgstr "Your visualization is now published. Share it by copying the URL or use the Embed menu above."
 
 #: app/charts/shared/chart-data-filters.tsx:96
 msgid "interactive.data.filters.hide"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -949,7 +949,7 @@ msgstr "Embed Code for AEM \"External Application\""
 
 #: app/components/publish-actions.tsx:324
 msgid "publication.embed.AEM.caption"
-msgstr "Use this link to insert this visualization into Adobe Experience Manager assets."
+msgstr "Use this link to embed the chart into Adobe Experience Manager assets."
 
 #: app/components/publish-actions.tsx:304
 msgid "publication.embed.iframe"
@@ -957,7 +957,7 @@ msgstr "Embed Code"
 
 #: app/components/publish-actions.tsx:307
 msgid "publication.embed.iframe.caption"
-msgstr "Use this link to insert this visualization into other webpages."
+msgstr "Use this link to embed the chart into other webpages."
 
 #: app/components/publish-actions.tsx:286
 msgid "publication.embed.style.minimal"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -13,19 +13,19 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:709
+#: app/configurator/components/chart-configurator.tsx:701
 msgid "Add filter"
 msgstr "Add filter"
 
-#: app/configurator/components/chart-configurator.tsx:682
+#: app/configurator/components/chart-configurator.tsx:674
 msgid "Drag filters to reorganize"
 msgstr "Drag filters to reorganize"
 
-#: app/configurator/components/chart-configurator.tsx:679
+#: app/configurator/components/chart-configurator.tsx:671
 msgid "Move filter down"
 msgstr "Move filter down"
 
-#: app/configurator/components/chart-configurator.tsx:676
+#: app/configurator/components/chart-configurator.tsx:668
 msgid "Move filter up"
 msgstr "Move filter up"
 
@@ -66,7 +66,7 @@ msgstr "Explore datasets provided by the LINDAS Linked Data Service by either fi
 msgid "button.back"
 msgstr "Back"
 
-#: app/pages/v/[chartId].tsx:166
+#: app/pages/v/[chartId].tsx:154
 msgid "button.copy.visualization"
 msgstr "Copy and edit this visualization"
 
@@ -90,20 +90,20 @@ msgstr "Chart dataset"
 msgid "button.download.runsparqlquery.visible"
 msgstr "Run SPARQL query"
 
-#: app/components/publish-actions.tsx:206
+#: app/components/publish-actions.tsx:240
 msgid "button.embed"
 msgstr "Embed"
 
-#: app/components/publish-actions.tsx:281
-#: app/components/publish-actions.tsx:287
+#: app/components/publish-actions.tsx:390
+#: app/components/publish-actions.tsx:396
 msgid "button.hint.click.to.copy"
 msgstr "Click to copy"
 
-#: app/components/publish-actions.tsx:311
+#: app/components/publish-actions.tsx:420
 msgid "button.hint.copied"
 msgstr "Copied!"
 
-#: app/pages/v/[chartId].tsx:151
+#: app/pages/v/[chartId].tsx:139
 msgid "button.new.visualization"
 msgstr "Create New Visualization"
 
@@ -111,7 +111,7 @@ msgstr "Create New Visualization"
 msgid "button.publish"
 msgstr "Publish this visualization"
 
-#: app/components/publish-actions.tsx:96
+#: app/components/publish-actions.tsx:102
 msgid "button.share"
 msgstr "Share"
 
@@ -119,7 +119,7 @@ msgstr "Share"
 msgid "chart.map.layers.area"
 msgstr "Areas"
 
-#: app/configurator/components/chart-configurator.tsx:762
+#: app/configurator/components/chart-configurator.tsx:754
 #: app/configurator/components/chart-options-selector.tsx:1055
 #: app/configurator/components/field-i18n.ts:31
 msgid "chart.map.layers.base"
@@ -307,8 +307,8 @@ msgstr "Description"
 #: app/charts/shared/chart-data-filters.tsx:249
 #: app/charts/shared/chart-data-filters.tsx:296
 #: app/configurator/components/field.tsx:167
-#: app/configurator/components/field.tsx:264
-#: app/configurator/components/field.tsx:364
+#: app/configurator/components/field.tsx:267
+#: app/configurator/components/field.tsx:367
 msgid "controls.dimensionvalue.none"
 msgstr "No Filter"
 
@@ -324,12 +324,12 @@ msgstr "Select all"
 msgid "controls.filter.select.none"
 msgstr "Select none"
 
-#: app/configurator/components/chart-configurator.tsx:512
+#: app/configurator/components/chart-configurator.tsx:513
 #: app/configurator/components/filters.tsx:366
 msgid "controls.filters.interactive.toggle"
 msgstr "Interactive"
 
-#: app/configurator/components/chart-configurator.tsx:505
+#: app/configurator/components/chart-configurator.tsx:506
 #: app/configurator/components/filters.tsx:360
 msgid "controls.filters.interactive.tooltip"
 msgstr "Allow users to change filters"
@@ -432,8 +432,8 @@ msgstr "Back to main"
 msgid "controls.nav.back-to-preview"
 msgstr "Back to preview"
 
-#: app/configurator/components/field.tsx:703
-#: app/configurator/components/field.tsx:875
+#: app/configurator/components/field.tsx:706
+#: app/configurator/components/field.tsx:878
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:244
 msgid "controls.none"
 msgstr "None"
@@ -450,7 +450,7 @@ msgstr "Off"
 msgid "controls.scale.type"
 msgstr "Scale type"
 
-#: app/components/form.tsx:611
+#: app/components/form.tsx:614
 msgid "controls.search.clear"
 msgstr "Clear search field"
 
@@ -458,7 +458,7 @@ msgstr "Clear search field"
 msgid "controls.section.additional-information"
 msgstr "Additional information"
 
-#: app/configurator/components/chart-configurator.tsx:595
+#: app/configurator/components/chart-configurator.tsx:587
 msgid "controls.section.chart.options"
 msgstr "Chart Options"
 
@@ -470,11 +470,11 @@ msgstr "Columns"
 msgid "controls.section.columnstyle"
 msgstr "Column Style"
 
-#: app/configurator/components/chart-configurator.tsx:613
+#: app/configurator/components/chart-configurator.tsx:605
 msgid "controls.section.data.filters"
 msgstr "Filters"
 
-#: app/configurator/components/chart-configurator.tsx:629
+#: app/configurator/components/chart-configurator.tsx:621
 msgid "controls.section.data.filters.possible-filters-error"
 msgstr "An error happened while fetching possible filters, please retry later or reload the page."
 
@@ -532,7 +532,7 @@ msgstr "Table Options"
 msgid "controls.section.title.warning"
 msgstr "Please add a title or description."
 
-#: app/configurator/components/chart-configurator.tsx:587
+#: app/configurator/components/chart-configurator.tsx:579
 #: app/configurator/components/chart-type-selector.tsx:131
 #: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
@@ -586,10 +586,10 @@ msgid "controls.select.measure"
 msgstr "Select a measure"
 
 #: app/configurator/components/field.tsx:172
-#: app/configurator/components/field.tsx:269
-#: app/configurator/components/field.tsx:369
-#: app/configurator/components/field.tsx:708
-#: app/configurator/components/field.tsx:880
+#: app/configurator/components/field.tsx:272
+#: app/configurator/components/field.tsx:372
+#: app/configurator/components/field.tsx:711
+#: app/configurator/components/field.tsx:883
 msgid "controls.select.optional"
 msgstr "optional"
 
@@ -726,7 +726,7 @@ msgstr "Cube IRI"
 msgid "data.source"
 msgstr "Data source"
 
-#: app/components/chart-published.tsx:196
+#: app/components/chart-published.tsx:209
 msgid "data.source.notTrusted"
 msgstr "This chart is not using a trusted data source."
 
@@ -738,15 +738,15 @@ msgstr "Back to the datasets"
 msgid "dataset-preview.keywords"
 msgstr "Keywords"
 
-#: app/components/chart-footnotes.tsx:117
+#: app/components/chart-footnotes.tsx:134
 msgid "dataset.footnotes.dataset"
 msgstr "Dataset"
 
-#: app/components/chart-footnotes.tsx:138
+#: app/components/chart-footnotes.tsx:156
 msgid "dataset.footnotes.updated"
 msgstr "Latest update"
 
-#: app/components/chart-published.tsx:205
+#: app/components/chart-published.tsx:218
 msgid "dataset.hasImputedValues"
 msgstr "Some data in this dataset is missing and has been interpolated to fill the gaps."
 
@@ -766,7 +766,7 @@ msgstr "Contact points"
 msgid "dataset.metadata.furtherinformation"
 msgstr "Further information"
 
-#: app/components/chart-footnotes.tsx:204
+#: app/components/chart-footnotes.tsx:234
 #: app/configurator/components/dataset-metadata.tsx:107
 msgid "dataset.metadata.learnmore"
 msgstr "Learn more about the dataset"
@@ -792,12 +792,12 @@ msgid "dataset.order.title"
 msgstr "Title"
 
 #: app/components/chart-preview.tsx:115
-#: app/components/chart-published.tsx:174
+#: app/components/chart-published.tsx:187
 #: app/configurator/components/dataset-preview.tsx:120
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Careful, this dataset is only a draft.<0/><1>Don't use for reporting!</1>"
 
-#: app/components/chart-published.tsx:185
+#: app/components/chart-published.tsx:198
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Careful, the data for this chart has expired.<0/><1>Don't use for reporting!</1>"
 
@@ -865,7 +865,7 @@ msgstr "There was a problem with loading the coordinates from geographical dimen
 msgid "hint.coordinatesloadingerror.title"
 msgstr "Coordinates loading error"
 
-#: app/pages/v/[chartId].tsx:128
+#: app/pages/v/[chartId].tsx:117
 msgid "hint.create.your.own.chart"
 msgstr "Copy this visualization or make a new visualization using Swiss Open Government Data."
 
@@ -881,11 +881,11 @@ msgstr "Check the status page for more information"
 msgid "hint.dataloadingerror.title"
 msgstr "Data loading error"
 
-#: app/pages/v/[chartId].tsx:122
+#: app/pages/v/[chartId].tsx:111
 msgid "hint.how.to.share"
 msgstr "You can share this visualization by copying the URL or by embedding it on your own website. You can also create a new visualization from scratch or start by copying the visualization above."
 
-#: app/components/form.tsx:282
+#: app/components/form.tsx:285
 #: app/components/hint.tsx:111
 msgid "hint.loading.data"
 msgstr "Loading data..."
@@ -927,55 +927,79 @@ msgstr "Show Filters"
 msgid "logo.swiss.confederation"
 msgstr "Logo of the Swiss Confederation"
 
-#: app/components/chart-footnotes.tsx:223
+#: app/components/chart-footnotes.tsx:254
 msgid "metadata.link.created.with.visualize"
 msgstr "Created with visualize.admin.ch"
 
-#: app/components/chart-footnotes.tsx:149
+#: app/components/chart-footnotes.tsx:168
 msgid "metadata.source"
 msgstr "Source"
 
-#: app/components/chart-footnotes.tsx:187
+#: app/components/chart-footnotes.tsx:211
 msgid "metadata.switch.chart"
 msgstr "Switch to chart view"
 
-#: app/components/chart-footnotes.tsx:189
+#: app/components/chart-footnotes.tsx:215
 msgid "metadata.switch.table"
 msgstr "Switch to table view"
 
-#: app/components/publish-actions.tsx:218
+#: app/components/publish-actions.tsx:319
 msgid "publication.embed.AEM"
-msgstr "Embed Code for AEM \"External Application\":"
+msgstr "Embed Code for AEM \"External Application\""
 
-#: app/components/publish-actions.tsx:211
+#: app/components/publish-actions.tsx:324
+msgid "publication.embed.AEM.caption"
+msgstr "Use this link to insert this visualization into Adobe Experience Manager assets."
+
+#: app/components/publish-actions.tsx:304
 msgid "publication.embed.iframe"
-msgstr "Embed Code:"
+msgstr "Embed Code"
 
-#: app/components/publish-actions.tsx:111
+#: app/components/publish-actions.tsx:307
+msgid "publication.embed.iframe.caption"
+msgstr "Use this link to insert this visualization into other webpages."
+
+#: app/components/publish-actions.tsx:286
+msgid "publication.embed.style.minimal"
+msgstr "Minimal"
+
+#: app/components/publish-actions.tsx:291
+msgid "publication.embed.style.minimal.caption"
+msgstr "Only the chart and a link for more information."
+
+#: app/components/publish-actions.tsx:266
+msgid "publication.embed.style.standard"
+msgstr "Standard"
+
+#: app/components/publish-actions.tsx:271
+msgid "publication.embed.style.standard.caption"
+msgstr "Chart, download the data links, attribution etc..."
+
+#: app/components/publish-actions.tsx:117
 msgid "publication.popup.share"
 msgstr "Share"
 
-#: app/components/publish-actions.tsx:159
+#: app/components/publish-actions.tsx:165
 msgid "publication.share.chart.url"
 msgstr "Chart URL:"
 
-#: app/components/publish-actions.tsx:117
+#: app/components/publish-actions.tsx:123
 msgid "publication.share.linktitle.facebook"
 msgstr "Share on Facebook"
 
-#: app/components/publish-actions.tsx:137
+#: app/components/publish-actions.tsx:143
 msgid "publication.share.linktitle.mail"
 msgstr "Share via Email"
 
-#: app/components/publish-actions.tsx:127
+#: app/components/publish-actions.tsx:133
 msgid "publication.share.linktitle.twitter"
 msgstr "Share on Twitter"
 
-#: app/components/publish-actions.tsx:148
+#: app/components/publish-actions.tsx:154
 msgid "publication.share.mail.body"
 msgstr "Here is a visualization I created using visualize.admin.ch"
 
-#: app/components/publish-actions.tsx:143
+#: app/components/publish-actions.tsx:149
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
@@ -992,8 +1016,8 @@ msgstr "Jump to..."
 msgid "table.column.no"
 msgstr "Column {0}"
 
-#: app/components/chart-footnotes.tsx:119
-#: app/components/chart-footnotes.tsx:140
-#: app/components/chart-footnotes.tsx:151
+#: app/components/chart-footnotes.tsx:136
+#: app/components/chart-footnotes.tsx:158
+#: app/components/chart-footnotes.tsx:170
 msgid "typography.colon"
 msgstr ": "

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -62,11 +62,11 @@ msgstr "All datasets"
 msgid "browse.datasets.description"
 msgstr "Explore datasets provided by the LINDAS Linked Data Service by either filtering by categories or organisations or search directly for specific keywords. Click on a dataset to see more detailed information and start creating your own visualizations."
 
-#: app/components/metadata-panel.tsx:426
+#: app/components/metadata-panel.tsx:438
 msgid "button.back"
 msgstr "Back"
 
-#: app/pages/v/[chartId].tsx:166
+#: app/pages/v/[chartId].tsx:165
 msgid "button.copy.visualization"
 msgstr "Copy and edit this visualization"
 
@@ -90,20 +90,20 @@ msgstr "Chart dataset"
 msgid "button.download.runsparqlquery.visible"
 msgstr "Run SPARQL query"
 
-#: app/components/publish-actions.tsx:240
+#: app/components/publish-actions.tsx:258
 msgid "button.embed"
 msgstr "Embed"
 
-#: app/components/publish-actions.tsx:390
-#: app/components/publish-actions.tsx:396
+#: app/components/publish-actions.tsx:409
+#: app/components/publish-actions.tsx:415
 msgid "button.hint.click.to.copy"
 msgstr "Click to copy"
 
-#: app/components/publish-actions.tsx:420
+#: app/components/publish-actions.tsx:439
 msgid "button.hint.copied"
 msgstr "Copied!"
 
-#: app/pages/v/[chartId].tsx:151
+#: app/pages/v/[chartId].tsx:155
 msgid "button.new.visualization"
 msgstr "Create New Visualization"
 
@@ -111,7 +111,7 @@ msgstr "Create New Visualization"
 msgid "button.publish"
 msgstr "Publish this visualization"
 
-#: app/components/publish-actions.tsx:102
+#: app/components/publish-actions.tsx:107
 msgid "button.share"
 msgstr "Share"
 
@@ -407,20 +407,20 @@ msgstr "Italian"
 msgid "controls.measure"
 msgstr "Measure"
 
-#: app/components/metadata-panel.tsx:568
+#: app/components/metadata-panel.tsx:580
 msgid "controls.metadata-panel.available-values"
 msgstr "Available values"
 
-#: app/components/metadata-panel.tsx:362
 #: app/components/metadata-panel.tsx:374
+#: app/components/metadata-panel.tsx:386
 msgid "controls.metadata-panel.metadata"
 msgstr "Metadata"
 
-#: app/components/metadata-panel.tsx:323
+#: app/components/metadata-panel.tsx:335
 msgid "controls.metadata-panel.section.data"
 msgstr "Data"
 
-#: app/components/metadata-panel.tsx:313
+#: app/components/metadata-panel.tsx:325
 msgid "controls.metadata-panel.section.general"
 msgstr "General"
 
@@ -726,7 +726,7 @@ msgstr "Cube IRI"
 msgid "data.source"
 msgstr "Data source"
 
-#: app/components/chart-published.tsx:209
+#: app/components/chart-published.tsx:199
 msgid "data.source.notTrusted"
 msgstr "This chart is not using a trusted data source."
 
@@ -738,15 +738,15 @@ msgstr "Back to the datasets"
 msgid "dataset-preview.keywords"
 msgstr "Keywords"
 
-#: app/components/chart-footnotes.tsx:134
+#: app/components/chart-footnotes.tsx:133
 msgid "dataset.footnotes.dataset"
 msgstr "Dataset"
 
-#: app/components/chart-footnotes.tsx:156
+#: app/components/chart-footnotes.tsx:155
 msgid "dataset.footnotes.updated"
 msgstr "Latest update"
 
-#: app/components/chart-published.tsx:218
+#: app/components/chart-published.tsx:208
 msgid "dataset.hasImputedValues"
 msgstr "Some data in this dataset is missing and has been interpolated to fill the gaps."
 
@@ -766,7 +766,7 @@ msgstr "Contact points"
 msgid "dataset.metadata.furtherinformation"
 msgstr "Further information"
 
-#: app/components/chart-footnotes.tsx:234
+#: app/components/chart-footnotes.tsx:233
 #: app/configurator/components/dataset-metadata.tsx:107
 msgid "dataset.metadata.learnmore"
 msgstr "Learn more about the dataset"
@@ -792,12 +792,12 @@ msgid "dataset.order.title"
 msgstr "Title"
 
 #: app/components/chart-preview.tsx:115
-#: app/components/chart-published.tsx:187
+#: app/components/chart-published.tsx:177
 #: app/configurator/components/dataset-preview.tsx:120
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Careful, this dataset is only a draft.<0/><1>Don't use for reporting!</1>"
 
-#: app/components/chart-published.tsx:198
+#: app/components/chart-published.tsx:188
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Careful, the data for this chart has expired.<0/><1>Don't use for reporting!</1>"
 
@@ -865,7 +865,7 @@ msgstr "There was a problem with loading the coordinates from geographical dimen
 msgid "hint.coordinatesloadingerror.title"
 msgstr "Coordinates loading error"
 
-#: app/pages/v/[chartId].tsx:128
+#: app/pages/v/[chartId].tsx:137
 msgid "hint.create.your.own.chart"
 msgstr "Copy this visualization or make a new visualization using Swiss Open Government Data."
 
@@ -881,7 +881,7 @@ msgstr "Check the status page for more information"
 msgid "hint.dataloadingerror.title"
 msgstr "Data loading error"
 
-#: app/pages/v/[chartId].tsx:122
+#: app/pages/v/[chartId].tsx:131
 msgid "hint.how.to.share"
 msgstr "You can share this visualization by copying the URL or by embedding it on your own website. You can also create a new visualization from scratch or start by copying the visualization above."
 
@@ -927,83 +927,83 @@ msgstr "Show Filters"
 msgid "logo.swiss.confederation"
 msgstr "Logo of the Swiss Confederation"
 
-#: app/components/chart-footnotes.tsx:254
+#: app/components/chart-footnotes.tsx:253
 msgid "metadata.link.created.with.visualize"
 msgstr "Created with visualize.admin.ch"
 
-#: app/components/chart-published.tsx:285
+#: app/components/chart-published.tsx:268
 msgid "metadata.link.created.with.visualize.alternate"
 msgstr "More information"
 
-#: app/components/chart-footnotes.tsx:168
+#: app/components/chart-footnotes.tsx:167
 msgid "metadata.source"
 msgstr "Source"
 
-#: app/components/chart-footnotes.tsx:211
+#: app/components/chart-footnotes.tsx:210
 msgid "metadata.switch.chart"
 msgstr "Switch to chart view"
 
-#: app/components/chart-footnotes.tsx:215
+#: app/components/chart-footnotes.tsx:214
 msgid "metadata.switch.table"
 msgstr "Switch to table view"
 
-#: app/components/publish-actions.tsx:319
+#: app/components/publish-actions.tsx:338
 msgid "publication.embed.AEM"
 msgstr "Embed Code for AEM \"External Application\""
 
-#: app/components/publish-actions.tsx:324
+#: app/components/publish-actions.tsx:343
 msgid "publication.embed.AEM.caption"
 msgstr "Use this link to embed the chart into Adobe Experience Manager assets."
 
-#: app/components/publish-actions.tsx:304
+#: app/components/publish-actions.tsx:323
 msgid "publication.embed.iframe"
 msgstr "Embed Code"
 
-#: app/components/publish-actions.tsx:307
+#: app/components/publish-actions.tsx:326
 msgid "publication.embed.iframe.caption"
-msgstr "Use this link to embed the chart into other webpages."
+msgstr "Use this link to embed the chart in any webpage."
 
-#: app/components/publish-actions.tsx:286
+#: app/components/publish-actions.tsx:304
 msgid "publication.embed.style.minimal"
 msgstr "Minimal"
 
-#: app/components/publish-actions.tsx:291
-#~ msgid "publication.embed.style.minimal.caption"
-#~ msgstr "Only the chart and a link for more information."
+#: app/components/publish-actions.tsx:309
+msgid "publication.embed.style.minimal.caption"
+msgstr "Chart only with link to full information on visualize.admin.ch."
 
-#: app/components/publish-actions.tsx:266
+#: app/components/publish-actions.tsx:284
 msgid "publication.embed.style.standard"
 msgstr "Standard"
 
-#: app/components/publish-actions.tsx:271
-#~ msgid "publication.embed.style.standard.caption"
-#~ msgstr "Chart, download the data links, attribution etc..."
+#: app/components/publish-actions.tsx:289
+msgid "publication.embed.style.standard.caption"
+msgstr "Provides metadata and download links for the dataset"
 
-#: app/components/publish-actions.tsx:117
+#: app/components/publish-actions.tsx:122
 msgid "publication.popup.share"
 msgstr "Share"
 
-#: app/components/publish-actions.tsx:165
+#: app/components/publish-actions.tsx:170
 msgid "publication.share.chart.url"
 msgstr "Chart URL:"
 
-#: app/components/publish-actions.tsx:123
+#: app/components/publish-actions.tsx:128
 msgid "publication.share.linktitle.facebook"
 msgstr "Share on Facebook"
 
-#: app/components/publish-actions.tsx:143
+#: app/components/publish-actions.tsx:148
 msgid "publication.share.linktitle.mail"
 msgstr "Share via Email"
 
-#: app/components/publish-actions.tsx:133
+#: app/components/publish-actions.tsx:138
 msgid "publication.share.linktitle.twitter"
 msgstr "Share on Twitter"
 
-#: app/components/publish-actions.tsx:154
+#: app/components/publish-actions.tsx:159
 msgid "publication.share.mail.body"
 msgstr "Here is a visualization I created using visualize.admin.ch"
 
-#: app/components/publish-actions.tsx:149
+#: app/components/publish-actions.tsx:154
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
@@ -1012,7 +1012,7 @@ msgstr "visualize.admin.ch"
 msgid "select.controls.filters.search"
 msgstr "Search"
 
-#: app/components/metadata-panel.tsx:450
+#: app/components/metadata-panel.tsx:462
 msgid "select.controls.metadata.search"
 msgstr "Jump to..."
 
@@ -1020,8 +1020,8 @@ msgstr "Jump to..."
 msgid "table.column.no"
 msgstr "Column {0}"
 
-#: app/components/chart-footnotes.tsx:136
-#: app/components/chart-footnotes.tsx:158
-#: app/components/chart-footnotes.tsx:170
+#: app/components/chart-footnotes.tsx:135
+#: app/components/chart-footnotes.tsx:157
+#: app/components/chart-footnotes.tsx:169
 msgid "typography.colon"
 msgstr ": "

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -13,19 +13,19 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:709
+#: app/configurator/components/chart-configurator.tsx:701
 msgid "Add filter"
 msgstr "Ajouter un filtre"
 
-#: app/configurator/components/chart-configurator.tsx:682
+#: app/configurator/components/chart-configurator.tsx:674
 msgid "Drag filters to reorganize"
 msgstr "Faites glisser les filtres pour les réorganiser"
 
-#: app/configurator/components/chart-configurator.tsx:679
+#: app/configurator/components/chart-configurator.tsx:671
 msgid "Move filter down"
 msgstr "Déplacer le filtre vers le bas"
 
-#: app/configurator/components/chart-configurator.tsx:676
+#: app/configurator/components/chart-configurator.tsx:668
 msgid "Move filter up"
 msgstr "Déplacer le filtre vers le haut"
 
@@ -66,7 +66,7 @@ msgstr "Explorez les jeux de données liés fournis par LINDAS, en filtrant par 
 msgid "button.back"
 msgstr "Précédent"
 
-#: app/pages/v/[chartId].tsx:166
+#: app/pages/v/[chartId].tsx:154
 msgid "button.copy.visualization"
 msgstr "Copier et éditer cette visualisation"
 
@@ -90,20 +90,20 @@ msgstr "Données du graphique"
 msgid "button.download.runsparqlquery.visible"
 msgstr "Lancer la requête SPARQL"
 
-#: app/components/publish-actions.tsx:206
+#: app/components/publish-actions.tsx:240
 msgid "button.embed"
 msgstr "Intégrer"
 
-#: app/components/publish-actions.tsx:281
-#: app/components/publish-actions.tsx:287
+#: app/components/publish-actions.tsx:390
+#: app/components/publish-actions.tsx:396
 msgid "button.hint.click.to.copy"
 msgstr "Cliquer pour copier"
 
-#: app/components/publish-actions.tsx:311
+#: app/components/publish-actions.tsx:420
 msgid "button.hint.copied"
 msgstr "Copié!"
 
-#: app/pages/v/[chartId].tsx:151
+#: app/pages/v/[chartId].tsx:139
 msgid "button.new.visualization"
 msgstr "Créer une nouvelle visualisation"
 
@@ -111,7 +111,7 @@ msgstr "Créer une nouvelle visualisation"
 msgid "button.publish"
 msgstr "Publier cette visualisation"
 
-#: app/components/publish-actions.tsx:96
+#: app/components/publish-actions.tsx:102
 msgid "button.share"
 msgstr "Partager"
 
@@ -119,7 +119,7 @@ msgstr "Partager"
 msgid "chart.map.layers.area"
 msgstr "Zones"
 
-#: app/configurator/components/chart-configurator.tsx:762
+#: app/configurator/components/chart-configurator.tsx:754
 #: app/configurator/components/chart-options-selector.tsx:1055
 #: app/configurator/components/field-i18n.ts:31
 msgid "chart.map.layers.base"
@@ -307,8 +307,8 @@ msgstr "Description"
 #: app/charts/shared/chart-data-filters.tsx:249
 #: app/charts/shared/chart-data-filters.tsx:296
 #: app/configurator/components/field.tsx:167
-#: app/configurator/components/field.tsx:264
-#: app/configurator/components/field.tsx:364
+#: app/configurator/components/field.tsx:267
+#: app/configurator/components/field.tsx:367
 msgid "controls.dimensionvalue.none"
 msgstr "Aucune filtre"
 
@@ -324,12 +324,12 @@ msgstr "Tout sélectionner"
 msgid "controls.filter.select.none"
 msgstr "Tout déselectionner"
 
-#: app/configurator/components/chart-configurator.tsx:512
+#: app/configurator/components/chart-configurator.tsx:513
 #: app/configurator/components/filters.tsx:366
 msgid "controls.filters.interactive.toggle"
 msgstr "Interactif"
 
-#: app/configurator/components/chart-configurator.tsx:505
+#: app/configurator/components/chart-configurator.tsx:506
 #: app/configurator/components/filters.tsx:360
 msgid "controls.filters.interactive.tooltip"
 msgstr "Permettre aux utilisateurs de changer le filtre"
@@ -432,8 +432,8 @@ msgstr "Retour aux paramètres généraux"
 msgid "controls.nav.back-to-preview"
 msgstr "Retour à l'aperçu"
 
-#: app/configurator/components/field.tsx:703
-#: app/configurator/components/field.tsx:875
+#: app/configurator/components/field.tsx:706
+#: app/configurator/components/field.tsx:878
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:244
 msgid "controls.none"
 msgstr "Aucun"
@@ -450,7 +450,7 @@ msgstr "Inactif"
 msgid "controls.scale.type"
 msgstr "Type d'échelle"
 
-#: app/components/form.tsx:611
+#: app/components/form.tsx:614
 msgid "controls.search.clear"
 msgstr "Effacer la recherche"
 
@@ -458,7 +458,7 @@ msgstr "Effacer la recherche"
 msgid "controls.section.additional-information"
 msgstr "Informations supplémentaires"
 
-#: app/configurator/components/chart-configurator.tsx:595
+#: app/configurator/components/chart-configurator.tsx:587
 msgid "controls.section.chart.options"
 msgstr "Paramètres graphiques"
 
@@ -470,11 +470,11 @@ msgstr "Colonnes"
 msgid "controls.section.columnstyle"
 msgstr "Style de la colonne"
 
-#: app/configurator/components/chart-configurator.tsx:613
+#: app/configurator/components/chart-configurator.tsx:605
 msgid "controls.section.data.filters"
 msgstr "Filtres"
 
-#: app/configurator/components/chart-configurator.tsx:629
+#: app/configurator/components/chart-configurator.tsx:621
 msgid "controls.section.data.filters.possible-filters-error"
 msgstr "Une erreur s'est produite lors de la récupération des filtres possibles. Merci de réessayer plus tard ou d'actualiser la page."
 
@@ -532,7 +532,7 @@ msgstr "Options du tableau"
 msgid "controls.section.title.warning"
 msgstr "Ajoutez un titre et une description"
 
-#: app/configurator/components/chart-configurator.tsx:587
+#: app/configurator/components/chart-configurator.tsx:579
 #: app/configurator/components/chart-type-selector.tsx:131
 #: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
@@ -586,10 +586,10 @@ msgid "controls.select.measure"
 msgstr "Sélectionner une variable"
 
 #: app/configurator/components/field.tsx:172
-#: app/configurator/components/field.tsx:269
-#: app/configurator/components/field.tsx:369
-#: app/configurator/components/field.tsx:708
-#: app/configurator/components/field.tsx:880
+#: app/configurator/components/field.tsx:272
+#: app/configurator/components/field.tsx:372
+#: app/configurator/components/field.tsx:711
+#: app/configurator/components/field.tsx:883
 msgid "controls.select.optional"
 msgstr ""
 
@@ -726,7 +726,7 @@ msgstr "IRI du cube"
 msgid "data.source"
 msgstr "Source des données"
 
-#: app/components/chart-published.tsx:196
+#: app/components/chart-published.tsx:209
 msgid "data.source.notTrusted"
 msgstr "Ce graphique n'utilise pas une source de données fiable."
 
@@ -738,15 +738,15 @@ msgstr "Revenir aux jeux de données"
 msgid "dataset-preview.keywords"
 msgstr "Mots clés"
 
-#: app/components/chart-footnotes.tsx:117
+#: app/components/chart-footnotes.tsx:134
 msgid "dataset.footnotes.dataset"
 msgstr "Jeu de données"
 
-#: app/components/chart-footnotes.tsx:138
+#: app/components/chart-footnotes.tsx:156
 msgid "dataset.footnotes.updated"
 msgstr "Mise à jour"
 
-#: app/components/chart-published.tsx:205
+#: app/components/chart-published.tsx:218
 msgid "dataset.hasImputedValues"
 msgstr "Certaines données de cet ensemble de données sont manquantes et ont été interpolées pour combler les lacunes."
 
@@ -766,7 +766,7 @@ msgstr "Points de contact"
 msgid "dataset.metadata.furtherinformation"
 msgstr "Informations complémentaires"
 
-#: app/components/chart-footnotes.tsx:204
+#: app/components/chart-footnotes.tsx:234
 #: app/configurator/components/dataset-metadata.tsx:107
 msgid "dataset.metadata.learnmore"
 msgstr "En savoir plus sur le jeu de données"
@@ -792,12 +792,12 @@ msgid "dataset.order.title"
 msgstr "Titre"
 
 #: app/components/chart-preview.tsx:115
-#: app/components/chart-published.tsx:174
+#: app/components/chart-published.tsx:187
 #: app/configurator/components/dataset-preview.tsx:120
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Attention, ce jeu de données est à l'état d'ébauche.<0/><1>Ne l'utilisez pas pour une publication!</1>"
 
-#: app/components/chart-published.tsx:185
+#: app/components/chart-published.tsx:198
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Attention, ce jeu de données est expiré.<0/><1>Ne l'utilisez pas pour une publication!</1>"
 
@@ -865,7 +865,7 @@ msgstr "Les données géographiques n’ont pas pu être chargées, merci de ré
 msgid "hint.coordinatesloadingerror.title"
 msgstr "Erreur de chargement des coordonnées"
 
-#: app/pages/v/[chartId].tsx:128
+#: app/pages/v/[chartId].tsx:117
 msgid "hint.create.your.own.chart"
 msgstr "Copiez cette visualisation ou créez une nouvelle visualisation à partir des données ouvertes de l’administration publique suisse."
 
@@ -881,11 +881,11 @@ msgstr "Consultez la page de statut pour plus d'informations"
 msgid "hint.dataloadingerror.title"
 msgstr "Problème de téléchargement des données"
 
-#: app/pages/v/[chartId].tsx:122
+#: app/pages/v/[chartId].tsx:111
 msgid "hint.how.to.share"
 msgstr "Vous pouvez partager cette visualisation en copiant l'URL ou en l'intégrant sur votre site Web. Vous pouvez également créer une toute nouvelle visualisation, ou bien copier et modifier la visualisation ci-dessus."
 
-#: app/components/form.tsx:282
+#: app/components/form.tsx:285
 #: app/components/hint.tsx:111
 msgid "hint.loading.data"
 msgstr "Chargement des données..."
@@ -927,55 +927,79 @@ msgstr "Afficher les filtres"
 msgid "logo.swiss.confederation"
 msgstr "Logo de la Confédération Suisse"
 
-#: app/components/chart-footnotes.tsx:223
+#: app/components/chart-footnotes.tsx:254
 msgid "metadata.link.created.with.visualize"
 msgstr "Créé avec visualize.admin.ch"
 
-#: app/components/chart-footnotes.tsx:149
+#: app/components/chart-footnotes.tsx:168
 msgid "metadata.source"
 msgstr "Source"
 
-#: app/components/chart-footnotes.tsx:187
+#: app/components/chart-footnotes.tsx:211
 msgid "metadata.switch.chart"
 msgstr "Passer à la vue graphique"
 
-#: app/components/chart-footnotes.tsx:189
+#: app/components/chart-footnotes.tsx:215
 msgid "metadata.switch.table"
 msgstr "Passer à la vue en tableau"
 
-#: app/components/publish-actions.tsx:218
+#: app/components/publish-actions.tsx:319
 msgid "publication.embed.AEM"
-msgstr "Code pour intégrer sur AEM comme \"External Application\":"
+msgstr "Code pour intégrer sur AEM comme \"External Application\""
 
-#: app/components/publish-actions.tsx:211
+#: app/components/publish-actions.tsx:324
+msgid "publication.embed.AEM.caption"
+msgstr ""
+
+#: app/components/publish-actions.tsx:304
 msgid "publication.embed.iframe"
-msgstr "Code pour intégrer:"
+msgstr "Code pour intégrer"
 
-#: app/components/publish-actions.tsx:111
+#: app/components/publish-actions.tsx:307
+msgid "publication.embed.iframe.caption"
+msgstr ""
+
+#: app/components/publish-actions.tsx:286
+msgid "publication.embed.style.minimal"
+msgstr ""
+
+#: app/components/publish-actions.tsx:291
+msgid "publication.embed.style.minimal.caption"
+msgstr ""
+
+#: app/components/publish-actions.tsx:266
+msgid "publication.embed.style.standard"
+msgstr ""
+
+#: app/components/publish-actions.tsx:271
+msgid "publication.embed.style.standard.caption"
+msgstr ""
+
+#: app/components/publish-actions.tsx:117
 msgid "publication.popup.share"
 msgstr "Partager"
 
-#: app/components/publish-actions.tsx:159
+#: app/components/publish-actions.tsx:165
 msgid "publication.share.chart.url"
 msgstr "URL du graphique:"
 
-#: app/components/publish-actions.tsx:117
+#: app/components/publish-actions.tsx:123
 msgid "publication.share.linktitle.facebook"
 msgstr "Partager sur Facebook"
 
-#: app/components/publish-actions.tsx:137
+#: app/components/publish-actions.tsx:143
 msgid "publication.share.linktitle.mail"
 msgstr "Partager par courriel"
 
-#: app/components/publish-actions.tsx:127
+#: app/components/publish-actions.tsx:133
 msgid "publication.share.linktitle.twitter"
 msgstr "Partager sur Twitter"
 
-#: app/components/publish-actions.tsx:148
+#: app/components/publish-actions.tsx:154
 msgid "publication.share.mail.body"
 msgstr "Voici une visualisation que j'ai créée sur visualize.admin.ch"
 
-#: app/components/publish-actions.tsx:143
+#: app/components/publish-actions.tsx:149
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
@@ -992,8 +1016,8 @@ msgstr "Sauter à..."
 msgid "table.column.no"
 msgstr "Colonne {0}"
 
-#: app/components/chart-footnotes.tsx:119
-#: app/components/chart-footnotes.tsx:140
-#: app/components/chart-footnotes.tsx:151
+#: app/components/chart-footnotes.tsx:136
+#: app/components/chart-footnotes.tsx:158
+#: app/components/chart-footnotes.tsx:170
 msgid "typography.colon"
 msgstr " : "

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -62,11 +62,11 @@ msgstr "Tous les jeux de données"
 msgid "browse.datasets.description"
 msgstr "Explorez les jeux de données liés fournis par LINDAS, en filtrant par catégories ou organisations, ou en recherchant par mots-clés. Cliquez sur un ensemble de données pour afficher des informations plus détaillées et commencer à créer vos propres visualisations. "
 
-#: app/components/metadata-panel.tsx:426
+#: app/components/metadata-panel.tsx:438
 msgid "button.back"
 msgstr "Précédent"
 
-#: app/pages/v/[chartId].tsx:166
+#: app/pages/v/[chartId].tsx:165
 msgid "button.copy.visualization"
 msgstr "Copier et éditer cette visualisation"
 
@@ -90,20 +90,20 @@ msgstr "Données du graphique"
 msgid "button.download.runsparqlquery.visible"
 msgstr "Lancer la requête SPARQL"
 
-#: app/components/publish-actions.tsx:240
+#: app/components/publish-actions.tsx:258
 msgid "button.embed"
 msgstr "Intégrer"
 
-#: app/components/publish-actions.tsx:390
-#: app/components/publish-actions.tsx:396
+#: app/components/publish-actions.tsx:409
+#: app/components/publish-actions.tsx:415
 msgid "button.hint.click.to.copy"
 msgstr "Cliquer pour copier"
 
-#: app/components/publish-actions.tsx:420
+#: app/components/publish-actions.tsx:439
 msgid "button.hint.copied"
 msgstr "Copié!"
 
-#: app/pages/v/[chartId].tsx:151
+#: app/pages/v/[chartId].tsx:155
 msgid "button.new.visualization"
 msgstr "Créer une nouvelle visualisation"
 
@@ -111,7 +111,7 @@ msgstr "Créer une nouvelle visualisation"
 msgid "button.publish"
 msgstr "Publier cette visualisation"
 
-#: app/components/publish-actions.tsx:102
+#: app/components/publish-actions.tsx:107
 msgid "button.share"
 msgstr "Partager"
 
@@ -407,20 +407,20 @@ msgstr "Italien"
 msgid "controls.measure"
 msgstr "Variable mesurée"
 
-#: app/components/metadata-panel.tsx:568
+#: app/components/metadata-panel.tsx:580
 msgid "controls.metadata-panel.available-values"
 msgstr "Valeurs disponibles"
 
-#: app/components/metadata-panel.tsx:362
 #: app/components/metadata-panel.tsx:374
+#: app/components/metadata-panel.tsx:386
 msgid "controls.metadata-panel.metadata"
 msgstr "Metadata"
 
-#: app/components/metadata-panel.tsx:323
+#: app/components/metadata-panel.tsx:335
 msgid "controls.metadata-panel.section.data"
 msgstr "Données"
 
-#: app/components/metadata-panel.tsx:313
+#: app/components/metadata-panel.tsx:325
 msgid "controls.metadata-panel.section.general"
 msgstr "Général"
 
@@ -726,7 +726,7 @@ msgstr "IRI du cube"
 msgid "data.source"
 msgstr "Source des données"
 
-#: app/components/chart-published.tsx:209
+#: app/components/chart-published.tsx:199
 msgid "data.source.notTrusted"
 msgstr "Ce graphique n'utilise pas une source de données fiable."
 
@@ -738,15 +738,15 @@ msgstr "Revenir aux jeux de données"
 msgid "dataset-preview.keywords"
 msgstr "Mots clés"
 
-#: app/components/chart-footnotes.tsx:134
+#: app/components/chart-footnotes.tsx:133
 msgid "dataset.footnotes.dataset"
 msgstr "Jeu de données"
 
-#: app/components/chart-footnotes.tsx:156
+#: app/components/chart-footnotes.tsx:155
 msgid "dataset.footnotes.updated"
 msgstr "Mise à jour"
 
-#: app/components/chart-published.tsx:218
+#: app/components/chart-published.tsx:208
 msgid "dataset.hasImputedValues"
 msgstr "Certaines données de cet ensemble de données sont manquantes et ont été interpolées pour combler les lacunes."
 
@@ -766,7 +766,7 @@ msgstr "Points de contact"
 msgid "dataset.metadata.furtherinformation"
 msgstr "Informations complémentaires"
 
-#: app/components/chart-footnotes.tsx:234
+#: app/components/chart-footnotes.tsx:233
 #: app/configurator/components/dataset-metadata.tsx:107
 msgid "dataset.metadata.learnmore"
 msgstr "En savoir plus sur le jeu de données"
@@ -792,12 +792,12 @@ msgid "dataset.order.title"
 msgstr "Titre"
 
 #: app/components/chart-preview.tsx:115
-#: app/components/chart-published.tsx:187
+#: app/components/chart-published.tsx:177
 #: app/configurator/components/dataset-preview.tsx:120
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Attention, ce jeu de données est à l'état d'ébauche.<0/><1>Ne l'utilisez pas pour une publication!</1>"
 
-#: app/components/chart-published.tsx:198
+#: app/components/chart-published.tsx:188
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Attention, ce jeu de données est expiré.<0/><1>Ne l'utilisez pas pour une publication!</1>"
 
@@ -865,7 +865,7 @@ msgstr "Les données géographiques n’ont pas pu être chargées, merci de ré
 msgid "hint.coordinatesloadingerror.title"
 msgstr "Erreur de chargement des coordonnées"
 
-#: app/pages/v/[chartId].tsx:128
+#: app/pages/v/[chartId].tsx:137
 msgid "hint.create.your.own.chart"
 msgstr "Copiez cette visualisation ou créez une nouvelle visualisation à partir des données ouvertes de l’administration publique suisse."
 
@@ -881,7 +881,7 @@ msgstr "Consultez la page de statut pour plus d'informations"
 msgid "hint.dataloadingerror.title"
 msgstr "Problème de téléchargement des données"
 
-#: app/pages/v/[chartId].tsx:122
+#: app/pages/v/[chartId].tsx:131
 msgid "hint.how.to.share"
 msgstr "Vous pouvez partager cette visualisation en copiant l'URL ou en l'intégrant sur votre site Web. Vous pouvez également créer une toute nouvelle visualisation, ou bien copier et modifier la visualisation ci-dessus."
 
@@ -927,83 +927,83 @@ msgstr "Afficher les filtres"
 msgid "logo.swiss.confederation"
 msgstr "Logo de la Confédération Suisse"
 
-#: app/components/chart-footnotes.tsx:254
+#: app/components/chart-footnotes.tsx:253
 msgid "metadata.link.created.with.visualize"
 msgstr "Créé avec visualize.admin.ch"
 
-#: app/components/chart-published.tsx:285
+#: app/components/chart-published.tsx:268
 msgid "metadata.link.created.with.visualize.alternate"
 msgstr "Plus d'informations"
 
-#: app/components/chart-footnotes.tsx:168
+#: app/components/chart-footnotes.tsx:167
 msgid "metadata.source"
 msgstr "Source"
 
-#: app/components/chart-footnotes.tsx:211
+#: app/components/chart-footnotes.tsx:210
 msgid "metadata.switch.chart"
 msgstr "Passer à la vue graphique"
 
-#: app/components/chart-footnotes.tsx:215
+#: app/components/chart-footnotes.tsx:214
 msgid "metadata.switch.table"
 msgstr "Passer à la vue en tableau"
 
-#: app/components/publish-actions.tsx:319
+#: app/components/publish-actions.tsx:338
 msgid "publication.embed.AEM"
 msgstr "Code pour intégrer sur AEM comme \"External Application\""
 
-#: app/components/publish-actions.tsx:324
+#: app/components/publish-actions.tsx:343
 msgid "publication.embed.AEM.caption"
 msgstr "Utilisez ce code pour intégrer le graphique sur Adobe Experience Manager"
 
-#: app/components/publish-actions.tsx:304
+#: app/components/publish-actions.tsx:323
 msgid "publication.embed.iframe"
 msgstr "Code pour intégrer"
 
-#: app/components/publish-actions.tsx:307
+#: app/components/publish-actions.tsx:326
 msgid "publication.embed.iframe.caption"
 msgstr "Utilisez ce code pour intégrer le graphique sur une page web"
 
-#: app/components/publish-actions.tsx:286
+#: app/components/publish-actions.tsx:304
 msgid "publication.embed.style.minimal"
 msgstr "Minimal"
 
-#: app/components/publish-actions.tsx:291
-#~ msgid "publication.embed.style.minimal.caption"
-#~ msgstr ""
+#: app/components/publish-actions.tsx:309
+msgid "publication.embed.style.minimal.caption"
+msgstr "Seulement le graphique et un lien vers visualize.admin.ch pour plus d'informations"
 
-#: app/components/publish-actions.tsx:266
+#: app/components/publish-actions.tsx:284
 msgid "publication.embed.style.standard"
 msgstr "Standard"
 
-#: app/components/publish-actions.tsx:271
-#~ msgid "publication.embed.style.standard.caption"
-#~ msgstr ""
+#: app/components/publish-actions.tsx:289
+msgid "publication.embed.style.standard.caption"
+msgstr "Inclut les métadonnées et un lien de téléchargement des données"
 
-#: app/components/publish-actions.tsx:117
+#: app/components/publish-actions.tsx:122
 msgid "publication.popup.share"
 msgstr "Partager"
 
-#: app/components/publish-actions.tsx:165
+#: app/components/publish-actions.tsx:170
 msgid "publication.share.chart.url"
 msgstr "URL du graphique:"
 
-#: app/components/publish-actions.tsx:123
+#: app/components/publish-actions.tsx:128
 msgid "publication.share.linktitle.facebook"
 msgstr "Partager sur Facebook"
 
-#: app/components/publish-actions.tsx:143
+#: app/components/publish-actions.tsx:148
 msgid "publication.share.linktitle.mail"
 msgstr "Partager par courriel"
 
-#: app/components/publish-actions.tsx:133
+#: app/components/publish-actions.tsx:138
 msgid "publication.share.linktitle.twitter"
 msgstr "Partager sur Twitter"
 
-#: app/components/publish-actions.tsx:154
+#: app/components/publish-actions.tsx:159
 msgid "publication.share.mail.body"
 msgstr "Voici une visualisation que j'ai créée sur visualize.admin.ch"
 
-#: app/components/publish-actions.tsx:149
+#: app/components/publish-actions.tsx:154
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
@@ -1012,7 +1012,7 @@ msgstr "visualize.admin.ch"
 msgid "select.controls.filters.search"
 msgstr "Chercher"
 
-#: app/components/metadata-panel.tsx:450
+#: app/components/metadata-panel.tsx:462
 msgid "select.controls.metadata.search"
 msgstr "Sauter à..."
 
@@ -1020,8 +1020,8 @@ msgstr "Sauter à..."
 msgid "table.column.no"
 msgstr "Colonne {0}"
 
-#: app/components/chart-footnotes.tsx:136
-#: app/components/chart-footnotes.tsx:158
-#: app/components/chart-footnotes.tsx:170
+#: app/components/chart-footnotes.tsx:135
+#: app/components/chart-footnotes.tsx:157
+#: app/components/chart-footnotes.tsx:169
 msgid "typography.colon"
 msgstr " : "

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -949,7 +949,7 @@ msgstr "Code pour intégrer sur AEM comme \"External Application\""
 
 #: app/components/publish-actions.tsx:324
 msgid "publication.embed.AEM.caption"
-msgstr ""
+msgstr "Utilisez ce code pour intégrer le graphique sur Adobe Experience Manager"
 
 #: app/components/publish-actions.tsx:304
 msgid "publication.embed.iframe"
@@ -957,11 +957,11 @@ msgstr "Code pour intégrer"
 
 #: app/components/publish-actions.tsx:307
 msgid "publication.embed.iframe.caption"
-msgstr ""
+msgstr "Utilisez ce code pour intégrer le graphique sur une page web"
 
 #: app/components/publish-actions.tsx:286
 msgid "publication.embed.style.minimal"
-msgstr ""
+msgstr "Minimal"
 
 #: app/components/publish-actions.tsx:291
 msgid "publication.embed.style.minimal.caption"
@@ -969,7 +969,7 @@ msgstr ""
 
 #: app/components/publish-actions.tsx:266
 msgid "publication.embed.style.standard"
-msgstr ""
+msgstr "Standard"
 
 #: app/components/publish-actions.tsx:271
 msgid "publication.embed.style.standard.caption"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -66,7 +66,7 @@ msgstr "Explorez les jeux de données liés fournis par LINDAS, en filtrant par 
 msgid "button.back"
 msgstr "Précédent"
 
-#: app/pages/v/[chartId].tsx:154
+#: app/pages/v/[chartId].tsx:166
 msgid "button.copy.visualization"
 msgstr "Copier et éditer cette visualisation"
 
@@ -103,7 +103,7 @@ msgstr "Cliquer pour copier"
 msgid "button.hint.copied"
 msgstr "Copié!"
 
-#: app/pages/v/[chartId].tsx:139
+#: app/pages/v/[chartId].tsx:151
 msgid "button.new.visualization"
 msgstr "Créer une nouvelle visualisation"
 
@@ -865,7 +865,7 @@ msgstr "Les données géographiques n’ont pas pu être chargées, merci de ré
 msgid "hint.coordinatesloadingerror.title"
 msgstr "Erreur de chargement des coordonnées"
 
-#: app/pages/v/[chartId].tsx:117
+#: app/pages/v/[chartId].tsx:128
 msgid "hint.create.your.own.chart"
 msgstr "Copiez cette visualisation ou créez une nouvelle visualisation à partir des données ouvertes de l’administration publique suisse."
 
@@ -881,7 +881,7 @@ msgstr "Consultez la page de statut pour plus d'informations"
 msgid "hint.dataloadingerror.title"
 msgstr "Problème de téléchargement des données"
 
-#: app/pages/v/[chartId].tsx:111
+#: app/pages/v/[chartId].tsx:122
 msgid "hint.how.to.share"
 msgstr "Vous pouvez partager cette visualisation en copiant l'URL ou en l'intégrant sur votre site Web. Vous pouvez également créer une toute nouvelle visualisation, ou bien copier et modifier la visualisation ci-dessus."
 
@@ -931,6 +931,10 @@ msgstr "Logo de la Confédération Suisse"
 msgid "metadata.link.created.with.visualize"
 msgstr "Créé avec visualize.admin.ch"
 
+#: app/components/chart-published.tsx:285
+msgid "metadata.link.created.with.visualize.alternate"
+msgstr "Plus d'informations"
+
 #: app/components/chart-footnotes.tsx:168
 msgid "metadata.source"
 msgstr "Source"
@@ -964,16 +968,16 @@ msgid "publication.embed.style.minimal"
 msgstr "Minimal"
 
 #: app/components/publish-actions.tsx:291
-msgid "publication.embed.style.minimal.caption"
-msgstr ""
+#~ msgid "publication.embed.style.minimal.caption"
+#~ msgstr ""
 
 #: app/components/publish-actions.tsx:266
 msgid "publication.embed.style.standard"
 msgstr "Standard"
 
 #: app/components/publish-actions.tsx:271
-msgid "publication.embed.style.standard.caption"
-msgstr ""
+#~ msgid "publication.embed.style.standard.caption"
+#~ msgstr ""
 
 #: app/components/publish-actions.tsx:117
 msgid "publication.popup.share"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -66,7 +66,7 @@ msgstr "Esplora i set di dati forniti dal LINDAS Linked Data Service filtrando p
 msgid "button.back"
 msgstr "Torna indietro"
 
-#: app/pages/v/[chartId].tsx:154
+#: app/pages/v/[chartId].tsx:166
 msgid "button.copy.visualization"
 msgstr "Copia e modifica questa visualizzazione"
 
@@ -103,7 +103,7 @@ msgstr "Clicca per copiare"
 msgid "button.hint.copied"
 msgstr "Copiato!"
 
-#: app/pages/v/[chartId].tsx:139
+#: app/pages/v/[chartId].tsx:151
 msgid "button.new.visualization"
 msgstr "Crea una nuova visualizzazione"
 
@@ -865,7 +865,7 @@ msgstr "C'è stato un problema con il caricamento delle coordinate dalle dimensi
 msgid "hint.coordinatesloadingerror.title"
 msgstr "Errore di caricamento delle coordinate"
 
-#: app/pages/v/[chartId].tsx:117
+#: app/pages/v/[chartId].tsx:128
 msgid "hint.create.your.own.chart"
 msgstr "Copia questa visualizzazione o crea una nuova visualizzazione usando «dati aperti» dell’amministrazione pubblica svizzera"
 
@@ -881,7 +881,7 @@ msgstr "Controlla la pagina di stato per ulteriori informazioni”"
 msgid "hint.dataloadingerror.title"
 msgstr "Problema di caricamento dei dati"
 
-#: app/pages/v/[chartId].tsx:111
+#: app/pages/v/[chartId].tsx:122
 msgid "hint.how.to.share"
 msgstr "È possibile condividere questa visualizzazione copiando l'URL o incorporandola nel vostro sito Web. Puoi anche creare una nuova visualizzazione partendo da zero oppure copiando e modificando la visualizzazione sopra."
 
@@ -931,6 +931,10 @@ msgstr "Logo della Confederazione svizzera"
 msgid "metadata.link.created.with.visualize"
 msgstr "Creato con visualize.admin.ch"
 
+#: app/components/chart-published.tsx:285
+msgid "metadata.link.created.with.visualize.alternate"
+msgstr "Più informazioni"
+
 #: app/components/chart-footnotes.tsx:168
 msgid "metadata.source"
 msgstr "Fonte"
@@ -964,16 +968,16 @@ msgid "publication.embed.style.minimal"
 msgstr "Minimal"
 
 #: app/components/publish-actions.tsx:291
-msgid "publication.embed.style.minimal.caption"
-msgstr ""
+#~ msgid "publication.embed.style.minimal.caption"
+#~ msgstr ""
 
 #: app/components/publish-actions.tsx:266
 msgid "publication.embed.style.standard"
 msgstr "Standard"
 
 #: app/components/publish-actions.tsx:271
-msgid "publication.embed.style.standard.caption"
-msgstr ""
+#~ msgid "publication.embed.style.standard.caption"
+#~ msgstr ""
 
 #: app/components/publish-actions.tsx:117
 msgid "publication.popup.share"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -13,19 +13,19 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:709
+#: app/configurator/components/chart-configurator.tsx:701
 msgid "Add filter"
 msgstr "Aggiungi filtro"
 
-#: app/configurator/components/chart-configurator.tsx:682
+#: app/configurator/components/chart-configurator.tsx:674
 msgid "Drag filters to reorganize"
 msgstr "Trascina i filtri per riorganizzarli"
 
-#: app/configurator/components/chart-configurator.tsx:679
+#: app/configurator/components/chart-configurator.tsx:671
 msgid "Move filter down"
 msgstr "Sposta il filtro in basso"
 
-#: app/configurator/components/chart-configurator.tsx:676
+#: app/configurator/components/chart-configurator.tsx:668
 msgid "Move filter up"
 msgstr "Sposta il filtro in alto"
 
@@ -66,7 +66,7 @@ msgstr "Esplora i set di dati forniti dal LINDAS Linked Data Service filtrando p
 msgid "button.back"
 msgstr "Torna indietro"
 
-#: app/pages/v/[chartId].tsx:166
+#: app/pages/v/[chartId].tsx:154
 msgid "button.copy.visualization"
 msgstr "Copia e modifica questa visualizzazione"
 
@@ -90,20 +90,20 @@ msgstr "Dati del grafico"
 msgid "button.download.runsparqlquery.visible"
 msgstr "Esegui query SPARQL"
 
-#: app/components/publish-actions.tsx:206
+#: app/components/publish-actions.tsx:240
 msgid "button.embed"
 msgstr "Incorpora"
 
-#: app/components/publish-actions.tsx:281
-#: app/components/publish-actions.tsx:287
+#: app/components/publish-actions.tsx:390
+#: app/components/publish-actions.tsx:396
 msgid "button.hint.click.to.copy"
 msgstr "Clicca per copiare"
 
-#: app/components/publish-actions.tsx:311
+#: app/components/publish-actions.tsx:420
 msgid "button.hint.copied"
 msgstr "Copiato!"
 
-#: app/pages/v/[chartId].tsx:151
+#: app/pages/v/[chartId].tsx:139
 msgid "button.new.visualization"
 msgstr "Crea una nuova visualizzazione"
 
@@ -111,7 +111,7 @@ msgstr "Crea una nuova visualizzazione"
 msgid "button.publish"
 msgstr "Pubblica questa visualizzazione"
 
-#: app/components/publish-actions.tsx:96
+#: app/components/publish-actions.tsx:102
 msgid "button.share"
 msgstr "Condividi"
 
@@ -119,7 +119,7 @@ msgstr "Condividi"
 msgid "chart.map.layers.area"
 msgstr "Aree"
 
-#: app/configurator/components/chart-configurator.tsx:762
+#: app/configurator/components/chart-configurator.tsx:754
 #: app/configurator/components/chart-options-selector.tsx:1055
 #: app/configurator/components/field-i18n.ts:31
 msgid "chart.map.layers.base"
@@ -307,8 +307,8 @@ msgstr "Descrizione"
 #: app/charts/shared/chart-data-filters.tsx:249
 #: app/charts/shared/chart-data-filters.tsx:296
 #: app/configurator/components/field.tsx:167
-#: app/configurator/components/field.tsx:264
-#: app/configurator/components/field.tsx:364
+#: app/configurator/components/field.tsx:267
+#: app/configurator/components/field.tsx:367
 msgid "controls.dimensionvalue.none"
 msgstr "Nessun filtro"
 
@@ -324,12 +324,12 @@ msgstr "Seleziona tutti"
 msgid "controls.filter.select.none"
 msgstr "Deseleziona tutto"
 
-#: app/configurator/components/chart-configurator.tsx:512
+#: app/configurator/components/chart-configurator.tsx:513
 #: app/configurator/components/filters.tsx:366
 msgid "controls.filters.interactive.toggle"
 msgstr "Interattivo"
 
-#: app/configurator/components/chart-configurator.tsx:505
+#: app/configurator/components/chart-configurator.tsx:506
 #: app/configurator/components/filters.tsx:360
 msgid "controls.filters.interactive.tooltip"
 msgstr "Consenti agli utenti di modificare il filtro"
@@ -432,8 +432,8 @@ msgstr "Torna alle impostazioni generali"
 msgid "controls.nav.back-to-preview"
 msgstr "Torna all'anteprima"
 
-#: app/configurator/components/field.tsx:703
-#: app/configurator/components/field.tsx:875
+#: app/configurator/components/field.tsx:706
+#: app/configurator/components/field.tsx:878
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:244
 msgid "controls.none"
 msgstr "Nessuno"
@@ -450,7 +450,7 @@ msgstr "Inattivo"
 msgid "controls.scale.type"
 msgstr "Tipo di scala"
 
-#: app/components/form.tsx:611
+#: app/components/form.tsx:614
 msgid "controls.search.clear"
 msgstr "Cancella la ricerca"
 
@@ -458,7 +458,7 @@ msgstr "Cancella la ricerca"
 msgid "controls.section.additional-information"
 msgstr "Informazioni aggiuntive"
 
-#: app/configurator/components/chart-configurator.tsx:595
+#: app/configurator/components/chart-configurator.tsx:587
 msgid "controls.section.chart.options"
 msgstr "Opzioni del grafico"
 
@@ -470,11 +470,11 @@ msgstr "Colonne"
 msgid "controls.section.columnstyle"
 msgstr "Stile della colonna"
 
-#: app/configurator/components/chart-configurator.tsx:613
+#: app/configurator/components/chart-configurator.tsx:605
 msgid "controls.section.data.filters"
 msgstr "Filtri"
 
-#: app/configurator/components/chart-configurator.tsx:629
+#: app/configurator/components/chart-configurator.tsx:621
 msgid "controls.section.data.filters.possible-filters-error"
 msgstr "Si è verificato un errore durante il recupero dei possibili filtri. Riprova più tardi o aggiorna la pagina."
 
@@ -532,7 +532,7 @@ msgstr "Opzioni della tabella"
 msgid "controls.section.title.warning"
 msgstr "Aggiungi un titolo o una descrizione"
 
-#: app/configurator/components/chart-configurator.tsx:587
+#: app/configurator/components/chart-configurator.tsx:579
 #: app/configurator/components/chart-type-selector.tsx:131
 #: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
@@ -586,10 +586,10 @@ msgid "controls.select.measure"
 msgstr "Seleziona una misura"
 
 #: app/configurator/components/field.tsx:172
-#: app/configurator/components/field.tsx:269
-#: app/configurator/components/field.tsx:369
-#: app/configurator/components/field.tsx:708
-#: app/configurator/components/field.tsx:880
+#: app/configurator/components/field.tsx:272
+#: app/configurator/components/field.tsx:372
+#: app/configurator/components/field.tsx:711
+#: app/configurator/components/field.tsx:883
 msgid "controls.select.optional"
 msgstr ""
 
@@ -726,7 +726,7 @@ msgstr "Cubo IRI"
 msgid "data.source"
 msgstr "Fonte di dati"
 
-#: app/components/chart-published.tsx:196
+#: app/components/chart-published.tsx:209
 msgid "data.source.notTrusted"
 msgstr "Questo grafico non utilizza una fonte di dati affidabile."
 
@@ -738,15 +738,15 @@ msgstr "Torna ai set di dati"
 msgid "dataset-preview.keywords"
 msgstr "Parole chiave"
 
-#: app/components/chart-footnotes.tsx:117
+#: app/components/chart-footnotes.tsx:134
 msgid "dataset.footnotes.dataset"
 msgstr "Set di dati"
 
-#: app/components/chart-footnotes.tsx:138
+#: app/components/chart-footnotes.tsx:156
 msgid "dataset.footnotes.updated"
 msgstr "Ultimo aggiornamento"
 
-#: app/components/chart-published.tsx:205
+#: app/components/chart-published.tsx:218
 msgid "dataset.hasImputedValues"
 msgstr "In questo set di dati mancano alcuni dati. Questi sono stati interpolati per colmare le lacune.."
 
@@ -766,7 +766,7 @@ msgstr "Punti di contatto"
 msgid "dataset.metadata.furtherinformation"
 msgstr "Addizionali informazioni"
 
-#: app/components/chart-footnotes.tsx:204
+#: app/components/chart-footnotes.tsx:234
 #: app/configurator/components/dataset-metadata.tsx:107
 msgid "dataset.metadata.learnmore"
 msgstr "Ulteriori informazioni sul set di dati"
@@ -792,12 +792,12 @@ msgid "dataset.order.title"
 msgstr "Titolo"
 
 #: app/components/chart-preview.tsx:115
-#: app/components/chart-published.tsx:174
+#: app/components/chart-published.tsx:187
 #: app/configurator/components/dataset-preview.tsx:120
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Attenzione, questo set di dati è una bozza.<0/><1>Non utilizzare questo grafico per un rapporto!</1>"
 
-#: app/components/chart-published.tsx:185
+#: app/components/chart-published.tsx:198
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Attenzione, questo set di dati è scaduto.<0/><1>Non utilizzare questo grafico per un rapporto!</1>"
 
@@ -865,7 +865,7 @@ msgstr "C'è stato un problema con il caricamento delle coordinate dalle dimensi
 msgid "hint.coordinatesloadingerror.title"
 msgstr "Errore di caricamento delle coordinate"
 
-#: app/pages/v/[chartId].tsx:128
+#: app/pages/v/[chartId].tsx:117
 msgid "hint.create.your.own.chart"
 msgstr "Copia questa visualizzazione o crea una nuova visualizzazione usando «dati aperti» dell’amministrazione pubblica svizzera"
 
@@ -881,11 +881,11 @@ msgstr "Controlla la pagina di stato per ulteriori informazioni”"
 msgid "hint.dataloadingerror.title"
 msgstr "Problema di caricamento dei dati"
 
-#: app/pages/v/[chartId].tsx:122
+#: app/pages/v/[chartId].tsx:111
 msgid "hint.how.to.share"
 msgstr "È possibile condividere questa visualizzazione copiando l'URL o incorporandola nel vostro sito Web. Puoi anche creare una nuova visualizzazione partendo da zero oppure copiando e modificando la visualizzazione sopra."
 
-#: app/components/form.tsx:282
+#: app/components/form.tsx:285
 #: app/components/hint.tsx:111
 msgid "hint.loading.data"
 msgstr "Caricamento dei dati..."
@@ -927,55 +927,79 @@ msgstr "Mostra i filtri"
 msgid "logo.swiss.confederation"
 msgstr "Logo della Confederazione svizzera"
 
-#: app/components/chart-footnotes.tsx:223
+#: app/components/chart-footnotes.tsx:254
 msgid "metadata.link.created.with.visualize"
 msgstr "Creato con visualize.admin.ch"
 
-#: app/components/chart-footnotes.tsx:149
+#: app/components/chart-footnotes.tsx:168
 msgid "metadata.source"
 msgstr "Fonte"
 
-#: app/components/chart-footnotes.tsx:187
+#: app/components/chart-footnotes.tsx:211
 msgid "metadata.switch.chart"
 msgstr "Passare alla visualizzazione del grafico"
 
-#: app/components/chart-footnotes.tsx:189
+#: app/components/chart-footnotes.tsx:215
 msgid "metadata.switch.table"
 msgstr "Passare alla vista tabella"
 
-#: app/components/publish-actions.tsx:218
+#: app/components/publish-actions.tsx:319
 msgid "publication.embed.AEM"
-msgstr "Codice da incorporare su AEM come \"External Application\":"
+msgstr "Codice da incorporare su AEM come \"External Application\""
 
-#: app/components/publish-actions.tsx:211
+#: app/components/publish-actions.tsx:324
+msgid "publication.embed.AEM.caption"
+msgstr ""
+
+#: app/components/publish-actions.tsx:304
 msgid "publication.embed.iframe"
-msgstr "Codice di incorporamento:"
+msgstr "Codice di incorporamento"
 
-#: app/components/publish-actions.tsx:111
+#: app/components/publish-actions.tsx:307
+msgid "publication.embed.iframe.caption"
+msgstr ""
+
+#: app/components/publish-actions.tsx:286
+msgid "publication.embed.style.minimal"
+msgstr ""
+
+#: app/components/publish-actions.tsx:291
+msgid "publication.embed.style.minimal.caption"
+msgstr ""
+
+#: app/components/publish-actions.tsx:266
+msgid "publication.embed.style.standard"
+msgstr ""
+
+#: app/components/publish-actions.tsx:271
+msgid "publication.embed.style.standard.caption"
+msgstr ""
+
+#: app/components/publish-actions.tsx:117
 msgid "publication.popup.share"
 msgstr "Condividi"
 
-#: app/components/publish-actions.tsx:159
+#: app/components/publish-actions.tsx:165
 msgid "publication.share.chart.url"
 msgstr "URL del grafico:"
 
-#: app/components/publish-actions.tsx:117
+#: app/components/publish-actions.tsx:123
 msgid "publication.share.linktitle.facebook"
 msgstr "Condividi su Facebook"
 
-#: app/components/publish-actions.tsx:137
+#: app/components/publish-actions.tsx:143
 msgid "publication.share.linktitle.mail"
 msgstr "Condividi via Email"
 
-#: app/components/publish-actions.tsx:127
+#: app/components/publish-actions.tsx:133
 msgid "publication.share.linktitle.twitter"
 msgstr "Condividi su Twitter"
 
-#: app/components/publish-actions.tsx:148
+#: app/components/publish-actions.tsx:154
 msgid "publication.share.mail.body"
 msgstr "Ecco una visualizzazione che ho creato usando visualize.admin.ch"
 
-#: app/components/publish-actions.tsx:143
+#: app/components/publish-actions.tsx:149
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
@@ -992,8 +1016,8 @@ msgstr "Salta a..."
 msgid "table.column.no"
 msgstr "Colonna {0}"
 
-#: app/components/chart-footnotes.tsx:119
-#: app/components/chart-footnotes.tsx:140
-#: app/components/chart-footnotes.tsx:151
+#: app/components/chart-footnotes.tsx:136
+#: app/components/chart-footnotes.tsx:158
+#: app/components/chart-footnotes.tsx:170
 msgid "typography.colon"
 msgstr ": "

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -62,11 +62,11 @@ msgstr "Tutti i set di dati"
 msgid "browse.datasets.description"
 msgstr "Esplora i set di dati forniti dal LINDAS Linked Data Service filtrando per categorie o organizzazioni oppure cercando direttamente per parole chiave specifiche. Clicca su un set di dati per vedere informazioni più dettagliate e iniziare a creare le tue visualizzazioni."
 
-#: app/components/metadata-panel.tsx:426
+#: app/components/metadata-panel.tsx:438
 msgid "button.back"
 msgstr "Torna indietro"
 
-#: app/pages/v/[chartId].tsx:166
+#: app/pages/v/[chartId].tsx:165
 msgid "button.copy.visualization"
 msgstr "Copia e modifica questa visualizzazione"
 
@@ -90,20 +90,20 @@ msgstr "Dati del grafico"
 msgid "button.download.runsparqlquery.visible"
 msgstr "Esegui query SPARQL"
 
-#: app/components/publish-actions.tsx:240
+#: app/components/publish-actions.tsx:258
 msgid "button.embed"
 msgstr "Incorpora"
 
-#: app/components/publish-actions.tsx:390
-#: app/components/publish-actions.tsx:396
+#: app/components/publish-actions.tsx:409
+#: app/components/publish-actions.tsx:415
 msgid "button.hint.click.to.copy"
 msgstr "Clicca per copiare"
 
-#: app/components/publish-actions.tsx:420
+#: app/components/publish-actions.tsx:439
 msgid "button.hint.copied"
 msgstr "Copiato!"
 
-#: app/pages/v/[chartId].tsx:151
+#: app/pages/v/[chartId].tsx:155
 msgid "button.new.visualization"
 msgstr "Crea una nuova visualizzazione"
 
@@ -111,7 +111,7 @@ msgstr "Crea una nuova visualizzazione"
 msgid "button.publish"
 msgstr "Pubblica questa visualizzazione"
 
-#: app/components/publish-actions.tsx:102
+#: app/components/publish-actions.tsx:107
 msgid "button.share"
 msgstr "Condividi"
 
@@ -407,20 +407,20 @@ msgstr "Italiano"
 msgid "controls.measure"
 msgstr "Misura"
 
-#: app/components/metadata-panel.tsx:568
+#: app/components/metadata-panel.tsx:580
 msgid "controls.metadata-panel.available-values"
 msgstr "Valori disponibili"
 
-#: app/components/metadata-panel.tsx:362
 #: app/components/metadata-panel.tsx:374
+#: app/components/metadata-panel.tsx:386
 msgid "controls.metadata-panel.metadata"
 msgstr "Metadata"
 
-#: app/components/metadata-panel.tsx:323
+#: app/components/metadata-panel.tsx:335
 msgid "controls.metadata-panel.section.data"
 msgstr "Dati"
 
-#: app/components/metadata-panel.tsx:313
+#: app/components/metadata-panel.tsx:325
 msgid "controls.metadata-panel.section.general"
 msgstr "Generale"
 
@@ -726,7 +726,7 @@ msgstr "Cubo IRI"
 msgid "data.source"
 msgstr "Fonte di dati"
 
-#: app/components/chart-published.tsx:209
+#: app/components/chart-published.tsx:199
 msgid "data.source.notTrusted"
 msgstr "Questo grafico non utilizza una fonte di dati affidabile."
 
@@ -738,15 +738,15 @@ msgstr "Torna ai set di dati"
 msgid "dataset-preview.keywords"
 msgstr "Parole chiave"
 
-#: app/components/chart-footnotes.tsx:134
+#: app/components/chart-footnotes.tsx:133
 msgid "dataset.footnotes.dataset"
 msgstr "Set di dati"
 
-#: app/components/chart-footnotes.tsx:156
+#: app/components/chart-footnotes.tsx:155
 msgid "dataset.footnotes.updated"
 msgstr "Ultimo aggiornamento"
 
-#: app/components/chart-published.tsx:218
+#: app/components/chart-published.tsx:208
 msgid "dataset.hasImputedValues"
 msgstr "In questo set di dati mancano alcuni dati. Questi sono stati interpolati per colmare le lacune.."
 
@@ -766,7 +766,7 @@ msgstr "Punti di contatto"
 msgid "dataset.metadata.furtherinformation"
 msgstr "Addizionali informazioni"
 
-#: app/components/chart-footnotes.tsx:234
+#: app/components/chart-footnotes.tsx:233
 #: app/configurator/components/dataset-metadata.tsx:107
 msgid "dataset.metadata.learnmore"
 msgstr "Ulteriori informazioni sul set di dati"
@@ -792,12 +792,12 @@ msgid "dataset.order.title"
 msgstr "Titolo"
 
 #: app/components/chart-preview.tsx:115
-#: app/components/chart-published.tsx:187
+#: app/components/chart-published.tsx:177
 #: app/configurator/components/dataset-preview.tsx:120
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Attenzione, questo set di dati è una bozza.<0/><1>Non utilizzare questo grafico per un rapporto!</1>"
 
-#: app/components/chart-published.tsx:198
+#: app/components/chart-published.tsx:188
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Attenzione, questo set di dati è scaduto.<0/><1>Non utilizzare questo grafico per un rapporto!</1>"
 
@@ -865,7 +865,7 @@ msgstr "C'è stato un problema con il caricamento delle coordinate dalle dimensi
 msgid "hint.coordinatesloadingerror.title"
 msgstr "Errore di caricamento delle coordinate"
 
-#: app/pages/v/[chartId].tsx:128
+#: app/pages/v/[chartId].tsx:137
 msgid "hint.create.your.own.chart"
 msgstr "Copia questa visualizzazione o crea una nuova visualizzazione usando «dati aperti» dell’amministrazione pubblica svizzera"
 
@@ -881,7 +881,7 @@ msgstr "Controlla la pagina di stato per ulteriori informazioni”"
 msgid "hint.dataloadingerror.title"
 msgstr "Problema di caricamento dei dati"
 
-#: app/pages/v/[chartId].tsx:122
+#: app/pages/v/[chartId].tsx:131
 msgid "hint.how.to.share"
 msgstr "È possibile condividere questa visualizzazione copiando l'URL o incorporandola nel vostro sito Web. Puoi anche creare una nuova visualizzazione partendo da zero oppure copiando e modificando la visualizzazione sopra."
 
@@ -927,83 +927,83 @@ msgstr "Mostra i filtri"
 msgid "logo.swiss.confederation"
 msgstr "Logo della Confederazione svizzera"
 
-#: app/components/chart-footnotes.tsx:254
+#: app/components/chart-footnotes.tsx:253
 msgid "metadata.link.created.with.visualize"
 msgstr "Creato con visualize.admin.ch"
 
-#: app/components/chart-published.tsx:285
+#: app/components/chart-published.tsx:268
 msgid "metadata.link.created.with.visualize.alternate"
 msgstr "Più informazioni"
 
-#: app/components/chart-footnotes.tsx:168
+#: app/components/chart-footnotes.tsx:167
 msgid "metadata.source"
 msgstr "Fonte"
 
-#: app/components/chart-footnotes.tsx:211
+#: app/components/chart-footnotes.tsx:210
 msgid "metadata.switch.chart"
 msgstr "Passare alla visualizzazione del grafico"
 
-#: app/components/chart-footnotes.tsx:215
+#: app/components/chart-footnotes.tsx:214
 msgid "metadata.switch.table"
 msgstr "Passare alla vista tabella"
 
-#: app/components/publish-actions.tsx:319
+#: app/components/publish-actions.tsx:338
 msgid "publication.embed.AEM"
 msgstr "Codice da incorporare su AEM come \"External Application\""
 
-#: app/components/publish-actions.tsx:324
+#: app/components/publish-actions.tsx:343
 msgid "publication.embed.AEM.caption"
 msgstr "Utilisez ce code pour intégrer le graphique sur une application Adobe Experience Manager"
 
-#: app/components/publish-actions.tsx:304
+#: app/components/publish-actions.tsx:323
 msgid "publication.embed.iframe"
 msgstr "Codice di incorporamento"
 
-#: app/components/publish-actions.tsx:307
+#: app/components/publish-actions.tsx:326
 msgid "publication.embed.iframe.caption"
 msgstr "Usa questo codice per incorporare il grafico in una pagina web"
 
-#: app/components/publish-actions.tsx:286
+#: app/components/publish-actions.tsx:304
 msgid "publication.embed.style.minimal"
 msgstr "Minimal"
 
-#: app/components/publish-actions.tsx:291
-#~ msgid "publication.embed.style.minimal.caption"
-#~ msgstr ""
+#: app/components/publish-actions.tsx:309
+msgid "publication.embed.style.minimal.caption"
+msgstr "Solo la grafica e un link a visualize.admin.ch per maggiori informazioni"
 
-#: app/components/publish-actions.tsx:266
+#: app/components/publish-actions.tsx:284
 msgid "publication.embed.style.standard"
 msgstr "Standard"
 
-#: app/components/publish-actions.tsx:271
-#~ msgid "publication.embed.style.standard.caption"
-#~ msgstr ""
+#: app/components/publish-actions.tsx:289
+msgid "publication.embed.style.standard.caption"
+msgstr "Include metadati e un link per il download dei dati"
 
-#: app/components/publish-actions.tsx:117
+#: app/components/publish-actions.tsx:122
 msgid "publication.popup.share"
 msgstr "Condividi"
 
-#: app/components/publish-actions.tsx:165
+#: app/components/publish-actions.tsx:170
 msgid "publication.share.chart.url"
 msgstr "URL del grafico:"
 
-#: app/components/publish-actions.tsx:123
+#: app/components/publish-actions.tsx:128
 msgid "publication.share.linktitle.facebook"
 msgstr "Condividi su Facebook"
 
-#: app/components/publish-actions.tsx:143
+#: app/components/publish-actions.tsx:148
 msgid "publication.share.linktitle.mail"
 msgstr "Condividi via Email"
 
-#: app/components/publish-actions.tsx:133
+#: app/components/publish-actions.tsx:138
 msgid "publication.share.linktitle.twitter"
 msgstr "Condividi su Twitter"
 
-#: app/components/publish-actions.tsx:154
+#: app/components/publish-actions.tsx:159
 msgid "publication.share.mail.body"
 msgstr "Ecco una visualizzazione che ho creato usando visualize.admin.ch"
 
-#: app/components/publish-actions.tsx:149
+#: app/components/publish-actions.tsx:154
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
@@ -1012,7 +1012,7 @@ msgstr "visualize.admin.ch"
 msgid "select.controls.filters.search"
 msgstr "Cerca"
 
-#: app/components/metadata-panel.tsx:450
+#: app/components/metadata-panel.tsx:462
 msgid "select.controls.metadata.search"
 msgstr "Salta a..."
 
@@ -1020,8 +1020,8 @@ msgstr "Salta a..."
 msgid "table.column.no"
 msgstr "Colonna {0}"
 
-#: app/components/chart-footnotes.tsx:136
-#: app/components/chart-footnotes.tsx:158
-#: app/components/chart-footnotes.tsx:170
+#: app/components/chart-footnotes.tsx:135
+#: app/components/chart-footnotes.tsx:157
+#: app/components/chart-footnotes.tsx:169
 msgid "typography.colon"
 msgstr ": "

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -949,7 +949,7 @@ msgstr "Codice da incorporare su AEM come \"External Application\""
 
 #: app/components/publish-actions.tsx:324
 msgid "publication.embed.AEM.caption"
-msgstr ""
+msgstr "Utilisez ce code pour intégrer le graphique sur une application Adobe Experience Manager"
 
 #: app/components/publish-actions.tsx:304
 msgid "publication.embed.iframe"
@@ -957,11 +957,11 @@ msgstr "Codice di incorporamento"
 
 #: app/components/publish-actions.tsx:307
 msgid "publication.embed.iframe.caption"
-msgstr ""
+msgstr "Usa questo codice per incorporare il grafico in una pagina web"
 
 #: app/components/publish-actions.tsx:286
 msgid "publication.embed.style.minimal"
-msgstr ""
+msgstr "Minimal"
 
 #: app/components/publish-actions.tsx:291
 msgid "publication.embed.style.minimal.caption"
@@ -969,7 +969,7 @@ msgstr ""
 
 #: app/components/publish-actions.tsx:266
 msgid "publication.embed.style.standard"
-msgstr ""
+msgstr "Standard"
 
 #: app/components/publish-actions.tsx:271
 msgid "publication.embed.style.standard.caption"

--- a/app/pages/__test/[env]/[slug].tsx
+++ b/app/pages/__test/[env]/[slug].tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react";
 import { ChartPublished } from "@/components/chart-published";
 import { ChartConfig, DataSource, Meta } from "@/configurator";
 import { migrateChartConfig } from "@/utils/chart-config/versioning";
+import { EmbedOptionsProvider } from "@/utils/embed";
 
 type DbConfig = {
   dataSet: string;
@@ -33,13 +34,15 @@ const Page: NextPage = () => {
     const migratedConfig = migrateChartConfig(chartConfig);
 
     return (
-      <ChartPublished
-        dataSet={dataSet}
-        dataSource={dataSource}
-        chartConfig={migratedConfig}
-        meta={meta}
-        configKey={config.key}
-      />
+      <EmbedOptionsProvider>
+        <ChartPublished
+          dataSet={dataSet}
+          dataSource={dataSource}
+          chartConfig={migratedConfig}
+          meta={meta}
+          configKey={config.key}
+        />
+      </EmbedOptionsProvider>
     );
   }
   return null;

--- a/app/pages/embed/[chartId].tsx
+++ b/app/pages/embed/[chartId].tsx
@@ -6,6 +6,7 @@ import { ChartPublished } from "@/components/chart-published";
 import { Config } from "@/configurator";
 import { getConfig } from "@/db/config";
 import { serializeProps } from "@/db/serialize";
+import { EmbedOptionsProvider } from "@/utils/embed";
 
 type PageProps =
   | {
@@ -49,13 +50,15 @@ const EmbedPage = (props: PageProps) => {
   } = props;
 
   return (
-    <ChartPublished
-      dataSet={dataSet}
-      dataSource={dataSource}
-      chartConfig={chartConfig}
-      meta={meta}
-      configKey={key}
-    />
+    <EmbedOptionsProvider>
+      <ChartPublished
+        dataSet={dataSet}
+        dataSource={dataSource}
+        chartConfig={chartConfig}
+        meta={meta}
+        configKey={key}
+      />
+    </EmbedOptionsProvider>
   );
 };
 

--- a/app/pages/v/[chartId].tsx
+++ b/app/pages/v/[chartId].tsx
@@ -16,6 +16,7 @@ import { Config } from "@/configurator";
 import { getConfig } from "@/db/config";
 import { deserializeProps, Serialized, serializeProps } from "@/db/serialize";
 import { useLocale } from "@/locales/use-locale";
+import { EmbedOptionsProvider } from "@/utils/embed";
 
 type PageProps =
   | {
@@ -72,7 +73,7 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
   } = (props as Exclude<PageProps, { status: "notfound" }>).config;
 
   return (
-    <>
+    <EmbedOptionsProvider>
       <Head>
         <meta name="twitter:card" content="summary_large_image" />
         <meta property="og:title" content={meta.title[locale]} />
@@ -172,7 +173,7 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
           </Box>
         </Box>
       </ContentLayout>
-    </>
+    </EmbedOptionsProvider>
   );
 };
 

--- a/app/pages/v/[chartId].tsx
+++ b/app/pages/v/[chartId].tsx
@@ -126,17 +126,7 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
               />
             </ChartPanelPublished>
 
-            <Typography
-              component="div"
-              variant="h3"
-              mt={3}
-              mb={4}
-              sx={{
-                color: "grey.800",
-                fontSize: "1.125rem",
-                fontWeight: "regular",
-              }}
-            >
+            <Typography component="div" my={4}>
               {publishSuccess ? (
                 <Trans id="hint.how.to.share">
                   You can share this chart either by sharing its URL or by
@@ -161,12 +151,7 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
               sx={{ mb: 5 }}
             >
               <NextLink href="/create/new" passHref>
-                <Button
-                  component="a"
-                  size="large"
-                  variant="contained"
-                  color="secondary"
-                >
+                <Button component="a" variant="contained" color="secondary">
                   <Trans id="button.new.visualization">
                     Create a new visualization
                   </Trans>
@@ -176,12 +161,7 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
                 href={{ pathname: "/create/new", query: { from: key } }}
                 passHref
               >
-                <Button
-                  component="a"
-                  size="large"
-                  variant="contained"
-                  color="secondary"
-                >
+                <Button component="a" variant="contained" color="secondary">
                   <Trans id="button.copy.visualization">
                     Copy and edit this visualization
                   </Trans>

--- a/app/pages/v/[chartId].tsx
+++ b/app/pages/v/[chartId].tsx
@@ -151,7 +151,7 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
               sx={{ mb: 5 }}
             >
               <NextLink href="/create/new" passHref>
-                <Button component="a" variant="contained" color="secondary">
+                <Button component="a" variant="outlined" color="primary">
                   <Trans id="button.new.visualization">
                     Create a new visualization
                   </Trans>
@@ -161,7 +161,7 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
                 href={{ pathname: "/create/new", query: { from: key } }}
                 passHref
               >
-                <Button component="a" variant="contained" color="secondary">
+                <Button component="a" variant="outlined" color="primary">
                   <Trans id="button.copy.visualization">
                     Copy and edit this visualization
                   </Trans>

--- a/app/pages/v/[chartId].tsx
+++ b/app/pages/v/[chartId].tsx
@@ -1,5 +1,6 @@
 import { Trans } from "@lingui/macro";
-import { Box, Button, Stack, Typography } from "@mui/material";
+import { Box, Button, Stack, Theme, Typography } from "@mui/material";
+import { makeStyles } from "@mui/styles";
 import { GetServerSideProps } from "next";
 import ErrorPage from "next/error";
 import Head from "next/head";
@@ -46,9 +47,25 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
   return { props: { status: "notfound" } };
 };
 
+const useStyles = makeStyles((theme: Theme) => ({
+  actionBar: {
+    backgroundColor: "white",
+    padding: `${theme.spacing(3)} 2.25rem`,
+    justifyContent: "flex-end",
+    display: "flex",
+    width: "100%",
+    borderBottom: "1px solid",
+    borderBottomColor: theme.palette.divider,
+    [theme.breakpoints.down("md")]: {
+      padding: `${theme.spacing(3)} 0.75rem`,
+    },
+  },
+}));
+
 const VisualizationPage = (props: Serialized<PageProps>) => {
   const locale = useLocale();
   const { query, replace } = useRouter();
+  const classes = useStyles();
 
   // Keep initial value of publishSuccess
   const [publishSuccess] = useState(() => !!query.publishSuccess);
@@ -81,6 +98,9 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
         {/* og:url is set in _app.tsx */}
       </Head>
       <ContentLayout>
+        <Box className={classes.actionBar}>
+          <PublishActions configKey={key} sx={{ m: 0 }} />
+        </Box>
         <Box
           px={[2, 4]}
           sx={{ backgroundColor: "muted.main" }}
@@ -105,8 +125,6 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
                 configKey={key}
               />
             </ChartPanelPublished>
-
-            <PublishActions configKey={key} sx={{ mt: 5, mb: 5 }} />
 
             <Typography
               component="div"

--- a/app/utils/embed.tsx
+++ b/app/utils/embed.tsx
@@ -1,8 +1,7 @@
 import { useRouter } from "next/router";
-import { useContext, useMemo } from "react";
+import React, { useContext, useMemo } from "react";
 
 import useEvent from "@/utils/use-event";
-import React from "react";
 
 export type EmbedOptions = {
   showDownload?: boolean;

--- a/app/utils/embed.tsx
+++ b/app/utils/embed.tsx
@@ -1,0 +1,35 @@
+import { useRouter } from "next/router";
+import { useMemo } from "react";
+
+import useEvent from "@/utils/use-event";
+
+import { EmbedOptions } from "../components/chart-published";
+
+export const useEmbedOptions = () => {
+  const router = useRouter();
+  const embedOptions = useMemo(() => {
+    try {
+      if (typeof router.query.embedOptions === "string") {
+        return JSON.parse(router.query.embedOptions) as EmbedOptions;
+      } else {
+        return {};
+      }
+    } catch (e) {
+      return {};
+    }
+  }, [router.query]);
+  const setEmbedOptions = useEvent((patch: EmbedOptions) => {
+    const newEmbedOptions: EmbedOptions = {
+      ...embedOptions,
+      ...patch,
+    };
+    router.push({
+      pathname: router.pathname,
+      query: {
+        ...router.query,
+        embedOptions: JSON.stringify(newEmbedOptions),
+      },
+    });
+  });
+  return [embedOptions, setEmbedOptions] as const;
+};

--- a/app/utils/embed.tsx
+++ b/app/utils/embed.tsx
@@ -1,11 +1,30 @@
 import { useRouter } from "next/router";
-import { useMemo } from "react";
+import { useContext, useMemo } from "react";
 
 import useEvent from "@/utils/use-event";
+import React from "react";
 
-import { EmbedOptions } from "../components/chart-published";
+export type EmbedOptions = {
+  showDownload?: boolean;
+  showLandingPage?: boolean;
+  showTableSwitch?: boolean;
+  showSparqlQuery?: boolean;
+  showDatePublished?: boolean;
+  showSource?: boolean;
+  showDatasetTitle?: boolean;
+  showMetadata?: boolean;
+};
 
-export const useEmbedOptions = () => {
+const EmbedOptionsContext = React.createContext([
+  {} as EmbedOptions,
+  (() => undefined) as (n: Partial<EmbedOptions>) => void,
+] as const);
+
+export const EmbedOptionsProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
   const router = useRouter();
   const embedOptions = useMemo(() => {
     try {
@@ -31,5 +50,15 @@ export const useEmbedOptions = () => {
       },
     });
   });
-  return [embedOptions, setEmbedOptions] as const;
+  return (
+    <EmbedOptionsContext.Provider
+      value={[embedOptions, setEmbedOptions] as const}
+    >
+      {children}
+    </EmbedOptionsContext.Provider>
+  );
+};
+
+export const useEmbedOptions = () => {
+  return useContext(EmbedOptionsContext);
 };


### PR DESCRIPTION
Adds an option in the embed popover to choose either minimal or standard view for the chart when it's embedded.

Technically, it adds a query parameter "embedOptions" that is then picked up by the view to hide some elements under the chart.

Fix #943 

How to test:

- Open on https://visualization-tool-git-feat-embed-options-ixt1.vercel.app/en/v/sO8qHplebSER?dataSource=Prod
- Click the embed options
- Choose either standard or minimal options.
- The page should refresh to show how the chart would be embedded (right now, on smaller screen, the refresh triggers a layout change, which makes the popover move a little, a possible solution could be to have an [alternate layout for published view](https://github.com/visualize-admin/visualization-tool/pull/948) but I am keeping the dicussion into the other PR)
- The codes should reflect the options and can be copy pasted into jsbin.com for example for testing. The resulting embedded chart should reflect the selected options
