### PR TITLE
fix: Color mapping for tables

### DIFF
--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -1,20 +1,20 @@
 import { t, Trans } from "@lingui/macro";
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
   Box,
   Button,
   ClickAwayListener,
-  Typography,
   Divider,
-  Theme,
-  IconButton,
-  Tooltip,
-  Accordion,
-  AccordionSummary,
-  AccordionDetails,
-  InputAdornment,
-  Input,
   FormControlLabel,
+  IconButton,
+  Input,
+  InputAdornment,
   Switch,
+  Theme,
+  Tooltip,
+  Typography,
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { makeStyles } from "@mui/styles";
@@ -25,7 +25,7 @@ import keyBy from "lodash/keyBy";
 import orderBy from "lodash/orderBy";
 import sortBy from "lodash/sortBy";
 import uniqBy from "lodash/uniqBy";
-import React, {
+import {
   forwardRef,
   MouseEventHandler,
   MutableRefObject,
@@ -165,9 +165,9 @@ const getColorConfig = (
     return;
   }
 
-  const path = `${config.activeField}${
-    colorConfigPath ? `.${colorConfigPath}` : ""
-  }`;
+  const path = colorConfigPath
+    ? [config.activeField, colorConfigPath]
+    : [config.activeField];
 
   return get(config.chartConfig.fields, path) as
     | GenericSegmentField

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -7,9 +7,9 @@ import sortBy from "lodash/sortBy";
 import unset from "lodash/unset";
 import { useRouter } from "next/router";
 import {
-  createContext,
   Dispatch,
   ReactNode,
+  createContext,
   useContext,
   useEffect,
   useMemo,
@@ -31,39 +31,37 @@ import {
 import { DEFAULT_FIXED_COLOR_FIELD } from "@/charts/map/constants";
 import { mapValueIrisToColor } from "@/configurator/components/ui-helpers";
 import {
+  ChartConfig,
+  ChartType,
+  ConfiguratorState,
   ConfiguratorStateConfiguringChart,
+  ConfiguratorStateSelectingDataSet,
   DataSource,
+  FilterValue,
+  FilterValueMultiValues,
+  Filters,
   GenericField,
+  GenericFields,
   ImputationType,
+  InteractiveFiltersConfig,
+  MapConfig,
+  MapFields,
+  NumericalColorField,
+  decodeConfiguratorState,
   isAreaConfig,
   isColorFieldInConfig,
   isColumnConfig,
   isMapConfig,
   isSegmentInConfig,
-  MapConfig,
-  MapFields,
-  NumericalColorField,
-} from "@/configurator/config-types";
-import {
-  ChartConfig,
-  ChartType,
-  ConfiguratorState,
-  ConfiguratorStateSelectingDataSet,
-  decodeConfiguratorState,
-  Filters,
-  FilterValue,
-  FilterValueMultiValues,
-  GenericFields,
-  InteractiveFiltersConfig,
 } from "@/configurator/config-types";
 import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import {
-  canDimensionBeMultiFiltered,
   DimensionValue,
-  isOrdinalMeasure,
+  canDimensionBeMultiFiltered,
   isGeoDimension,
   isGeoShapesDimension,
   isNumericalMeasure,
+  isOrdinalMeasure,
   isTemporalDimension,
 } from "@/domain/data";
 import { DEFAULT_DATA_SOURCE } from "@/domain/datasource";
@@ -85,7 +83,7 @@ import {
   getDataSourceFromLocalStorage,
   useDataSourceStore,
 } from "@/stores/data-source";
-import { fetchChartConfig, createConfig } from "@/utils/chart-config/api";
+import { createConfig, fetchChartConfig } from "@/utils/chart-config/api";
 import { migrateChartConfig } from "@/utils/chart-config/versioning";
 import { createChartId } from "@/utils/create-chart-id";
 import { unreachableError } from "@/utils/unreachable";
@@ -1031,9 +1029,10 @@ export const updateColorMapping = (
   if (draft.state === "CONFIGURING_CHART") {
     const { field, colorConfigPath, dimensionIri, values, random } =
       action.value;
-    const path = `fields.${field}${
-      colorConfigPath ? `.${colorConfigPath}` : ""
-    }`;
+    const path = colorConfigPath
+      ? [`fields.${field}`, colorConfigPath]
+      : [`fields.${field}`];
+
     const fieldValue = get(draft.chartConfig, path) as
       | (GenericField & { palette: string })
       | undefined;
@@ -1044,7 +1043,7 @@ export const updateColorMapping = (
         dimensionValues: values,
         random,
       });
-      setWith(draft.chartConfig, `${path}.colorMapping`, colorMapping);
+      setWith(draft.chartConfig, path.concat("colorMapping"), colorMapping);
     }
   }
 

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -33,6 +33,8 @@ import { mapValueIrisToColor } from "@/configurator/components/ui-helpers";
 import {
   ChartConfig,
   ChartType,
+  ColorMapping,
+  ColumnStyleCategory,
   ConfiguratorState,
   ConfiguratorStateConfiguringChart,
   ConfiguratorStateSelectingDataSet,
@@ -53,8 +55,10 @@ import {
   isColumnConfig,
   isMapConfig,
   isSegmentInConfig,
+  isTableConfig,
 } from "@/configurator/config-types";
 import { FIELD_VALUE_NONE } from "@/configurator/constants";
+import { toggleInteractiveFilterDataDimension } from "@/configurator/interactive-filters/interactive-filters-config-state";
 import {
   DimensionValue,
   canDimensionBeMultiFiltered,
@@ -87,8 +91,6 @@ import { createConfig, fetchChartConfig } from "@/utils/chart-config/api";
 import { migrateChartConfig } from "@/utils/chart-config/versioning";
 import { createChartId } from "@/utils/create-chart-id";
 import { unreachableError } from "@/utils/unreachable";
-
-import { toggleInteractiveFilterDataDimension } from "./interactive-filters/interactive-filters-config-state";
 
 export type ConfiguratorStateAction =
   | {
@@ -1030,19 +1032,37 @@ export const updateColorMapping = (
     const { field, colorConfigPath, dimensionIri, values, random } =
       action.value;
     const path = colorConfigPath
-      ? [`fields.${field}`, colorConfigPath]
-      : [`fields.${field}`];
+      ? ["fields", field, colorConfigPath]
+      : ["fields", field];
+    let colorMapping: ColorMapping | undefined;
 
-    const fieldValue = get(draft.chartConfig, path) as
-      | (GenericField & { palette: string })
-      | undefined;
+    if (isTableConfig(draft.chartConfig)) {
+      const fieldValue = get(draft.chartConfig, path) as
+        | ColumnStyleCategory
+        | undefined;
 
-    if (fieldValue?.componentIri === dimensionIri) {
-      const colorMapping = mapValueIrisToColor({
-        palette: fieldValue.palette,
-        dimensionValues: values,
-        random,
-      });
+      if (fieldValue) {
+        colorMapping = mapValueIrisToColor({
+          palette: fieldValue.palette,
+          dimensionValues: values,
+          random,
+        });
+      }
+    } else {
+      const fieldValue = get(draft.chartConfig, path) as
+        | (GenericField & { palette: string })
+        | undefined;
+
+      if (fieldValue?.componentIri === dimensionIri) {
+        colorMapping = mapValueIrisToColor({
+          palette: fieldValue.palette,
+          dimensionValues: values,
+          random,
+        });
+      }
+    }
+
+    if (colorMapping) {
       setWith(draft.chartConfig, path.concat("colorMapping"), colorMapping);
     }
   }

--- a/app/configurator/table/table-chart-options.tsx
+++ b/app/configurator/table/table-chart-options.tsx
@@ -194,6 +194,13 @@ export const TableColumnOptions = ({
           label: t({ id: "columnStyle.bar", message: `Bar Chart` }),
         },
       ]
+    : isTemporalDimension(component)
+    ? [
+        {
+          value: "text",
+          label: t({ id: "columnStyle.text", message: `Text` }),
+        },
+      ]
     : [
         {
           value: "text",
@@ -204,6 +211,7 @@ export const TableColumnOptions = ({
           label: t({ id: "columnStyle.categories", message: `Categories` }),
         },
       ];
+
   return (
     <div
       key={`control-panel-table-column-${activeField}`}

--- a/app/configurator/table/table-chart-options.tsx
+++ b/app/configurator/table/table-chart-options.tsx
@@ -1,7 +1,7 @@
 import { t, Trans } from "@lingui/macro";
-import { Box, Alert, Typography } from "@mui/material";
+import { Alert, Box, Typography } from "@mui/material";
 import get from "lodash/get";
-import React, { ChangeEvent, useCallback, useEffect, useRef } from "react";
+import { ChangeEvent, useCallback, useEffect, useRef } from "react";
 
 import { Checkbox } from "@/components/form";
 import { ColorPalette } from "@/configurator/components/chart-controls/color-palette";
@@ -330,8 +330,10 @@ export const TableColumnOptions = ({
             ) : (
               <DimensionValuesMultiFilter
                 key={component.iri}
+                field={component.iri}
                 dimensionIri={component.iri}
                 dataSetIri={metaData.iri}
+                colorComponent={component}
                 colorConfigPath="columnStyle"
               />
             )}


### PR DESCRIPTION
Fixes #872.

There was an issue with subsetting the chart config (lodash's `get`) when using strings for table fields, which are iris and not "regular" strings, like `segment` or `x`. This PR fixes that by using an array instead of string.

Also, there was a problem with refreshing color mappings for table, as we were expecting a `segment` field to be passed to `updateColorMapping`, while we also can pass table fields.

### To test
1. Go to https://visualization-tool-7acz0ufkc-ixt1.vercel.app
2. Look for Einmalvergütung für Photovoltaikanlagen dataset (INT).
3. Create a chart.
4. Switch to a table chart.
5. Change Standort der Anlage's column type to Category.
6. See that it's possible to map the colors individually to each value.
7. See that it's possible to refresh the colors.
8. Switch to Jahr column.
9. Change type to category.
10. See that more than two colors are mapped.

~~We also fetch all values for `TemporalDimensions` with resolution of Year, so the color mapping inside a table for such dimensions won't just map two colors. I feel like it's not an ideal solution – other way would be to add a `forceLoadAll` property to GQL query for dimension values and load them just inside the panel where we modify column options for table.~~

But then the question still remains, should we be able to modify each color individually like for multi-filter panel? Should the year be colored only with sequential color palettes, as it's kinda numerical? If we would like to go with the "color-each-value-individually" approach, there would be a need to modify much more logic, as right now multi-filter panel is only supposed to work with dimensions that can be multi-filtered, while for year we have different logic (slider).

What do you think @ptbrowne?