### PR TITLE
fix: Selecting top-most hierarchy value by default in filters

### DIFF
--- a/app/charts/index.spec.ts
+++ b/app/charts/index.spec.ts
@@ -1,6 +1,5 @@
 import { TableFields } from "@/configurator";
-import { DataCubeMetadataWithComponentValuesQuery } from "@/graphql/query-hooks";
-import { DataCubeMetadata } from "@/graphql/types";
+import { ComponentsQuery } from "@/graphql/query-hooks";
 
 import bathingWaterData from "../test/__fixtures/data/DataCubeMetadataWithComponentValues-bathingWater.json";
 import forestAreaData from "../test/__fixtures/data/forest-area-by-production-region.json";
@@ -12,10 +11,10 @@ describe("initial config", () => {
     const config = getInitialConfig({
       chartType: "table",
       dimensions: forestAreaData.data.dataCubeByIri.dimensions as NonNullable<
-        DataCubeMetadataWithComponentValuesQuery["dataCubeByIri"]
+        ComponentsQuery["dataCubeByIri"]
       >["dimensions"],
       measures: forestAreaData.data.dataCubeByIri.measures as NonNullable<
-        DataCubeMetadataWithComponentValuesQuery["dataCubeByIri"]
+        ComponentsQuery["dataCubeByIri"]
       >["measures"],
     });
     expect(
@@ -40,28 +39,31 @@ describe("possible chart types", () => {
   it("should allow appropriate chart types based on available dimensions", () => {
     const expectedChartTypes = ["area", "column", "line", "pie", "table"];
     const possibleChartTypes = getPossibleChartType({
-      metadata: bathingWaterData.data.dataCubeByIri as DataCubeMetadata,
+      dimensions: bathingWaterData.data.dataCubeByIri.dimensions as NonNullable<
+        ComponentsQuery["dataCubeByIri"]
+      >["dimensions"],
+      measures: bathingWaterData.data.dataCubeByIri.measures as NonNullable<
+        ComponentsQuery["dataCubeByIri"]
+      >["measures"],
     }).sort();
 
     expect(possibleChartTypes).toEqual(expectedChartTypes);
   });
 
   it("should only allow table if there are only measures available", () => {
-    const metadata = {
+    const possibleChartTypes = getPossibleChartType({
       dimensions: [],
-      measures: [{ __typename: "NumericalMeasure" }],
-    } as any;
-    const possibleChartTypes = getPossibleChartType({ metadata }).sort();
+      measures: [{ __typename: "NumericalMeasure" }] as any,
+    });
 
     expect(possibleChartTypes).toEqual(["table"]);
   });
 
   it("should only allow column, map, pie and table if only geo dimensions are available", () => {
-    const metadata = {
-      dimensions: [{ __typename: "GeoShapesDimension" }],
-      measures: [{ __typename: "NumericalMeasure" }],
-    } as any;
-    const possibleChartTypes = getPossibleChartType({ metadata }).sort();
+    const possibleChartTypes = getPossibleChartType({
+      dimensions: [{ __typename: "GeoShapesDimension" }] as any,
+      measures: [{ __typename: "NumericalMeasure" }] as any,
+    }).sort();
 
     expect(possibleChartTypes).toEqual(["column", "map", "pie", "table"]);
   });

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -1108,12 +1108,12 @@ const adjustSegmentSorting = ({
 
 // Helpers
 export const getPossibleChartType = ({
-  metadata,
+  dimensions,
+  measures,
 }: {
-  metadata: DataCubeMetadata;
+  dimensions: DimensionMetadataFragment[];
+  measures: DimensionMetadataFragment[];
 }): ChartType[] => {
-  const { measures, dimensions } = metadata;
-
   const numericalMeasures = measures.filter(isNumericalMeasure);
   const ordinalMeasures = measures.filter(isOrdinalMeasure);
   const categoricalDimensions = getCategoricalDimensions(dimensions);

--- a/app/components/chart-filters-list.tsx
+++ b/app/components/chart-filters-list.tsx
@@ -6,7 +6,7 @@ import { OpenMetadataPanelWrapper } from "@/components/metadata-panel";
 import { ChartConfig, DataSource } from "@/configurator";
 import { isTemporalDimension } from "@/domain/data";
 import { useTimeFormatUnit } from "@/formatters";
-import { useDataCubeMetadataWithComponentValuesQuery } from "@/graphql/query-hooks";
+import { useComponentsQuery } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
 export const ChartFiltersList = ({
@@ -21,7 +21,7 @@ export const ChartFiltersList = ({
   const locale = useLocale();
   const timeFormatUnit = useTimeFormatUnit();
 
-  const [{ data }] = useDataCubeMetadataWithComponentValuesQuery({
+  const [{ data }] = useComponentsQuery({
     variables: {
       iri: dataSetIri,
       sourceType: dataSource.type,

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -1,26 +1,26 @@
 import { t, Trans } from "@lingui/macro";
 import {
+  Badge,
+  BadgeProps,
   Box,
   Button,
-  Tooltip,
   CircularProgress,
+  FormControlLabel,
+  FormControlLabelProps,
   IconButton,
   Menu,
   MenuItem,
-  Theme,
-  Typography,
   Switch,
-  FormControlLabel,
-  FormControlLabelProps,
-  Badge,
-  BadgeProps,
+  Theme,
+  Tooltip,
+  Typography,
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import isEmpty from "lodash/isEmpty";
 import isEqual from "lodash/isEqual";
 import omitBy from "lodash/omitBy";
 import sortBy from "lodash/sortBy";
-import { useEffect, useRef, useState, useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   DragDropContext,
   Draggable,
@@ -66,7 +66,7 @@ import {
   PossibleFiltersDocument,
   PossibleFiltersQuery,
   PossibleFiltersQueryVariables,
-  useDataCubeMetadataWithComponentValuesQuery,
+  useDataCubeMetadataWithComponentValuesAndHierarchiesQuery,
   useDimensionHierarchyQuery,
 } from "@/graphql/query-hooks";
 import { DataCubeMetadata } from "@/graphql/types";
@@ -310,7 +310,7 @@ const useFilterReorder = ({
   ]);
 
   const [{ data, fetching: dataFetching }, executeQuery] =
-    useDataCubeMetadataWithComponentValuesQuery({
+    useDataCubeMetadataWithComponentValuesAndHierarchiesQuery({
       variables: variables,
     });
 

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -61,7 +61,6 @@ import {
 } from "@/configurator/configurator-state";
 import { isStandardErrorDimension, isTemporalDimension } from "@/domain/data";
 import {
-  DataCubeMetadataWithComponentValuesQuery,
   HierarchyValue,
   PossibleFiltersDocument,
   PossibleFiltersQuery,
@@ -266,9 +265,7 @@ const useEnsurePossibleFilters = ({
 };
 
 type Dimension = NonNullable<
-  NonNullable<
-    DataCubeMetadataWithComponentValuesQuery["dataCubeByIri"]
-  >["dimensions"]
+  NonNullable<DataCubeMetadata>["dimensions"]
 >[number];
 
 const useFilterReorder = ({

--- a/app/configurator/components/chart-controls/drag-and-drop-tab.tsx
+++ b/app/configurator/components/chart-controls/drag-and-drop-tab.tsx
@@ -14,7 +14,7 @@ import { getIconName } from "@/configurator/components/ui-helpers";
 import { useActiveFieldField } from "@/configurator/config-form";
 import { TableColumn } from "@/configurator/config-types";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
-import { DataCubeMetadata } from "@/graphql/types";
+import { DataCubeMetadataWithHierarchies } from "@/graphql/types";
 import { Icon } from "@/icons";
 
 const useStyles = makeStyles((theme: Theme) => ({
@@ -36,7 +36,7 @@ type Props = {
   id: string;
   title: ReactNode;
   items: TableColumn[];
-  metaData: DataCubeMetadata;
+  metaData: DataCubeMetadataWithHierarchies;
   isDropDisabled?: boolean;
   emptyComponent?: React.ReactNode;
 };

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -67,10 +67,11 @@ import {
 } from "@/domain/data";
 import {
   DimensionMetadataFragment,
-  useDataCubeMetadataWithComponentValuesAndHierarchiesQuery,
+  useComponentsWithHierarchiesQuery,
+  useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
-import { DataCubeMetadata } from "@/graphql/types";
+import { DataCubeMetadataWithHierarchies } from "@/graphql/types";
 import { useLocale } from "@/locales/use-locale";
 
 import { ColorRampField } from "./chart-controls/color-ramp";
@@ -92,16 +93,22 @@ export const ChartOptionsSelector = ({
     },
   });
 
-  // Unfiltered dimensions & measures values.
-  const [{ data: metadataData }] =
-    useDataCubeMetadataWithComponentValuesAndHierarchiesQuery({
-      variables: {
-        iri: dataSet,
-        sourceType: dataSource.type,
-        sourceUrl: dataSource.url,
-        locale,
-      },
-    });
+  const [{ data: metadataData }] = useDataCubeMetadataQuery({
+    variables: {
+      iri: dataSet,
+      sourceType: dataSource.type,
+      sourceUrl: dataSource.url,
+      locale,
+    },
+  });
+  const [{ data: componentsData }] = useComponentsWithHierarchiesQuery({
+    variables: {
+      iri: dataSet,
+      sourceType: dataSource.type,
+      sourceUrl: dataSource.url,
+      locale,
+    },
+  });
 
   const imputationNeeded = useImputationNeeded({
     chartConfig,
@@ -109,20 +116,21 @@ export const ChartOptionsSelector = ({
   });
 
   const metaData = useMemo(() => {
-    if (metadataData?.dataCubeByIri) {
+    if (metadataData?.dataCubeByIri && componentsData?.dataCubeByIri) {
       return {
         ...metadataData.dataCubeByIri,
+        measures: componentsData.dataCubeByIri.measures,
         dimensions: isTableConfig(chartConfig)
-          ? metadataData.dataCubeByIri.dimensions
+          ? componentsData.dataCubeByIri.dimensions
           : [
               // There are no fields that make use of numeric dimensions at the moment.
-              ...metadataData.dataCubeByIri.dimensions.filter(
+              ...componentsData.dataCubeByIri.dimensions.filter(
                 (d) => !d.isNumerical
               ),
             ],
       };
     }
-  }, [chartConfig, metadataData?.dataCubeByIri]);
+  }, [chartConfig, metadataData?.dataCubeByIri, componentsData?.dataCubeByIri]);
 
   if (metaData) {
     return (
@@ -162,7 +170,7 @@ const ActiveFieldSwitch = ({
   imputationNeeded,
 }: {
   state: ConfiguratorStateConfiguringChart;
-  metaData: DataCubeMetadata;
+  metaData: DataCubeMetadataWithHierarchies;
   imputationNeeded: boolean;
 }) => {
   const { activeField } = state;
@@ -182,8 +190,8 @@ const ActiveFieldSwitch = ({
     activeField
   );
 
-  const allDimensions = [...metaData.dimensions, ...metaData.measures];
-  const component = allDimensions.find(
+  const allComponents = [...metaData.dimensions, ...metaData.measures];
+  const component = allComponents.find(
     (d) => d.iri === activeFieldComponentIri
   );
 
@@ -193,8 +201,9 @@ const ActiveFieldSwitch = ({
       state={state}
       field={activeField} // FIXME: or encoding.field?
       chartType={state.chartConfig.chartType}
-      metaData={metaData}
       component={component}
+      dimensions={metaData.dimensions}
+      measures={metaData.measures}
       imputationNeeded={imputationNeeded}
     />
   );
@@ -206,7 +215,8 @@ const EncodingOptionsPanel = ({
   field,
   chartType,
   component,
-  metaData,
+  dimensions,
+  measures,
   imputationNeeded,
 }: {
   encoding: EncodingSpec;
@@ -214,10 +224,10 @@ const EncodingOptionsPanel = ({
   field: string;
   chartType: ChartType;
   component: DimensionMetadataFragment | undefined;
-  metaData: DataCubeMetadata;
+  dimensions: DimensionMetadataFragment[];
+  measures: DimensionMetadataFragment[];
   imputationNeeded: boolean;
 }) => {
-  const { measures, dimensions } = metaData;
   const panelRef = useRef<HTMLDivElement>(null);
 
   const getFieldLabelHint = {
@@ -265,7 +275,7 @@ const EncodingOptionsPanel = ({
     otherFieldsIris,
   ]);
 
-  const allDimensions = useMemo(() => {
+  const allComponents = useMemo(() => {
     return [...measures, ...dimensions];
   }, [measures, dimensions]);
 
@@ -274,16 +284,16 @@ const EncodingOptionsPanel = ({
       (fields as any)?.[encoding.field] as GenericField | undefined
     )?.componentIri;
 
-    return allDimensions.find((d) => d.iri === encodingIri);
-  }, [allDimensions, fields, encoding.field]);
+    return allComponents.find((d) => d.iri === encodingIri);
+  }, [allComponents, fields, encoding.field]);
 
   const hasStandardError = useMemo(() => {
-    return allDimensions.find((d) =>
+    return allComponents.find((d) =>
       d.related?.some(
         (r) => r.type === "StandardError" && r.iri === component?.iri
       )
     );
-  }, [allDimensions, component]);
+  }, [allComponents, component]);
 
   // TODO: Add proper types here.
   const optionsByField = useMemo(
@@ -358,7 +368,8 @@ const EncodingOptionsPanel = ({
         <ChartFieldSize
           field={field}
           componentTypes={optionsByField["size"].componentTypes}
-          dataSetMetadata={metaData}
+          dimensions={dimensions}
+          measures={measures}
           optional={optionsByField["size"].optional}
         />
       )}
@@ -367,11 +378,13 @@ const EncodingOptionsPanel = ({
         optionsByField["color"].type === "component" &&
         component && (
           <ChartFieldColorComponent
+            state={state}
             chartConfig={state.chartConfig}
             field={encoding.field}
             component={component}
             componentTypes={optionsByField["color"].componentTypes}
-            dataSetMetadata={metaData}
+            dimensions={dimensions}
+            measures={measures}
             optional={optionsByField["color"].optional}
             enableUseAbbreviations={
               optionsByField["color"].enableUseAbbreviations
@@ -403,7 +416,8 @@ const EncodingOptionsPanel = ({
         component={component}
         encoding={encoding}
         field={field}
-        metaData={metaData}
+        dimensions={dimensions}
+        measures={measures}
       />
     </div>
   );
@@ -438,19 +452,21 @@ const ChartFieldMultiFilter = ({
   component,
   encoding,
   field,
-  metaData,
+  dimensions,
+  measures,
 }: {
   state: ConfiguratorStateConfiguringChart;
   component: DimensionMetadataFragment | undefined;
   encoding: EncodingSpec;
   field: string;
-  metaData: DataCubeMetadata;
+  dimensions: DimensionMetadataFragment[];
+  measures: DimensionMetadataFragment[];
 }) => {
   const colorComponentIri = get(
     state.chartConfig,
     `fields.${field}.color.componentIri`
   );
-  const colorComponent = [...metaData.dimensions, ...metaData.measures].find(
+  const colorComponent = [...dimensions, ...measures].find(
     (d) => d.iri === colorComponentIri
   );
   const colorType = get(state.chartConfig, `fields.${field}.color.type`) as
@@ -474,14 +490,14 @@ const ChartFieldMultiFilter = ({
           <TimeFilter
             key={component.iri}
             dimensionIri={component.iri}
-            dataSetIri={metaData.iri}
+            dataSetIri={state.dataSet}
           />
         ) : (
           component && (
             <DimensionValuesMultiFilter
               key={component.iri}
               dimensionIri={component.iri}
-              dataSetIri={metaData.iri}
+              dataSetIri={state.dataSet}
               field={field}
               colorComponent={colorComponent || component}
               // If colorType is defined, we are dealing with color field and
@@ -673,21 +689,23 @@ const ChartFieldSorting = ({
 const ChartFieldSize = ({
   field,
   componentTypes,
-  dataSetMetadata,
+  dimensions,
+  measures,
   optional,
 }: {
   field: string;
   componentTypes: ComponentType[];
-  dataSetMetadata: DataCubeMetadata;
+  dimensions: DimensionMetadataFragment[];
+  measures: DimensionMetadataFragment[];
   optional: boolean;
 }) => {
   const measuresOptions = useMemo(() => {
     return getDimensionsByDimensionType({
       dimensionTypes: componentTypes,
-      dimensions: dataSetMetadata.dimensions,
-      measures: dataSetMetadata.measures,
+      dimensions,
+      measures,
     }).map(({ iri, label }) => ({ value: iri, label }));
-  }, [dataSetMetadata.dimensions, dataSetMetadata.measures, componentTypes]);
+  }, [dimensions, measures, componentTypes]);
 
   return (
     <ControlSection>
@@ -715,19 +733,23 @@ const ChartFieldSize = ({
 };
 
 const ChartFieldColorComponent = ({
+  state,
   chartConfig,
   field,
   component,
   componentTypes,
-  dataSetMetadata,
+  dimensions,
+  measures,
   optional,
   enableUseAbbreviations,
 }: {
+  state: ConfiguratorStateConfiguringChart;
   chartConfig: ChartConfig;
   field: EncodingFieldType;
   component: DimensionMetadataFragment;
   componentTypes: ComponentType[];
-  dataSetMetadata: DataCubeMetadata;
+  dimensions: DimensionMetadataFragment[];
+  measures: DimensionMetadataFragment[];
   optional: boolean;
   enableUseAbbreviations: boolean;
 }) => {
@@ -735,10 +757,10 @@ const ChartFieldColorComponent = ({
   const measuresOptions = useMemo(() => {
     return getDimensionsByDimensionType({
       dimensionTypes: componentTypes,
-      dimensions: dataSetMetadata.dimensions,
-      measures: dataSetMetadata.measures,
+      dimensions,
+      measures,
     }).map(({ iri, label }) => ({ value: iri, label }));
-  }, [dataSetMetadata.dimensions, dataSetMetadata.measures, componentTypes]);
+  }, [dimensions, measures, componentTypes]);
   const nbColorOptions = useMemo(() => {
     return Array.from(
       { length: Math.min(7, Math.max(0, nbOptions - 2)) },
@@ -752,10 +774,9 @@ const ChartFieldColorComponent = ({
     "color",
     "componentIri",
   ]) as string | undefined;
-  const colorComponent = [
-    ...dataSetMetadata.dimensions,
-    ...dataSetMetadata.measures,
-  ].find((d) => d.iri === colorComponentIri);
+  const colorComponent = [...dimensions, ...measures].find(
+    (d) => d.iri === colorComponentIri
+  );
   const colorType = get(chartConfig, [
     "fields",
     field,
@@ -827,7 +848,7 @@ const ChartFieldColorComponent = ({
           colorComponentIri && component.iri !== colorComponentIri ? (
             <DimensionValuesMultiFilter
               key={component.iri}
-              dataSetIri={dataSetMetadata.iri}
+              dataSetIri={state.dataSet}
               dimensionIri={colorComponentIri}
               field={field}
               colorConfigPath="color"

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -67,7 +67,7 @@ import {
 } from "@/domain/data";
 import {
   DimensionMetadataFragment,
-  useDataCubeMetadataWithComponentValuesQuery,
+  useDataCubeMetadataWithComponentValuesAndHierarchiesQuery,
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
 import { DataCubeMetadata } from "@/graphql/types";
@@ -93,14 +93,15 @@ export const ChartOptionsSelector = ({
   });
 
   // Unfiltered dimensions & measures values.
-  const [{ data: metadataData }] = useDataCubeMetadataWithComponentValuesQuery({
-    variables: {
-      iri: dataSet,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-    },
-  });
+  const [{ data: metadataData }] =
+    useDataCubeMetadataWithComponentValuesAndHierarchiesQuery({
+      variables: {
+        iri: dataSet,
+        sourceType: dataSource.type,
+        sourceUrl: dataSource.url,
+        locale,
+      },
+    });
 
   const imputationNeeded = useImputationNeeded({
     chartConfig,

--- a/app/configurator/components/chart-type-selector.tsx
+++ b/app/configurator/components/chart-type-selector.tsx
@@ -11,7 +11,7 @@ import { ControlSectionSkeleton } from "@/configurator/components/chart-controls
 import { getFieldLabel } from "@/configurator/components/field-i18n";
 import { getIconName } from "@/configurator/components/ui-helpers";
 import { FieldProps, useChartType } from "@/configurator/config-form";
-import { useDataCubeMetadataWithComponentValuesQuery } from "@/graphql/query-hooks";
+import { useComponentsQuery } from "@/graphql/query-hooks";
 import { Icon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
 
@@ -109,7 +109,7 @@ export const ChartTypeSelector = ({
 } & BoxProps) => {
   const locale = useLocale();
   const { value: chartType, onChange: onChangeChartType } = useChartType();
-  const [{ data }] = useDataCubeMetadataWithComponentValuesQuery({
+  const [{ data }] = useComponentsQuery({
     variables: {
       iri: state.dataSet,
       sourceType: state.dataSource.type,
@@ -117,13 +117,15 @@ export const ChartTypeSelector = ({
       locale,
     },
   });
-  const metadata = data?.dataCubeByIri;
 
-  if (!metadata) {
+  if (!data?.dataCubeByIri) {
     return <ControlSectionSkeleton />;
   }
 
-  const possibleChartTypes = getPossibleChartType({ metadata });
+  const possibleChartTypes = getPossibleChartType({
+    dimensions: data.dataCubeByIri.dimensions,
+    measures: data.dataCubeByIri.measures,
+  });
 
   return (
     <Box sx={sx} {...props}>

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -26,7 +26,10 @@ import {
   moveFilterField,
   updateColorMapping,
 } from "@/configurator/configurator-state";
-import { DimensionMetadataFragment } from "@/graphql/query-hooks";
+import {
+  DimensionMetadataFragment,
+  DimensionMetadataWithHierarchiesFragment,
+} from "@/graphql/query-hooks";
 import { DataCubeMetadata } from "@/graphql/types";
 import covid19ColumnChartConfig from "@/test/__fixtures/config/dev/chartConfig-column-covid19.json";
 import covid19TableChartConfig from "@/test/__fixtures/config/dev/chartConfig-table-covid19.json";
@@ -181,6 +184,38 @@ describe("applyDimensionToFilters", () => {
     __typename: "NominalDimension",
   } as DimensionMetadataFragment;
 
+  const keyDimensionWithHierarchy = {
+    __typename: "NominalDimension",
+    iri: "nominalDimensionIri",
+    label: "Nominal Dimension with Hierarchy",
+    isKeyDimension: true,
+    isNumerical: false,
+    values: [
+      { value: "brienz", label: "Brienz" },
+      { value: "switzerland", label: "Switzerland" },
+    ],
+    hierarchy: [
+      {
+        __typename: "HierarchyValue",
+        dimensionIri: "nominalDimensionIri",
+        value: "brienz",
+        label: "Brienz",
+        depth: 0,
+        hasValue: true,
+        children: [],
+      },
+      {
+        __typename: "HierarchyValue",
+        dimensionIri: "nominalDimensionIri",
+        value: "switzerland",
+        label: "Switzerland",
+        depth: -1,
+        hasValue: true,
+        children: [],
+      },
+    ],
+  } as DimensionMetadataWithHierarchiesFragment;
+
   const optionalDimension = {
     iri: "https://environment.ld.admin.ch/foen/ubd0104/parametertype",
     label: "Parameter",
@@ -243,6 +278,24 @@ describe("applyDimensionToFilters", () => {
         filters: initialFilters,
         dimension: optionalDimension,
         isField: true,
+      });
+
+      expect(initialFilters).toEqual(expectedFilters);
+    });
+
+    it("should select top-most hierarchy value by default", () => {
+      const initialFilters = {};
+      const expectedFilters = {
+        nominalDimensionIri: {
+          type: "single",
+          value: "switzerland",
+        },
+      };
+
+      applyNonTableDimensionToFilters({
+        filters: initialFilters,
+        dimension: keyDimensionWithHierarchy,
+        isField: false,
       });
 
       expect(initialFilters).toEqual(expectedFilters);

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -485,7 +485,7 @@ describe("moveField", () => {
 
 describe("retainChartConfigWhenSwitchingChartType", () => {
   const dataSetMetadata = covid19Metadata.data
-    .dataCubeByIri as DataCubeMetadata;
+    .dataCubeByIri as unknown as DataCubeMetadata;
 
   const deriveNewChartConfig = (
     oldConfig: ChartConfig,

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -71,15 +71,15 @@ import {
 import { DEFAULT_DATA_SOURCE } from "@/domain/datasource";
 import { client } from "@/graphql/client";
 import {
+  ComponentsDocument,
+  ComponentsQuery,
+  ComponentsQueryVariables,
   ComponentsWithHierarchiesDocument,
   ComponentsWithHierarchiesQuery,
   ComponentsWithHierarchiesQueryVariables,
   DataCubeMetadataDocument,
   DataCubeMetadataQuery,
   DataCubeMetadataQueryVariables,
-  DataCubeMetadataWithComponentValuesAndHierarchiesDocument,
-  DataCubeMetadataWithComponentValuesAndHierarchiesQuery,
-  DataCubeMetadataWithComponentValuesAndHierarchiesQueryVariables,
   DimensionMetadataFragment,
   DimensionMetadataWithHierarchiesFragment,
   NumericalMeasure,
@@ -313,17 +313,32 @@ const getCachedCubeMetadataWithComponentValuesAndHierarchies = (
   draft: ConfiguratorStateConfiguringChart,
   locale: Locale
 ) => {
-  const query = client.readQuery<
-    DataCubeMetadataWithComponentValuesAndHierarchiesQuery,
-    DataCubeMetadataWithComponentValuesAndHierarchiesQueryVariables
-  >(DataCubeMetadataWithComponentValuesAndHierarchiesDocument, {
+  const metadataQuery = client.readQuery<
+    DataCubeMetadataQuery,
+    DataCubeMetadataQueryVariables
+  >(DataCubeMetadataDocument, {
+    iri: draft.dataSet,
+    locale,
+    sourceType: draft.dataSource.type,
+    sourceUrl: draft.dataSource.url,
+  });
+  const componentsQuery = client.readQuery<
+    ComponentsQuery,
+    ComponentsQueryVariables
+  >(ComponentsDocument, {
     iri: draft.dataSet,
     locale,
     sourceType: draft.dataSource.type,
     sourceUrl: draft.dataSource.url,
   });
 
-  return query?.data?.dataCubeByIri;
+  return metadataQuery?.data?.dataCubeByIri &&
+    componentsQuery?.data?.dataCubeByIri
+    ? {
+        ...metadataQuery.data.dataCubeByIri,
+        ...componentsQuery.data.dataCubeByIri,
+      }
+    : null;
 };
 
 export const getFilterValue = (

--- a/app/configurator/interactive-filters/helpers.ts
+++ b/app/configurator/interactive-filters/helpers.ts
@@ -1,11 +1,11 @@
 import { getFieldComponentIri, getFieldComponentIris } from "@/charts";
 import { isTemporalDimension } from "@/domain/data";
 import {
-  DataCubeMetadataWithComponentValuesQuery,
   DimensionMetadataFragment,
   TemporalDimension,
   TimeUnit,
 } from "@/graphql/query-hooks";
+import { DataCubeMetadata } from "@/graphql/types";
 
 import {
   ChartConfig,
@@ -42,9 +42,7 @@ export const getTimeSliderFilterDimensions = ({
 
 export const getDataFilterDimensions = (
   chartConfig: ConfiguratorStateConfiguringChart["chartConfig"],
-  dataCube: NonNullable<
-    DataCubeMetadataWithComponentValuesQuery["dataCubeByIri"]
-  >
+  dataCube: DataCubeMetadata
 ) => {
   const mappedIris = getFieldComponentIris(chartConfig.fields);
   // Dimensions that are not encoded in the visualization

--- a/app/configurator/interactive-filters/interactive-filters-config-options.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-config-options.tsx
@@ -2,7 +2,7 @@ import { t, Trans } from "@lingui/macro";
 import { Box } from "@mui/material";
 import { extent } from "d3";
 import get from "lodash/get";
-import React, { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 import { getFieldComponentIri } from "@/charts";
 import { Checkbox, Select } from "@/components/form";
@@ -21,10 +21,7 @@ import {
 } from "@/configurator/interactive-filters/interactive-filters-config-state";
 import { InteractiveFilterType } from "@/configurator/interactive-filters/interactive-filters-configurator";
 import { useFormatFullDateAuto } from "@/formatters";
-import {
-  TemporalDimension,
-  useDataCubeMetadataWithComponentValuesQuery,
-} from "@/graphql/query-hooks";
+import { TemporalDimension, useComponentsQuery } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
 import { FIELD_VALUE_NONE } from "../constants";
@@ -40,7 +37,7 @@ export const InteractiveFiltersOptions = ({
   const activeField = state.activeField as InteractiveFilterType;
   const locale = useLocale();
 
-  const [{ data }] = useDataCubeMetadataWithComponentValuesQuery({
+  const [{ data }] = useComponentsQuery({
     variables: {
       iri: dataSet,
       sourceType: dataSource.type,
@@ -123,7 +120,7 @@ const InteractiveTimeRangeFilterOptions = ({
   const locale = useLocale();
   const formatDateAuto = useFormatFullDateAuto();
 
-  const [{ data }] = useDataCubeMetadataWithComponentValuesQuery({
+  const [{ data }] = useComponentsQuery({
     variables: {
       iri: state.dataSet,
       sourceType: state.dataSource.type,
@@ -200,7 +197,7 @@ const InteractiveTimeSliderFilterOptions = ({
   state: ConfiguratorStateConfiguringChart;
 }) => {
   const locale = useLocale();
-  const [{ data }] = useDataCubeMetadataWithComponentValuesQuery({
+  const [{ data }] = useComponentsQuery({
     variables: {
       iri: dataSet,
       sourceType: dataSource.type,

--- a/app/configurator/interactive-filters/interactive-filters-configurator.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-configurator.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/configurator/configurator-state";
 import { isTemporalDimension } from "@/domain/data";
 import { flag } from "@/flags/flag";
-import { useDataCubeMetadataWithComponentValuesQuery } from "@/graphql/query-hooks";
+import { useComponentsQuery } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
 import { getTimeSliderFilterDimensions } from "./helpers";
@@ -49,7 +49,7 @@ export const InteractiveFiltersConfigurator = ({
 }) => {
   const { chartType, fields } = chartConfig;
   const locale = useLocale();
-  const [{ data }] = useDataCubeMetadataWithComponentValuesQuery({
+  const [{ data }] = useComponentsQuery({
     variables: {
       iri: dataSet,
       sourceType: dataSource.type,

--- a/app/configurator/table/table-chart-configurator.tsx
+++ b/app/configurator/table/table-chart-configurator.tsx
@@ -1,7 +1,7 @@
 import { Trans } from "@lingui/macro";
 import { Theme, Typography } from "@mui/material";
 import { makeStyles } from "@mui/styles";
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   DragDropContext,
   OnDragEndResponder,
@@ -21,7 +21,10 @@ import { useOrderedTableColumns } from "@/configurator/components/ui-helpers";
 import { TableFields } from "@/configurator/config-types";
 import { useConfiguratorState } from "@/configurator/configurator-state";
 import { moveFields } from "@/configurator/table/table-config-state";
-import { useDataCubeMetadataWithComponentValuesAndHierarchiesQuery } from "@/graphql/query-hooks";
+import {
+  useComponentsWithHierarchiesQuery,
+  useDataCubeMetadataQuery,
+} from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
 import { ChartTypeSelector } from "../components/chart-type-selector";
@@ -55,7 +58,15 @@ export const ChartConfiguratorTable = ({
   state: ConfiguratorStateConfiguringChart;
 }) => {
   const locale = useLocale();
-  const [{ data }] = useDataCubeMetadataWithComponentValuesAndHierarchiesQuery({
+  const [{ data: metadata }] = useDataCubeMetadataQuery({
+    variables: {
+      iri: state.dataSet,
+      sourceType: state.dataSource.type,
+      sourceUrl: state.dataSource.url,
+      locale,
+    },
+  });
+  const [{ data: components }] = useComponentsWithHierarchiesQuery({
     variables: {
       iri: state.dataSet,
       sourceType: state.dataSource.type,
@@ -64,7 +75,14 @@ export const ChartConfiguratorTable = ({
     },
   });
 
-  const metaData = data?.dataCubeByIri;
+  const metaData = useMemo(() => {
+    return metadata?.dataCubeByIri && components?.dataCubeByIri
+      ? {
+          ...metadata.dataCubeByIri,
+          ...components.dataCubeByIri,
+        }
+      : null;
+  }, [metadata?.dataCubeByIri, components?.dataCubeByIri]);
 
   const [, dispatch] = useConfiguratorState();
 
@@ -107,7 +125,7 @@ export const ChartConfiguratorTable = ({
   const fields = state.chartConfig.fields as TableFields;
   const fieldsArray = useOrderedTableColumns(fields);
 
-  if (data?.dataCubeByIri) {
+  if (metaData) {
     const groupFields = [...fieldsArray.filter((f) => f.isGroup)];
     const columnFields = [...fieldsArray.filter((f) => !f.isGroup)];
 
@@ -154,18 +172,18 @@ export const ChartConfiguratorTable = ({
           <TabDropZone
             id="groups"
             title={<Trans id="controls.section.groups">Groups</Trans>}
-            metaData={data.dataCubeByIri}
+            metaData={metaData}
             items={groupFields}
             isDropDisabled={isGroupsDropDisabled}
             emptyComponent={<EmptyGroups />}
-          ></TabDropZone>
+          />
 
           <TabDropZone
             id="columns"
             title={<Trans id="controls.section.columns">Columns</Trans>}
-            metaData={data.dataCubeByIri}
+            metaData={metaData}
             items={columnFields}
-          ></TabDropZone>
+          />
         </DragDropContext>
       </>
     );

--- a/app/configurator/table/table-chart-configurator.tsx
+++ b/app/configurator/table/table-chart-configurator.tsx
@@ -21,7 +21,7 @@ import { useOrderedTableColumns } from "@/configurator/components/ui-helpers";
 import { TableFields } from "@/configurator/config-types";
 import { useConfiguratorState } from "@/configurator/configurator-state";
 import { moveFields } from "@/configurator/table/table-config-state";
-import { useDataCubeMetadataWithComponentValuesQuery } from "@/graphql/query-hooks";
+import { useDataCubeMetadataWithComponentValuesAndHierarchiesQuery } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
 import { ChartTypeSelector } from "../components/chart-type-selector";
@@ -55,7 +55,7 @@ export const ChartConfiguratorTable = ({
   state: ConfiguratorStateConfiguringChart;
 }) => {
   const locale = useLocale();
-  const [{ data }] = useDataCubeMetadataWithComponentValuesQuery({
+  const [{ data }] = useDataCubeMetadataWithComponentValuesAndHierarchiesQuery({
     variables: {
       iri: state.dataSet,
       sourceType: state.dataSource.type,

--- a/app/configurator/table/table-chart-options.tsx
+++ b/app/configurator/table/table-chart-options.tsx
@@ -45,7 +45,10 @@ import {
   isTemporalDimension,
 } from "@/domain/data";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
-import { DataCubeMetadata } from "@/graphql/types";
+import {
+  DataCubeMetadata,
+  DataCubeMetadataWithHierarchies,
+} from "@/graphql/types";
 import {
   getDefaultCategoricalPalette,
   getDefaultCategoricalPaletteName,
@@ -135,7 +138,7 @@ export const TableColumnOptions = ({
   metaData,
 }: {
   state: ConfiguratorStateConfiguringChart;
-  metaData: DataCubeMetadata;
+  metaData: DataCubeMetadataWithHierarchies;
 }) => {
   const { activeField, chartConfig } = state;
 

--- a/app/configurator/table/table-chart-sorting-options.tsx
+++ b/app/configurator/table/table-chart-sorting-options.tsx
@@ -8,7 +8,7 @@ import {
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import { ascending } from "d3";
-import React, { ChangeEvent, useCallback } from "react";
+import { ChangeEvent, useCallback } from "react";
 import {
   DragDropContext,
   Draggable,
@@ -39,7 +39,7 @@ import {
   removeSortingOption,
 } from "@/configurator/table/table-config-state";
 import { isNumericalMeasure } from "@/domain/data";
-import { DataCubeMetadata } from "@/graphql/types";
+import { DataCubeMetadataWithHierarchies } from "@/graphql/types";
 import { Icon } from "@/icons";
 import useEvent from "@/utils/use-event";
 
@@ -102,7 +102,7 @@ const TableSortingOptionItem = ({
   sortingOrder,
   metaData,
 }: {
-  metaData: DataCubeMetadata;
+  metaData: DataCubeMetadataWithHierarchies;
   index: number;
   chartConfig: TableConfig;
 } & TableSortingOption) => {
@@ -188,7 +188,7 @@ const AddTableSortingOption = ({
   metaData,
   chartConfig,
 }: {
-  metaData: DataCubeMetadata;
+  metaData: DataCubeMetadataWithHierarchies;
   chartConfig: TableConfig;
 }) => {
   const [, dispatch] = useConfiguratorState();
@@ -275,7 +275,7 @@ const ChangeTableSortingOption = ({
   chartConfig,
   index,
 }: {
-  metaData: DataCubeMetadata;
+  metaData: DataCubeMetadataWithHierarchies;
   chartConfig: TableConfig;
   index: number;
 }) => {
@@ -343,7 +343,7 @@ export const TableSortingOptions = ({
   dataSetMetadata,
 }: {
   state: ConfiguratorStateConfiguringChart;
-  dataSetMetadata: DataCubeMetadata;
+  dataSetMetadata: DataCubeMetadataWithHierarchies;
 }) => {
   const [, dispatch] = useConfiguratorState();
   const { activeField, chartConfig } = state;

--- a/app/graphql/apollo-sentry-plugin.ts
+++ b/app/graphql/apollo-sentry-plugin.ts
@@ -7,7 +7,8 @@ const getDataCubeIri = (req: GraphQLRequest) => {
     operationName === "DataCubePreview" ||
     operationName === "DataCubeMetadata" ||
     operationName === "DataCubeObservations" ||
-    operationName === "DataCubeMetadataWithComponentValues" ||
+    operationName === "Components" ||
+    operationName === "ComponentsWithHierarchies" ||
     operationName === "PossibleFilters"
   ) {
     return variables?.iri;

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -183,41 +183,6 @@ query DataCubeMetadata(
   }
 }
 
-query DataCubeMetadataWithComponentValues(
-  $iri: String!
-  $sourceType: String!
-  $sourceUrl: String!
-  $locale: String!
-  $latest: Boolean
-  $filters: Filters
-) {
-  dataCubeByIri(
-    iri: $iri
-    sourceType: $sourceType
-    sourceUrl: $sourceUrl
-    locale: $locale
-    latest: $latest
-  ) {
-    iri
-    title
-    publisher
-    publicationStatus
-    expires
-    identifier
-    workExamples
-    creator {
-      iri
-    }
-    landingPage
-    dimensions(sourceType: $sourceType, sourceUrl: $sourceUrl) {
-      ...dimensionMetadata
-    }
-    measures(sourceType: $sourceType, sourceUrl: $sourceUrl) {
-      ...dimensionMetadata
-    }
-  }
-}
-
 query DataCubeMetadataWithComponentValuesAndHierarchies(
   $iri: String!
   $sourceType: String!

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -253,6 +253,54 @@ query DataCubeMetadataWithComponentValuesAndHierarchies(
   }
 }
 
+query Components(
+  $iri: String!
+  $sourceType: String!
+  $sourceUrl: String!
+  $locale: String!
+  $latest: Boolean
+  $filters: Filters
+) {
+  dataCubeByIri(
+    iri: $iri
+    sourceType: $sourceType
+    sourceUrl: $sourceUrl
+    locale: $locale
+    latest: $latest
+  ) {
+    dimensions(sourceType: $sourceType, sourceUrl: $sourceUrl) {
+      ...dimensionMetadata
+    }
+    measures(sourceType: $sourceType, sourceUrl: $sourceUrl) {
+      ...dimensionMetadata
+    }
+  }
+}
+
+query ComponentsWithHierarchies(
+  $iri: String!
+  $sourceType: String!
+  $sourceUrl: String!
+  $locale: String!
+  $latest: Boolean
+  $filters: Filters
+) {
+  dataCubeByIri(
+    iri: $iri
+    sourceType: $sourceType
+    sourceUrl: $sourceUrl
+    locale: $locale
+    latest: $latest
+  ) {
+    dimensions(sourceType: $sourceType, sourceUrl: $sourceUrl) {
+      ...dimensionMetadataWithHierarchies
+    }
+    measures(sourceType: $sourceType, sourceUrl: $sourceUrl) {
+      ...dimensionMetadataWithHierarchies
+    }
+  }
+}
+
 query DimensionValues(
   $dataCubeIri: String!
   $dimensionIri: String!

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -183,41 +183,6 @@ query DataCubeMetadata(
   }
 }
 
-query DataCubeMetadataWithComponentValuesAndHierarchies(
-  $iri: String!
-  $sourceType: String!
-  $sourceUrl: String!
-  $locale: String!
-  $latest: Boolean
-  $filters: Filters
-) {
-  dataCubeByIri(
-    iri: $iri
-    sourceType: $sourceType
-    sourceUrl: $sourceUrl
-    locale: $locale
-    latest: $latest
-  ) {
-    iri
-    title
-    publisher
-    publicationStatus
-    expires
-    identifier
-    workExamples
-    creator {
-      iri
-    }
-    landingPage
-    dimensions(sourceType: $sourceType, sourceUrl: $sourceUrl) {
-      ...dimensionMetadataWithHierarchies
-    }
-    measures(sourceType: $sourceType, sourceUrl: $sourceUrl) {
-      ...dimensionMetadataWithHierarchies
-    }
-  }
-}
-
 query Components(
   $iri: String!
   $sourceType: String!

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -755,45 +755,6 @@ export type DataCubeMetadataQueryVariables = Exact<{
 
 export type DataCubeMetadataQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', iri: string, identifier?: Maybe<string>, title: string, description?: Maybe<string>, publisher?: Maybe<string>, version?: Maybe<string>, workExamples?: Maybe<Array<Maybe<string>>>, contactName?: Maybe<string>, contactEmail?: Maybe<string>, landingPage?: Maybe<string>, expires?: Maybe<string>, datePublished?: Maybe<string>, dateModified?: Maybe<string>, publicationStatus: DataCubePublicationStatus, themes: Array<{ __typename: 'DataCubeTheme', iri: string, label?: Maybe<string> }>, creator?: Maybe<{ __typename: 'DataCubeOrganization', iri: string, label?: Maybe<string> }> }> };
 
-export type DataCubeMetadataWithComponentValuesQueryVariables = Exact<{
-  iri: Scalars['String'];
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  locale: Scalars['String'];
-  latest?: Maybe<Scalars['Boolean']>;
-  filters?: Maybe<Scalars['Filters']>;
-}>;
-
-
-export type DataCubeMetadataWithComponentValuesQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', iri: string, title: string, publisher?: Maybe<string>, publicationStatus: DataCubePublicationStatus, expires?: Maybe<string>, identifier?: Maybe<string>, workExamples?: Maybe<Array<Maybe<string>>>, landingPage?: Maybe<string>, creator?: Maybe<{ __typename: 'DataCubeOrganization', iri: string }>, dimensions: Array<(
-      { __typename: 'GeoCoordinatesDimension' }
-      & DimensionMetadata_GeoCoordinatesDimension_Fragment
-    ) | (
-      { __typename: 'GeoShapesDimension' }
-      & DimensionMetadata_GeoShapesDimension_Fragment
-    ) | (
-      { __typename: 'NominalDimension' }
-      & DimensionMetadata_NominalDimension_Fragment
-    ) | (
-      { __typename: 'NumericalMeasure' }
-      & DimensionMetadata_NumericalMeasure_Fragment
-    ) | (
-      { __typename: 'OrdinalDimension' }
-      & DimensionMetadata_OrdinalDimension_Fragment
-    ) | (
-      { __typename: 'OrdinalMeasure' }
-      & DimensionMetadata_OrdinalMeasure_Fragment
-    ) | (
-      { __typename: 'TemporalDimension' }
-      & DimensionMetadata_TemporalDimension_Fragment
-    )>, measures: Array<(
-      { __typename: 'NumericalMeasure' }
-      & DimensionMetadata_NumericalMeasure_Fragment
-    ) | (
-      { __typename: 'OrdinalMeasure' }
-      & DimensionMetadata_OrdinalMeasure_Fragment
-    )> }> };
-
 export type DataCubeMetadataWithComponentValuesAndHierarchiesQueryVariables = Exact<{
   iri: Scalars['String'];
   sourceType: Scalars['String'];
@@ -1303,39 +1264,6 @@ export const DataCubeMetadataDocument = gql`
 
 export function useDataCubeMetadataQuery(options: Omit<Urql.UseQueryArgs<DataCubeMetadataQueryVariables>, 'query'> = {}) {
   return Urql.useQuery<DataCubeMetadataQuery>({ query: DataCubeMetadataDocument, ...options });
-};
-export const DataCubeMetadataWithComponentValuesDocument = gql`
-    query DataCubeMetadataWithComponentValues($iri: String!, $sourceType: String!, $sourceUrl: String!, $locale: String!, $latest: Boolean, $filters: Filters) {
-  dataCubeByIri(
-    iri: $iri
-    sourceType: $sourceType
-    sourceUrl: $sourceUrl
-    locale: $locale
-    latest: $latest
-  ) {
-    iri
-    title
-    publisher
-    publicationStatus
-    expires
-    identifier
-    workExamples
-    creator {
-      iri
-    }
-    landingPage
-    dimensions(sourceType: $sourceType, sourceUrl: $sourceUrl) {
-      ...dimensionMetadata
-    }
-    measures(sourceType: $sourceType, sourceUrl: $sourceUrl) {
-      ...dimensionMetadata
-    }
-  }
-}
-    ${DimensionMetadataFragmentDoc}`;
-
-export function useDataCubeMetadataWithComponentValuesQuery(options: Omit<Urql.UseQueryArgs<DataCubeMetadataWithComponentValuesQueryVariables>, 'query'> = {}) {
-  return Urql.useQuery<DataCubeMetadataWithComponentValuesQuery>({ query: DataCubeMetadataWithComponentValuesDocument, ...options });
 };
 export const DataCubeMetadataWithComponentValuesAndHierarchiesDocument = gql`
     query DataCubeMetadataWithComponentValuesAndHierarchies($iri: String!, $sourceType: String!, $sourceUrl: String!, $locale: String!, $latest: Boolean, $filters: Filters) {

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -755,45 +755,6 @@ export type DataCubeMetadataQueryVariables = Exact<{
 
 export type DataCubeMetadataQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', iri: string, identifier?: Maybe<string>, title: string, description?: Maybe<string>, publisher?: Maybe<string>, version?: Maybe<string>, workExamples?: Maybe<Array<Maybe<string>>>, contactName?: Maybe<string>, contactEmail?: Maybe<string>, landingPage?: Maybe<string>, expires?: Maybe<string>, datePublished?: Maybe<string>, dateModified?: Maybe<string>, publicationStatus: DataCubePublicationStatus, themes: Array<{ __typename: 'DataCubeTheme', iri: string, label?: Maybe<string> }>, creator?: Maybe<{ __typename: 'DataCubeOrganization', iri: string, label?: Maybe<string> }> }> };
 
-export type DataCubeMetadataWithComponentValuesAndHierarchiesQueryVariables = Exact<{
-  iri: Scalars['String'];
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  locale: Scalars['String'];
-  latest?: Maybe<Scalars['Boolean']>;
-  filters?: Maybe<Scalars['Filters']>;
-}>;
-
-
-export type DataCubeMetadataWithComponentValuesAndHierarchiesQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', iri: string, title: string, publisher?: Maybe<string>, publicationStatus: DataCubePublicationStatus, expires?: Maybe<string>, identifier?: Maybe<string>, workExamples?: Maybe<Array<Maybe<string>>>, landingPage?: Maybe<string>, creator?: Maybe<{ __typename: 'DataCubeOrganization', iri: string }>, dimensions: Array<(
-      { __typename: 'GeoCoordinatesDimension' }
-      & DimensionMetadataWithHierarchies_GeoCoordinatesDimension_Fragment
-    ) | (
-      { __typename: 'GeoShapesDimension' }
-      & DimensionMetadataWithHierarchies_GeoShapesDimension_Fragment
-    ) | (
-      { __typename: 'NominalDimension' }
-      & DimensionMetadataWithHierarchies_NominalDimension_Fragment
-    ) | (
-      { __typename: 'NumericalMeasure' }
-      & DimensionMetadataWithHierarchies_NumericalMeasure_Fragment
-    ) | (
-      { __typename: 'OrdinalDimension' }
-      & DimensionMetadataWithHierarchies_OrdinalDimension_Fragment
-    ) | (
-      { __typename: 'OrdinalMeasure' }
-      & DimensionMetadataWithHierarchies_OrdinalMeasure_Fragment
-    ) | (
-      { __typename: 'TemporalDimension' }
-      & DimensionMetadataWithHierarchies_TemporalDimension_Fragment
-    )>, measures: Array<(
-      { __typename: 'NumericalMeasure' }
-      & DimensionMetadataWithHierarchies_NumericalMeasure_Fragment
-    ) | (
-      { __typename: 'OrdinalMeasure' }
-      & DimensionMetadataWithHierarchies_OrdinalMeasure_Fragment
-    )> }> };
-
 export type ComponentsQueryVariables = Exact<{
   iri: Scalars['String'];
   sourceType: Scalars['String'];
@@ -1264,39 +1225,6 @@ export const DataCubeMetadataDocument = gql`
 
 export function useDataCubeMetadataQuery(options: Omit<Urql.UseQueryArgs<DataCubeMetadataQueryVariables>, 'query'> = {}) {
   return Urql.useQuery<DataCubeMetadataQuery>({ query: DataCubeMetadataDocument, ...options });
-};
-export const DataCubeMetadataWithComponentValuesAndHierarchiesDocument = gql`
-    query DataCubeMetadataWithComponentValuesAndHierarchies($iri: String!, $sourceType: String!, $sourceUrl: String!, $locale: String!, $latest: Boolean, $filters: Filters) {
-  dataCubeByIri(
-    iri: $iri
-    sourceType: $sourceType
-    sourceUrl: $sourceUrl
-    locale: $locale
-    latest: $latest
-  ) {
-    iri
-    title
-    publisher
-    publicationStatus
-    expires
-    identifier
-    workExamples
-    creator {
-      iri
-    }
-    landingPage
-    dimensions(sourceType: $sourceType, sourceUrl: $sourceUrl) {
-      ...dimensionMetadataWithHierarchies
-    }
-    measures(sourceType: $sourceType, sourceUrl: $sourceUrl) {
-      ...dimensionMetadataWithHierarchies
-    }
-  }
-}
-    ${DimensionMetadataWithHierarchiesFragmentDoc}`;
-
-export function useDataCubeMetadataWithComponentValuesAndHierarchiesQuery(options: Omit<Urql.UseQueryArgs<DataCubeMetadataWithComponentValuesAndHierarchiesQueryVariables>, 'query'> = {}) {
-  return Urql.useQuery<DataCubeMetadataWithComponentValuesAndHierarchiesQuery>({ query: DataCubeMetadataWithComponentValuesAndHierarchiesDocument, ...options });
 };
 export const ComponentsDocument = gql`
     query Components($iri: String!, $sourceType: String!, $sourceUrl: String!, $locale: String!, $latest: Boolean, $filters: Filters) {

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -833,6 +833,84 @@ export type DataCubeMetadataWithComponentValuesAndHierarchiesQuery = { __typenam
       & DimensionMetadataWithHierarchies_OrdinalMeasure_Fragment
     )> }> };
 
+export type ComponentsQueryVariables = Exact<{
+  iri: Scalars['String'];
+  sourceType: Scalars['String'];
+  sourceUrl: Scalars['String'];
+  locale: Scalars['String'];
+  latest?: Maybe<Scalars['Boolean']>;
+  filters?: Maybe<Scalars['Filters']>;
+}>;
+
+
+export type ComponentsQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', dimensions: Array<(
+      { __typename: 'GeoCoordinatesDimension' }
+      & DimensionMetadata_GeoCoordinatesDimension_Fragment
+    ) | (
+      { __typename: 'GeoShapesDimension' }
+      & DimensionMetadata_GeoShapesDimension_Fragment
+    ) | (
+      { __typename: 'NominalDimension' }
+      & DimensionMetadata_NominalDimension_Fragment
+    ) | (
+      { __typename: 'NumericalMeasure' }
+      & DimensionMetadata_NumericalMeasure_Fragment
+    ) | (
+      { __typename: 'OrdinalDimension' }
+      & DimensionMetadata_OrdinalDimension_Fragment
+    ) | (
+      { __typename: 'OrdinalMeasure' }
+      & DimensionMetadata_OrdinalMeasure_Fragment
+    ) | (
+      { __typename: 'TemporalDimension' }
+      & DimensionMetadata_TemporalDimension_Fragment
+    )>, measures: Array<(
+      { __typename: 'NumericalMeasure' }
+      & DimensionMetadata_NumericalMeasure_Fragment
+    ) | (
+      { __typename: 'OrdinalMeasure' }
+      & DimensionMetadata_OrdinalMeasure_Fragment
+    )> }> };
+
+export type ComponentsWithHierarchiesQueryVariables = Exact<{
+  iri: Scalars['String'];
+  sourceType: Scalars['String'];
+  sourceUrl: Scalars['String'];
+  locale: Scalars['String'];
+  latest?: Maybe<Scalars['Boolean']>;
+  filters?: Maybe<Scalars['Filters']>;
+}>;
+
+
+export type ComponentsWithHierarchiesQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', dimensions: Array<(
+      { __typename: 'GeoCoordinatesDimension' }
+      & DimensionMetadataWithHierarchies_GeoCoordinatesDimension_Fragment
+    ) | (
+      { __typename: 'GeoShapesDimension' }
+      & DimensionMetadataWithHierarchies_GeoShapesDimension_Fragment
+    ) | (
+      { __typename: 'NominalDimension' }
+      & DimensionMetadataWithHierarchies_NominalDimension_Fragment
+    ) | (
+      { __typename: 'NumericalMeasure' }
+      & DimensionMetadataWithHierarchies_NumericalMeasure_Fragment
+    ) | (
+      { __typename: 'OrdinalDimension' }
+      & DimensionMetadataWithHierarchies_OrdinalDimension_Fragment
+    ) | (
+      { __typename: 'OrdinalMeasure' }
+      & DimensionMetadataWithHierarchies_OrdinalMeasure_Fragment
+    ) | (
+      { __typename: 'TemporalDimension' }
+      & DimensionMetadataWithHierarchies_TemporalDimension_Fragment
+    )>, measures: Array<(
+      { __typename: 'NumericalMeasure' }
+      & DimensionMetadataWithHierarchies_NumericalMeasure_Fragment
+    ) | (
+      { __typename: 'OrdinalMeasure' }
+      & DimensionMetadataWithHierarchies_OrdinalMeasure_Fragment
+    )> }> };
+
 export type DimensionValuesQueryVariables = Exact<{
   dataCubeIri: Scalars['String'];
   dimensionIri: Scalars['String'];
@@ -1291,6 +1369,50 @@ export const DataCubeMetadataWithComponentValuesAndHierarchiesDocument = gql`
 
 export function useDataCubeMetadataWithComponentValuesAndHierarchiesQuery(options: Omit<Urql.UseQueryArgs<DataCubeMetadataWithComponentValuesAndHierarchiesQueryVariables>, 'query'> = {}) {
   return Urql.useQuery<DataCubeMetadataWithComponentValuesAndHierarchiesQuery>({ query: DataCubeMetadataWithComponentValuesAndHierarchiesDocument, ...options });
+};
+export const ComponentsDocument = gql`
+    query Components($iri: String!, $sourceType: String!, $sourceUrl: String!, $locale: String!, $latest: Boolean, $filters: Filters) {
+  dataCubeByIri(
+    iri: $iri
+    sourceType: $sourceType
+    sourceUrl: $sourceUrl
+    locale: $locale
+    latest: $latest
+  ) {
+    dimensions(sourceType: $sourceType, sourceUrl: $sourceUrl) {
+      ...dimensionMetadata
+    }
+    measures(sourceType: $sourceType, sourceUrl: $sourceUrl) {
+      ...dimensionMetadata
+    }
+  }
+}
+    ${DimensionMetadataFragmentDoc}`;
+
+export function useComponentsQuery(options: Omit<Urql.UseQueryArgs<ComponentsQueryVariables>, 'query'> = {}) {
+  return Urql.useQuery<ComponentsQuery>({ query: ComponentsDocument, ...options });
+};
+export const ComponentsWithHierarchiesDocument = gql`
+    query ComponentsWithHierarchies($iri: String!, $sourceType: String!, $sourceUrl: String!, $locale: String!, $latest: Boolean, $filters: Filters) {
+  dataCubeByIri(
+    iri: $iri
+    sourceType: $sourceType
+    sourceUrl: $sourceUrl
+    locale: $locale
+    latest: $latest
+  ) {
+    dimensions(sourceType: $sourceType, sourceUrl: $sourceUrl) {
+      ...dimensionMetadataWithHierarchies
+    }
+    measures(sourceType: $sourceType, sourceUrl: $sourceUrl) {
+      ...dimensionMetadataWithHierarchies
+    }
+  }
+}
+    ${DimensionMetadataWithHierarchiesFragmentDoc}`;
+
+export function useComponentsWithHierarchiesQuery(options: Omit<Urql.UseQueryArgs<ComponentsWithHierarchiesQueryVariables>, 'query'> = {}) {
+  return Urql.useQuery<ComponentsWithHierarchiesQuery>({ query: ComponentsWithHierarchiesDocument, ...options });
 };
 export const DimensionValuesDocument = gql`
     query DimensionValues($dataCubeIri: String!, $dimensionIri: String!, $sourceType: String!, $sourceUrl: String!, $locale: String!, $latest: Boolean, $filters: Filters) {

--- a/app/graphql/types.ts
+++ b/app/graphql/types.ts
@@ -1,12 +1,14 @@
 import {
-  DataCubeMetadataWithComponentValuesAndHierarchiesQuery,
-  DataCubeMetadataWithComponentValuesQuery,
+  ComponentsQuery,
+  ComponentsWithHierarchiesQuery,
+  DataCubeMetadataQuery,
 } from "./query-hooks";
 
 export type DataCubeMetadata = NonNullable<
-  DataCubeMetadataWithComponentValuesQuery["dataCubeByIri"]
+  DataCubeMetadataQuery["dataCubeByIri"] & ComponentsQuery["dataCubeByIri"]
 >;
 
 export type DataCubeMetadataWithHierarchies = NonNullable<
-  DataCubeMetadataWithComponentValuesAndHierarchiesQuery["dataCubeByIri"]
+  DataCubeMetadataQuery["dataCubeByIri"] &
+    ComponentsWithHierarchiesQuery["dataCubeByIri"]
 >;

--- a/app/scripts/cube.ts
+++ b/app/scripts/cube.ts
@@ -9,12 +9,12 @@ import { DataSource } from "@/configurator";
 
 import { GRAPHQL_ENDPOINT } from "../domain/env";
 import {
+  ComponentsDocument,
+  ComponentsQuery,
+  ComponentsQueryVariables,
   DataCubeMetadataDocument,
   DataCubeMetadataQuery,
   DataCubeMetadataQueryVariables,
-  DataCubeMetadataWithComponentValuesDocument,
-  DataCubeMetadataWithComponentValuesQuery,
-  DataCubeMetadataWithComponentValuesQueryVariables,
   DataCubePreviewDocument,
   DataCubePreviewQuery,
   DataCubePreviewQueryVariables,
@@ -80,10 +80,7 @@ const showCubeComponents = async ({
   report,
 }: Args<CubeQueryOptions>) => {
   const res = await client
-    .query<
-      DataCubeMetadataWithComponentValuesQuery,
-      DataCubeMetadataWithComponentValuesQueryVariables
-    >(DataCubeMetadataWithComponentValuesDocument, {
+    .query<ComponentsQuery, ComponentsQueryVariables>(ComponentsDocument, {
       iri,
       sourceType,
       sourceUrl,
@@ -109,16 +106,16 @@ const previewCube = async ({
   report,
 }: Args<CubeQueryOptions>) => {
   const { data: info, error } = await client
-    .query<
-      DataCubeMetadataWithComponentValuesQuery,
-      DataCubeMetadataWithComponentValuesQueryVariables
-    >(DataCubeMetadataWithComponentValuesDocument, {
-      iri,
-      sourceType,
-      sourceUrl,
-      locale,
-      latest,
-    })
+    .query<DataCubeMetadataQuery, DataCubeMetadataQueryVariables>(
+      DataCubeMetadataDocument,
+      {
+        iri,
+        sourceType,
+        sourceUrl,
+        locale,
+        latest,
+      }
+    )
     .toPromise();
 
   if (error) {

--- a/app/utils/opendata.ts
+++ b/app/utils/opendata.ts
@@ -1,13 +1,8 @@
-import {
-  DataCubeMetadataWithComponentValuesQuery,
-  DataCubeMetadataQuery,
-} from "@/graphql/query-hooks";
+import { DataCubeMetadataQuery } from "@/graphql/query-hooks";
 
 const makeOpenDataLink = (
   lang: string,
-  cube:
-    | DataCubeMetadataWithComponentValuesQuery["dataCubeByIri"]
-    | DataCubeMetadataQuery["dataCubeByIri"]
+  cube: DataCubeMetadataQuery["dataCubeByIri"]
 ) => {
   const identifier = cube?.identifier;
   const creatorIri = cube?.creator?.iri;


### PR DESCRIPTION
Fixes #1017.

The main problem with #1016 was that I only updated the types in `client.readQuery` in `configurator-state.tsx` 

`DataCubeMetadataWithComponentValuesQuery` → `DataCubeMetadataWithComponentValuesQueryVariables`
`DataCubeMetadataWithComponentValuesQueryVariables` → `DataCubeMetadataWithComponentValuesAndHierarchiesQueryVariables`

but missed updating the document (`DataCubeMetadataWithComponentValuesDocument` → `DataCubeMetadataWithComponentValuesAndHierarchiesDocument`), so we were accessing dimensions without hierarchies in this place.

This PR fixes that (and also adds a unit test to make sure we select top-most hierarchy value by default in filters).

TODO
- [x] Remove `DataCubeMetadataWithComponentValues` & `DataCubeMetadataWithComponentsValuesAndHierarchies` in favor of using `DataCubeMetadata` & `DimensionValues` (so we can avoid fetching the dimension data twice in the editor mode in some cases)