### PR TITLE
fix: Do not show spinner in chart page when cube is not found

### DIFF
--- a/app/components/hint.tsx
+++ b/app/components/hint.tsx
@@ -138,7 +138,16 @@ export const NoDataHint = () => (
 );
 
 export const LoadingDataError = ({ message }: { message?: string }) => (
-  <Alert severity="error" icon={<Icon name="hintWarning" size={64} />}>
+  <Alert
+    severity="error"
+    icon={<Icon name="hintWarning" size={64} />}
+    sx={{
+      "& > .MuiAlert-icon": {
+        ml: "2rem",
+        mr: "1.5rem",
+      },
+    }}
+  >
     <AlertTitle>
       <Trans id="hint.dataloadingerror.title">Data loading error</Trans>
     </AlertTitle>

--- a/app/graphql/resolvers/rdf.ts
+++ b/app/graphql/resolvers/rdf.ts
@@ -93,7 +93,7 @@ export const dataCubeByIri: NonNullable<QueryResolvers["dataCubeByIri"]> =
     const cube = await loaders.cube.load(iri);
 
     if (!cube) {
-      return null;
+      throw new Error("Cube not found");
     }
 
     return getResolvedCube({ cube, locale: locale || "de", latest });


### PR DESCRIPTION
Throw error when cube is not found

Fix https://github.com/visualize-admin/visualization-tool/issues/967
