### PR TITLE
fix: Search performance and empty results

### DIFF
--- a/app/rdf/query-search.ts
+++ b/app/rdf/query-search.ts
@@ -168,6 +168,10 @@ export const searchCubes = async ({
     ${makeInFilter("theme", themeValues)}
     ${makeInFilter("creator", creatorValues)}
 
+    FILTER(LANG(?name) = LANG(?description))
+    FILTER(LANG(?name) = LANG(?creatorLabel))
+    FILTER(LANG(?name) = LANG(?themeName))
+
       ${
         query
           ? `FILTER(


### PR DESCRIPTION
Fixes on search

- Empty list of IRIs was not taken into account
- Different languages lead to combinatorial explosion and poor performance as the dataset list grew 
Previously the table returned in the results would be like so

`cubeIRI` | `cube` | `theme` | `creator` 
--- | --- | --- | ---
1 | Snowfalls | Snow | WSL
1 | Schneefall | Schnee | WSL
1 | Snowfalls | Schnee | WSL
1 | Schneefall | Snow | WSL

So for a single cube we would have 4  (more generally N_LANGUAGE*N_FIELDS_WITH_LANGUAGE) different rows instead of 2 (one row for each language). The added equality filter ensures each row is in the same language.

Fix https://github.com/visualize-admin/visualization-tool/issues/963
Fix https://github.com/visualize-admin/visualization-tool/issues/959
