### PR TITLE
Publish view alternate layout

### DIFF
--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -57,12 +57,28 @@ export const ChartFootnotes = ({
   chartConfig,
   configKey,
   onToggleTableView,
+  showDownload,
+  showTableSwitch,
+  showSparqlQuery,
+  visualizeLinkText,
+  showLandingPage,
+  showSource,
+  showDatasetTitle,
+  showDatePublished,
 }: {
   dataSetIri: string;
   dataSource: DataSource;
   chartConfig: ChartConfig;
   configKey?: string;
   onToggleTableView: () => void;
+  showDownload?: boolean;
+  showLandingPage?: boolean;
+  showTableSwitch?: boolean;
+  showSparqlQuery?: boolean;
+  showSource?: boolean;
+  showDatasetTitle?: boolean;
+  showDatePublished?: boolean;
+  visualizeLinkText?: JSX.Element;
 }) => {
   const classes = useFootnotesStyles({ useMarginTop: true });
   const locale = useLocale();
@@ -112,26 +128,28 @@ export const ChartFootnotes = ({
 
     return (
       <Box sx={{ mt: 2 }}>
-        <Typography component="span" variant="caption" color="grey.600">
-          <strong>
-            <Trans id="dataset.footnotes.dataset">Dataset</Trans>
-          </strong>
-          <Trans id="typography.colon">: </Trans>
-          {cubeLink ? (
-            <Link target="_blank" href={cubeLink} rel="noreferrer">
-              {dataCubeByIri.title}{" "}
-              <Icon
-                name="linkExternal"
-                size="1em"
-                style={{ display: "inline" }}
-              />
-            </Link>
-          ) : (
-            dataCubeByIri.title
-          )}
-        </Typography>
+        {showDatasetTitle !== false ? (
+          <Typography component="span" variant="caption" color="grey.600">
+            <strong>
+              <Trans id="dataset.footnotes.dataset">Dataset</Trans>
+            </strong>
+            <Trans id="typography.colon">: </Trans>
+            {cubeLink ? (
+              <Link target="_blank" href={cubeLink} rel="noreferrer">
+                {dataCubeByIri.title}{" "}
+                <Icon
+                  name="linkExternal"
+                  size="1em"
+                  style={{ display: "inline" }}
+                />
+              </Link>
+            ) : (
+              dataCubeByIri.title
+            )}
+          </Typography>
+        ) : null}
 
-        {dataCubeByIri.dateModified ? (
+        {dataCubeByIri.dateModified && showDatePublished !== false ? (
           <Typography component="span" variant="caption" color="grey.600">
             ,&nbsp;
             <strong>
@@ -144,53 +162,65 @@ export const ChartFootnotes = ({
           </Typography>
         ) : null}
 
-        <Typography component="div" variant="caption" color="grey.600">
-          <strong>
-            <Trans id="metadata.source">Source</Trans>
-          </strong>
-          <Trans id="typography.colon">: </Trans>
-          {dataCubeByIri.publisher && (
-            <Box
-              component="span"
-              sx={{ "> a": { color: "grey.600" } }}
-              dangerouslySetInnerHTML={{ __html: dataCubeByIri.publisher }}
-            ></Box>
-          )}
-        </Typography>
+        {showSource !== false ? (
+          <Typography component="div" variant="caption" color="grey.600">
+            <strong>
+              <Trans id="metadata.source">Source</Trans>
+            </strong>
+            <Trans id="typography.colon">: </Trans>
+            {dataCubeByIri.publisher && (
+              <Box
+                component="span"
+                sx={{ "> a": { color: "grey.600" } }}
+                dangerouslySetInnerHTML={{ __html: dataCubeByIri.publisher }}
+              ></Box>
+            )}
+          </Typography>
+        ) : null}
 
         <Box className={classes.actions}>
-          <DataDownloadMenu
-            dataSetIri={dataSetIri}
-            dataSource={dataSource}
-            title={dataCubeByIri.title}
-            filters={filters}
-          />
-          {chartConfig.chartType !== "table" && (
-            <Button
-              component="a"
-              color="primary"
-              variant="text"
-              size="small"
-              startIcon={
-                <Icon
-                  name={
-                    isTablePreview
-                      ? getChartIcon(chartConfig.chartType)
-                      : "table"
+          {showDownload !== false ? (
+            <DataDownloadMenu
+              dataSetIri={dataSetIri}
+              dataSource={dataSource}
+              title={dataCubeByIri.title}
+              filters={filters}
+            />
+          ) : null}
+          {showTableSwitch !== false ? (
+            <>
+              {chartConfig.chartType !== "table" && (
+                <Button
+                  component="a"
+                  color="primary"
+                  variant="text"
+                  size="small"
+                  startIcon={
+                    <Icon
+                      name={
+                        isTablePreview
+                          ? getChartIcon(chartConfig.chartType)
+                          : "table"
+                      }
+                    />
                   }
-                />
-              }
-              onClick={onToggleTableView}
-              sx={{ p: 0, typography: "caption" }}
-            >
-              {isTablePreview ? (
-                <Trans id="metadata.switch.chart">Switch to chart view</Trans>
-              ) : (
-                <Trans id="metadata.switch.table">Switch to table view</Trans>
+                  onClick={onToggleTableView}
+                  sx={{ p: 0, typography: "caption" }}
+                >
+                  {isTablePreview ? (
+                    <Trans id="metadata.switch.chart">
+                      Switch to chart view
+                    </Trans>
+                  ) : (
+                    <Trans id="metadata.switch.table">
+                      Switch to table view
+                    </Trans>
+                  )}
+                </Button>
               )}
-            </Button>
-          )}
-          {dataCubeByIri.landingPage && (
+            </>
+          ) : null}
+          {dataCubeByIri.landingPage && showLandingPage !== false && (
             <Button
               variant="text"
               component="a"
@@ -206,7 +236,7 @@ export const ChartFootnotes = ({
               </Trans>
             </Button>
           )}
-          {sparqlEditorUrl && (
+          {sparqlEditorUrl && showSparqlQuery !== false && (
             <RunSparqlQuery url={sparqlEditorUrl as string} />
           )}
           {configKey && shareUrl && (
@@ -220,9 +250,11 @@ export const ChartFootnotes = ({
               target="_blank"
               rel="noopener noreferrer"
             >
-              <Trans id="metadata.link.created.with.visualize">
-                Created with visualize.admin.ch
-              </Trans>
+              {visualizeLinkText ?? (
+                <Trans id="metadata.link.created.with.visualize">
+                  Created with visualize.admin.ch
+                </Trans>
+              )}
             </Button>
           )}
         </Box>

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -47,6 +47,8 @@ import { DataCubePublicationStatus } from "@/graphql/resolver-types";
 import { useLocale } from "@/locales/use-locale";
 import useEvent from "@/utils/use-event";
 
+import { useEmbedOptions } from "../utils/embed";
+
 export const ChartPublished = ({
   dataSet,
   dataSource,
@@ -87,6 +89,16 @@ const useStyles = makeStyles<Theme, { shrink: boolean }>((theme) => ({
     transition: "padding 0.25s ease",
   },
 }));
+
+export type EmbedOptions = {
+  showDownload?: boolean;
+  showLandingPage?: boolean;
+  showTableSwitch?: boolean;
+  showSparqlQuery?: boolean;
+  showDatePublished?: boolean;
+  showSource?: boolean;
+  showDatasetTitle?: boolean;
+};
 
 export const ChartPublishedInner = ({
   dataSet,
@@ -163,6 +175,7 @@ export const ChartPublishedInner = ({
     ];
   }, [metaData?.dataCubeByIri?.dimensions, metaData?.dataCubeByIri?.measures]);
 
+  const [embedOptions] = useEmbedOptions();
   return (
     <MetadataPanelStoreContext.Provider value={metadataPanelStore}>
       <Box className={classes.root} ref={rootRef}>
@@ -260,6 +273,20 @@ export const ChartPublishedInner = ({
               chartConfig={chartConfig}
               configKey={configKey}
               onToggleTableView={handleToggleTableView}
+              showDownload={embedOptions.showDownload}
+              showLandingPage={embedOptions.showLandingPage}
+              showTableSwitch={embedOptions.showTableSwitch}
+              showSparqlQuery={embedOptions.showSparqlQuery}
+              showDatePublished={embedOptions.showDatePublished}
+              showSource={embedOptions.showSource}
+              showDatasetTitle={embedOptions.showDatasetTitle}
+              visualizeLinkText={
+                embedOptions.showDownload === false ? (
+                  <Trans id="metadata.link.created.with.visualize.alternate">
+                    More information
+                  </Trans>
+                ) : undefined
+              }
             />
           </InteractiveFiltersProvider>
         </ChartErrorBoundary>

--- a/app/components/publish-actions.tsx
+++ b/app/components/publish-actions.tsx
@@ -267,11 +267,11 @@ export const Embed = ({ configKey, locale }: EmbedShareProps) => {
                         Standard
                       </Trans>
                     </Typography>
-                    <Typography variant="caption" display="block">
+                    {/* <Typography variant="caption" display="block">
                       <Trans id="publication.embed.style.standard.caption">
                         Chart, download the data links, attribution etc...
                       </Trans>
-                    </Typography>
+                    </Typography> */}
                   </div>
                 }
                 disableTypography
@@ -287,11 +287,11 @@ export const Embed = ({ configKey, locale }: EmbedShareProps) => {
                         Minimal
                       </Trans>
                     </Typography>
-                    <Typography variant="caption" display="block">
+                    {/* <Typography variant="caption" display="block">
                       <Trans id="publication.embed.style.minimal.caption">
                         Only the chart and a link for more information.
                       </Trans>
-                    </Typography>
+                    </Typography> */}
                   </div>
                 }
                 disableTypography
@@ -305,7 +305,7 @@ export const Embed = ({ configKey, locale }: EmbedShareProps) => {
           </Typography>
           <Typography variant="caption">
             <Trans id="publication.embed.iframe.caption">
-              Use this link to insert this visualization into other webpages.
+              Use this link to embed the chart into other webpages.
             </Trans>
           </Typography>
 
@@ -322,8 +322,8 @@ export const Embed = ({ configKey, locale }: EmbedShareProps) => {
           </Typography>
           <Typography variant="caption">
             <Trans id="publication.embed.AEM.caption">
-              Use this link to insert this visualization into Adobe Experience
-              Manager assets.
+              Use this link to embed the chart into Adobe Experience Manager
+              assets.
             </Trans>
           </Typography>
 

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -949,7 +949,7 @@ msgstr "Einbett-Code für AEM «Externe Applikation»"
 
 #: app/components/publish-actions.tsx:324
 msgid "publication.embed.AEM.caption"
-msgstr ""
+msgstr "Verwenden Sie diesen Code, um das Diagramm in Adobe Experience Manager einzubetten"
 
 #: app/components/publish-actions.tsx:304
 msgid "publication.embed.iframe"
@@ -957,11 +957,11 @@ msgstr "Einbett-Code"
 
 #: app/components/publish-actions.tsx:307
 msgid "publication.embed.iframe.caption"
-msgstr ""
+msgstr "Verwenden Sie diesen Code, um das Diagramm auf einer Webseite einzubetten"
 
 #: app/components/publish-actions.tsx:286
 msgid "publication.embed.style.minimal"
-msgstr ""
+msgstr "Minimale"
 
 #: app/components/publish-actions.tsx:291
 msgid "publication.embed.style.minimal.caption"
@@ -969,7 +969,7 @@ msgstr ""
 
 #: app/components/publish-actions.tsx:266
 msgid "publication.embed.style.standard"
-msgstr ""
+msgstr "Standard"
 
 #: app/components/publish-actions.tsx:271
 msgid "publication.embed.style.standard.caption"

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -13,19 +13,19 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:709
+#: app/configurator/components/chart-configurator.tsx:701
 msgid "Add filter"
 msgstr "Filter hinzufügen"
 
-#: app/configurator/components/chart-configurator.tsx:682
+#: app/configurator/components/chart-configurator.tsx:674
 msgid "Drag filters to reorganize"
 msgstr "Ziehen Sie die Filter per Drag & Drop, um sie neu zu organisieren"
 
-#: app/configurator/components/chart-configurator.tsx:679
+#: app/configurator/components/chart-configurator.tsx:671
 msgid "Move filter down"
 msgstr "Filter nach unten verschieben"
 
-#: app/configurator/components/chart-configurator.tsx:676
+#: app/configurator/components/chart-configurator.tsx:668
 msgid "Move filter up"
 msgstr "Filter nach oben verschieben"
 
@@ -66,7 +66,7 @@ msgstr "Erkunden Sie die vom LINDAS Linked Data Service bereitgestellten Datens�
 msgid "button.back"
 msgstr "Zurück"
 
-#: app/pages/v/[chartId].tsx:166
+#: app/pages/v/[chartId].tsx:154
 msgid "button.copy.visualization"
 msgstr "Diese Visualisierung kopieren und editieren"
 
@@ -90,20 +90,20 @@ msgstr "Gefilterter Datensatz"
 msgid "button.download.runsparqlquery.visible"
 msgstr "SPARQL-Abfrage ausführen"
 
-#: app/components/publish-actions.tsx:206
+#: app/components/publish-actions.tsx:240
 msgid "button.embed"
 msgstr "Einbetten"
 
-#: app/components/publish-actions.tsx:281
-#: app/components/publish-actions.tsx:287
+#: app/components/publish-actions.tsx:390
+#: app/components/publish-actions.tsx:396
 msgid "button.hint.click.to.copy"
 msgstr "Kopieren"
 
-#: app/components/publish-actions.tsx:311
+#: app/components/publish-actions.tsx:420
 msgid "button.hint.copied"
 msgstr "Kopiert!"
 
-#: app/pages/v/[chartId].tsx:151
+#: app/pages/v/[chartId].tsx:139
 msgid "button.new.visualization"
 msgstr "Neue Visualisierung erstellen"
 
@@ -111,7 +111,7 @@ msgstr "Neue Visualisierung erstellen"
 msgid "button.publish"
 msgstr "Diese Visualisierung veröffentlichen"
 
-#: app/components/publish-actions.tsx:96
+#: app/components/publish-actions.tsx:102
 msgid "button.share"
 msgstr "Teilen"
 
@@ -119,7 +119,7 @@ msgstr "Teilen"
 msgid "chart.map.layers.area"
 msgstr "Flächen"
 
-#: app/configurator/components/chart-configurator.tsx:762
+#: app/configurator/components/chart-configurator.tsx:754
 #: app/configurator/components/chart-options-selector.tsx:1055
 #: app/configurator/components/field-i18n.ts:31
 msgid "chart.map.layers.base"
@@ -307,8 +307,8 @@ msgstr "Beschreibung hinzufügen"
 #: app/charts/shared/chart-data-filters.tsx:249
 #: app/charts/shared/chart-data-filters.tsx:296
 #: app/configurator/components/field.tsx:167
-#: app/configurator/components/field.tsx:264
-#: app/configurator/components/field.tsx:364
+#: app/configurator/components/field.tsx:267
+#: app/configurator/components/field.tsx:367
 msgid "controls.dimensionvalue.none"
 msgstr "Kein Filter"
 
@@ -324,12 +324,12 @@ msgstr "Alle auswählen"
 msgid "controls.filter.select.none"
 msgstr "Alle abwählen"
 
-#: app/configurator/components/chart-configurator.tsx:512
+#: app/configurator/components/chart-configurator.tsx:513
 #: app/configurator/components/filters.tsx:366
 msgid "controls.filters.interactive.toggle"
 msgstr "Interaktiv"
 
-#: app/configurator/components/chart-configurator.tsx:505
+#: app/configurator/components/chart-configurator.tsx:506
 #: app/configurator/components/filters.tsx:360
 msgid "controls.filters.interactive.tooltip"
 msgstr "Erlauben Sie Benutzern, Filter zu ändern"
@@ -432,8 +432,8 @@ msgstr "Zurück zur Übersicht"
 msgid "controls.nav.back-to-preview"
 msgstr "Zurück zur Vorschau"
 
-#: app/configurator/components/field.tsx:703
-#: app/configurator/components/field.tsx:875
+#: app/configurator/components/field.tsx:706
+#: app/configurator/components/field.tsx:878
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:244
 msgid "controls.none"
 msgstr "Keine"
@@ -450,7 +450,7 @@ msgstr "Aus"
 msgid "controls.scale.type"
 msgstr "Skalierungstyp"
 
-#: app/components/form.tsx:611
+#: app/components/form.tsx:614
 msgid "controls.search.clear"
 msgstr "Suche zurücksetzen"
 
@@ -458,7 +458,7 @@ msgstr "Suche zurücksetzen"
 msgid "controls.section.additional-information"
 msgstr "Zusätzliche Informationen"
 
-#: app/configurator/components/chart-configurator.tsx:595
+#: app/configurator/components/chart-configurator.tsx:587
 msgid "controls.section.chart.options"
 msgstr "Diagramm-Einstellungen"
 
@@ -470,11 +470,11 @@ msgstr "Spalten"
 msgid "controls.section.columnstyle"
 msgstr "Spaltenstil"
 
-#: app/configurator/components/chart-configurator.tsx:613
+#: app/configurator/components/chart-configurator.tsx:605
 msgid "controls.section.data.filters"
 msgstr "Filter"
 
-#: app/configurator/components/chart-configurator.tsx:629
+#: app/configurator/components/chart-configurator.tsx:621
 msgid "controls.section.data.filters.possible-filters-error"
 msgstr "Beim Abrufen möglicher Filter ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut oder laden Sie die Seite neu."
 
@@ -532,7 +532,7 @@ msgstr "Tabellenoptionen"
 msgid "controls.section.title.warning"
 msgstr "Fügen Sie einen Titel oder eine Beschreibung hinzu"
 
-#: app/configurator/components/chart-configurator.tsx:587
+#: app/configurator/components/chart-configurator.tsx:579
 #: app/configurator/components/chart-type-selector.tsx:131
 #: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
@@ -586,10 +586,10 @@ msgid "controls.select.measure"
 msgstr "Messwert auswählen"
 
 #: app/configurator/components/field.tsx:172
-#: app/configurator/components/field.tsx:269
-#: app/configurator/components/field.tsx:369
-#: app/configurator/components/field.tsx:708
-#: app/configurator/components/field.tsx:880
+#: app/configurator/components/field.tsx:272
+#: app/configurator/components/field.tsx:372
+#: app/configurator/components/field.tsx:711
+#: app/configurator/components/field.tsx:883
 msgid "controls.select.optional"
 msgstr ""
 
@@ -726,7 +726,7 @@ msgstr "Cube IRI"
 msgid "data.source"
 msgstr "Datenquelle"
 
-#: app/components/chart-published.tsx:196
+#: app/components/chart-published.tsx:209
 msgid "data.source.notTrusted"
 msgstr "Dieses Diagramm verwendet keine vertrauenswürdige Datenquelle."
 
@@ -738,15 +738,15 @@ msgstr "Zurück zu den Datensätzen"
 msgid "dataset-preview.keywords"
 msgstr "Schlüsselwörter"
 
-#: app/components/chart-footnotes.tsx:117
+#: app/components/chart-footnotes.tsx:134
 msgid "dataset.footnotes.dataset"
 msgstr "Datensatz"
 
-#: app/components/chart-footnotes.tsx:138
+#: app/components/chart-footnotes.tsx:156
 msgid "dataset.footnotes.updated"
 msgstr "Neuestes Update"
 
-#: app/components/chart-published.tsx:205
+#: app/components/chart-published.tsx:218
 msgid "dataset.hasImputedValues"
 msgstr "Einige Daten in diesem Datensatz fehlen und wurden interpoliert, um die Lücken zu füllen."
 
@@ -766,7 +766,7 @@ msgstr "Kontaktstellen"
 msgid "dataset.metadata.furtherinformation"
 msgstr "Weitere Informationen"
 
-#: app/components/chart-footnotes.tsx:204
+#: app/components/chart-footnotes.tsx:234
 #: app/configurator/components/dataset-metadata.tsx:107
 msgid "dataset.metadata.learnmore"
 msgstr "Erfahren Sie mehr über diesen Datensatz"
@@ -792,12 +792,12 @@ msgid "dataset.order.title"
 msgstr "Titel"
 
 #: app/components/chart-preview.tsx:115
-#: app/components/chart-published.tsx:174
+#: app/components/chart-published.tsx:187
 #: app/configurator/components/dataset-preview.tsx:120
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Achtung, dieser Datensatz ist im Entwurfs-Stadium.<0/><1>Diese Grafik nicht für Berichte verwenden.</1>"
 
-#: app/components/chart-published.tsx:185
+#: app/components/chart-published.tsx:198
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Achtung, dieser Datensatz ist abgelaufen.<0/><1>Diese Grafik nicht für Berichte verwenden.</1>"
 
@@ -865,7 +865,7 @@ msgstr "Es gab ein Problem beim Laden der Koordinaten aus den geografischen Dime
 msgid "hint.coordinatesloadingerror.title"
 msgstr "Koordinaten-Ladefehler"
 
-#: app/pages/v/[chartId].tsx:128
+#: app/pages/v/[chartId].tsx:117
 msgid "hint.create.your.own.chart"
 msgstr "Kopieren Sie diese Visualisierung oder erstellen Sie eine neue Visualisierung mit Swiss Open Government Data."
 
@@ -881,11 +881,11 @@ msgstr "Weitere Informationen finden Sie auf der Statusseite"
 msgid "hint.dataloadingerror.title"
 msgstr "Daten-Ladefehler"
 
-#: app/pages/v/[chartId].tsx:122
+#: app/pages/v/[chartId].tsx:111
 msgid "hint.how.to.share"
 msgstr "Sie können diese Visualisierung teilen oder sie einbetten. Zudem können Sie eine neue Visualisierung erstellen oder die gezeigte Visualisierung kopieren."
 
-#: app/components/form.tsx:282
+#: app/components/form.tsx:285
 #: app/components/hint.tsx:111
 msgid "hint.loading.data"
 msgstr "Lade Daten …"
@@ -927,55 +927,79 @@ msgstr "Filter anzeigen"
 msgid "logo.swiss.confederation"
 msgstr "Logo der Schweizerischen Eidgenossenschaft"
 
-#: app/components/chart-footnotes.tsx:223
+#: app/components/chart-footnotes.tsx:254
 msgid "metadata.link.created.with.visualize"
 msgstr "Erstellt mit visualize.admin.ch"
 
-#: app/components/chart-footnotes.tsx:149
+#: app/components/chart-footnotes.tsx:168
 msgid "metadata.source"
 msgstr "Quelle"
 
-#: app/components/chart-footnotes.tsx:187
+#: app/components/chart-footnotes.tsx:211
 msgid "metadata.switch.chart"
 msgstr "Zur Diagrammansicht wechseln"
 
-#: app/components/chart-footnotes.tsx:189
+#: app/components/chart-footnotes.tsx:215
 msgid "metadata.switch.table"
 msgstr "Zur Tabellenansicht wechseln"
 
-#: app/components/publish-actions.tsx:218
+#: app/components/publish-actions.tsx:319
 msgid "publication.embed.AEM"
-msgstr "Einbett-Code für AEM «Externe Applikation»:"
+msgstr "Einbett-Code für AEM «Externe Applikation»"
 
-#: app/components/publish-actions.tsx:211
+#: app/components/publish-actions.tsx:324
+msgid "publication.embed.AEM.caption"
+msgstr ""
+
+#: app/components/publish-actions.tsx:304
 msgid "publication.embed.iframe"
-msgstr "Einbett-Code:"
+msgstr "Einbett-Code"
 
-#: app/components/publish-actions.tsx:111
+#: app/components/publish-actions.tsx:307
+msgid "publication.embed.iframe.caption"
+msgstr ""
+
+#: app/components/publish-actions.tsx:286
+msgid "publication.embed.style.minimal"
+msgstr ""
+
+#: app/components/publish-actions.tsx:291
+msgid "publication.embed.style.minimal.caption"
+msgstr ""
+
+#: app/components/publish-actions.tsx:266
+msgid "publication.embed.style.standard"
+msgstr ""
+
+#: app/components/publish-actions.tsx:271
+msgid "publication.embed.style.standard.caption"
+msgstr ""
+
+#: app/components/publish-actions.tsx:117
 msgid "publication.popup.share"
 msgstr "Teilen"
 
-#: app/components/publish-actions.tsx:159
+#: app/components/publish-actions.tsx:165
 msgid "publication.share.chart.url"
 msgstr "Diagramm-URL:"
 
-#: app/components/publish-actions.tsx:117
+#: app/components/publish-actions.tsx:123
 msgid "publication.share.linktitle.facebook"
 msgstr "Teilen via Facebook"
 
-#: app/components/publish-actions.tsx:137
+#: app/components/publish-actions.tsx:143
 msgid "publication.share.linktitle.mail"
 msgstr "Versenden via E-Mail"
 
-#: app/components/publish-actions.tsx:127
+#: app/components/publish-actions.tsx:133
 msgid "publication.share.linktitle.twitter"
 msgstr "Teilen via Twitter"
 
-#: app/components/publish-actions.tsx:148
+#: app/components/publish-actions.tsx:154
 msgid "publication.share.mail.body"
 msgstr "Hier ist eine Visualisierung, die ich mit visualize.admin.ch erstellt habe"
 
-#: app/components/publish-actions.tsx:143
+#: app/components/publish-actions.tsx:149
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
@@ -992,8 +1016,8 @@ msgstr "Springen zu..."
 msgid "table.column.no"
 msgstr "Spalte {0}"
 
-#: app/components/chart-footnotes.tsx:119
-#: app/components/chart-footnotes.tsx:140
-#: app/components/chart-footnotes.tsx:151
+#: app/components/chart-footnotes.tsx:136
+#: app/components/chart-footnotes.tsx:158
+#: app/components/chart-footnotes.tsx:170
 msgid "typography.colon"
 msgstr ": "

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -13,19 +13,19 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:709
+#: app/configurator/components/chart-configurator.tsx:701
 msgid "Add filter"
 msgstr "Add filter"
 
-#: app/configurator/components/chart-configurator.tsx:682
+#: app/configurator/components/chart-configurator.tsx:674
 msgid "Drag filters to reorganize"
 msgstr "Drag filters to reorganize"
 
-#: app/configurator/components/chart-configurator.tsx:679
+#: app/configurator/components/chart-configurator.tsx:671
 msgid "Move filter down"
 msgstr "Move filter down"
 
-#: app/configurator/components/chart-configurator.tsx:676
+#: app/configurator/components/chart-configurator.tsx:668
 msgid "Move filter up"
 msgstr "Move filter up"
 
@@ -66,7 +66,7 @@ msgstr "Explore datasets provided by the LINDAS Linked Data Service by either fi
 msgid "button.back"
 msgstr "Back"
 
-#: app/pages/v/[chartId].tsx:166
+#: app/pages/v/[chartId].tsx:154
 msgid "button.copy.visualization"
 msgstr "Copy and edit this visualization"
 
@@ -90,20 +90,20 @@ msgstr "Filtered dataset"
 msgid "button.download.runsparqlquery.visible"
 msgstr "Run SPARQL query"
 
-#: app/components/publish-actions.tsx:206
+#: app/components/publish-actions.tsx:240
 msgid "button.embed"
 msgstr "Embed"
 
-#: app/components/publish-actions.tsx:281
-#: app/components/publish-actions.tsx:287
+#: app/components/publish-actions.tsx:390
+#: app/components/publish-actions.tsx:396
 msgid "button.hint.click.to.copy"
 msgstr "Click to copy"
 
-#: app/components/publish-actions.tsx:311
+#: app/components/publish-actions.tsx:420
 msgid "button.hint.copied"
 msgstr "Copied!"
 
-#: app/pages/v/[chartId].tsx:151
+#: app/pages/v/[chartId].tsx:139
 msgid "button.new.visualization"
 msgstr "Create New Visualization"
 
@@ -111,7 +111,7 @@ msgstr "Create New Visualization"
 msgid "button.publish"
 msgstr "Publish this visualization"
 
-#: app/components/publish-actions.tsx:96
+#: app/components/publish-actions.tsx:102
 msgid "button.share"
 msgstr "Share"
 
@@ -119,7 +119,7 @@ msgstr "Share"
 msgid "chart.map.layers.area"
 msgstr "Areas"
 
-#: app/configurator/components/chart-configurator.tsx:762
+#: app/configurator/components/chart-configurator.tsx:754
 #: app/configurator/components/chart-options-selector.tsx:1055
 #: app/configurator/components/field-i18n.ts:31
 msgid "chart.map.layers.base"
@@ -307,8 +307,8 @@ msgstr "Description"
 #: app/charts/shared/chart-data-filters.tsx:249
 #: app/charts/shared/chart-data-filters.tsx:296
 #: app/configurator/components/field.tsx:167
-#: app/configurator/components/field.tsx:264
-#: app/configurator/components/field.tsx:364
+#: app/configurator/components/field.tsx:267
+#: app/configurator/components/field.tsx:367
 msgid "controls.dimensionvalue.none"
 msgstr "No Filter"
 
@@ -324,12 +324,12 @@ msgstr "Select all"
 msgid "controls.filter.select.none"
 msgstr "Select none"
 
-#: app/configurator/components/chart-configurator.tsx:512
+#: app/configurator/components/chart-configurator.tsx:513
 #: app/configurator/components/filters.tsx:366
 msgid "controls.filters.interactive.toggle"
 msgstr "Interactive"
 
-#: app/configurator/components/chart-configurator.tsx:505
+#: app/configurator/components/chart-configurator.tsx:506
 #: app/configurator/components/filters.tsx:360
 msgid "controls.filters.interactive.tooltip"
 msgstr "Allow users to change filters"
@@ -432,8 +432,8 @@ msgstr "Back to main"
 msgid "controls.nav.back-to-preview"
 msgstr "Back to preview"
 
-#: app/configurator/components/field.tsx:703
-#: app/configurator/components/field.tsx:875
+#: app/configurator/components/field.tsx:706
+#: app/configurator/components/field.tsx:878
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:244
 msgid "controls.none"
 msgstr "None"
@@ -450,7 +450,7 @@ msgstr "Off"
 msgid "controls.scale.type"
 msgstr "Scale type"
 
-#: app/components/form.tsx:611
+#: app/components/form.tsx:614
 msgid "controls.search.clear"
 msgstr "Clear search field"
 
@@ -458,7 +458,7 @@ msgstr "Clear search field"
 msgid "controls.section.additional-information"
 msgstr "Additional information"
 
-#: app/configurator/components/chart-configurator.tsx:595
+#: app/configurator/components/chart-configurator.tsx:587
 msgid "controls.section.chart.options"
 msgstr "Chart Options"
 
@@ -470,11 +470,11 @@ msgstr "Columns"
 msgid "controls.section.columnstyle"
 msgstr "Column Style"
 
-#: app/configurator/components/chart-configurator.tsx:613
+#: app/configurator/components/chart-configurator.tsx:605
 msgid "controls.section.data.filters"
 msgstr "Filters"
 
-#: app/configurator/components/chart-configurator.tsx:629
+#: app/configurator/components/chart-configurator.tsx:621
 msgid "controls.section.data.filters.possible-filters-error"
 msgstr "An error happened while fetching possible filters, please retry later or reload the page."
 
@@ -532,7 +532,7 @@ msgstr "Table Options"
 msgid "controls.section.title.warning"
 msgstr "Please add a title or description."
 
-#: app/configurator/components/chart-configurator.tsx:587
+#: app/configurator/components/chart-configurator.tsx:579
 #: app/configurator/components/chart-type-selector.tsx:131
 #: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
@@ -586,10 +586,10 @@ msgid "controls.select.measure"
 msgstr "Select a measure"
 
 #: app/configurator/components/field.tsx:172
-#: app/configurator/components/field.tsx:269
-#: app/configurator/components/field.tsx:369
-#: app/configurator/components/field.tsx:708
-#: app/configurator/components/field.tsx:880
+#: app/configurator/components/field.tsx:272
+#: app/configurator/components/field.tsx:372
+#: app/configurator/components/field.tsx:711
+#: app/configurator/components/field.tsx:883
 msgid "controls.select.optional"
 msgstr "optional"
 
@@ -726,7 +726,7 @@ msgstr "Cube IRI"
 msgid "data.source"
 msgstr "Data source"
 
-#: app/components/chart-published.tsx:196
+#: app/components/chart-published.tsx:209
 msgid "data.source.notTrusted"
 msgstr "This chart is not using a trusted data source."
 
@@ -738,15 +738,15 @@ msgstr "Back to the datasets"
 msgid "dataset-preview.keywords"
 msgstr "Keywords"
 
-#: app/components/chart-footnotes.tsx:117
+#: app/components/chart-footnotes.tsx:134
 msgid "dataset.footnotes.dataset"
 msgstr "Dataset"
 
-#: app/components/chart-footnotes.tsx:138
+#: app/components/chart-footnotes.tsx:156
 msgid "dataset.footnotes.updated"
 msgstr "Latest update"
 
-#: app/components/chart-published.tsx:205
+#: app/components/chart-published.tsx:218
 msgid "dataset.hasImputedValues"
 msgstr "Some data in this dataset is missing and has been interpolated to fill the gaps."
 
@@ -766,7 +766,7 @@ msgstr "Contact points"
 msgid "dataset.metadata.furtherinformation"
 msgstr "Further information"
 
-#: app/components/chart-footnotes.tsx:204
+#: app/components/chart-footnotes.tsx:234
 #: app/configurator/components/dataset-metadata.tsx:107
 msgid "dataset.metadata.learnmore"
 msgstr "Learn more about the dataset"
@@ -792,12 +792,12 @@ msgid "dataset.order.title"
 msgstr "Title"
 
 #: app/components/chart-preview.tsx:115
-#: app/components/chart-published.tsx:174
+#: app/components/chart-published.tsx:187
 #: app/configurator/components/dataset-preview.tsx:120
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Careful, this dataset is only a draft.<0/><1>Don't use for reporting!</1>"
 
-#: app/components/chart-published.tsx:185
+#: app/components/chart-published.tsx:198
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Careful, the data for this chart has expired.<0/><1>Don't use for reporting!</1>"
 
@@ -865,7 +865,7 @@ msgstr "There was a problem with loading the coordinates from geographical dimen
 msgid "hint.coordinatesloadingerror.title"
 msgstr "Coordinates loading error"
 
-#: app/pages/v/[chartId].tsx:128
+#: app/pages/v/[chartId].tsx:117
 msgid "hint.create.your.own.chart"
 msgstr "Copy this visualization or make a new visualization using Swiss Open Government Data."
 
@@ -881,11 +881,11 @@ msgstr "Check the status page for more information"
 msgid "hint.dataloadingerror.title"
 msgstr "Data loading error"
 
-#: app/pages/v/[chartId].tsx:122
+#: app/pages/v/[chartId].tsx:111
 msgid "hint.how.to.share"
 msgstr "You can share this visualization by copying the URL or by embedding it on your own website. You can also create a new visualization from scratch or start by copying the visualization above."
 
-#: app/components/form.tsx:282
+#: app/components/form.tsx:285
 #: app/components/hint.tsx:111
 msgid "hint.loading.data"
 msgstr "Loading data..."
@@ -927,55 +927,79 @@ msgstr "Show Filters"
 msgid "logo.swiss.confederation"
 msgstr "Logo of the Swiss Confederation"
 
-#: app/components/chart-footnotes.tsx:223
+#: app/components/chart-footnotes.tsx:254
 msgid "metadata.link.created.with.visualize"
 msgstr "Created with visualize.admin.ch"
 
-#: app/components/chart-footnotes.tsx:149
+#: app/components/chart-footnotes.tsx:168
 msgid "metadata.source"
 msgstr "Source"
 
-#: app/components/chart-footnotes.tsx:187
+#: app/components/chart-footnotes.tsx:211
 msgid "metadata.switch.chart"
 msgstr "Switch to chart view"
 
-#: app/components/chart-footnotes.tsx:189
+#: app/components/chart-footnotes.tsx:215
 msgid "metadata.switch.table"
 msgstr "Switch to table view"
 
-#: app/components/publish-actions.tsx:218
+#: app/components/publish-actions.tsx:319
 msgid "publication.embed.AEM"
-msgstr "Embed Code for AEM \"External Application\":"
+msgstr "Embed Code for AEM \"External Application\""
 
-#: app/components/publish-actions.tsx:211
+#: app/components/publish-actions.tsx:324
+msgid "publication.embed.AEM.caption"
+msgstr "Use this link to insert this visualization into Adobe Experience Manager assets."
+
+#: app/components/publish-actions.tsx:304
 msgid "publication.embed.iframe"
-msgstr "Embed Code:"
+msgstr "Embed Code"
 
-#: app/components/publish-actions.tsx:111
+#: app/components/publish-actions.tsx:307
+msgid "publication.embed.iframe.caption"
+msgstr "Use this link to insert this visualization into other webpages."
+
+#: app/components/publish-actions.tsx:286
+msgid "publication.embed.style.minimal"
+msgstr "Minimal"
+
+#: app/components/publish-actions.tsx:291
+msgid "publication.embed.style.minimal.caption"
+msgstr "Only the chart and a link for more information."
+
+#: app/components/publish-actions.tsx:266
+msgid "publication.embed.style.standard"
+msgstr "Standard"
+
+#: app/components/publish-actions.tsx:271
+msgid "publication.embed.style.standard.caption"
+msgstr "Chart, download the data links, attribution etc..."
+
+#: app/components/publish-actions.tsx:117
 msgid "publication.popup.share"
 msgstr "Share"
 
-#: app/components/publish-actions.tsx:159
+#: app/components/publish-actions.tsx:165
 msgid "publication.share.chart.url"
 msgstr "Chart URL:"
 
-#: app/components/publish-actions.tsx:117
+#: app/components/publish-actions.tsx:123
 msgid "publication.share.linktitle.facebook"
 msgstr "Share on Facebook"
 
-#: app/components/publish-actions.tsx:137
+#: app/components/publish-actions.tsx:143
 msgid "publication.share.linktitle.mail"
 msgstr "Share via Email"
 
-#: app/components/publish-actions.tsx:127
+#: app/components/publish-actions.tsx:133
 msgid "publication.share.linktitle.twitter"
 msgstr "Share on Twitter"
 
-#: app/components/publish-actions.tsx:148
+#: app/components/publish-actions.tsx:154
 msgid "publication.share.mail.body"
 msgstr "Here is a visualization I created using visualize.admin.ch"
 
-#: app/components/publish-actions.tsx:143
+#: app/components/publish-actions.tsx:149
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
@@ -992,8 +1016,8 @@ msgstr "Jump to..."
 msgid "table.column.no"
 msgstr "Column {0}"
 
-#: app/components/chart-footnotes.tsx:119
-#: app/components/chart-footnotes.tsx:140
-#: app/components/chart-footnotes.tsx:151
+#: app/components/chart-footnotes.tsx:136
+#: app/components/chart-footnotes.tsx:158
+#: app/components/chart-footnotes.tsx:170
 msgid "typography.colon"
 msgstr ": "

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -949,7 +949,7 @@ msgstr "Embed Code for AEM \"External Application\""
 
 #: app/components/publish-actions.tsx:324
 msgid "publication.embed.AEM.caption"
-msgstr "Use this link to insert this visualization into Adobe Experience Manager assets."
+msgstr "Use this link to embed the chart into Adobe Experience Manager assets."
 
 #: app/components/publish-actions.tsx:304
 msgid "publication.embed.iframe"
@@ -957,7 +957,7 @@ msgstr "Embed Code"
 
 #: app/components/publish-actions.tsx:307
 msgid "publication.embed.iframe.caption"
-msgstr "Use this link to insert this visualization into other webpages."
+msgstr "Use this link to embed the chart into other webpages."
 
 #: app/components/publish-actions.tsx:286
 msgid "publication.embed.style.minimal"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -13,19 +13,19 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:709
+#: app/configurator/components/chart-configurator.tsx:701
 msgid "Add filter"
 msgstr "Ajouter un filtre"
 
-#: app/configurator/components/chart-configurator.tsx:682
+#: app/configurator/components/chart-configurator.tsx:674
 msgid "Drag filters to reorganize"
 msgstr "Faites glisser les filtres pour les réorganiser"
 
-#: app/configurator/components/chart-configurator.tsx:679
+#: app/configurator/components/chart-configurator.tsx:671
 msgid "Move filter down"
 msgstr "Déplacer le filtre vers le bas"
 
-#: app/configurator/components/chart-configurator.tsx:676
+#: app/configurator/components/chart-configurator.tsx:668
 msgid "Move filter up"
 msgstr "Déplacer le filtre vers le haut"
 
@@ -66,7 +66,7 @@ msgstr "Explorez les jeux de données liés fournis par LINDAS, en filtrant par 
 msgid "button.back"
 msgstr "Précédent"
 
-#: app/pages/v/[chartId].tsx:166
+#: app/pages/v/[chartId].tsx:154
 msgid "button.copy.visualization"
 msgstr "Copier et éditer cette visualisation"
 
@@ -90,20 +90,20 @@ msgstr "Jeu de données filtrées"
 msgid "button.download.runsparqlquery.visible"
 msgstr "Lancer la requête SPARQL"
 
-#: app/components/publish-actions.tsx:206
+#: app/components/publish-actions.tsx:240
 msgid "button.embed"
 msgstr "Intégrer"
 
-#: app/components/publish-actions.tsx:281
-#: app/components/publish-actions.tsx:287
+#: app/components/publish-actions.tsx:390
+#: app/components/publish-actions.tsx:396
 msgid "button.hint.click.to.copy"
 msgstr "Cliquer pour copier"
 
-#: app/components/publish-actions.tsx:311
+#: app/components/publish-actions.tsx:420
 msgid "button.hint.copied"
 msgstr "Copié!"
 
-#: app/pages/v/[chartId].tsx:151
+#: app/pages/v/[chartId].tsx:139
 msgid "button.new.visualization"
 msgstr "Créer une nouvelle visualisation"
 
@@ -111,7 +111,7 @@ msgstr "Créer une nouvelle visualisation"
 msgid "button.publish"
 msgstr "Publier cette visualisation"
 
-#: app/components/publish-actions.tsx:96
+#: app/components/publish-actions.tsx:102
 msgid "button.share"
 msgstr "Partager"
 
@@ -119,7 +119,7 @@ msgstr "Partager"
 msgid "chart.map.layers.area"
 msgstr "Zones"
 
-#: app/configurator/components/chart-configurator.tsx:762
+#: app/configurator/components/chart-configurator.tsx:754
 #: app/configurator/components/chart-options-selector.tsx:1055
 #: app/configurator/components/field-i18n.ts:31
 msgid "chart.map.layers.base"
@@ -307,8 +307,8 @@ msgstr "Description"
 #: app/charts/shared/chart-data-filters.tsx:249
 #: app/charts/shared/chart-data-filters.tsx:296
 #: app/configurator/components/field.tsx:167
-#: app/configurator/components/field.tsx:264
-#: app/configurator/components/field.tsx:364
+#: app/configurator/components/field.tsx:267
+#: app/configurator/components/field.tsx:367
 msgid "controls.dimensionvalue.none"
 msgstr "Aucune filtre"
 
@@ -324,12 +324,12 @@ msgstr "Tout sélectionner"
 msgid "controls.filter.select.none"
 msgstr "Tout déselectionner"
 
-#: app/configurator/components/chart-configurator.tsx:512
+#: app/configurator/components/chart-configurator.tsx:513
 #: app/configurator/components/filters.tsx:366
 msgid "controls.filters.interactive.toggle"
 msgstr "Interactif"
 
-#: app/configurator/components/chart-configurator.tsx:505
+#: app/configurator/components/chart-configurator.tsx:506
 #: app/configurator/components/filters.tsx:360
 msgid "controls.filters.interactive.tooltip"
 msgstr "Permettre aux utilisateurs de changer le filtre"
@@ -432,8 +432,8 @@ msgstr "Retour aux paramètres généraux"
 msgid "controls.nav.back-to-preview"
 msgstr "Retour à l'aperçu"
 
-#: app/configurator/components/field.tsx:703
-#: app/configurator/components/field.tsx:875
+#: app/configurator/components/field.tsx:706
+#: app/configurator/components/field.tsx:878
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:244
 msgid "controls.none"
 msgstr "Aucun"
@@ -450,7 +450,7 @@ msgstr "Inactif"
 msgid "controls.scale.type"
 msgstr "Type d'échelle"
 
-#: app/components/form.tsx:611
+#: app/components/form.tsx:614
 msgid "controls.search.clear"
 msgstr "Effacer la recherche"
 
@@ -458,7 +458,7 @@ msgstr "Effacer la recherche"
 msgid "controls.section.additional-information"
 msgstr "Informations supplémentaires"
 
-#: app/configurator/components/chart-configurator.tsx:595
+#: app/configurator/components/chart-configurator.tsx:587
 msgid "controls.section.chart.options"
 msgstr "Paramètres graphiques"
 
@@ -470,11 +470,11 @@ msgstr "Colonnes"
 msgid "controls.section.columnstyle"
 msgstr "Style de la colonne"
 
-#: app/configurator/components/chart-configurator.tsx:613
+#: app/configurator/components/chart-configurator.tsx:605
 msgid "controls.section.data.filters"
 msgstr "Filtres"
 
-#: app/configurator/components/chart-configurator.tsx:629
+#: app/configurator/components/chart-configurator.tsx:621
 msgid "controls.section.data.filters.possible-filters-error"
 msgstr "Une erreur s'est produite lors de la récupération des filtres possibles. Merci de réessayer plus tard ou d'actualiser la page."
 
@@ -532,7 +532,7 @@ msgstr "Options du tableau"
 msgid "controls.section.title.warning"
 msgstr "Ajoutez un titre et une description"
 
-#: app/configurator/components/chart-configurator.tsx:587
+#: app/configurator/components/chart-configurator.tsx:579
 #: app/configurator/components/chart-type-selector.tsx:131
 #: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
@@ -586,10 +586,10 @@ msgid "controls.select.measure"
 msgstr "Sélectionner une variable"
 
 #: app/configurator/components/field.tsx:172
-#: app/configurator/components/field.tsx:269
-#: app/configurator/components/field.tsx:369
-#: app/configurator/components/field.tsx:708
-#: app/configurator/components/field.tsx:880
+#: app/configurator/components/field.tsx:272
+#: app/configurator/components/field.tsx:372
+#: app/configurator/components/field.tsx:711
+#: app/configurator/components/field.tsx:883
 msgid "controls.select.optional"
 msgstr ""
 
@@ -726,7 +726,7 @@ msgstr "IRI du cube"
 msgid "data.source"
 msgstr "Source des données"
 
-#: app/components/chart-published.tsx:196
+#: app/components/chart-published.tsx:209
 msgid "data.source.notTrusted"
 msgstr "Ce graphique n'utilise pas une source de données fiable."
 
@@ -738,15 +738,15 @@ msgstr "Revenir aux jeux de données"
 msgid "dataset-preview.keywords"
 msgstr "Mots clés"
 
-#: app/components/chart-footnotes.tsx:117
+#: app/components/chart-footnotes.tsx:134
 msgid "dataset.footnotes.dataset"
 msgstr "Jeu de données"
 
-#: app/components/chart-footnotes.tsx:138
+#: app/components/chart-footnotes.tsx:156
 msgid "dataset.footnotes.updated"
 msgstr "Mise à jour"
 
-#: app/components/chart-published.tsx:205
+#: app/components/chart-published.tsx:218
 msgid "dataset.hasImputedValues"
 msgstr "Certaines données de cet ensemble de données sont manquantes et ont été interpolées pour combler les lacunes."
 
@@ -766,7 +766,7 @@ msgstr "Points de contact"
 msgid "dataset.metadata.furtherinformation"
 msgstr "Informations complémentaires"
 
-#: app/components/chart-footnotes.tsx:204
+#: app/components/chart-footnotes.tsx:234
 #: app/configurator/components/dataset-metadata.tsx:107
 msgid "dataset.metadata.learnmore"
 msgstr "En savoir plus sur le jeu de données"
@@ -792,12 +792,12 @@ msgid "dataset.order.title"
 msgstr "Titre"
 
 #: app/components/chart-preview.tsx:115
-#: app/components/chart-published.tsx:174
+#: app/components/chart-published.tsx:187
 #: app/configurator/components/dataset-preview.tsx:120
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Attention, ce jeu de données est à l'état d'ébauche.<0/><1>Ne l'utilisez pas pour une publication!</1>"
 
-#: app/components/chart-published.tsx:185
+#: app/components/chart-published.tsx:198
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Attention, ce jeu de données est expiré.<0/><1>Ne l'utilisez pas pour une publication!</1>"
 
@@ -865,7 +865,7 @@ msgstr "Les données géographiques n’ont pas pu être chargées, merci de ré
 msgid "hint.coordinatesloadingerror.title"
 msgstr "Erreur de chargement des coordonnées"
 
-#: app/pages/v/[chartId].tsx:128
+#: app/pages/v/[chartId].tsx:117
 msgid "hint.create.your.own.chart"
 msgstr "Copiez cette visualisation ou créez une nouvelle visualisation à partir des données ouvertes de l’administration publique suisse."
 
@@ -881,11 +881,11 @@ msgstr "Consultez la page de statut pour plus d'informations"
 msgid "hint.dataloadingerror.title"
 msgstr "Problème de téléchargement des données"
 
-#: app/pages/v/[chartId].tsx:122
+#: app/pages/v/[chartId].tsx:111
 msgid "hint.how.to.share"
 msgstr "Vous pouvez partager cette visualisation en copiant l'URL ou en l'intégrant sur votre site Web. Vous pouvez également créer une toute nouvelle visualisation, ou bien copier et modifier la visualisation ci-dessus."
 
-#: app/components/form.tsx:282
+#: app/components/form.tsx:285
 #: app/components/hint.tsx:111
 msgid "hint.loading.data"
 msgstr "Chargement des données..."
@@ -927,55 +927,79 @@ msgstr "Afficher les filtres"
 msgid "logo.swiss.confederation"
 msgstr "Logo de la Confédération Suisse"
 
-#: app/components/chart-footnotes.tsx:223
+#: app/components/chart-footnotes.tsx:254
 msgid "metadata.link.created.with.visualize"
 msgstr "Créé avec visualize.admin.ch"
 
-#: app/components/chart-footnotes.tsx:149
+#: app/components/chart-footnotes.tsx:168
 msgid "metadata.source"
 msgstr "Source"
 
-#: app/components/chart-footnotes.tsx:187
+#: app/components/chart-footnotes.tsx:211
 msgid "metadata.switch.chart"
 msgstr "Passer à la vue graphique"
 
-#: app/components/chart-footnotes.tsx:189
+#: app/components/chart-footnotes.tsx:215
 msgid "metadata.switch.table"
 msgstr "Passer à la vue en tableau"
 
-#: app/components/publish-actions.tsx:218
+#: app/components/publish-actions.tsx:319
 msgid "publication.embed.AEM"
-msgstr "Code pour intégrer sur AEM comme \"External Application\":"
+msgstr "Code pour intégrer sur AEM comme \"External Application\""
 
-#: app/components/publish-actions.tsx:211
+#: app/components/publish-actions.tsx:324
+msgid "publication.embed.AEM.caption"
+msgstr ""
+
+#: app/components/publish-actions.tsx:304
 msgid "publication.embed.iframe"
-msgstr "Code pour intégrer:"
+msgstr "Code pour intégrer"
 
-#: app/components/publish-actions.tsx:111
+#: app/components/publish-actions.tsx:307
+msgid "publication.embed.iframe.caption"
+msgstr ""
+
+#: app/components/publish-actions.tsx:286
+msgid "publication.embed.style.minimal"
+msgstr ""
+
+#: app/components/publish-actions.tsx:291
+msgid "publication.embed.style.minimal.caption"
+msgstr ""
+
+#: app/components/publish-actions.tsx:266
+msgid "publication.embed.style.standard"
+msgstr ""
+
+#: app/components/publish-actions.tsx:271
+msgid "publication.embed.style.standard.caption"
+msgstr ""
+
+#: app/components/publish-actions.tsx:117
 msgid "publication.popup.share"
 msgstr "Partager"
 
-#: app/components/publish-actions.tsx:159
+#: app/components/publish-actions.tsx:165
 msgid "publication.share.chart.url"
 msgstr "URL du graphique:"
 
-#: app/components/publish-actions.tsx:117
+#: app/components/publish-actions.tsx:123
 msgid "publication.share.linktitle.facebook"
 msgstr "Partager sur Facebook"
 
-#: app/components/publish-actions.tsx:137
+#: app/components/publish-actions.tsx:143
 msgid "publication.share.linktitle.mail"
 msgstr "Partager par courriel"
 
-#: app/components/publish-actions.tsx:127
+#: app/components/publish-actions.tsx:133
 msgid "publication.share.linktitle.twitter"
 msgstr "Partager sur Twitter"
 
-#: app/components/publish-actions.tsx:148
+#: app/components/publish-actions.tsx:154
 msgid "publication.share.mail.body"
 msgstr "Voici une visualisation que j'ai créée sur visualize.admin.ch"
 
-#: app/components/publish-actions.tsx:143
+#: app/components/publish-actions.tsx:149
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
@@ -992,8 +1016,8 @@ msgstr "Sauter à..."
 msgid "table.column.no"
 msgstr "Colonne {0}"
 
-#: app/components/chart-footnotes.tsx:119
-#: app/components/chart-footnotes.tsx:140
-#: app/components/chart-footnotes.tsx:151
+#: app/components/chart-footnotes.tsx:136
+#: app/components/chart-footnotes.tsx:158
+#: app/components/chart-footnotes.tsx:170
 msgid "typography.colon"
 msgstr " : "

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -949,7 +949,7 @@ msgstr "Code pour intégrer sur AEM comme \"External Application\""
 
 #: app/components/publish-actions.tsx:324
 msgid "publication.embed.AEM.caption"
-msgstr ""
+msgstr "Utilisez ce code pour intégrer le graphique sur Adobe Experience Manager"
 
 #: app/components/publish-actions.tsx:304
 msgid "publication.embed.iframe"
@@ -957,11 +957,11 @@ msgstr "Code pour intégrer"
 
 #: app/components/publish-actions.tsx:307
 msgid "publication.embed.iframe.caption"
-msgstr ""
+msgstr "Utilisez ce code pour intégrer le graphique sur une page web"
 
 #: app/components/publish-actions.tsx:286
 msgid "publication.embed.style.minimal"
-msgstr ""
+msgstr "Minimal"
 
 #: app/components/publish-actions.tsx:291
 msgid "publication.embed.style.minimal.caption"
@@ -969,7 +969,7 @@ msgstr ""
 
 #: app/components/publish-actions.tsx:266
 msgid "publication.embed.style.standard"
-msgstr ""
+msgstr "Standard"
 
 #: app/components/publish-actions.tsx:271
 msgid "publication.embed.style.standard.caption"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -13,19 +13,19 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: app/configurator/components/chart-configurator.tsx:709
+#: app/configurator/components/chart-configurator.tsx:701
 msgid "Add filter"
 msgstr "Aggiungi filtro"
 
-#: app/configurator/components/chart-configurator.tsx:682
+#: app/configurator/components/chart-configurator.tsx:674
 msgid "Drag filters to reorganize"
 msgstr "Trascina i filtri per riorganizzarli"
 
-#: app/configurator/components/chart-configurator.tsx:679
+#: app/configurator/components/chart-configurator.tsx:671
 msgid "Move filter down"
 msgstr "Sposta il filtro in basso"
 
-#: app/configurator/components/chart-configurator.tsx:676
+#: app/configurator/components/chart-configurator.tsx:668
 msgid "Move filter up"
 msgstr "Sposta il filtro in alto"
 
@@ -66,7 +66,7 @@ msgstr "Esplora i set di dati forniti dal LINDAS Linked Data Service filtrando p
 msgid "button.back"
 msgstr "Torna indietro"
 
-#: app/pages/v/[chartId].tsx:166
+#: app/pages/v/[chartId].tsx:154
 msgid "button.copy.visualization"
 msgstr "Copia e modifica questa visualizzazione"
 
@@ -90,20 +90,20 @@ msgstr "Set di dati filtrati"
 msgid "button.download.runsparqlquery.visible"
 msgstr "Esegui query SPARQL"
 
-#: app/components/publish-actions.tsx:206
+#: app/components/publish-actions.tsx:240
 msgid "button.embed"
 msgstr "Incorpora"
 
-#: app/components/publish-actions.tsx:281
-#: app/components/publish-actions.tsx:287
+#: app/components/publish-actions.tsx:390
+#: app/components/publish-actions.tsx:396
 msgid "button.hint.click.to.copy"
 msgstr "Clicca per copiare"
 
-#: app/components/publish-actions.tsx:311
+#: app/components/publish-actions.tsx:420
 msgid "button.hint.copied"
 msgstr "Copiato!"
 
-#: app/pages/v/[chartId].tsx:151
+#: app/pages/v/[chartId].tsx:139
 msgid "button.new.visualization"
 msgstr "Crea una nuova visualizzazione"
 
@@ -111,7 +111,7 @@ msgstr "Crea una nuova visualizzazione"
 msgid "button.publish"
 msgstr "Pubblica questa visualizzazione"
 
-#: app/components/publish-actions.tsx:96
+#: app/components/publish-actions.tsx:102
 msgid "button.share"
 msgstr "Condividi"
 
@@ -119,7 +119,7 @@ msgstr "Condividi"
 msgid "chart.map.layers.area"
 msgstr "Aree"
 
-#: app/configurator/components/chart-configurator.tsx:762
+#: app/configurator/components/chart-configurator.tsx:754
 #: app/configurator/components/chart-options-selector.tsx:1055
 #: app/configurator/components/field-i18n.ts:31
 msgid "chart.map.layers.base"
@@ -307,8 +307,8 @@ msgstr "Descrizione"
 #: app/charts/shared/chart-data-filters.tsx:249
 #: app/charts/shared/chart-data-filters.tsx:296
 #: app/configurator/components/field.tsx:167
-#: app/configurator/components/field.tsx:264
-#: app/configurator/components/field.tsx:364
+#: app/configurator/components/field.tsx:267
+#: app/configurator/components/field.tsx:367
 msgid "controls.dimensionvalue.none"
 msgstr "Nessun filtro"
 
@@ -324,12 +324,12 @@ msgstr "Seleziona tutti"
 msgid "controls.filter.select.none"
 msgstr "Deseleziona tutto"
 
-#: app/configurator/components/chart-configurator.tsx:512
+#: app/configurator/components/chart-configurator.tsx:513
 #: app/configurator/components/filters.tsx:366
 msgid "controls.filters.interactive.toggle"
 msgstr "Interattivo"
 
-#: app/configurator/components/chart-configurator.tsx:505
+#: app/configurator/components/chart-configurator.tsx:506
 #: app/configurator/components/filters.tsx:360
 msgid "controls.filters.interactive.tooltip"
 msgstr "Consenti agli utenti di modificare il filtro"
@@ -432,8 +432,8 @@ msgstr "Torna alle impostazioni generali"
 msgid "controls.nav.back-to-preview"
 msgstr "Torna all'anteprima"
 
-#: app/configurator/components/field.tsx:703
-#: app/configurator/components/field.tsx:875
+#: app/configurator/components/field.tsx:706
+#: app/configurator/components/field.tsx:878
 #: app/configurator/interactive-filters/interactive-filters-config-options.tsx:244
 msgid "controls.none"
 msgstr "Nessuno"
@@ -450,7 +450,7 @@ msgstr "Inattivo"
 msgid "controls.scale.type"
 msgstr "Tipo di scala"
 
-#: app/components/form.tsx:611
+#: app/components/form.tsx:614
 msgid "controls.search.clear"
 msgstr "Cancella la ricerca"
 
@@ -458,7 +458,7 @@ msgstr "Cancella la ricerca"
 msgid "controls.section.additional-information"
 msgstr "Informazioni aggiuntive"
 
-#: app/configurator/components/chart-configurator.tsx:595
+#: app/configurator/components/chart-configurator.tsx:587
 msgid "controls.section.chart.options"
 msgstr "Opzioni del grafico"
 
@@ -470,11 +470,11 @@ msgstr "Colonne"
 msgid "controls.section.columnstyle"
 msgstr "Stile della colonna"
 
-#: app/configurator/components/chart-configurator.tsx:613
+#: app/configurator/components/chart-configurator.tsx:605
 msgid "controls.section.data.filters"
 msgstr "Filtri"
 
-#: app/configurator/components/chart-configurator.tsx:629
+#: app/configurator/components/chart-configurator.tsx:621
 msgid "controls.section.data.filters.possible-filters-error"
 msgstr "Si è verificato un errore durante il recupero dei possibili filtri. Riprova più tardi o aggiorna la pagina."
 
@@ -532,7 +532,7 @@ msgstr "Opzioni della tabella"
 msgid "controls.section.title.warning"
 msgstr "Aggiungi un titolo o una descrizione"
 
-#: app/configurator/components/chart-configurator.tsx:587
+#: app/configurator/components/chart-configurator.tsx:579
 #: app/configurator/components/chart-type-selector.tsx:131
 #: app/configurator/table/table-chart-configurator.tsx:123
 msgid "controls.select.chart.type"
@@ -586,10 +586,10 @@ msgid "controls.select.measure"
 msgstr "Seleziona una misura"
 
 #: app/configurator/components/field.tsx:172
-#: app/configurator/components/field.tsx:269
-#: app/configurator/components/field.tsx:369
-#: app/configurator/components/field.tsx:708
-#: app/configurator/components/field.tsx:880
+#: app/configurator/components/field.tsx:272
+#: app/configurator/components/field.tsx:372
+#: app/configurator/components/field.tsx:711
+#: app/configurator/components/field.tsx:883
 msgid "controls.select.optional"
 msgstr ""
 
@@ -726,7 +726,7 @@ msgstr "Cubo IRI"
 msgid "data.source"
 msgstr "Fonte di dati"
 
-#: app/components/chart-published.tsx:196
+#: app/components/chart-published.tsx:209
 msgid "data.source.notTrusted"
 msgstr "Questo grafico non utilizza una fonte di dati affidabile."
 
@@ -738,15 +738,15 @@ msgstr "Torna ai set di dati"
 msgid "dataset-preview.keywords"
 msgstr "Parole chiave"
 
-#: app/components/chart-footnotes.tsx:117
+#: app/components/chart-footnotes.tsx:134
 msgid "dataset.footnotes.dataset"
 msgstr "Set di dati"
 
-#: app/components/chart-footnotes.tsx:138
+#: app/components/chart-footnotes.tsx:156
 msgid "dataset.footnotes.updated"
 msgstr "Ultimo aggiornamento"
 
-#: app/components/chart-published.tsx:205
+#: app/components/chart-published.tsx:218
 msgid "dataset.hasImputedValues"
 msgstr "In questo set di dati mancano alcuni dati. Questi sono stati interpolati per colmare le lacune.."
 
@@ -766,7 +766,7 @@ msgstr "Punti di contatto"
 msgid "dataset.metadata.furtherinformation"
 msgstr "Addizionali informazioni"
 
-#: app/components/chart-footnotes.tsx:204
+#: app/components/chart-footnotes.tsx:234
 #: app/configurator/components/dataset-metadata.tsx:107
 msgid "dataset.metadata.learnmore"
 msgstr "Ulteriori informazioni sul set di dati"
@@ -792,12 +792,12 @@ msgid "dataset.order.title"
 msgstr "Titolo"
 
 #: app/components/chart-preview.tsx:115
-#: app/components/chart-published.tsx:174
+#: app/components/chart-published.tsx:187
 #: app/configurator/components/dataset-preview.tsx:120
 msgid "dataset.publicationStatus.draft.warning"
 msgstr "Attenzione, questo set di dati è una bozza.<0/><1>Non utilizzare questo grafico per un rapporto!</1>"
 
-#: app/components/chart-published.tsx:185
+#: app/components/chart-published.tsx:198
 msgid "dataset.publicationStatus.expires.warning"
 msgstr "Attenzione, questo set di dati è scaduto.<0/><1>Non utilizzare questo grafico per un rapporto!</1>"
 
@@ -865,7 +865,7 @@ msgstr "C'è stato un problema con il caricamento delle coordinate dalle dimensi
 msgid "hint.coordinatesloadingerror.title"
 msgstr "Errore di caricamento delle coordinate"
 
-#: app/pages/v/[chartId].tsx:128
+#: app/pages/v/[chartId].tsx:117
 msgid "hint.create.your.own.chart"
 msgstr "Copia questa visualizzazione o crea una nuova visualizzazione usando «dati aperti» dell’amministrazione pubblica svizzera"
 
@@ -881,11 +881,11 @@ msgstr "Controlla la pagina di stato per ulteriori informazioni”"
 msgid "hint.dataloadingerror.title"
 msgstr "Problema di caricamento dei dati"
 
-#: app/pages/v/[chartId].tsx:122
+#: app/pages/v/[chartId].tsx:111
 msgid "hint.how.to.share"
 msgstr "È possibile condividere questa visualizzazione copiando l'URL o incorporandola nel vostro sito Web. Puoi anche creare una nuova visualizzazione partendo da zero oppure copiando e modificando la visualizzazione sopra."
 
-#: app/components/form.tsx:282
+#: app/components/form.tsx:285
 #: app/components/hint.tsx:111
 msgid "hint.loading.data"
 msgstr "Caricamento dei dati..."
@@ -927,55 +927,79 @@ msgstr "Mostra i filtri"
 msgid "logo.swiss.confederation"
 msgstr "Logo della Confederazione svizzera"
 
-#: app/components/chart-footnotes.tsx:223
+#: app/components/chart-footnotes.tsx:254
 msgid "metadata.link.created.with.visualize"
 msgstr "Creato con visualize.admin.ch"
 
-#: app/components/chart-footnotes.tsx:149
+#: app/components/chart-footnotes.tsx:168
 msgid "metadata.source"
 msgstr "Fonte"
 
-#: app/components/chart-footnotes.tsx:187
+#: app/components/chart-footnotes.tsx:211
 msgid "metadata.switch.chart"
 msgstr "Passare alla visualizzazione del grafico"
 
-#: app/components/chart-footnotes.tsx:189
+#: app/components/chart-footnotes.tsx:215
 msgid "metadata.switch.table"
 msgstr "Passare alla vista tabella"
 
-#: app/components/publish-actions.tsx:218
+#: app/components/publish-actions.tsx:319
 msgid "publication.embed.AEM"
-msgstr "Codice da incorporare su AEM come \"External Application\":"
+msgstr "Codice da incorporare su AEM come \"External Application\""
 
-#: app/components/publish-actions.tsx:211
+#: app/components/publish-actions.tsx:324
+msgid "publication.embed.AEM.caption"
+msgstr ""
+
+#: app/components/publish-actions.tsx:304
 msgid "publication.embed.iframe"
-msgstr "Codice di incorporamento:"
+msgstr "Codice di incorporamento"
 
-#: app/components/publish-actions.tsx:111
+#: app/components/publish-actions.tsx:307
+msgid "publication.embed.iframe.caption"
+msgstr ""
+
+#: app/components/publish-actions.tsx:286
+msgid "publication.embed.style.minimal"
+msgstr ""
+
+#: app/components/publish-actions.tsx:291
+msgid "publication.embed.style.minimal.caption"
+msgstr ""
+
+#: app/components/publish-actions.tsx:266
+msgid "publication.embed.style.standard"
+msgstr ""
+
+#: app/components/publish-actions.tsx:271
+msgid "publication.embed.style.standard.caption"
+msgstr ""
+
+#: app/components/publish-actions.tsx:117
 msgid "publication.popup.share"
 msgstr "Condividi"
 
-#: app/components/publish-actions.tsx:159
+#: app/components/publish-actions.tsx:165
 msgid "publication.share.chart.url"
 msgstr "URL del grafico:"
 
-#: app/components/publish-actions.tsx:117
+#: app/components/publish-actions.tsx:123
 msgid "publication.share.linktitle.facebook"
 msgstr "Condividi su Facebook"
 
-#: app/components/publish-actions.tsx:137
+#: app/components/publish-actions.tsx:143
 msgid "publication.share.linktitle.mail"
 msgstr "Condividi via Email"
 
-#: app/components/publish-actions.tsx:127
+#: app/components/publish-actions.tsx:133
 msgid "publication.share.linktitle.twitter"
 msgstr "Condividi su Twitter"
 
-#: app/components/publish-actions.tsx:148
+#: app/components/publish-actions.tsx:154
 msgid "publication.share.mail.body"
 msgstr "Ecco una visualizzazione che ho creato usando visualize.admin.ch"
 
-#: app/components/publish-actions.tsx:143
+#: app/components/publish-actions.tsx:149
 msgid "publication.share.mail.subject"
 msgstr "visualize.admin.ch"
 
@@ -992,8 +1016,8 @@ msgstr "Salta a..."
 msgid "table.column.no"
 msgstr "Colonna {0}"
 
-#: app/components/chart-footnotes.tsx:119
-#: app/components/chart-footnotes.tsx:140
-#: app/components/chart-footnotes.tsx:151
+#: app/components/chart-footnotes.tsx:136
+#: app/components/chart-footnotes.tsx:158
+#: app/components/chart-footnotes.tsx:170
 msgid "typography.colon"
 msgstr ": "

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -949,7 +949,7 @@ msgstr "Codice da incorporare su AEM come \"External Application\""
 
 #: app/components/publish-actions.tsx:324
 msgid "publication.embed.AEM.caption"
-msgstr ""
+msgstr "Utilisez ce code pour intégrer le graphique sur une application Adobe Experience Manager"
 
 #: app/components/publish-actions.tsx:304
 msgid "publication.embed.iframe"
@@ -957,11 +957,11 @@ msgstr "Codice di incorporamento"
 
 #: app/components/publish-actions.tsx:307
 msgid "publication.embed.iframe.caption"
-msgstr ""
+msgstr "Usa questo codice per incorporare il grafico in una pagina web"
 
 #: app/components/publish-actions.tsx:286
 msgid "publication.embed.style.minimal"
-msgstr ""
+msgstr "Minimal"
 
 #: app/components/publish-actions.tsx:291
 msgid "publication.embed.style.minimal.caption"
@@ -969,7 +969,7 @@ msgstr ""
 
 #: app/components/publish-actions.tsx:266
 msgid "publication.embed.style.standard"
-msgstr ""
+msgstr "Standard"
 
 #: app/components/publish-actions.tsx:271
 msgid "publication.embed.style.standard.caption"

--- a/app/pages/v/[chartId].tsx
+++ b/app/pages/v/[chartId].tsx
@@ -88,13 +88,76 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
           width="100%"
           overflow="hidden"
         >
-          <Box sx={{ pt: 4, maxWidth: "50rem", margin: "auto" }}>
+          <Box sx={{ py: 4, maxWidth: "70rem", margin: "auto" }}>
             {publishSuccess && (
               <Box mt={2} mb={5}>
                 <Success />
               </Box>
             )}
 
+            <Box sx={{ mr: 5, float: "left", width: "20rem" }}>
+              <PublishActions configKey={key} />
+              <Typography
+                component="div"
+                variant="body1"
+                mt={3}
+                mb={4}
+                sx={{
+                  color: "grey.800",
+                  fontWeight: "regular",
+                }}
+              >
+                {publishSuccess ? (
+                  <Trans id="hint.how.to.share">
+                    You can share this chart either by sharing its URL or by
+                    embedding it on your website. You can also create a new
+                    visualization or duplicate the above chart.
+                  </Trans>
+                ) : (
+                  <Trans id="hint.create.your.own.chart">
+                    Create your own graphic now! With the visualization tool,
+                    you can create your own graphics, based on a large number of
+                    Swiss federal data.
+                  </Trans>
+                )}
+              </Typography>
+              <Stack
+                alignItems="flex-start"
+                direction={{ xs: "column", sm: "row" }}
+                // We need to use responsive syntax for spacing when using responsive
+                // syntax for direction, otherwise it does not work
+                spacing={{ xs: 2, sm: 2 }}
+                sx={{ mb: 5 }}
+              >
+                <NextLink href="/create/new" passHref>
+                  <Button
+                    component="a"
+                    size="large"
+                    variant="contained"
+                    color="secondary"
+                  >
+                    <Trans id="button.new.visualization">
+                      Create a new visualization
+                    </Trans>
+                  </Button>
+                </NextLink>
+                <NextLink
+                  href={{ pathname: "/create/new", query: { from: key } }}
+                  passHref
+                >
+                  <Button
+                    component="a"
+                    size="large"
+                    variant="contained"
+                    color="secondary"
+                  >
+                    <Trans id="button.copy.visualization">
+                      Copy and edit this visualization
+                    </Trans>
+                  </Button>
+                </NextLink>
+              </Stack>
+            </Box>
             <ChartPanelPublished chartType={chartConfig.chartType}>
               <ChartPublished
                 dataSet={dataSet}
@@ -104,71 +167,6 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
                 configKey={key}
               />
             </ChartPanelPublished>
-
-            <PublishActions configKey={key} sx={{ mt: 5, mb: 5 }} />
-
-            <Typography
-              component="div"
-              variant="h3"
-              mt={3}
-              mb={4}
-              sx={{
-                color: "grey.800",
-                fontSize: "1.125rem",
-                fontWeight: "regular",
-              }}
-            >
-              {publishSuccess ? (
-                <Trans id="hint.how.to.share">
-                  You can share this chart either by sharing its URL or by
-                  embedding it on your website. You can also create a new
-                  visualization or duplicate the above chart.
-                </Trans>
-              ) : (
-                <Trans id="hint.create.your.own.chart">
-                  Create your own graphic now! With the visualization tool, you
-                  can create your own graphics, based on a large number of Swiss
-                  federal data.
-                </Trans>
-              )}
-            </Typography>
-
-            <Stack
-              alignItems="flex-start"
-              direction={{ xs: "column", sm: "row" }}
-              // We need to use responsive syntax for spacing when using responsive
-              // syntax for direction, otherwise it does not work
-              spacing={{ xs: 2, sm: 2 }}
-              sx={{ mb: 5 }}
-            >
-              <NextLink href="/create/new" passHref>
-                <Button
-                  component="a"
-                  size="large"
-                  variant="contained"
-                  color="secondary"
-                >
-                  <Trans id="button.new.visualization">
-                    Create a new visualization
-                  </Trans>
-                </Button>
-              </NextLink>
-              <NextLink
-                href={{ pathname: "/create/new", query: { from: key } }}
-                passHref
-              >
-                <Button
-                  component="a"
-                  size="large"
-                  variant="contained"
-                  color="secondary"
-                >
-                  <Trans id="button.copy.visualization">
-                    Copy and edit this visualization
-                  </Trans>
-                </Button>
-              </NextLink>
-            </Stack>
           </Box>
         </Box>
       </ContentLayout>

--- a/app/utils/embed.tsx
+++ b/app/utils/embed.tsx
@@ -1,0 +1,35 @@
+import { useRouter } from "next/router";
+import { useMemo } from "react";
+
+import useEvent from "@/utils/use-event";
+
+import { EmbedOptions } from "../components/chart-published";
+
+export const useEmbedOptions = () => {
+  const router = useRouter();
+  const embedOptions = useMemo(() => {
+    try {
+      if (typeof router.query.embedOptions === "string") {
+        return JSON.parse(router.query.embedOptions) as EmbedOptions;
+      } else {
+        return {};
+      }
+    } catch (e) {
+      return {};
+    }
+  }, [router.query]);
+  const setEmbedOptions = useEvent((patch: EmbedOptions) => {
+    const newEmbedOptions: EmbedOptions = {
+      ...embedOptions,
+      ...patch,
+    };
+    router.push({
+      pathname: router.pathname,
+      query: {
+        ...router.query,
+        embedOptions: JSON.stringify(newEmbedOptions),
+      },
+    });
+  });
+  return [embedOptions, setEmbedOptions] as const;
+};


### PR DESCRIPTION
I wonder if it could not be helpful to have the publish actions
as part of a side pane instead of below the chart. It would
make share/publish actions more prominent, especially on smaller
screens where right now, the publish actions are below the fold.


| Normal layout | Alternative Layout |
------------|-----------------------
| <img width="933" alt="image" src="https://user-images.githubusercontent.com/465582/215092624-3c1e7fc9-4955-44ba-baa0-ac0936219481.png"> | <img width="500px" alt="image" src="https://user-images.githubusercontent.com/465582/215092293-e6f4fe83-82e3-42fd-a446-5df3f216050a.png"> | 


How to test

Go to https://visualization-tool-nnrpkidag-ixt1.vercel.app/en/v/sO8qHplebSER?dataSource=Prod