### PR TITLE
fix: Navigation with browser buttons

### DIFF
--- a/app/utils/router/helpers.ts
+++ b/app/utils/router/helpers.ts
@@ -25,5 +25,9 @@ export const setURLParam = (param: string, value: string) => {
   qs.delete(param);
   qs.append(param, value);
   const newUrl = `${protocol}//${host}${pathname}?${qs}`;
-  window.history.replaceState({ path: newUrl }, "", newUrl);
+  window.history.replaceState(
+    { ...window.history.state, path: newUrl },
+    "",
+    newUrl
+  );
 };


### PR DESCRIPTION
Fixes #853.

In order for the browser buttons to work properly there was a need to include current window state when doing `window.history.replaceState` when setting URL params; otherwise the navigation didn't work properly.