### PR TITLE
Fix: sort values with equally labelled values inside the hierarchy

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 /test-results/
 /playwright-report/
 /playwright/.cache/
+
+**/tsconfig.tsbuildinfo

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -203,6 +203,9 @@ const useAreasState = (
   const segmentSortingType = segmentSorting?.sortingType;
   const segmentSortingOrder = segmentSorting?.sortingOrder;
 
+  const segmentFilter = segmentDimension?.iri
+    ? chartConfig.filters[segmentDimension?.iri]
+    : undefined;
   const segments = useMemo(() => {
     const totalValueBySegment = Object.fromEntries([
       ...rollup(
@@ -215,10 +218,12 @@ const useAreasState = (
     const uniqueSegments = Array.from(
       new Set(plottableSortedData.map((d) => getSegment(d)))
     );
+
     const sorters = makeDimensionValueSorters(segmentDimension, {
       sorting: segmentSorting,
       sumsBySegment: totalValueBySegment,
       useAbbreviations: fields.segment?.useAbbreviations,
+      dimensionFilter: segmentFilter,
     });
 
     return orderBy(
@@ -230,6 +235,7 @@ const useAreasState = (
     plottableSortedData,
     segmentDimension,
     segmentSorting,
+    segmentFilter,
     getY,
     getSegment,
     fields.segment?.useAbbreviations,

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -39,7 +39,7 @@ import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { Observer, useWidth } from "@/charts/shared/use-width";
-import { AreaFields } from "@/configurator";
+import { AreaConfig, AreaFields } from "@/configurator";
 import { isTemporalDimension, Observation } from "@/domain/data";
 import {
   formatNumberWithUnit,
@@ -80,20 +80,13 @@ export interface AreasState extends CommonChartState {
 const useAreasState = (
   chartProps: Pick<
     ChartProps,
-    "data" | "dimensions" | "measures" | "interactiveFiltersConfig"
+    "data" | "dimensions" | "measures" | "chartConfig"
   > & {
-    fields: AreaFields;
     aspectRatio: number;
   }
 ): AreasState => {
-  const {
-    data,
-    fields,
-    dimensions,
-    measures,
-    interactiveFiltersConfig,
-    aspectRatio,
-  } = chartProps;
+  const { data, dimensions, measures, chartConfig, aspectRatio } = chartProps;
+  const { fields, interactiveFiltersConfig } = chartConfig as AreaConfig;
   const width = useWidth();
   const formatNumber = useFormatNumber({ decimals: "auto" });
   const estimateNumberWidth = (d: number) => estimateTextWidth(formatNumber(d));
@@ -418,25 +411,20 @@ const useAreasState = (
 
 const AreaChartProvider = ({
   data,
-  fields,
   measures,
   dimensions,
-  interactiveFiltersConfig,
+  chartConfig,
   aspectRatio,
   children,
-}: Pick<
-  ChartProps,
-  "data" | "fields" | "dimensions" | "measures" | "interactiveFiltersConfig"
-> & {
+}: Pick<ChartProps, "data" | "dimensions" | "measures" | "chartConfig"> & {
   children: ReactNode;
   aspectRatio: number;
-} & { fields: AreaFields }) => {
+}) => {
   const state = useAreasState({
     data,
-    fields,
     dimensions,
     measures,
-    interactiveFiltersConfig,
+    chartConfig,
     aspectRatio,
   });
   return (
@@ -446,16 +434,12 @@ const AreaChartProvider = ({
 
 export const AreaChart = ({
   data,
-  fields,
   measures,
   dimensions,
-  interactiveFiltersConfig,
+  chartConfig,
   aspectRatio,
   children,
-}: Pick<
-  ChartProps,
-  "data" | "fields" | "dimensions" | "measures" | "interactiveFiltersConfig"
-> & {
+}: Pick<ChartProps, "data" | "dimensions" | "measures" | "chartConfig"> & {
   children: ReactNode;
   fields: AreaFields;
   aspectRatio: number;
@@ -465,10 +449,9 @@ export const AreaChart = ({
       <InteractionProvider>
         <AreaChartProvider
           data={data}
-          fields={fields}
           dimensions={dimensions}
           measures={measures}
-          interactiveFiltersConfig={interactiveFiltersConfig}
+          chartConfig={chartConfig}
           aspectRatio={aspectRatio}
         >
           {children}

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -12,9 +12,7 @@ import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import {
   AreaConfig,
-  AreaFields,
   DataSource,
-  InteractiveFiltersConfig,
   QueryFilters,
 } from "@/configurator/config-types";
 import { Observation } from "@/domain/data";
@@ -62,22 +60,21 @@ export const ChartAreas = memo(
     observations,
     dimensions,
     measures,
-    fields,
-    interactiveFiltersConfig,
+    chartConfig,
   }: {
     observations: Observation[];
     dimensions: DimensionMetadataFragment[];
     measures: DimensionMetadataFragment[];
-    fields: AreaFields;
-    interactiveFiltersConfig: InteractiveFiltersConfig;
+    chartConfig: AreaConfig;
   }) => {
+    const { fields, interactiveFiltersConfig } = chartConfig;
     return (
       <AreaChart
         data={observations}
         fields={fields}
         dimensions={dimensions}
         measures={measures}
-        interactiveFiltersConfig={interactiveFiltersConfig}
+        chartConfig={chartConfig}
         aspectRatio={0.4}
       >
         <ChartContainer>

--- a/app/charts/chart-loading-wrapper.tsx
+++ b/app/charts/chart-loading-wrapper.tsx
@@ -22,7 +22,7 @@ type ChartCommonProps<TChartConfig extends ChartConfig> = {
   observations: Observation[];
   measures: DimensionMetadataFragment[];
   dimensions: DimensionMetadataFragment[];
-  interactiveFiltersConfig: TChartConfig["interactiveFiltersConfig"];
+  chartConfig: TChartConfig;
 };
 
 type ElementProps<RE> = RE extends React.ElementType<infer P> ? P : never;
@@ -63,8 +63,7 @@ export const ChartLoadingWrapper = <
           observations: observations.data,
           dimensions: dimensions,
           measures: measures,
-          fields: chartConfig.fields,
-          interactiveFiltersConfig: chartConfig.interactiveFiltersConfig,
+          chartConfig: chartConfig,
           ...ComponentProps,
         } as ChartCommonProps<TChartConfig> & TOtherProps)}
         {fetching && <LoadingOverlay />}

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -21,9 +21,7 @@ import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import {
   ColumnConfig,
-  ColumnFields,
   DataSource,
-  InteractiveFiltersConfig,
   QueryFilters,
 } from "@/configurator/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
@@ -73,15 +71,14 @@ export const ChartColumns = memo(
     observations,
     dimensions,
     measures,
-    fields,
-    interactiveFiltersConfig,
+    chartConfig,
   }: {
     observations: Observation[];
     dimensions: DimensionMetadataFragment[];
     measures: DimensionMetadataFragment[];
-    interactiveFiltersConfig: InteractiveFiltersConfig;
-    fields: ColumnFields;
+    chartConfig: ColumnConfig;
   }) => {
+    const { fields, interactiveFiltersConfig } = chartConfig;
     return (
       <>
         {/* FIXME: These checks should probably be handled somewhere else */}
@@ -91,8 +88,8 @@ export const ChartColumns = memo(
             fields={fields}
             dimensions={dimensions}
             measures={measures}
-            interactiveFiltersConfig={interactiveFiltersConfig}
             aspectRatio={0.4}
+            chartConfig={chartConfig}
           >
             <ChartContainer>
               <ChartSvg>
@@ -123,8 +120,8 @@ export const ChartColumns = memo(
             fields={fields}
             dimensions={dimensions}
             measures={measures}
-            interactiveFiltersConfig={interactiveFiltersConfig}
             aspectRatio={0.4}
+            chartConfig={chartConfig}
           >
             <ChartContainer>
               <ChartSvg>
@@ -157,8 +154,8 @@ export const ChartColumns = memo(
             fields={fields}
             measures={measures}
             dimensions={dimensions}
-            interactiveFiltersConfig={interactiveFiltersConfig}
             aspectRatio={0.4}
+            chartConfig={chartConfig}
           >
             <ChartContainer>
               <ChartSvg>

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -151,7 +151,6 @@ export const ChartColumns = memo(
         ) : (
           <ColumnChart
             data={observations}
-            fields={fields}
             measures={measures}
             dimensions={dimensions}
             aspectRatio={0.4}

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -183,6 +183,9 @@ const useGroupedColumnsState = (
     ]);
   }, [plottableSortedData, getY, getSegment]);
 
+  const segmentFilter = segmentDimension?.iri
+    ? chartConfig.filters[segmentDimension?.iri]
+    : undefined;
   const segments = useMemo(() => {
     const uniqueSegments = Array.from(
       new Set(plottableSortedData.map((d) => getSegment(d)))
@@ -193,6 +196,7 @@ const useGroupedColumnsState = (
       sorting,
       sumsBySegment,
       useAbbreviations: fields.segment?.useAbbreviations,
+      dimensionFilter: segmentFilter,
     });
 
     return orderBy(uniqueSegments, sorters, getSortingOrders(sorters, sorting));
@@ -202,6 +206,7 @@ const useGroupedColumnsState = (
     fields.segment?.sorting,
     fields.segment?.useAbbreviations,
     sumsBySegment,
+    segmentFilter,
     getSegment,
   ]);
 

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -84,20 +84,15 @@ export interface GroupedColumnsState extends CommonChartState {
 const useGroupedColumnsState = (
   chartProps: Pick<
     ChartProps,
-    "data" | "dimensions" | "measures" | "interactiveFiltersConfig"
+    "data" | "dimensions" | "measures" | "chartConfig"
   > & {
     fields: ColumnFields;
     aspectRatio: number;
   }
 ): GroupedColumnsState => {
-  const {
-    data,
-    fields,
-    dimensions,
-    measures,
-    interactiveFiltersConfig,
-    aspectRatio,
-  } = chartProps;
+  const { data, fields, dimensions, measures, chartConfig, aspectRatio } =
+    chartProps;
+  const { interactiveFiltersConfig } = chartConfig;
   const width = useWidth();
   const formatNumber = useFormatNumber({ decimals: "auto" });
 
@@ -464,13 +459,10 @@ const GroupedColumnChartProvider = ({
   fields,
   dimensions,
   measures,
-  interactiveFiltersConfig,
+  chartConfig,
   aspectRatio,
   children,
-}: Pick<
-  ChartProps,
-  "data" | "dimensions" | "measures" | "interactiveFiltersConfig"
-> & {
+}: Pick<ChartProps, "data" | "dimensions" | "measures" | "chartConfig"> & {
   children: ReactNode;
   fields: ColumnFields;
   aspectRatio: number;
@@ -480,7 +472,7 @@ const GroupedColumnChartProvider = ({
     fields,
     dimensions,
     measures,
-    interactiveFiltersConfig,
+    chartConfig,
     aspectRatio,
   });
   return (
@@ -493,13 +485,10 @@ export const GroupedColumnChart = ({
   fields,
   dimensions,
   measures,
-  interactiveFiltersConfig,
+  chartConfig,
   aspectRatio,
   children,
-}: Pick<
-  ChartProps,
-  "data" | "dimensions" | "measures" | "interactiveFiltersConfig"
-> & {
+}: Pick<ChartProps, "data" | "dimensions" | "measures" | "chartConfig"> & {
   aspectRatio: number;
   children: ReactNode;
   fields: ColumnFields;
@@ -512,7 +501,7 @@ export const GroupedColumnChart = ({
           fields={fields}
           dimensions={dimensions}
           measures={measures}
-          interactiveFiltersConfig={interactiveFiltersConfig}
+          chartConfig={chartConfig}
           aspectRatio={aspectRatio}
         >
           {children}

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -219,6 +219,9 @@ const useColumnsStackedState = (
     [getSegment, getY, plottableSortedData]
   );
 
+  const segmentFilter = segmentDimension?.iri
+    ? chartConfig.filters[segmentDimension?.iri]
+    : undefined;
   const segments = useMemo(() => {
     const uniqueSegments = Array.from(
       new Set(plottableSortedData.map((d) => getSegment(d)))
@@ -229,6 +232,7 @@ const useColumnsStackedState = (
       sorting,
       sumsBySegment,
       useAbbreviations: fields.segment?.useAbbreviations,
+      dimensionFilter: segmentFilter,
     });
 
     return orderBy(uniqueSegments, sorters, getSortingOrders(sorters, sorting));
@@ -238,6 +242,7 @@ const useColumnsStackedState = (
     fields.segment?.sorting,
     fields.segment?.useAbbreviations,
     sumsBySegment,
+    segmentFilter,
     getSegment,
   ]);
 

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -85,20 +85,15 @@ export interface StackedColumnsState extends CommonChartState {
 const useColumnsStackedState = (
   chartProps: Pick<
     ChartProps,
-    "data" | "dimensions" | "measures" | "interactiveFiltersConfig"
+    "data" | "dimensions" | "measures" | "chartConfig"
   > & {
     fields: ColumnFields;
     aspectRatio: number;
   }
 ): StackedColumnsState => {
-  const {
-    data,
-    fields,
-    measures,
-    dimensions,
-    interactiveFiltersConfig,
-    aspectRatio,
-  } = chartProps;
+  const { data, fields, measures, dimensions, chartConfig, aspectRatio } =
+    chartProps;
+  const { interactiveFiltersConfig } = chartConfig;
   const width = useWidth();
   const formatNumber = useFormatNumber({ decimals: "auto" });
 
@@ -540,13 +535,10 @@ const StackedColumnsChartProvider = ({
   fields,
   measures,
   dimensions,
-  interactiveFiltersConfig,
+  chartConfig,
   aspectRatio,
   children,
-}: Pick<
-  ChartProps,
-  "data" | "dimensions" | "measures" | "interactiveFiltersConfig"
-> & {
+}: Pick<ChartProps, "data" | "dimensions" | "measures" | "chartConfig"> & {
   children: ReactNode;
   fields: ColumnFields;
   aspectRatio: number;
@@ -555,7 +547,7 @@ const StackedColumnsChartProvider = ({
     data,
     fields,
     dimensions,
-    interactiveFiltersConfig,
+    chartConfig,
     measures,
     aspectRatio,
   });
@@ -569,13 +561,10 @@ export const StackedColumnsChart = ({
   fields,
   measures,
   dimensions,
-  interactiveFiltersConfig,
+  chartConfig,
   aspectRatio,
   children,
-}: Pick<
-  ChartProps,
-  "data" | "dimensions" | "measures" | "interactiveFiltersConfig"
-> & {
+}: Pick<ChartProps, "data" | "dimensions" | "measures" | "chartConfig"> & {
   aspectRatio: number;
   children: ReactNode;
   fields: ColumnFields;
@@ -588,7 +577,7 @@ export const StackedColumnsChart = ({
           fields={fields}
           dimensions={dimensions}
           measures={measures}
-          interactiveFiltersConfig={interactiveFiltersConfig}
+          chartConfig={chartConfig}
           aspectRatio={aspectRatio}
         >
           {children}

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -181,11 +181,15 @@ const useColumnsState = (
       const sorters = makeDimensionValueSorters(xDimension, {
         sorting: fields.x.sorting,
         useAbbreviations: fields.x.useAbbreviations,
+        dimensionFilter: xDimension?.iri
+          ? chartConfig.filters[xDimension?.iri]
+          : undefined,
       });
+      const sortingOrders = getSortingOrders(sorters, fields.x.sorting);
       const bandDomain = orderBy(
         [...new Set(scalesData.map(getX))],
         sorters,
-        getSortingOrders(sorters, fields.x.sorting)
+        sortingOrders
       );
       const xScale = scaleBand()
         .domain(bandDomain)
@@ -413,6 +417,7 @@ export const ColumnChart = ({
   aspectRatio: number;
   children: ReactNode;
   fields: ColumnFields;
+  chartConfig: ChartConfig;
 }) => {
   return (
     <Observer>

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -40,7 +40,12 @@ import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { Observer, useWidth } from "@/charts/shared/use-width";
-import { ColumnFields, SortingOrder, SortingType } from "@/configurator";
+import {
+  ChartConfig,
+  ColumnFields,
+  SortingOrder,
+  SortingType,
+} from "@/configurator";
 import {
   useErrorMeasure,
   useErrorRange,
@@ -90,20 +95,15 @@ export interface ColumnsState extends CommonChartState {
 const useColumnsState = (
   chartProps: Pick<
     ChartProps,
-    "data" | "measures" | "dimensions" | "interactiveFiltersConfig"
+    "data" | "measures" | "dimensions" | "chartConfig"
   > & {
     fields: ColumnFields;
     aspectRatio: number;
   }
 ): ColumnsState => {
-  const {
-    data,
-    fields,
-    measures,
-    dimensions,
-    interactiveFiltersConfig,
-    aspectRatio,
-  } = chartProps;
+  const { data, fields, measures, dimensions, aspectRatio, chartConfig } =
+    chartProps;
+  const { interactiveFiltersConfig } = chartConfig;
   const width = useWidth();
   const formatNumber = useFormatNumber({ decimals: "auto" });
   const timeFormatUnit = useTimeFormatUnit();
@@ -380,13 +380,10 @@ const ColumnChartProvider = ({
   fields,
   measures,
   dimensions,
-  interactiveFiltersConfig,
   aspectRatio,
   children,
-}: Pick<
-  ChartProps,
-  "data" | "measures" | "dimensions" | "interactiveFiltersConfig"
-> & {
+  chartConfig,
+}: Pick<ChartProps, "data" | "measures" | "dimensions" | "chartConfig"> & {
   children: ReactNode;
   fields: ColumnFields;
   aspectRatio: number;
@@ -396,8 +393,8 @@ const ColumnChartProvider = ({
     fields,
     measures,
     dimensions,
-    interactiveFiltersConfig,
     aspectRatio,
+    chartConfig,
   });
   return (
     <ChartContext.Provider value={state}>{children}</ChartContext.Provider>
@@ -409,13 +406,10 @@ export const ColumnChart = ({
   fields,
   measures,
   dimensions,
-  interactiveFiltersConfig,
+  chartConfig,
   aspectRatio,
   children,
-}: Pick<
-  ChartProps,
-  "data" | "measures" | "dimensions" | "interactiveFiltersConfig"
-> & {
+}: Pick<ChartProps, "data" | "measures" | "dimensions" | "chartConfig"> & {
   aspectRatio: number;
   children: ReactNode;
   fields: ColumnFields;
@@ -428,8 +422,8 @@ export const ColumnChart = ({
           fields={fields}
           measures={measures}
           dimensions={dimensions}
-          interactiveFiltersConfig={interactiveFiltersConfig}
           aspectRatio={aspectRatio}
+          chartConfig={chartConfig}
         >
           {children}
         </ColumnChartProvider>

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -40,12 +40,7 @@ import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { Observer, useWidth } from "@/charts/shared/use-width";
-import {
-  ChartConfig,
-  ColumnFields,
-  SortingOrder,
-  SortingType,
-} from "@/configurator";
+import { ColumnConfig, SortingOrder, SortingType } from "@/configurator";
 import {
   useErrorMeasure,
   useErrorRange,
@@ -93,17 +88,13 @@ export interface ColumnsState extends CommonChartState {
 }
 
 const useColumnsState = (
-  chartProps: Pick<
-    ChartProps,
-    "data" | "measures" | "dimensions" | "chartConfig"
-  > & {
-    fields: ColumnFields;
+  chartProps: Pick<ChartProps, "data" | "measures" | "dimensions"> & {
+    chartConfig: ColumnConfig;
     aspectRatio: number;
   }
 ): ColumnsState => {
-  const { data, fields, measures, dimensions, aspectRatio, chartConfig } =
-    chartProps;
-  const { interactiveFiltersConfig } = chartConfig;
+  const { data, measures, dimensions, aspectRatio, chartConfig } = chartProps;
+  const { interactiveFiltersConfig, fields } = chartConfig;
   const width = useWidth();
   const formatNumber = useFormatNumber({ decimals: "auto" });
   const timeFormatUnit = useTimeFormatUnit();
@@ -381,20 +372,18 @@ const useColumnsState = (
 
 const ColumnChartProvider = ({
   data,
-  fields,
   measures,
   dimensions,
   aspectRatio,
   children,
   chartConfig,
-}: Pick<ChartProps, "data" | "measures" | "dimensions" | "chartConfig"> & {
+}: Pick<ChartProps, "data" | "measures" | "dimensions"> & {
   children: ReactNode;
-  fields: ColumnFields;
   aspectRatio: number;
+  chartConfig: ColumnConfig;
 }) => {
   const state = useColumnsState({
     data,
-    fields,
     measures,
     dimensions,
     aspectRatio,
@@ -407,24 +396,21 @@ const ColumnChartProvider = ({
 
 export const ColumnChart = ({
   data,
-  fields,
   measures,
   dimensions,
   chartConfig,
   aspectRatio,
   children,
-}: Pick<ChartProps, "data" | "measures" | "dimensions" | "chartConfig"> & {
+}: Pick<ChartProps, "data" | "measures" | "dimensions"> & {
   aspectRatio: number;
   children: ReactNode;
-  fields: ColumnFields;
-  chartConfig: ChartConfig;
+  chartConfig: ColumnConfig;
 }) => {
   return (
     <Observer>
       <InteractionProvider>
         <ColumnChartProvider
           data={data}
-          fields={fields}
           measures={measures}
           dimensions={dimensions}
           aspectRatio={aspectRatio}

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -14,7 +14,6 @@ import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import {
   DataSource,
   LineConfig,
-  LineFields,
   QueryFilters,
 } from "@/configurator/config-types";
 import { Observation } from "@/domain/data";
@@ -62,16 +61,15 @@ export const ChartLines = memo(function ChartLines({
   observations,
   dimensions,
   measures,
-  fields,
+
   chartConfig,
 }: {
   observations: Observation[];
   dimensions: DimensionMetadataFragment[];
   measures: DimensionMetadataFragment[];
-  fields: LineFields;
   chartConfig: LineConfig;
 }) {
-  const { interactiveFiltersConfig } = chartConfig;
+  const { interactiveFiltersConfig, fields } = chartConfig;
   return (
     <LineChart
       data={observations}

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -13,7 +13,6 @@ import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import {
   DataSource,
-  InteractiveFiltersConfig,
   LineConfig,
   LineFields,
   QueryFilters,
@@ -64,21 +63,21 @@ export const ChartLines = memo(function ChartLines({
   dimensions,
   measures,
   fields,
-  interactiveFiltersConfig,
+  chartConfig,
 }: {
   observations: Observation[];
   dimensions: DimensionMetadataFragment[];
   measures: DimensionMetadataFragment[];
   fields: LineFields;
-  interactiveFiltersConfig: InteractiveFiltersConfig;
+  chartConfig: LineConfig;
 }) {
+  const { interactiveFiltersConfig } = chartConfig;
   return (
     <LineChart
       data={observations}
-      fields={fields}
       dimensions={dimensions}
       measures={measures}
-      interactiveFiltersConfig={interactiveFiltersConfig}
+      chartConfig={chartConfig}
       aspectRatio={0.4}
     >
       <ChartContainer>

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -32,7 +32,7 @@ import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { Observer, useWidth } from "@/charts/shared/use-width";
-import { LineFields } from "@/configurator";
+import { LineConfig } from "@/configurator";
 import { isTemporalDimension, Observation } from "@/domain/data";
 import {
   formatNumberWithUnit,
@@ -73,20 +73,14 @@ export interface LinesState extends CommonChartState {
 const useLinesState = (
   chartProps: Pick<
     ChartProps,
-    "data" | "dimensions" | "measures" | "interactiveFiltersConfig"
+    "data" | "dimensions" | "measures" | "chartConfig"
   > & {
-    fields: LineFields;
+    chartConfig: LineConfig;
     aspectRatio: number;
   }
 ): LinesState => {
-  const {
-    data,
-    fields,
-    dimensions,
-    measures,
-    interactiveFiltersConfig,
-    aspectRatio,
-  } = chartProps;
+  const { data, dimensions, measures, chartConfig, aspectRatio } = chartProps;
+  const { fields, interactiveFiltersConfig } = chartConfig;
   const width = useWidth();
   const formatNumber = useFormatNumber({ decimals: "auto" });
   const timeFormatUnit = useTimeFormatUnit();
@@ -351,26 +345,21 @@ const useLinesState = (
 
 const LineChartProvider = ({
   data,
-  fields,
   dimensions,
   measures,
-  interactiveFiltersConfig,
+  chartConfig,
   aspectRatio,
   children,
-}: Pick<
-  ChartProps,
-  "data" | "dimensions" | "measures" | "interactiveFiltersConfig"
-> & {
+}: Pick<ChartProps, "data" | "dimensions" | "measures"> & {
   children: ReactNode;
-  fields: LineFields;
+  chartConfig: LineConfig;
   aspectRatio: number;
 }) => {
   const state = useLinesState({
     data,
-    fields,
     dimensions,
     measures,
-    interactiveFiltersConfig,
+    chartConfig,
     aspectRatio,
   });
   return (
@@ -380,18 +369,14 @@ const LineChartProvider = ({
 
 export const LineChart = ({
   data,
-  fields,
   dimensions,
   measures,
-  interactiveFiltersConfig,
+  chartConfig,
   aspectRatio,
   children,
-}: Pick<
-  ChartProps,
-  "data" | "dimensions" | "measures" | "interactiveFiltersConfig"
-> & {
+}: Pick<ChartProps, "data" | "dimensions" | "measures"> & {
   aspectRatio: number;
-  fields: LineFields;
+  chartConfig: LineConfig;
   children: ReactNode;
 }) => {
   return (
@@ -399,10 +384,9 @@ export const LineChart = ({
       <InteractionProvider>
         <LineChartProvider
           data={data}
-          fields={fields}
           dimensions={dimensions}
           measures={measures}
-          interactiveFiltersConfig={interactiveFiltersConfig}
+          chartConfig={chartConfig}
           aspectRatio={aspectRatio}
         >
           {children}

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -197,12 +197,16 @@ const useLinesState = (
   const yAxisLabel = getLabelWithUnit(yMeasure);
 
   // segments
+  const segmentFilter = segmentDimension?.iri
+    ? chartConfig.filters[segmentDimension?.iri]
+    : undefined;
   const segments = useMemo(() => {
     const uniqueSegments = [...new Set(plottableSortedData.map(getSegment))];
     const sorting = fields?.segment?.sorting;
     const sorters = makeDimensionValueSorters(segmentDimension, {
       sorting,
       useAbbreviations: fields.segment?.useAbbreviations,
+      dimensionFilter: segmentFilter,
     });
     return orderBy(
       uniqueSegments,
@@ -215,6 +219,7 @@ const useLinesState = (
     fields.segment?.sorting,
     fields.segment?.useAbbreviations,
     plottableSortedData,
+    segmentFilter,
   ]);
 
   // Map ordered segments to colors

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -12,7 +12,6 @@ import {
   BaseLayer,
   DataSource,
   MapConfig,
-  MapFields,
   QueryFilters,
 } from "@/configurator/config-types";
 import {
@@ -238,7 +237,7 @@ export const ChartMapVisualization = ({
 export const ChartMap = ({
   observations,
   features,
-  fields,
+  chartConfig,
   measures,
   dimensions,
   baseLayer,
@@ -247,23 +246,23 @@ export const ChartMap = ({
   observations: Observation[];
   measures: DimensionMetadataFragment[];
   dimensions: DimensionMetadataFragment[];
-  fields: MapFields;
+  chartConfig: MapConfig;
   baseLayer: BaseLayer;
 }) => {
   return (
     <MapChart
       data={observations}
       features={features}
-      fields={fields}
       measures={measures}
       dimensions={dimensions}
       baseLayer={baseLayer}
+      chartConfig={chartConfig}
     >
       <ChartContainer>
         <MapComponent />
         <MapTooltip />
       </ChartContainer>
-      <MapLegend />
+      <MapLegend chartConfig={chartConfig} />
     </MapChart>
   );
 };

--- a/app/charts/map/map-legend.tsx
+++ b/app/charts/map/map-legend.tsx
@@ -22,6 +22,7 @@ import { useChartTheme } from "@/charts/shared/use-chart-theme";
 import { useInteraction } from "@/charts/shared/use-interaction";
 import { useWidth } from "@/charts/shared/use-width";
 import Flex from "@/components/flex";
+import { MapConfig } from "@/configurator";
 import { ColorRamp } from "@/configurator/components/chart-controls/color-ramp";
 import { Observation } from "@/domain/data";
 import { truthy } from "@/domain/types";
@@ -71,7 +72,7 @@ const makeAxis = (
     .attr("text-anchor", "start");
 };
 
-export const MapLegend = () => {
+export const MapLegend = ({ chartConfig }: { chartConfig: MapConfig }) => {
   const { areaLayer, symbolLayer } = useChartState() as MapState;
   const showAreaLegend =
     areaLayer &&
@@ -196,6 +197,7 @@ export const MapLegend = () => {
 
       {areaLayer?.colors.type === "categorical" && (
         <MapLegendColor
+          chartConfig={chartConfig}
           component={areaLayer.colors.component}
           getColor={areaLayer.colors.getColor}
           useAbbreviations={areaLayer.colors.useAbbreviations}
@@ -206,6 +208,7 @@ export const MapLegend = () => {
         symbolLayer.colors.component.iri !==
           areaLayer?.colors.component.iri && (
           <MapLegendColor
+            chartConfig={chartConfig}
             component={symbolLayer.colors.component}
             getColor={symbolLayer.colors.getColor}
             useAbbreviations={symbolLayer.colors.useAbbreviations}

--- a/app/charts/map/map-state.tsx
+++ b/app/charts/map/map-state.tsx
@@ -554,7 +554,9 @@ const useMapState = (
           )
         : undefined,
       symbolLayer?.componentIri !== undefined
-        ? features.symbolLayer?.points.filter((p) => p?.properties?.observation !== undefined)
+        ? features.symbolLayer?.points.filter(
+            (p) => p?.properties?.observation !== undefined
+          )
         : undefined
     );
   }, [

--- a/app/charts/map/map-state.tsx
+++ b/app/charts/map/map-state.tsx
@@ -45,7 +45,7 @@ import {
   CategoricalColorField,
   ColorScaleInterpolationType,
   FixedColorField,
-  MapFields,
+  MapConfig,
   MapSymbolLayer,
   NumericalColorField,
 } from "@/configurator/config-types";
@@ -448,13 +448,14 @@ const filterFeatureCollection = <TFeatureCollection extends FeatureCollection>(
 const useMapState = (
   chartProps: Pick<ChartProps, "data" | "measures" | "dimensions"> & {
     features: GeoData;
-    fields: MapFields;
+    chartConfig: MapConfig;
     baseLayer: BaseLayer;
   }
 ): MapState => {
   const width = useWidth();
-  const { data, features, fields, measures, dimensions, baseLayer } =
+  const { data, features, chartConfig, measures, dimensions, baseLayer } =
     chartProps;
+  const { fields } = chartConfig;
   const { areaLayer, symbolLayer } = fields;
 
   const areaLayerState = useLayerState({
@@ -580,7 +581,7 @@ const useMapState = (
 const MapChartProvider = ({
   data,
   features,
-  fields,
+  chartConfig,
   measures,
   dimensions,
   baseLayer,
@@ -588,13 +589,13 @@ const MapChartProvider = ({
 }: Pick<ChartProps, "data" | "measures" | "dimensions"> & {
   features: GeoData;
   children: ReactNode;
-  fields: MapFields;
+  chartConfig: MapConfig;
   baseLayer: BaseLayer;
 }) => {
   const state = useMapState({
     data,
     features,
-    fields,
+    chartConfig,
     measures,
     dimensions,
     baseLayer,
@@ -607,14 +608,14 @@ const MapChartProvider = ({
 export const MapChart = ({
   data,
   features,
-  fields,
   measures,
+  chartConfig,
   dimensions,
   baseLayer,
   children,
 }: Pick<ChartProps, "data" | "measures" | "dimensions"> & {
   features: GeoData;
-  fields: MapFields;
+  chartConfig: MapConfig;
   baseLayer: BaseLayer;
   children: ReactNode;
 }) => {
@@ -624,7 +625,7 @@ export const MapChart = ({
         <MapChartProvider
           data={data}
           features={features}
-          fields={fields}
+          chartConfig={chartConfig}
           measures={measures}
           dimensions={dimensions}
           baseLayer={baseLayer}

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -16,9 +16,7 @@ import {
 } from "@/components/hint";
 import {
   DataSource,
-  InteractiveFiltersConfig,
   PieConfig,
-  PieFields,
   QueryFilters,
 } from "@/configurator/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
@@ -67,8 +65,7 @@ export const ChartPieVisualization = ({
           observations={observations.data}
           dimensions={dimensions}
           measures={measures}
-          fields={chartConfig.fields}
-          interactiveFiltersConfig={chartConfig.interactiveFiltersConfig}
+          chartConfig={chartConfig}
         />
         {fetching && <LoadingOverlay />}
       </Box>
@@ -87,15 +84,14 @@ export const ChartPie = memo(
     observations,
     dimensions,
     measures,
-    fields,
-    interactiveFiltersConfig,
+    chartConfig,
   }: {
     observations: Observation[];
     dimensions: DimensionMetadataFragment[];
     measures: DimensionMetadataFragment[];
-    fields: PieFields;
-    interactiveFiltersConfig: InteractiveFiltersConfig;
+    chartConfig: PieConfig;
   }) => {
+    const { fields } = chartConfig;
     const somePositive = observations.some(
       (d) => d[fields?.y?.componentIri]! > 0
     );
@@ -104,13 +100,13 @@ export const ChartPie = memo(
       return <OnlyNegativeDataHint />;
     }
 
+    const { interactiveFiltersConfig } = chartConfig;
     return (
       <PieChart
         data={observations}
-        fields={fields}
         dimensions={dimensions}
         measures={measures}
-        interactiveFiltersConfig={interactiveFiltersConfig}
+        chartConfig={chartConfig}
         aspectRatio={0.5}
       >
         <ChartContainer>

--- a/app/charts/pie/pie-state.tsx
+++ b/app/charts/pie/pie-state.tsx
@@ -95,6 +95,9 @@ const usePieState = (
   });
 
   // Map ordered segments to colors
+  const segmentFilter = segmentDimension?.iri
+    ? chartConfig.filters[segmentDimension.iri]
+    : undefined;
   const colors = useMemo(() => {
     const colors = scaleOrdinal<string, string>();
     const measureBySegment = Object.fromEntries(
@@ -109,6 +112,7 @@ const usePieState = (
       sorting: sorting,
       measureBySegment,
       useAbbreviations: fields.segment.useAbbreviations,
+      dimensionFilter: segmentFilter,
     });
 
     const segments = orderBy(

--- a/app/charts/pie/pie-state.tsx
+++ b/app/charts/pie/pie-state.tsx
@@ -22,7 +22,7 @@ import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { Observer, useWidth } from "@/charts/shared/use-width";
-import { PieFields } from "@/configurator";
+import { PieConfig } from "@/configurator";
 import { Observation } from "@/domain/data";
 import { formatNumberWithUnit, useFormatNumber } from "@/formatters";
 import { getPalette } from "@/palettes";
@@ -44,22 +44,13 @@ export interface PieState extends CommonChartState {
 }
 
 const usePieState = (
-  chartProps: Pick<
-    ChartProps,
-    "data" | "dimensions" | "measures" | "interactiveFiltersConfig"
-  > & {
-    fields: PieFields;
+  chartProps: Pick<ChartProps, "data" | "dimensions" | "measures"> & {
+    chartConfig: PieConfig;
     aspectRatio: number;
   }
 ): PieState => {
-  const {
-    data,
-    fields,
-    dimensions,
-    measures,
-    interactiveFiltersConfig,
-    aspectRatio,
-  } = chartProps;
+  const { data, dimensions, measures, chartConfig, aspectRatio } = chartProps;
+  const { interactiveFiltersConfig, fields } = chartConfig;
   const width = useWidth();
   const formatNumber = useFormatNumber();
 
@@ -263,26 +254,21 @@ const usePieState = (
 
 const PieChartProvider = ({
   data,
-  fields,
   dimensions,
   measures,
-  interactiveFiltersConfig,
+  chartConfig,
   aspectRatio,
   children,
-}: Pick<
-  ChartProps,
-  "data" | "dimensions" | "measures" | "interactiveFiltersConfig"
-> & {
+}: Pick<ChartProps, "data" | "dimensions" | "measures"> & {
   children: ReactNode;
-  fields: PieFields;
+  chartConfig: PieConfig;
   aspectRatio: number;
 }) => {
   const state = usePieState({
     data,
-    fields,
     dimensions,
     measures,
-    interactiveFiltersConfig,
+    chartConfig,
     aspectRatio,
   });
   return (
@@ -292,18 +278,14 @@ const PieChartProvider = ({
 
 export const PieChart = ({
   data,
-  fields,
   measures,
   dimensions,
   aspectRatio,
-  interactiveFiltersConfig,
+  chartConfig,
   children,
-}: Pick<
-  ChartProps,
-  "data" | "dimensions" | "measures" | "interactiveFiltersConfig"
-> & {
+}: Pick<ChartProps, "data" | "dimensions" | "measures"> & {
   aspectRatio: number;
-  fields: PieFields;
+  chartConfig: PieConfig;
   children: ReactNode;
 }) => {
   return (
@@ -311,10 +293,9 @@ export const PieChart = ({
       <InteractionProvider>
         <PieChartProvider
           data={data}
-          fields={fields}
           dimensions={dimensions}
           measures={measures}
-          interactiveFiltersConfig={interactiveFiltersConfig}
+          chartConfig={chartConfig}
           aspectRatio={aspectRatio}
         >
           {children}

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -16,10 +16,8 @@ import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionVoronoi } from "@/charts/shared/overlay-voronoi";
 import {
   DataSource,
-  InteractiveFiltersConfig,
   QueryFilters,
   ScatterPlotConfig,
-  ScatterPlotFields,
 } from "@/configurator/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import { Observation } from "@/domain/data";
@@ -68,22 +66,20 @@ export const ChartScatterplot = memo(
     observations,
     dimensions,
     measures,
-    fields,
-    interactiveFiltersConfig,
+    chartConfig,
   }: {
     observations: Observation[];
     dimensions: DimensionMetadataFragment[];
     measures: DimensionMetadataFragment[];
-    fields: ScatterPlotFields;
-    interactiveFiltersConfig: InteractiveFiltersConfig;
+    chartConfig: ScatterPlotConfig;
   }) => {
+    const { interactiveFiltersConfig, fields } = chartConfig;
     return (
       <ScatterplotChart
         data={observations}
-        fields={fields}
         dimensions={dimensions}
         measures={measures}
-        interactiveFiltersConfig={interactiveFiltersConfig}
+        chartConfig={chartConfig}
         aspectRatio={1}
       >
         <ChartContainer>

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -23,7 +23,7 @@ import { useMaybeAbbreviations } from "@/charts/shared/use-abbreviations";
 import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { Observer, useWidth } from "@/charts/shared/use-width";
-import { ScatterPlotFields } from "@/configurator";
+import { ScatterPlotConfig } from "@/configurator";
 import { Observation } from "@/domain/data";
 import { useFormatNumber } from "@/formatters";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
@@ -51,19 +51,16 @@ export interface ScatterplotState extends CommonChartState {
 
 const useScatterplotState = ({
   data,
-  fields,
   dimensions,
   measures,
-  interactiveFiltersConfig,
+  chartConfig,
   aspectRatio,
-}: Pick<
-  ChartProps,
-  "data" | "dimensions" | "measures" | "interactiveFiltersConfig"
-> & {
-  fields: ScatterPlotFields;
+}: Pick<ChartProps, "data" | "dimensions" | "measures"> & {
   aspectRatio: number;
+  chartConfig: ScatterPlotConfig;
 }): ScatterplotState => {
   const width = useWidth();
+  const { fields } = chartConfig;
   const formatNumber = useFormatNumber({ decimals: "auto" });
 
   const getX = useOptionalNumericVariable(fields.x.componentIri);
@@ -98,6 +95,7 @@ const useScatterplotState = ({
   });
 
   // Data for chart
+  const { interactiveFiltersConfig } = chartConfig;
   const { preparedData, scalesData } = useDataAfterInteractiveFilters({
     sortedData: plottableSortedData,
     interactiveFiltersConfig,
@@ -256,26 +254,21 @@ const useScatterplotState = ({
 
 const ScatterplotChartProvider = ({
   data,
-  fields,
   dimensions,
   measures,
-  interactiveFiltersConfig,
+  chartConfig,
   aspectRatio,
   children,
-}: Pick<
-  ChartProps,
-  "data" | "dimensions" | "measures" | "interactiveFiltersConfig"
-> & {
+}: Pick<ChartProps, "data" | "dimensions" | "measures"> & {
   children: ReactNode;
-  fields: ScatterPlotFields;
   aspectRatio: number;
+  chartConfig: ScatterPlotConfig;
 }) => {
   const state = useScatterplotState({
     data,
-    fields,
     dimensions,
     measures,
-    interactiveFiltersConfig,
+    chartConfig,
     aspectRatio,
   });
   return (
@@ -285,29 +278,24 @@ const ScatterplotChartProvider = ({
 
 export const ScatterplotChart = ({
   data,
-  fields,
   dimensions,
   measures,
-  interactiveFiltersConfig,
+  chartConfig,
   aspectRatio,
   children,
-}: Pick<
-  ChartProps,
-  "data" | "dimensions" | "measures" | "interactiveFiltersConfig"
-> & {
+}: Pick<ChartProps, "data" | "dimensions" | "measures"> & {
   aspectRatio: number;
-  fields: ScatterPlotFields;
   children: ReactNode;
+  chartConfig: ScatterPlotConfig;
 }) => {
   return (
     <Observer>
       <InteractionProvider>
         <ScatterplotChartProvider
           data={data}
-          fields={fields}
           dimensions={dimensions}
           measures={measures}
-          interactiveFiltersConfig={interactiveFiltersConfig}
+          chartConfig={chartConfig}
           aspectRatio={aspectRatio}
         >
           {children}

--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -15,6 +15,7 @@ import {
   DataSource,
   GenericSegmentField,
   isSegmentInConfig,
+  MapConfig,
   useReadOnlyConfiguratorState,
 } from "@/configurator";
 import { Observation } from "@/domain/data";
@@ -223,23 +224,27 @@ export const MapLegendColor = memo(function LegendColor({
   component,
   getColor,
   useAbbreviations,
+  chartConfig,
 }: {
   component: DimensionMetadataFragment;
   getColor: (d: Observation) => number[];
   useAbbreviations: boolean;
+  chartConfig: MapConfig;
 }) {
+  const componentFilter = chartConfig.filters[component.iri];
   const sortedValues = useMemo(() => {
     const sorters = makeDimensionValueSorters(component, {
       sorting: {
         sortingType: "byAuto",
         sortingOrder: "asc",
       },
+      dimensionFilter: componentFilter,
     });
     return orderBy(
       component.values,
       sorters.map((s) => (dv) => s(dv.label))
     ) as typeof component.values;
-  }, [component]);
+  }, [component, componentFilter]);
   const getLabel = useAbbreviations
     ? (d: string) => {
         const v = component.values.find((v) => v.value === d);

--- a/app/charts/shared/padding.tsx
+++ b/app/charts/shared/padding.tsx
@@ -3,14 +3,14 @@ import { useMemo } from "react";
 
 import { getTickNumber } from "@/charts/shared/axis-height-linear";
 import { BRUSH_BOTTOM_SPACE } from "@/charts/shared/brush";
-import { ChartProps } from "@/charts/shared/use-chart-state";
+import { ChartConfig } from "@/configurator";
 import { estimateTextWidth } from "@/utils/estimate-text-width";
 
 const computeChartPadding = (
   yScale: d3.ScaleLinear<number, number>,
   width: number,
   aspectRatio: number,
-  interactiveFiltersConfig: ChartProps["interactiveFiltersConfig"],
+  interactiveFiltersConfig: ChartConfig["interactiveFiltersConfig"],
   formatNumber: (n: number) => string,
   bandDomain?: string[]
 ) => {
@@ -37,7 +37,7 @@ export const useChartPadding = (
   yScale: d3.ScaleLinear<number, number>,
   width: number,
   aspectRatio: number,
-  interactiveFiltersConfig: ChartProps["interactiveFiltersConfig"],
+  interactiveFiltersConfig: ChartConfig["interactiveFiltersConfig"],
   formatNumber: (n: number) => string,
   bandDomain?: string[]
 ) => {

--- a/app/charts/shared/use-chart-state.tsx
+++ b/app/charts/shared/use-chart-state.tsx
@@ -9,17 +9,16 @@ import { MapState } from "@/charts/map/map-state";
 import { PieState } from "@/charts/pie/pie-state";
 import { ScatterplotState } from "@/charts/scatterplot/scatterplot-state";
 import { TableChartState } from "@/charts/table/table-state";
-import { ChartFields, InteractiveFiltersConfig } from "@/configurator";
+import { ChartConfig } from "@/configurator";
 import { Observation } from "@/domain/data";
 import { Has } from "@/domain/types";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 
 export interface ChartProps {
   data: Observation[];
-  fields: ChartFields;
-  interactiveFiltersConfig: InteractiveFiltersConfig;
   dimensions: DimensionMetadataFragment[];
   measures: DimensionMetadataFragment[];
+  chartConfig: ChartConfig;
 }
 
 export type ChartState =

--- a/app/configurator/config-types.ts
+++ b/app/configurator/config-types.ts
@@ -62,7 +62,6 @@ export type FilterValueMultiValues = FilterValueMulti["values"];
 const Filters = t.record(t.string, FilterValue, "Filters");
 
 export type Filters = t.TypeOf<typeof Filters>;
-
 export type QueryFilters = Filters | FilterValueSingle;
 
 // Meta

--- a/app/docs/annotations.docs.tsx
+++ b/app/docs/annotations.docs.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/charts/shared/interaction/tooltip-content";
 import { InteractiveFiltersProvider } from "@/charts/shared/use-interactive-filters";
 import Flex from "@/components/flex";
+import { ColumnConfig } from "@/configurator";
 import {
   fields,
   margins,
@@ -34,21 +35,25 @@ ${(
     <InteractiveFiltersProvider>
       <ColumnChart
         data={observations}
-        fields={fields}
         measures={measures}
         dimensions={dimensions}
-        interactiveFiltersConfig={{
-          legend: { active: false, componentIri: "" },
-          timeRange: {
-            active: false,
-            componentIri: "",
-            presets: { type: "range", from: "", to: "" },
-          },
-          timeSlider: {
-            componentIri: "",
-          },
-          dataFilters: { active: false, componentIris: [] },
-        }}
+        chartConfig={
+          {
+            fields: fields,
+            interactiveFiltersConfig: {
+              legend: { active: false, componentIri: "" },
+              timeRange: {
+                active: false,
+                componentIri: "",
+                presets: { type: "range", from: "", to: "" },
+              },
+              timeSlider: {
+                componentIri: "",
+              },
+              dataFilters: { active: false, componentIris: [] },
+            },
+          } as unknown as ColumnConfig
+        }
         aspectRatio={0.4}
       >
         <Flex>
@@ -177,21 +182,25 @@ ${(
     <InteractiveFiltersProvider>
       <ColumnChart
         data={observations}
-        fields={fields}
         measures={measures}
         dimensions={dimensions}
-        interactiveFiltersConfig={{
-          legend: { active: false, componentIri: "" },
-          timeRange: {
-            active: false,
-            componentIri: "",
-            presets: { type: "range", from: "", to: "" },
-          },
-          timeSlider: {
-            componentIri: "",
-          },
-          dataFilters: { active: false, componentIris: [] },
-        }}
+        chartConfig={
+          {
+            fields,
+            interactiveFiltersConfig: {
+              legend: { active: false, componentIri: "" },
+              timeRange: {
+                active: false,
+                componentIri: "",
+                presets: { type: "range", from: "", to: "" },
+              },
+              timeSlider: {
+                componentIri: "",
+              },
+              dataFilters: { active: false, componentIris: [] },
+            },
+          } as unknown as ColumnConfig
+        }
         aspectRatio={0.4}
       >
         <div style={{ width: 200, height: 150, position: "relative" }}>
@@ -219,21 +228,25 @@ ${(
     <InteractiveFiltersProvider>
       <ColumnChart
         data={observations}
-        fields={fields}
         measures={measures}
         dimensions={dimensions}
-        interactiveFiltersConfig={{
-          legend: { active: false, componentIri: "" },
-          timeRange: {
-            active: false,
-            componentIri: "",
-            presets: { type: "range", from: "", to: "" },
-          },
-          timeSlider: {
-            componentIri: "",
-          },
-          dataFilters: { active: false, componentIris: [] },
-        }}
+        chartConfig={
+          {
+            fields,
+            interactiveFiltersConfig: {
+              legend: { active: false, componentIri: "" },
+              timeRange: {
+                active: false,
+                componentIri: "",
+                presets: { type: "range", from: "", to: "" },
+              },
+              timeSlider: {
+                componentIri: "",
+              },
+              dataFilters: { active: false, componentIris: [] },
+            },
+          } as unknown as ColumnConfig
+        }
         aspectRatio={0.4}
       >
         <div style={{ width: 200, height: 150, position: "relative" }}>

--- a/app/docs/columns.docs.tsx
+++ b/app/docs/columns.docs.tsx
@@ -11,6 +11,7 @@ import {
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { InteractiveFiltersProvider } from "@/charts/shared/use-interactive-filters";
+import { ColumnConfig } from "@/configurator";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 
 export const Docs = () => markdown`
@@ -23,29 +24,34 @@ ${(
       <ColumnChart
         data={columnObservations}
         dimensions={columnDimensions}
-        interactiveFiltersConfig={{
-          legend: {
-            active: false,
-            componentIri: "",
-          },
-          dataFilters: {
-            active: false,
-            componentIris: [],
-          },
-          timeRange: {
-            presets: {
-              type: "range",
-              from: "0",
-              to: "0",
+        chartConfig={
+          {
+            fields: columnFields,
+
+            interactiveFiltersConfig: {
+              legend: {
+                active: false,
+                componentIri: "",
+              },
+              dataFilters: {
+                active: false,
+                componentIris: [],
+              },
+              timeRange: {
+                presets: {
+                  type: "range",
+                  from: "0",
+                  to: "0",
+                },
+                active: false,
+                componentIri: "http://fake-iri",
+              },
+              timeSlider: {
+                componentIri: "",
+              },
             },
-            active: false,
-            componentIri: "http://fake-iri",
-          },
-          timeSlider: {
-            componentIri: "",
-          },
-        }}
-        fields={columnFields}
+          } as unknown as ColumnConfig
+        }
         measures={columnMeasures}
         aspectRatio={0.4}
       >

--- a/app/docs/lines.docs.tsx
+++ b/app/docs/lines.docs.tsx
@@ -9,7 +9,11 @@ import { BrushTime } from "@/charts/shared/brush";
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractiveFiltersProvider } from "@/charts/shared/use-interactive-filters";
-import { InteractiveFiltersConfig, SortingField } from "@/configurator";
+import {
+  InteractiveFiltersConfig,
+  LineConfig,
+  SortingField,
+} from "@/configurator";
 import { PublishedConfiguratorStateProvider } from "@/configurator/configurator-state";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 
@@ -58,10 +62,9 @@ ${(
       <InteractiveFiltersProvider>
         <LineChart
           data={observations}
-          fields={fields}
           dimensions={dimensions}
           measures={measures}
-          interactiveFiltersConfig={interactiveFiltersConfig}
+          chartConfig={{ interactiveFiltersConfig } as unknown as LineConfig}
           aspectRatio={0.4}
         >
           <ChartContainer>

--- a/app/docs/scatterplot.docs.tsx
+++ b/app/docs/scatterplot.docs.tsx
@@ -16,7 +16,7 @@ import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionVoronoi } from "@/charts/shared/overlay-voronoi";
 import { InteractiveFiltersProvider } from "@/charts/shared/use-interactive-filters";
-import { InteractiveFiltersConfig } from "@/configurator";
+import { InteractiveFiltersConfig, ScatterPlotConfig } from "@/configurator";
 import { PublishedConfiguratorStateProvider } from "@/configurator/configurator-state";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 
@@ -65,10 +65,11 @@ ${(
       <InteractiveFiltersProvider>
         <ScatterplotChart
           data={scatterplotObservations}
-          fields={scatterplotFields}
           dimensions={scatterplotDimensions}
           measures={scatterplotMeasures}
-          interactiveFiltersConfig={interactiveFiltersConfig}
+          chartConfig={
+            { interactiveFiltersConfig } as unknown as ScatterPlotConfig
+          }
           aspectRatio={1}
         >
           <ChartContainer>

--- a/app/package.json
+++ b/app/package.json
@@ -138,7 +138,7 @@
     "@lingui/macro": "^3.2.3",
     "@mdx-js/loader": "^1.6.22",
     "@playwright-testing-library/test": "^4.5.0",
-    "@playwright/test": "^1.26.1",
+    "@playwright/test": "^1.32.1",
     "@svgr/cli": "^5.5.0",
     "@testing-library/react": "^12.1.2",
     "@testing-library/react-hooks": "^7.0.2",

--- a/app/utils/sorting-values.ts
+++ b/app/utils/sorting-values.ts
@@ -30,7 +30,7 @@ export const makeDimensionValueSorters = (
       >["dimensions"][number]
     | undefined,
   options: {
-    dimensionFilter: FilterValue | undefined;
+    dimensionFilter?: FilterValue;
     sorting?:
       | NonNullable<SortingField["sorting"]>
       | {

--- a/e2e/abbreviations.spec.ts
+++ b/e2e/abbreviations.spec.ts
@@ -121,11 +121,5 @@ test("localized abbreviations", async ({ actions, selectors }) => {
     await selectors.chart.colorLegendItems()
   ).allInnerTexts();
 
-  expect(legendItems).toEqual([
-    "No measures",
-    "Warning",
-    "Conditional ban on fires",
-    "Fire ban in the forest",
-    "Ban on fires",
-  ]);
+  expect(legendItems).toEqual(["No measures", "Warning"]);
 });

--- a/e2e/abbreviations.spec.ts
+++ b/e2e/abbreviations.spec.ts
@@ -90,7 +90,7 @@ test("hierarchies: it should be possible to enable abbreviations for colors", as
   // Wait for the data to load.
   await selectors.chart.loaded();
   await selectors.edition.filtersLoaded();
-  await selectors.chart.colorLegend(undefined, { setTimeout: 5_000 });
+  await selectors.chart.colorLegend(undefined, { timeout: 5_000 });
 
   const legendItems = await (
     await selectors.chart.colorLegendItems()
@@ -115,7 +115,7 @@ test("localized abbreviations", async ({ actions, selectors }) => {
   // Wait for the data to load.
   await selectors.chart.loaded();
   await selectors.edition.filtersLoaded();
-  await selectors.chart.colorLegend(undefined, { setTimeout: 5_000 });
+  await selectors.chart.colorLegend(undefined, { timeout: 5_000 });
 
   const legendItems = await (
     await selectors.chart.colorLegendItems()

--- a/e2e/fixtures/hierarchy-test-13-municipality-population.json
+++ b/e2e/fixtures/hierarchy-test-13-municipality-population.json
@@ -1,0 +1,48 @@
+{
+  "state": "CONFIGURING_CHART",
+  "dataSet": "https://environment.ld.admin.ch/foen/fab_hierarchy_test13_switzerland_canton_municipality/3",
+  "dataSource": {
+    "type": "sparql",
+    "url": "https://int.lindas.admin.ch/query"
+  },
+  "meta": {
+    "title": { "de": "", "fr": "", "it": "", "en": "" },
+    "description": { "de": "", "fr": "", "it": "", "en": "" }
+  },
+  "chartConfig": {
+    "version": "1.3.0",
+    "chartType": "column",
+    "filters": {
+      "https://environment.ld.admin.ch/foen/fab_hierarchy_test13_switzerland_canton_municipality/date": {
+        "type": "single",
+        "value": "2022-01-01"
+      },
+      "https://environment.ld.admin.ch/foen/fab_hierarchy_test13_switzerland_canton_municipality/BFSIdentifier": {
+        "type": "multi",
+        "values": {
+          "https://ld.admin.ch/municipality/261": true,
+          "https://ld.admin.ch/municipality/351": true
+        }
+      }
+    },
+    "interactiveFiltersConfig": {
+      "legend": { "active": false, "componentIri": "" },
+      "timeRange": {
+        "active": false,
+        "componentIri": "",
+        "presets": { "type": "range", "from": "", "to": "" }
+      },
+      "timeSlider": { "componentIri": "" },
+      "dataFilters": { "active": false, "componentIris": [] }
+    },
+    "fields": {
+      "x": {
+        "componentIri": "https://environment.ld.admin.ch/foen/fab_hierarchy_test13_switzerland_canton_municipality/BFSIdentifier"
+      },
+      "y": {
+        "componentIri": "https://environment.ld.admin.ch/foen/fab_hierarchy_test13_switzerland_canton_municipality/population"
+      }
+    }
+  },
+  "activeField": "x"
+}

--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -85,6 +85,7 @@ export const createSelectors = ({ screen, page, within }: Ctx) => {
       ) => screen.findByTestId("colorLegend", options, waitForOptions),
       colorLegendItems: async () =>
         (await selectors.chart.colorLegend()).locator("div"),
+      legendTicks: async () => {},
       loaded: async (options: { timeout?: number } = {}) => {
         await page
           .locator(`[data-chart-loaded="true"]`)

--- a/e2e/sorting.spec.ts
+++ b/e2e/sorting.spec.ts
@@ -82,14 +82,16 @@ test("Segment sorting", async ({
   }
 });
 
-test("Segment sorting with hierarchy", async ({
+// TODO Find correct cube
+// @see https://github.com/visualize-admin/visualization-tool/discussions/1007
+test.skip("Segment sorting with hierarchy", async ({
   actions,
   selectors,
   screen,
   within,
 }) => {
   await actions.chart.createFrom(
-    "https://environment.ld.admin.ch/foen/nfi/49-19-44/cube/1",
+    "https://environment.ld.admin.ch/foen/nfi/C-96/cube/1",
     "Int"
   );
   await actions.editor.selectActiveField("Color");
@@ -101,7 +103,7 @@ test("Segment sorting with hierarchy", async ({
     .getByText("None")
     .click();
 
-  await actions.mui.selectOption("Production region");
+  await actions.mui.selectOption("Region");
   await selectors.chart.loaded();
 
   await selectors.edition.filtersLoaded();

--- a/e2e/sorting.spec.ts
+++ b/e2e/sorting.spec.ts
@@ -149,9 +149,7 @@ test("Map legend categorical values sorting", async ({
   expect(await legendItems.allInnerTexts()).toEqual([
     "low danger",
     "moderate danger",
-    "considerable danger",
     "high danger",
-    "very high danger",
   ]);
 });
 
@@ -187,9 +185,7 @@ test("Map legend preview table sorting", async ({
   expect(uniqueWithoutSorting(texts)).toEqual([
     "low danger",
     "moderate danger",
-    "considerable danger",
     "high danger",
-    "very high danger",
   ]);
 });
 

--- a/e2e/sorting.spec.ts
+++ b/e2e/sorting.spec.ts
@@ -1,4 +1,6 @@
+import { loadChartInLocalStorage } from "./charts-utils";
 import { test, expect } from "./common";
+import hierarchyTest13 from "./fixtures/hierarchy-test-13-municipality-population.json";
 
 /**
  * - Creates a chart from the photovoltaik dataset
@@ -45,7 +47,7 @@ test("Segment sorting", async ({
     // Wait for chart to be loaded
     await selectors.chart.loaded();
     await selectors.edition.filtersLoaded();
-    await selectors.chart.colorLegend(undefined, { setTimeout: 5_000 });
+    await selectors.chart.colorLegend(undefined, { timeout: 5_000 });
 
     const legendItems = await selectors.chart.colorLegendItems();
     const legendTexts = await legendItems.allInnerTexts();
@@ -189,4 +191,27 @@ test("Map legend preview table sorting", async ({
     "high danger",
     "very high danger",
   ]);
+});
+
+test("Sorting with values with same label as other values in the tree", async ({
+  actions,
+  selectors,
+  page,
+}) => {
+  const key = "sorting-hierarchy-values-same-label.spec";
+  const config = hierarchyTest13;
+  await loadChartInLocalStorage(page, key, config);
+  page.goto(`/en/create/${key}`);
+  await selectors.chart.loaded({ timeout: 30_000 });
+
+  const texts = await Promise.all(
+    await (
+      await page.locator('[data-testid="axis-width-band"] text').all()
+    ).map((loc) => {
+      return loc.innerHTML();
+    })
+  );
+
+  // Zürich has id 261 while Bern has id 351
+  expect(texts).toEqual(["Zürich", "Bern"]);
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -27,7 +27,7 @@ const config: PlaywrightTestConfig = {
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 1 : 0,
   workers: 1,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: process.env.CI ? "list" : "line",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,14 @@
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.0"
 
+"@ampproject/remapping@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
+  integrity sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.1.0"
+    "@jridgewell/trace-mapping" "^0.3.9"
+
 "@apollo/client@^3.2.5", "@apollo/client@~3.2.5 || ~3.3.0":
   version "3.3.20"
   resolved "https://registry.npmjs.org/@apollo/client/-/client-3.3.20.tgz"
@@ -133,43 +141,21 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.20.10.tgz#9d92fa81b87542fff50e848ed585b4212c1d34ec"
   integrity sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==
 
-"@babel/core@7.12.9":
-  version "7.12.9"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.9.tgz#fd450c4ec10cdbb980e2928b7aa7a28484593fc8"
-  integrity sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==
+"@babel/core@7.12.9", "@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.10.5", "@babel/core@^7.12.3", "@babel/core@^7.12.9", "@babel/core@^7.14.6", "@babel/core@^7.7.2", "@babel/core@^7.7.5", "@babel/core@^7.7.7":
+  version "7.21.3"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.21.3.tgz#cf1c877284a469da5d1ce1d1e53665253fae712e"
+  integrity sha512-qIJONzoa/qiHghnm0l1n4i/6IIziDpzqc36FBs4pzMhDUraHqponwJLiAKm1hGLP3OSB/TVNz6rMwVGpwxxySw==
   dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/generator" "^7.12.5"
-    "@babel/helper-module-transforms" "^7.12.1"
-    "@babel/helpers" "^7.12.5"
-    "@babel/parser" "^7.12.7"
-    "@babel/template" "^7.12.7"
-    "@babel/traverse" "^7.12.9"
-    "@babel/types" "^7.12.7"
-    convert-source-map "^1.7.0"
-    debug "^4.1.0"
-    gensync "^1.0.0-beta.1"
-    json5 "^2.1.2"
-    lodash "^4.17.19"
-    resolve "^1.3.2"
-    semver "^5.4.1"
-    source-map "^0.5.0"
-
-"@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.10.5", "@babel/core@^7.12.3", "@babel/core@^7.12.9", "@babel/core@^7.7.2", "@babel/core@^7.7.5", "@babel/core@^7.7.7":
-  version "7.20.12"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.20.12.tgz#7930db57443c6714ad216953d1356dac0eb8496d"
-  integrity sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==
-  dependencies:
-    "@ampproject/remapping" "^2.1.0"
+    "@ampproject/remapping" "^2.2.0"
     "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.20.7"
+    "@babel/generator" "^7.21.3"
     "@babel/helper-compilation-targets" "^7.20.7"
-    "@babel/helper-module-transforms" "^7.20.11"
-    "@babel/helpers" "^7.20.7"
-    "@babel/parser" "^7.20.7"
+    "@babel/helper-module-transforms" "^7.21.2"
+    "@babel/helpers" "^7.21.0"
+    "@babel/parser" "^7.21.3"
     "@babel/template" "^7.20.7"
-    "@babel/traverse" "^7.20.12"
-    "@babel/types" "^7.20.7"
+    "@babel/traverse" "^7.21.3"
+    "@babel/types" "^7.21.3"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
@@ -185,16 +171,6 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.12.5", "@babel/generator@^7.21.3":
-  version "7.21.3"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.21.3.tgz#232359d0874b392df04045d72ce2fd9bb5045fce"
-  integrity sha512-QS3iR1GYC/YGUnW7IdggFeN5c1poPUurnGttOV/bZgPGV+izC/D8HnD6DLwod0fsatNyVn1G3EVWMYIF0nHbeA==
-  dependencies:
-    "@babel/types" "^7.21.3"
-    "@jridgewell/gen-mapping" "^0.3.2"
-    "@jridgewell/trace-mapping" "^0.3.17"
-    jsesc "^2.5.1"
-
 "@babel/generator@^7.20.7":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.20.7.tgz#f8ef57c8242665c5929fe2e8d82ba75460187b4a"
@@ -202,6 +178,16 @@
   dependencies:
     "@babel/types" "^7.20.7"
     "@jridgewell/gen-mapping" "^0.3.2"
+    jsesc "^2.5.1"
+
+"@babel/generator@^7.21.3":
+  version "7.21.3"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.21.3.tgz#232359d0874b392df04045d72ce2fd9bb5045fce"
+  integrity sha512-QS3iR1GYC/YGUnW7IdggFeN5c1poPUurnGttOV/bZgPGV+izC/D8HnD6DLwod0fsatNyVn1G3EVWMYIF0nHbeA==
+  dependencies:
+    "@babel/types" "^7.21.3"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    "@jridgewell/trace-mapping" "^0.3.17"
     jsesc "^2.5.1"
 
 "@babel/helper-annotate-as-pure@^7.14.5":
@@ -323,20 +309,6 @@
   dependencies:
     "@babel/types" "^7.18.6"
 
-"@babel/helper-module-transforms@^7.12.1":
-  version "7.21.2"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.21.2.tgz#160caafa4978ac8c00ac66636cb0fa37b024e2d2"
-  integrity sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==
-  dependencies:
-    "@babel/helper-environment-visitor" "^7.18.9"
-    "@babel/helper-module-imports" "^7.18.6"
-    "@babel/helper-simple-access" "^7.20.2"
-    "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/helper-validator-identifier" "^7.19.1"
-    "@babel/template" "^7.20.7"
-    "@babel/traverse" "^7.21.2"
-    "@babel/types" "^7.21.2"
-
 "@babel/helper-module-transforms@^7.14.5":
   version "7.15.8"
   resolved "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.8.tgz"
@@ -364,6 +336,20 @@
     "@babel/template" "^7.20.7"
     "@babel/traverse" "^7.20.10"
     "@babel/types" "^7.20.7"
+
+"@babel/helper-module-transforms@^7.21.2":
+  version "7.21.2"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.21.2.tgz#160caafa4978ac8c00ac66636cb0fa37b024e2d2"
+  integrity sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-module-imports" "^7.18.6"
+    "@babel/helper-simple-access" "^7.20.2"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/helper-validator-identifier" "^7.19.1"
+    "@babel/template" "^7.20.7"
+    "@babel/traverse" "^7.21.2"
+    "@babel/types" "^7.21.2"
 
 "@babel/helper-optimise-call-expression@^7.14.5", "@babel/helper-optimise-call-expression@^7.15.4":
   version "7.15.4"
@@ -472,15 +458,6 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz#bf0d2b5a509b1f336099e4ff36e1a63aa5db4db8"
   integrity sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==
 
-"@babel/helpers@^7.12.5":
-  version "7.21.0"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.21.0.tgz#9dd184fb5599862037917cdc9eecb84577dc4e7e"
-  integrity sha512-XXve0CBtOW0pd7MRzzmoyuSj0e3SEzj8pgyFxnTT1NJZL38BD1MK7yYrm8yefRPIDvNNe14xR4FdbHwpInD4rA==
-  dependencies:
-    "@babel/template" "^7.20.7"
-    "@babel/traverse" "^7.21.0"
-    "@babel/types" "^7.21.0"
-
 "@babel/helpers@^7.20.7":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.20.7.tgz#04502ff0feecc9f20ecfaad120a18f011a8e6dce"
@@ -489,6 +466,15 @@
     "@babel/template" "^7.20.7"
     "@babel/traverse" "^7.20.7"
     "@babel/types" "^7.20.7"
+
+"@babel/helpers@^7.21.0":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.21.0.tgz#9dd184fb5599862037917cdc9eecb84577dc4e7e"
+  integrity sha512-XXve0CBtOW0pd7MRzzmoyuSj0e3SEzj8pgyFxnTT1NJZL38BD1MK7yYrm8yefRPIDvNNe14xR4FdbHwpInD4rA==
+  dependencies:
+    "@babel/template" "^7.20.7"
+    "@babel/traverse" "^7.21.0"
+    "@babel/types" "^7.21.0"
 
 "@babel/highlight@^7.10.4", "@babel/highlight@^7.18.6":
   version "7.18.6"
@@ -508,17 +494,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@7.12.16":
-  version "7.12.16"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.16.tgz#cc31257419d2c3189d394081635703f549fc1ed4"
-  integrity sha512-c/+u9cqV6F0+4Hpq01jnJO+GLp2DdT63ppz9Xa+6cHaajM9VFzK/iDXiKK65YtpeVwu+ctfS6iqlMqRgQRzeCw==
-
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.11.5", "@babel/parser@^7.12.13", "@babel/parser@^7.14.7", "@babel/parser@^7.15.4", "@babel/parser@^7.18.10", "@babel/parser@^7.20.7", "@babel/parser@^7.7.2":
-  version "7.20.13"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.13.tgz#ddf1eb5a813588d2fb1692b70c6fce75b945c088"
-  integrity sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==
-
-"@babel/parser@^7.12.7", "@babel/parser@^7.21.3":
+"@babel/parser@7.12.16", "@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.11.5", "@babel/parser@^7.12.13", "@babel/parser@^7.14.6", "@babel/parser@^7.14.7", "@babel/parser@^7.15.4", "@babel/parser@^7.18.10", "@babel/parser@^7.20.7", "@babel/parser@^7.21.3", "@babel/parser@^7.7.2":
   version "7.21.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.21.3.tgz#1d285d67a19162ff9daa358d4cb41d50c06220b3"
   integrity sha512-lobG0d7aOfQRXh8AyklEAgZGvA4FShxo6xQbUrrT/cNBPUdIDojlokwJsQyCC/eKia7ifqM0yP+2DRZ4WKw2RQ==
@@ -868,15 +844,6 @@
   resolved "https://registry.npmjs.org/@babel/standalone/-/standalone-7.14.6.tgz"
   integrity sha512-oAoSp82jhJFnXKybKTOj5QF04XxiDRyiiqrFToiU1udlBXuZoADlPmmnOcuqBrZxSNNUjzJIVK8vt838Qoqjxg==
 
-"@babel/template@^7.12.7", "@babel/template@^7.20.7":
-  version "7.20.7"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
-  integrity sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==
-  dependencies:
-    "@babel/code-frame" "^7.18.6"
-    "@babel/parser" "^7.20.7"
-    "@babel/types" "^7.20.7"
-
 "@babel/template@^7.15.4", "@babel/template@^7.3.3":
   version "7.15.4"
   resolved "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz"
@@ -894,6 +861,15 @@
     "@babel/code-frame" "^7.18.6"
     "@babel/parser" "^7.18.10"
     "@babel/types" "^7.18.10"
+
+"@babel/template@^7.20.7":
+  version "7.20.7"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
+  integrity sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==
+  dependencies:
+    "@babel/code-frame" "^7.18.6"
+    "@babel/parser" "^7.20.7"
+    "@babel/types" "^7.20.7"
 
 "@babel/traverse@7.12.13":
   version "7.12.13"
@@ -925,22 +901,6 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/traverse@^7.12.9", "@babel/traverse@^7.21.0", "@babel/traverse@^7.21.2":
-  version "7.21.3"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.21.3.tgz#4747c5e7903d224be71f90788b06798331896f67"
-  integrity sha512-XLyopNeaTancVitYZe2MlUEvgKb6YVVPXzofHgqHijCImG33b/uTurMS488ht/Hbsb2XK3U2BnSTxKVNGV3nGQ==
-  dependencies:
-    "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.21.3"
-    "@babel/helper-environment-visitor" "^7.18.9"
-    "@babel/helper-function-name" "^7.21.0"
-    "@babel/helper-hoist-variables" "^7.18.6"
-    "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/parser" "^7.21.3"
-    "@babel/types" "^7.21.3"
-    debug "^4.1.0"
-    globals "^11.1.0"
-
 "@babel/traverse@^7.20.10", "@babel/traverse@^7.20.12", "@babel/traverse@^7.20.7":
   version "7.20.12"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.20.12.tgz#7f0f787b3a67ca4475adef1f56cb94f6abd4a4b5"
@@ -954,6 +914,22 @@
     "@babel/helper-split-export-declaration" "^7.18.6"
     "@babel/parser" "^7.20.7"
     "@babel/types" "^7.20.7"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
+"@babel/traverse@^7.21.0", "@babel/traverse@^7.21.2", "@babel/traverse@^7.21.3":
+  version "7.21.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.21.3.tgz#4747c5e7903d224be71f90788b06798331896f67"
+  integrity sha512-XLyopNeaTancVitYZe2MlUEvgKb6YVVPXzofHgqHijCImG33b/uTurMS488ht/Hbsb2XK3U2BnSTxKVNGV3nGQ==
+  dependencies:
+    "@babel/code-frame" "^7.18.6"
+    "@babel/generator" "^7.21.3"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-function-name" "^7.21.0"
+    "@babel/helper-hoist-variables" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/parser" "^7.21.3"
+    "@babel/types" "^7.21.3"
     debug "^4.1.0"
     globals "^11.1.0"
 
@@ -980,15 +956,6 @@
   integrity sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.9"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.12.7", "@babel/types@^7.21.0", "@babel/types@^7.21.2", "@babel/types@^7.21.3":
-  version "7.21.3"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.21.3.tgz#4865a5357ce40f64e3400b0f3b737dc6d4f64d05"
-  integrity sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==
-  dependencies:
-    "@babel/helper-string-parser" "^7.19.4"
-    "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.16.7":
@@ -1038,6 +1005,15 @@
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.20.7.tgz#54ec75e252318423fc07fb644dc6a58a64c09b7f"
   integrity sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.19.4"
+    "@babel/helper-validator-identifier" "^7.19.1"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.21.0", "@babel/types@^7.21.2", "@babel/types@^7.21.3":
+  version "7.21.3"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.21.3.tgz#4865a5357ce40f64e3400b0f3b737dc6d4f64d05"
+  integrity sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==
   dependencies:
     "@babel/helper-string-parser" "^7.19.4"
     "@babel/helper-validator-identifier" "^7.19.1"
@@ -2083,6 +2059,14 @@
   resolved "https://registry.npmjs.org/@josephg/resolvable/-/resolvable-1.0.1.tgz"
   integrity sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg==
 
+"@jridgewell/gen-mapping@^0.1.0":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz#e5d2e450306a9491e3bd77e323e38d7aff315996"
+  integrity sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==
+  dependencies:
+    "@jridgewell/set-array" "^1.0.0"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+
 "@jridgewell/gen-mapping@^0.3.2":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz#c1aedc61e853f2bb9f5dfe6d4442d3b565b253b9"
@@ -2102,7 +2086,7 @@
   resolved "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.4.tgz"
   integrity sha512-cz8HFjOFfUBtvN+NXYSFMHYRdxZMaEl0XypVrhzxBgadKIXhIkRd8aMeHhmF56Sl7SuS8OnUpQ73/k9LE4VnLg==
 
-"@jridgewell/set-array@^1.0.1":
+"@jridgewell/set-array@^1.0.0", "@jridgewell/set-array@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
   integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
@@ -8590,7 +8574,7 @@ fwd-stream@^1.0.4:
   dependencies:
     readable-stream "~1.0.26-4"
 
-gensync@^1.0.0-beta.1, gensync@^1.0.0-beta.2:
+gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
@@ -9612,13 +9596,6 @@ is-core-module@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211"
   integrity sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
-  dependencies:
-    has "^1.0.3"
-
-is-core-module@^2.9.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz#ad4cb3e3863e814523c96f3f58d26cc570ff0144"
-  integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
   dependencies:
     has "^1.0.3"
 
@@ -13771,15 +13748,6 @@ resolve@^1.12.0:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
-resolve@^1.3.2:
-  version "1.22.1"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
-  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
-  dependencies:
-    is-core-module "^2.9.0"
-    path-parse "^1.0.7"
-    supports-preserve-symlinks-flag "^1.0.0"
-
 resolve@^2.0.0-next.3:
   version "2.0.0-next.3"
   resolved "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.3.tgz"
@@ -14017,7 +13985,7 @@ semver-diff@^4.0.0:
   dependencies:
     semver "^7.3.5"
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,7 +133,29 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.20.10.tgz#9d92fa81b87542fff50e848ed585b4212c1d34ec"
   integrity sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==
 
-"@babel/core@7.12.9", "@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.10.5", "@babel/core@^7.12.3", "@babel/core@^7.12.9", "@babel/core@^7.14.6", "@babel/core@^7.7.2", "@babel/core@^7.7.5", "@babel/core@^7.7.7":
+"@babel/core@7.12.9":
+  version "7.12.9"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.9.tgz#fd450c4ec10cdbb980e2928b7aa7a28484593fc8"
+  integrity sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.12.5"
+    "@babel/helper-module-transforms" "^7.12.1"
+    "@babel/helpers" "^7.12.5"
+    "@babel/parser" "^7.12.7"
+    "@babel/template" "^7.12.7"
+    "@babel/traverse" "^7.12.9"
+    "@babel/types" "^7.12.7"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.1"
+    json5 "^2.1.2"
+    lodash "^4.17.19"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.10.5", "@babel/core@^7.12.3", "@babel/core@^7.12.9", "@babel/core@^7.7.2", "@babel/core@^7.7.5", "@babel/core@^7.7.7":
   version "7.20.12"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.20.12.tgz#7930db57443c6714ad216953d1356dac0eb8496d"
   integrity sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==
@@ -162,6 +184,16 @@
     "@babel/types" "^7.15.6"
     jsesc "^2.5.1"
     source-map "^0.5.0"
+
+"@babel/generator@^7.12.5", "@babel/generator@^7.21.3":
+  version "7.21.3"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.21.3.tgz#232359d0874b392df04045d72ce2fd9bb5045fce"
+  integrity sha512-QS3iR1GYC/YGUnW7IdggFeN5c1poPUurnGttOV/bZgPGV+izC/D8HnD6DLwod0fsatNyVn1G3EVWMYIF0nHbeA==
+  dependencies:
+    "@babel/types" "^7.21.3"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    "@jridgewell/trace-mapping" "^0.3.17"
+    jsesc "^2.5.1"
 
 "@babel/generator@^7.20.7":
   version "7.20.7"
@@ -234,6 +266,14 @@
     "@babel/template" "^7.18.10"
     "@babel/types" "^7.19.0"
 
+"@babel/helper-function-name@^7.21.0":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.21.0.tgz#d552829b10ea9f120969304023cd0645fa00b1b4"
+  integrity sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==
+  dependencies:
+    "@babel/template" "^7.20.7"
+    "@babel/types" "^7.21.0"
+
 "@babel/helper-get-function-arity@^7.15.4":
   version "7.15.4"
   resolved "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz"
@@ -282,6 +322,20 @@
   integrity sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==
   dependencies:
     "@babel/types" "^7.18.6"
+
+"@babel/helper-module-transforms@^7.12.1":
+  version "7.21.2"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.21.2.tgz#160caafa4978ac8c00ac66636cb0fa37b024e2d2"
+  integrity sha512-79yj2AR4U/Oqq/WOV7Lx6hUjau1Zfo4cI+JLAVYeMV5XIlbOhmjEk5ulbTc9fMpmlojzZHkUUxAiK+UKn+hNQQ==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-module-imports" "^7.18.6"
+    "@babel/helper-simple-access" "^7.20.2"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/helper-validator-identifier" "^7.19.1"
+    "@babel/template" "^7.20.7"
+    "@babel/traverse" "^7.21.2"
+    "@babel/types" "^7.21.2"
 
 "@babel/helper-module-transforms@^7.14.5":
   version "7.15.8"
@@ -418,6 +472,15 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz#bf0d2b5a509b1f336099e4ff36e1a63aa5db4db8"
   integrity sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==
 
+"@babel/helpers@^7.12.5":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.21.0.tgz#9dd184fb5599862037917cdc9eecb84577dc4e7e"
+  integrity sha512-XXve0CBtOW0pd7MRzzmoyuSj0e3SEzj8pgyFxnTT1NJZL38BD1MK7yYrm8yefRPIDvNNe14xR4FdbHwpInD4rA==
+  dependencies:
+    "@babel/template" "^7.20.7"
+    "@babel/traverse" "^7.21.0"
+    "@babel/types" "^7.21.0"
+
 "@babel/helpers@^7.20.7":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.20.7.tgz#04502ff0feecc9f20ecfaad120a18f011a8e6dce"
@@ -445,10 +508,20 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@7.12.16", "@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.11.5", "@babel/parser@^7.12.13", "@babel/parser@^7.14.6", "@babel/parser@^7.14.7", "@babel/parser@^7.15.4", "@babel/parser@^7.18.10", "@babel/parser@^7.20.7", "@babel/parser@^7.7.2":
+"@babel/parser@7.12.16":
+  version "7.12.16"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.16.tgz#cc31257419d2c3189d394081635703f549fc1ed4"
+  integrity sha512-c/+u9cqV6F0+4Hpq01jnJO+GLp2DdT63ppz9Xa+6cHaajM9VFzK/iDXiKK65YtpeVwu+ctfS6iqlMqRgQRzeCw==
+
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.11.5", "@babel/parser@^7.12.13", "@babel/parser@^7.14.7", "@babel/parser@^7.15.4", "@babel/parser@^7.18.10", "@babel/parser@^7.20.7", "@babel/parser@^7.7.2":
   version "7.20.13"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.13.tgz#ddf1eb5a813588d2fb1692b70c6fce75b945c088"
   integrity sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==
+
+"@babel/parser@^7.12.7", "@babel/parser@^7.21.3":
+  version "7.21.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.21.3.tgz#1d285d67a19162ff9daa358d4cb41d50c06220b3"
+  integrity sha512-lobG0d7aOfQRXh8AyklEAgZGvA4FShxo6xQbUrrT/cNBPUdIDojlokwJsQyCC/eKia7ifqM0yP+2DRZ4WKw2RQ==
 
 "@babel/plugin-proposal-class-properties@^7.0.0":
   version "7.14.5"
@@ -795,6 +868,15 @@
   resolved "https://registry.npmjs.org/@babel/standalone/-/standalone-7.14.6.tgz"
   integrity sha512-oAoSp82jhJFnXKybKTOj5QF04XxiDRyiiqrFToiU1udlBXuZoADlPmmnOcuqBrZxSNNUjzJIVK8vt838Qoqjxg==
 
+"@babel/template@^7.12.7", "@babel/template@^7.20.7":
+  version "7.20.7"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
+  integrity sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==
+  dependencies:
+    "@babel/code-frame" "^7.18.6"
+    "@babel/parser" "^7.20.7"
+    "@babel/types" "^7.20.7"
+
 "@babel/template@^7.15.4", "@babel/template@^7.3.3":
   version "7.15.4"
   resolved "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz"
@@ -812,15 +894,6 @@
     "@babel/code-frame" "^7.18.6"
     "@babel/parser" "^7.18.10"
     "@babel/types" "^7.18.10"
-
-"@babel/template@^7.20.7":
-  version "7.20.7"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
-  integrity sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==
-  dependencies:
-    "@babel/code-frame" "^7.18.6"
-    "@babel/parser" "^7.20.7"
-    "@babel/types" "^7.20.7"
 
 "@babel/traverse@7.12.13":
   version "7.12.13"
@@ -849,6 +922,22 @@
     "@babel/helper-split-export-declaration" "^7.15.4"
     "@babel/parser" "^7.15.4"
     "@babel/types" "^7.15.4"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
+"@babel/traverse@^7.12.9", "@babel/traverse@^7.21.0", "@babel/traverse@^7.21.2":
+  version "7.21.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.21.3.tgz#4747c5e7903d224be71f90788b06798331896f67"
+  integrity sha512-XLyopNeaTancVitYZe2MlUEvgKb6YVVPXzofHgqHijCImG33b/uTurMS488ht/Hbsb2XK3U2BnSTxKVNGV3nGQ==
+  dependencies:
+    "@babel/code-frame" "^7.18.6"
+    "@babel/generator" "^7.21.3"
+    "@babel/helper-environment-visitor" "^7.18.9"
+    "@babel/helper-function-name" "^7.21.0"
+    "@babel/helper-hoist-variables" "^7.18.6"
+    "@babel/helper-split-export-declaration" "^7.18.6"
+    "@babel/parser" "^7.21.3"
+    "@babel/types" "^7.21.3"
     debug "^4.1.0"
     globals "^11.1.0"
 
@@ -891,6 +980,15 @@
   integrity sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.9"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.12.7", "@babel/types@^7.21.0", "@babel/types@^7.21.2", "@babel/types@^7.21.3":
+  version "7.21.3"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.21.3.tgz#4865a5357ce40f64e3400b0f3b737dc6d4f64d05"
+  integrity sha512-sBGdETxC+/M4o/zKC0sl6sjWv62WFR/uzxrJ6uYyMLZOUlPnwzw0tKgVHOXxaAd5l2g8pEDM5RZ495GPQI77kg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.19.4"
+    "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.16.7":
@@ -1994,6 +2092,11 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@jridgewell/resolve-uri@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
+  integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
+
 "@jridgewell/resolve-uri@^3.0.3":
   version "3.0.4"
   resolved "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.4.tgz"
@@ -2003,6 +2106,11 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
   integrity sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==
+
+"@jridgewell/sourcemap-codec@1.4.14":
+  version "1.4.14"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
+  integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
 
 "@jridgewell/sourcemap-codec@^1.4.10":
   version "1.4.11"
@@ -2016,6 +2124,14 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@jridgewell/trace-mapping@^0.3.17":
+  version "0.3.17"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz#793041277af9073b0951a7fe0f0d8c4c98c36985"
+  integrity sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==
+  dependencies:
+    "@jridgewell/resolve-uri" "3.1.0"
+    "@jridgewell/sourcemap-codec" "1.4.14"
 
 "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.14"
@@ -2791,13 +2907,15 @@
     "@testing-library/dom" "^7.31.2"
     wait-for-expect "^3.0.2"
 
-"@playwright/test@^1.26.1":
-  version "1.26.1"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.26.1.tgz#73ada4e70f618bca69ba7509c4ba65b5a41c4b10"
-  integrity sha512-bNxyZASVt2adSZ9gbD7NCydzcb5JaI0OR9hc7s+nmPeH604gwp0zp17NNpwXY4c8nvuBGQQ9oGDx72LE+cUWvw==
+"@playwright/test@^1.32.1":
+  version "1.32.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.32.1.tgz#749c9791adb048c266277a39ba0f7e33fe593ffe"
+  integrity sha512-FTwjCuhlm1qHUGf4hWjfr64UMJD/z0hXYbk+O387Ioe6WdyZQ+0TBDAc6P+pHjx2xCv1VYNgrKbYrNixFWy4Dg==
   dependencies:
     "@types/node" "*"
-    playwright-core "1.26.1"
+    playwright-core "1.32.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 "@pnpm/network.ca-file@^1.0.1":
   version "1.0.1"
@@ -8430,7 +8548,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@^2.3.2, fsevents@~2.3.1, fsevents@~2.3.2:
+fsevents@2.3.2, fsevents@^2.3.2, fsevents@~2.3.1, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -8472,7 +8590,7 @@ fwd-stream@^1.0.4:
   dependencies:
     readable-stream "~1.0.26-4"
 
-gensync@^1.0.0-beta.2:
+gensync@^1.0.0-beta.1, gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
@@ -9494,6 +9612,13 @@ is-core-module@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211"
   integrity sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
+  dependencies:
+    has "^1.0.3"
+
+is-core-module@^2.9.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.11.0.tgz#ad4cb3e3863e814523c96f3f58d26cc570ff0144"
+  integrity sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==
   dependencies:
     has "^1.0.3"
 
@@ -12577,10 +12702,10 @@ platform@1.3.6:
   resolved "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz"
   integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
-playwright-core@1.26.1:
-  version "1.26.1"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.26.1.tgz#a162f476488312dcf12638d97685144de6ada512"
-  integrity sha512-hzFchhhxnEiPc4qVPs9q2ZR+5eKNifY2hQDHtg1HnTTUuphYCBP8ZRb2si+B1TR7BHirgXaPi48LIye5SgrLAA==
+playwright-core@1.32.1:
+  version "1.32.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.32.1.tgz#5a10c32403323b07d75ea428ebeed866a80b76a1"
+  integrity sha512-KZYUQC10mXD2Am1rGlidaalNGYk3LU1vZqqNk0gT4XPty1jOqgup8KDP8l2CUlqoNKhXM5IfGjWgW37xvGllBA==
 
 playwright-testing-library@^4.5.0:
   version "4.5.0"
@@ -13646,6 +13771,15 @@ resolve@^1.12.0:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+resolve@^1.3.2:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
+  integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
+  dependencies:
+    is-core-module "^2.9.0"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
+
 resolve@^2.0.0-next.3:
   version "2.0.0-next.3"
   resolved "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.3.tgz"
@@ -13883,7 +14017,7 @@ semver-diff@^4.0.0:
   dependencies:
     semver "^7.3.5"
 
-"semver@2 || 3 || 4 || 5", semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==


### PR DESCRIPTION
Previously, when sorting values, we have to build a dimension value
index, indexed by label, since the data that we receive does not contain
the value iris, but it contains the value labels.

The problem occurs
when two dimension values have the same label, but not the same IRI,
for example in the case of hierarchy, where two different regions
are named the same but are located in two different parts of the tree.

Previously, the sorting would end up wrong, since we would make a mistake
when getting the dimension value (finding one dimension value from the
index, when we should have found the other).

To remediate the problem, when there is a filter on the dimension, we
pass it to the function creating the sorting, so that only values
present in the filter are used. This way, we lower the risk of using
two values with the same label.

The problem would still be there if the chart creator selects two
values with the same label, to be displayed at the same time on the
same chart. For example if someone decides to display at the same time
Bern the canton, and Bern the city. Then we would have trouble indexing
correctly. In this case, the person reading the chart would also have
trouble though.

Fix https://github.com/visualize-admin/visualization-tool/issues/978