### PR TITLE
perf: Do not load hierarchies when fetching DataCubePreview

### DIFF
--- a/app/configurator/components/datatable.tsx
+++ b/app/configurator/components/datatable.tsx
@@ -3,12 +3,12 @@ import {
   SxProps,
   Table,
   TableBody,
-  Tooltip,
   TableCell,
   TableHead,
   TableRow,
   TableSortLabel,
   Theme,
+  Tooltip,
   TooltipProps,
 } from "@mui/material";
 import { ascending, descending } from "d3";
@@ -18,10 +18,11 @@ import { useQueryFilters } from "@/charts/shared/chart-helpers";
 import { Loading } from "@/components/hint";
 import { OpenMetadataPanelWrapper } from "@/components/metadata-panel";
 import { ChartConfig, DataSource } from "@/configurator/config-types";
-import { isNumericalMeasure, Observation } from "@/domain/data";
+import { Observation, isNumericalMeasure } from "@/domain/data";
 import { useDimensionFormatters } from "@/formatters";
 import {
   DimensionMetadataFragment,
+  DimensionMetadataWithoutHierarchiesFragment,
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
 import SvgIcChevronDown from "@/icons/components/IcChevronDown";
@@ -280,8 +281,8 @@ export const DataSetTable = ({
 };
 
 export const getSortedColumns = (
-  dimensions: DimensionMetadataFragment[],
-  measures: DimensionMetadataFragment[]
+  dimensions: DimensionMetadataWithoutHierarchiesFragment[],
+  measures: DimensionMetadataWithoutHierarchiesFragment[]
 ) => {
   const allDimensions = [...dimensions, ...measures];
   allDimensions.sort((a, b) =>

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -64,6 +64,32 @@ fragment dimensionMetadata on Dimension {
   }
 }
 
+fragment dimensionMetadataWithoutHierarchies on Dimension {
+  iri
+  label
+  description
+  isNumerical
+  isKeyDimension
+  dataType
+  order
+  values(sourceType: $sourceType, sourceUrl: $sourceUrl, filters: $filters)
+  unit
+  related {
+    iri
+    type
+  }
+  ... on TemporalDimension {
+    timeUnit
+    timeFormat
+  }
+  ... on NumericalMeasure {
+    isCurrency
+    currencyExponent
+    resolution
+    isDecimal
+  }
+}
+
 query DataCubePreview(
   $iri: String!
   $sourceType: String!
@@ -84,10 +110,10 @@ query DataCubePreview(
     description
     publicationStatus
     dimensions(sourceType: $sourceType, sourceUrl: $sourceUrl) {
-      ...dimensionMetadata
+      ...dimensionMetadataWithoutHierarchies
     }
     measures(sourceType: $sourceType, sourceUrl: $sourceUrl) {
-      ...dimensionMetadata
+      ...dimensionMetadataWithoutHierarchies
     }
     observations(sourceType: $sourceType, sourceUrl: $sourceUrl, limit: 10) {
       data

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -547,6 +547,22 @@ type DimensionMetadata_TemporalDimension_Fragment = (
 
 export type DimensionMetadataFragment = DimensionMetadata_GeoCoordinatesDimension_Fragment | DimensionMetadata_GeoShapesDimension_Fragment | DimensionMetadata_NominalDimension_Fragment | DimensionMetadata_NumericalMeasure_Fragment | DimensionMetadata_OrdinalDimension_Fragment | DimensionMetadata_OrdinalMeasure_Fragment | DimensionMetadata_TemporalDimension_Fragment;
 
+type DimensionMetadataWithoutHierarchies_GeoCoordinatesDimension_Fragment = { __typename: 'GeoCoordinatesDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+
+type DimensionMetadataWithoutHierarchies_GeoShapesDimension_Fragment = { __typename: 'GeoShapesDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+
+type DimensionMetadataWithoutHierarchies_NominalDimension_Fragment = { __typename: 'NominalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+
+type DimensionMetadataWithoutHierarchies_NumericalMeasure_Fragment = { __typename: 'NumericalMeasure', isCurrency?: Maybe<boolean>, currencyExponent?: Maybe<number>, resolution?: Maybe<number>, isDecimal?: Maybe<boolean>, iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+
+type DimensionMetadataWithoutHierarchies_OrdinalDimension_Fragment = { __typename: 'OrdinalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+
+type DimensionMetadataWithoutHierarchies_OrdinalMeasure_Fragment = { __typename: 'OrdinalMeasure', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+
+type DimensionMetadataWithoutHierarchies_TemporalDimension_Fragment = { __typename: 'TemporalDimension', timeUnit: TimeUnit, timeFormat: string, iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+
+export type DimensionMetadataWithoutHierarchiesFragment = DimensionMetadataWithoutHierarchies_GeoCoordinatesDimension_Fragment | DimensionMetadataWithoutHierarchies_GeoShapesDimension_Fragment | DimensionMetadataWithoutHierarchies_NominalDimension_Fragment | DimensionMetadataWithoutHierarchies_NumericalMeasure_Fragment | DimensionMetadataWithoutHierarchies_OrdinalDimension_Fragment | DimensionMetadataWithoutHierarchies_OrdinalMeasure_Fragment | DimensionMetadataWithoutHierarchies_TemporalDimension_Fragment;
+
 export type DataCubePreviewQueryVariables = Exact<{
   iri: Scalars['String'];
   sourceType: Scalars['String'];
@@ -559,31 +575,31 @@ export type DataCubePreviewQueryVariables = Exact<{
 
 export type DataCubePreviewQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', iri: string, title: string, description?: Maybe<string>, publicationStatus: DataCubePublicationStatus, dimensions: Array<(
       { __typename: 'GeoCoordinatesDimension' }
-      & DimensionMetadata_GeoCoordinatesDimension_Fragment
+      & DimensionMetadataWithoutHierarchies_GeoCoordinatesDimension_Fragment
     ) | (
       { __typename: 'GeoShapesDimension' }
-      & DimensionMetadata_GeoShapesDimension_Fragment
+      & DimensionMetadataWithoutHierarchies_GeoShapesDimension_Fragment
     ) | (
       { __typename: 'NominalDimension' }
-      & DimensionMetadata_NominalDimension_Fragment
+      & DimensionMetadataWithoutHierarchies_NominalDimension_Fragment
     ) | (
       { __typename: 'NumericalMeasure' }
-      & DimensionMetadata_NumericalMeasure_Fragment
+      & DimensionMetadataWithoutHierarchies_NumericalMeasure_Fragment
     ) | (
       { __typename: 'OrdinalDimension' }
-      & DimensionMetadata_OrdinalDimension_Fragment
+      & DimensionMetadataWithoutHierarchies_OrdinalDimension_Fragment
     ) | (
       { __typename: 'OrdinalMeasure' }
-      & DimensionMetadata_OrdinalMeasure_Fragment
+      & DimensionMetadataWithoutHierarchies_OrdinalMeasure_Fragment
     ) | (
       { __typename: 'TemporalDimension' }
-      & DimensionMetadata_TemporalDimension_Fragment
+      & DimensionMetadataWithoutHierarchies_TemporalDimension_Fragment
     )>, measures: Array<(
       { __typename: 'NumericalMeasure' }
-      & DimensionMetadata_NumericalMeasure_Fragment
+      & DimensionMetadataWithoutHierarchies_NumericalMeasure_Fragment
     ) | (
       { __typename: 'OrdinalMeasure' }
-      & DimensionMetadata_OrdinalMeasure_Fragment
+      & DimensionMetadataWithoutHierarchies_OrdinalMeasure_Fragment
     )>, observations: { __typename: 'ObservationsQuery', data: Array<Observation>, sparql: string, sparqlEditorUrl?: Maybe<string> } }> };
 
 export type DataCubeMetadataQueryVariables = Exact<{
@@ -1055,6 +1071,33 @@ export const DimensionMetadataFragmentDoc = gql`
   }
 }
     ${HierarchyMetadataFragmentDoc}`;
+export const DimensionMetadataWithoutHierarchiesFragmentDoc = gql`
+    fragment dimensionMetadataWithoutHierarchies on Dimension {
+  iri
+  label
+  description
+  isNumerical
+  isKeyDimension
+  dataType
+  order
+  values(sourceType: $sourceType, sourceUrl: $sourceUrl, filters: $filters)
+  unit
+  related {
+    iri
+    type
+  }
+  ... on TemporalDimension {
+    timeUnit
+    timeFormat
+  }
+  ... on NumericalMeasure {
+    isCurrency
+    currencyExponent
+    resolution
+    isDecimal
+  }
+}
+    `;
 export const DataCubesDocument = gql`
     query DataCubes($sourceType: String!, $sourceUrl: String!, $locale: String!, $query: String, $order: DataCubeResultOrder, $includeDrafts: Boolean, $filters: [DataCubeSearchFilter!]) {
   dataCubes(
@@ -1105,10 +1148,10 @@ export const DataCubePreviewDocument = gql`
     description
     publicationStatus
     dimensions(sourceType: $sourceType, sourceUrl: $sourceUrl) {
-      ...dimensionMetadata
+      ...dimensionMetadataWithoutHierarchies
     }
     measures(sourceType: $sourceType, sourceUrl: $sourceUrl) {
-      ...dimensionMetadata
+      ...dimensionMetadataWithoutHierarchies
     }
     observations(sourceType: $sourceType, sourceUrl: $sourceUrl, limit: 10) {
       data
@@ -1117,7 +1160,7 @@ export const DataCubePreviewDocument = gql`
     }
   }
 }
-    ${DimensionMetadataFragmentDoc}`;
+    ${DimensionMetadataWithoutHierarchiesFragmentDoc}`;
 
 export function useDataCubePreviewQuery(options: Omit<Urql.UseQueryArgs<DataCubePreviewQueryVariables>, 'query'> = {}) {
   return Urql.useQuery<DataCubePreviewQuery>({ query: DataCubePreviewDocument, ...options });


### PR DESCRIPTION
Fixes #1002.

As the dimensions are only required to know how to sort the columns, we do not need to load the hierarchies in the `DataCubePreview` query. Loading them can be the most time consuming part of the query in some cases.

Basing on the example shared in #1002, it makes it fast  to load the preview, instead of taking ~10s as is currently the case.