### PR TITLE
fix: Redirect to versioned cube

### DIFF
--- a/app/configurator/components/use-redirect-to-versioned-cube.tsx
+++ b/app/configurator/components/use-redirect-to-versioned-cube.tsx
@@ -50,6 +50,7 @@ export const useRedirectToVersionedCube = ({
         router.replace({
           pathname: `/${locale}/browse`,
           query: {
+            ...router.query,
             dataset: resp.iri,
           },
         });
@@ -57,6 +58,7 @@ export const useRedirectToVersionedCube = ({
         router.replace({
           pathname: `/`,
           query: getErrorQueryParams("CANNOT_FIND_CUBE", {
+            ...router.query,
             iri: datasetIri,
           }),
         });

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -7,9 +7,9 @@ import sortBy from "lodash/sortBy";
 import unset from "lodash/unset";
 import { useRouter } from "next/router";
 import {
-  createContext,
   Dispatch,
   ReactNode,
+  createContext,
   useContext,
   useEffect,
   useMemo,
@@ -31,39 +31,37 @@ import {
 import { DEFAULT_FIXED_COLOR_FIELD } from "@/charts/map/constants";
 import { mapValueIrisToColor } from "@/configurator/components/ui-helpers";
 import {
+  ChartConfig,
+  ChartType,
+  ConfiguratorState,
   ConfiguratorStateConfiguringChart,
+  ConfiguratorStateSelectingDataSet,
   DataSource,
+  FilterValue,
+  FilterValueMultiValues,
+  Filters,
   GenericField,
+  GenericFields,
   ImputationType,
+  InteractiveFiltersConfig,
+  MapConfig,
+  MapFields,
+  NumericalColorField,
+  decodeConfiguratorState,
   isAreaConfig,
   isColorFieldInConfig,
   isColumnConfig,
   isMapConfig,
   isSegmentInConfig,
-  MapConfig,
-  MapFields,
-  NumericalColorField,
-} from "@/configurator/config-types";
-import {
-  ChartConfig,
-  ChartType,
-  ConfiguratorState,
-  ConfiguratorStateSelectingDataSet,
-  decodeConfiguratorState,
-  Filters,
-  FilterValue,
-  FilterValueMultiValues,
-  GenericFields,
-  InteractiveFiltersConfig,
 } from "@/configurator/config-types";
 import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import {
-  canDimensionBeMultiFiltered,
   DimensionValue,
-  isOrdinalMeasure,
+  canDimensionBeMultiFiltered,
   isGeoDimension,
   isGeoShapesDimension,
   isNumericalMeasure,
+  isOrdinalMeasure,
   isTemporalDimension,
 } from "@/domain/data";
 import { DEFAULT_DATA_SOURCE } from "@/domain/datasource";
@@ -85,7 +83,7 @@ import {
   getDataSourceFromLocalStorage,
   useDataSourceStore,
 } from "@/stores/data-source";
-import { fetchChartConfig, createConfig } from "@/utils/chart-config/api";
+import { createConfig, fetchChartConfig } from "@/utils/chart-config/api";
 import { migrateChartConfig } from "@/utils/chart-config/versioning";
 import { createChartId } from "@/utils/create-chart-id";
 import { unreachableError } from "@/utils/unreachable";
@@ -1502,15 +1500,18 @@ const ConfiguratorStateProviderInternal = ({
   allowDefaultRedirect?: boolean;
 }) => {
   const { dataSource } = useDataSourceStore();
+  const initialStateWithDataSource = useMemo(() => {
+    return { ...initialState, dataSource };
+  }, [initialState, dataSource]);
   const locale = useLocale();
-  const stateAndDispatch = useImmerReducer(reducer, initialState);
+  const stateAndDispatch = useImmerReducer(reducer, initialStateWithDataSource);
   const [state, dispatch] = stateAndDispatch;
   const { asPath, push, replace, query } = useRouter();
   const client = useClient();
 
   // Re-initialize state on page load
   useEffect(() => {
-    let stateToInitialize = getStateWithCurrentDataSource(initialState);
+    let stateToInitialize = initialStateWithDataSource;
 
     const initialize = async () => {
       try {
@@ -1544,7 +1545,7 @@ const ConfiguratorStateProviderInternal = ({
     dispatch,
     chartId,
     replace,
-    initialState,
+    initialStateWithDataSource,
     allowDefaultRedirect,
     query,
     locale,


### PR DESCRIPTION
Fixes #939.

We were initializing configurator state with default data source – this PR fixes that by correctly initializing the state with correct data source.

### To test
1. Go to `/en/browse?dataset=https%3A%2F%2Fenergy.ld.admin.ch%2Fsfoe%2Fbfe_ogd102_fuellstand_gasspeicher&dataSource=Int `(see that no cube version is specified in the URL).
2. See that the cube loads correctly (version 6).