### PR TITLE
feat: Improve sorting for mix of hierarchical and regular values

### DIFF
--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import { memo } from "react";
 
 import { Areas } from "@/charts/area/areas";
 import { AreaChart } from "@/charts/area/areas-state";
@@ -18,6 +18,8 @@ import {
 import { Observation } from "@/domain/data";
 import {
   DimensionMetadataFragment,
+  useComponentsQuery,
+  useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
@@ -36,19 +38,38 @@ export const ChartAreasVisualization = ({
   queryFilters: QueryFilters;
 }) => {
   const locale = useLocale();
-  const [queryResp] = useDataCubeObservationsQuery({
+  const [metadataQuery] = useDataCubeMetadataQuery({
     variables: {
       iri: dataSetIri,
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      dimensions: null, // FIXME: Try to load less dimensions
+    },
+  });
+  const [componentsQuery] = useComponentsQuery({
+    variables: {
+      iri: dataSetIri,
+      sourceType: dataSource.type,
+      sourceUrl: dataSource.url,
+      locale,
+    },
+  });
+  const [observationsQuery] = useDataCubeObservationsQuery({
+    variables: {
+      iri: dataSetIri,
+      sourceType: dataSource.type,
+      sourceUrl: dataSource.url,
+      locale,
+      dimensions: null,
       filters: queryFilters,
     },
   });
+
   return (
     <ChartLoadingWrapper
-      query={queryResp}
+      metadataQuery={metadataQuery}
+      componentsQuery={componentsQuery}
+      observationsQuery={observationsQuery}
       chartConfig={chartConfig}
       Component={ChartAreas}
     />

--- a/app/charts/chart-loading-wrapper.tsx
+++ b/app/charts/chart-loading-wrapper.tsx
@@ -13,6 +13,8 @@ import {
 import { ChartConfig } from "@/configurator";
 import { Observation } from "@/domain/data";
 import {
+  ComponentsQuery,
+  DataCubeMetadataQuery,
   DataCubeObservationsQuery,
   DimensionMetadataFragment,
 } from "@/graphql/query-hooks";
@@ -32,12 +34,22 @@ export const ChartLoadingWrapper = <
   TOtherProps,
   TChartComponent extends React.ElementType
 >({
-  query,
+  metadataQuery,
+  componentsQuery,
+  observationsQuery,
   chartConfig,
   Component,
   ComponentProps,
 }: {
-  query: Pick<
+  metadataQuery: Pick<
+    UseQueryResponse<DataCubeMetadataQuery>[0],
+    "data" | "fetching" | "error"
+  >;
+  componentsQuery: Pick<
+    UseQueryResponse<ComponentsQuery>[0],
+    "data" | "fetching" | "error"
+  >;
+  observationsQuery: Pick<
     UseQueryResponse<DataCubeObservationsQuery>[0],
     "data" | "fetching" | "error"
   >;
@@ -48,11 +60,38 @@ export const ChartLoadingWrapper = <
     keyof ChartCommonProps<TChartConfig>
   >;
 }) => {
-  const { data, fetching, error } = query;
-  if (data?.dataCubeByIri) {
-    const { title, dimensions, measures, observations } = data?.dataCubeByIri;
+  const {
+    data: metadataData,
+    fetching: fetchingMetadata,
+    error: metadataError,
+  } = metadataQuery;
+  const {
+    data: componentsData,
+    fetching: fetchingComponents,
+    error: componentsError,
+  } = componentsQuery;
+  const {
+    data: observationsData,
+    fetching: fetchingObservations,
+    error: observationsError,
+  } = observationsQuery;
+
+  if (
+    metadataData?.dataCubeByIri &&
+    componentsData?.dataCubeByIri &&
+    observationsData?.dataCubeByIri
+  ) {
+    const { title } = metadataData.dataCubeByIri;
+    const { dimensions, measures } = componentsData.dataCubeByIri;
+    const { observations } = observationsData.dataCubeByIri;
+
     return observations.data.length > 0 ? (
-      <Box data-chart-loaded={!fetching} sx={{ position: "relative" }}>
+      <Box
+        data-chart-loaded={
+          !(fetchingMetadata && fetchingComponents && fetchingObservations)
+        }
+        sx={{ position: "relative" }}
+      >
         <A11yTable
           title={title}
           observations={observations.data}
@@ -61,20 +100,24 @@ export const ChartLoadingWrapper = <
         />
         {React.createElement(Component, {
           observations: observations.data,
-          dimensions: dimensions,
-          measures: measures,
-          chartConfig: chartConfig,
+          dimensions,
+          measures,
+          chartConfig,
           ...ComponentProps,
         } as ChartCommonProps<TChartConfig> & TOtherProps)}
-        {fetching && <LoadingOverlay />}
+        {(fetchingMetadata || fetchingComponents || fetchingObservations) && (
+          <LoadingOverlay />
+        )}
       </Box>
     ) : (
       <NoDataHint />
     );
-  } else if (error) {
+  } else if (metadataError || componentsError || observationsError) {
     return (
-      <Flex flexGrow={1} justifyContent="center" minHeight={300}>
-        <LoadingDataError message={error.message} />
+      <Flex sx={{ flexDirection: "column", gap: 3 }}>
+        {metadataError && <Error message={metadataError.message} />}
+        {componentsError && <Error message={componentsError.message} />}
+        {observationsError && <Error message={observationsError.message} />}
       </Flex>
     );
   } else {
@@ -84,4 +127,12 @@ export const ChartLoadingWrapper = <
       </Flex>
     );
   }
+};
+
+const Error = ({ message }: { message: string }) => {
+  return (
+    <Flex flexGrow={1} justifyContent="center" minHeight={300}>
+      <LoadingDataError message={message} />
+    </Flex>
+  );
 };

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -28,7 +28,7 @@ import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import { Observation } from "@/domain/data";
 import {
   DimensionMetadataFragment,
-  useComponentsQuery,
+  useComponentsWithHierarchiesQuery,
   useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
@@ -56,7 +56,7 @@ export const ChartColumnsVisualization = ({
       locale,
     },
   });
-  const [componentsQuery] = useComponentsQuery({
+  const [componentsWithHierarchiesQuery] = useComponentsWithHierarchiesQuery({
     variables: {
       iri: dataSetIri,
       sourceType: dataSource.type,
@@ -78,7 +78,7 @@ export const ChartColumnsVisualization = ({
   return (
     <ChartLoadingWrapper
       metadataQuery={metadataQuery}
-      componentsQuery={componentsQuery}
+      componentsQuery={componentsWithHierarchiesQuery}
       observationsQuery={observationsQuery}
       chartConfig={chartConfig}
       Component={ChartColumns}

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -28,6 +28,8 @@ import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import { Observation } from "@/domain/data";
 import {
   DimensionMetadataFragment,
+  useComponentsQuery,
+  useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
@@ -46,7 +48,23 @@ export const ChartColumnsVisualization = ({
   queryFilters: QueryFilters;
 }) => {
   const locale = useLocale();
-  const [queryResp] = useDataCubeObservationsQuery({
+  const [metadataQuery] = useDataCubeMetadataQuery({
+    variables: {
+      iri: dataSetIri,
+      sourceType: dataSource.type,
+      sourceUrl: dataSource.url,
+      locale,
+    },
+  });
+  const [componentsQuery] = useComponentsQuery({
+    variables: {
+      iri: dataSetIri,
+      sourceType: dataSource.type,
+      sourceUrl: dataSource.url,
+      locale,
+    },
+  });
+  const [observationsQuery] = useDataCubeObservationsQuery({
     variables: {
       iri: dataSetIri,
       sourceType: dataSource.type,
@@ -59,7 +77,9 @@ export const ChartColumnsVisualization = ({
 
   return (
     <ChartLoadingWrapper
-      query={queryResp}
+      metadataQuery={metadataQuery}
+      componentsQuery={componentsQuery}
+      observationsQuery={observationsQuery}
       chartConfig={chartConfig}
       Component={ChartColumns}
     />

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -15,7 +15,7 @@ import {
 } from "d3";
 import get from "lodash/get";
 import orderBy from "lodash/orderBy";
-import { ReactNode, useCallback, useMemo } from "react";
+import { ReactNode, useMemo } from "react";
 
 import {
   BOTTOM_MARGIN_OFFSET,
@@ -38,6 +38,7 @@ import { useMaybeAbbreviations } from "@/charts/shared/use-abbreviations";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { ChartContext, ChartProps } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
+import { useObservationLabels } from "@/charts/shared/use-observation-labels";
 import { Observer, useWidth } from "@/charts/shared/use-width";
 import { ColumnConfig, SortingOrder, SortingType } from "@/configurator";
 import {
@@ -118,35 +119,10 @@ const useColumnsState = (
       dimension: xDimension,
     });
 
-  const getXIri = useCallback(
-    (d: Observation) => {
-      return d[`${fields.x.componentIri}/__iri__`] as string | undefined;
-    },
-    [fields.x.componentIri]
-  );
-
-  const observationXLabelsLookup = useMemo(() => {
-    const lookup = new Map<string, string>();
-    data.forEach((d) => {
-      const iri = getXIri(d);
-      const label = getXAbbreviationOrLabel(d);
-      lookup.set(iri ?? label, label);
-    });
-
-    return lookup;
-  }, [data, getXAbbreviationOrLabel, getXIri]);
-
-  const getX = useCallback(
-    (d: Observation) => {
-      return getXIri(d) ?? getXAbbreviationOrLabel(d);
-    },
-    [getXIri, getXAbbreviationOrLabel]
-  );
-  const getXLabel = useCallback(
-    (d: string) => {
-      return observationXLabelsLookup.get(d) ?? d;
-    },
-    [observationXLabelsLookup]
+  const { getValue: getX, getLabel: getXLabel } = useObservationLabels(
+    data,
+    getXAbbreviationOrLabel,
+    fields.x.componentIri
   );
 
   const getXAsDate = useTemporalVariable(fields.x.componentIri);

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -19,6 +19,8 @@ import {
 import { Observation } from "@/domain/data";
 import {
   DimensionMetadataFragment,
+  useComponentsQuery,
+  useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
@@ -37,20 +39,38 @@ export const ChartLinesVisualization = ({
   queryFilters: QueryFilters;
 }) => {
   const locale = useLocale();
-  const [queryResp] = useDataCubeObservationsQuery({
+  const [metadataQuery] = useDataCubeMetadataQuery({
     variables: {
       iri: dataSetIri,
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      dimensions: null, // FIXME: Try to load less dimensions
+    },
+  });
+  const [componentsQuery] = useComponentsQuery({
+    variables: {
+      iri: dataSetIri,
+      sourceType: dataSource.type,
+      sourceUrl: dataSource.url,
+      locale,
+    },
+  });
+  const [observationsQuery] = useDataCubeObservationsQuery({
+    variables: {
+      iri: dataSetIri,
+      sourceType: dataSource.type,
+      sourceUrl: dataSource.url,
+      locale,
+      dimensions: null,
       filters: queryFilters,
     },
   });
 
   return (
     <ChartLoadingWrapper
-      query={queryResp}
+      metadataQuery={metadataQuery}
+      componentsQuery={componentsQuery}
+      observationsQuery={observationsQuery}
       chartConfig={chartConfig}
       Component={ChartLines}
     />

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -1,19 +1,12 @@
-import { Box } from "@mui/material";
 import { memo } from "react";
 
+import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
 import { Pie } from "@/charts/pie/pie";
 import { PieChart } from "@/charts/pie/pie-state";
-import { A11yTable } from "@/charts/shared/a11y-table";
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
-import {
-  Loading,
-  LoadingDataError,
-  LoadingOverlay,
-  NoDataHint,
-  OnlyNegativeDataHint,
-} from "@/components/hint";
+import { OnlyNegativeDataHint } from "@/components/hint";
 import {
   DataSource,
   PieConfig,
@@ -23,6 +16,8 @@ import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import { Observation } from "@/domain/data";
 import {
   DimensionMetadataFragment,
+  useComponentsQuery,
+  useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
@@ -39,7 +34,23 @@ export const ChartPieVisualization = ({
   queryFilters: QueryFilters;
 }) => {
   const locale = useLocale();
-  const [{ data, fetching, error }] = useDataCubeObservationsQuery({
+  const [metadataQuery] = useDataCubeMetadataQuery({
+    variables: {
+      iri: dataSetIri,
+      sourceType: dataSource.type,
+      sourceUrl: dataSource.url,
+      locale,
+    },
+  });
+  const [componentsQuery] = useComponentsQuery({
+    variables: {
+      iri: dataSetIri,
+      sourceType: dataSource.type,
+      sourceUrl: dataSource.url,
+      locale,
+    },
+  });
+  const [observationsQuery] = useDataCubeObservationsQuery({
     variables: {
       iri: dataSetIri,
       sourceType: dataSource.type,
@@ -50,33 +61,15 @@ export const ChartPieVisualization = ({
     },
   });
 
-  if (data?.dataCubeByIri) {
-    const { title, dimensions, measures, observations } = data?.dataCubeByIri;
-
-    return observations.data.length > 0 ? (
-      <Box data-chart-loaded={!fetching} sx={{ position: "relative" }}>
-        <A11yTable
-          title={title}
-          observations={observations.data}
-          dimensions={dimensions}
-          measures={measures}
-        />
-        <ChartPie
-          observations={observations.data}
-          dimensions={dimensions}
-          measures={measures}
-          chartConfig={chartConfig}
-        />
-        {fetching && <LoadingOverlay />}
-      </Box>
-    ) : (
-      <NoDataHint />
-    );
-  } else if (error) {
-    return <LoadingDataError />;
-  } else {
-    return <Loading />;
-  }
+  return (
+    <ChartLoadingWrapper
+      metadataQuery={metadataQuery}
+      componentsQuery={componentsQuery}
+      observationsQuery={observationsQuery}
+      chartConfig={chartConfig}
+      Component={ChartPie}
+    />
+  );
 };
 
 export const ChartPie = memo(
@@ -93,7 +86,7 @@ export const ChartPie = memo(
   }) => {
     const { fields } = chartConfig;
     const somePositive = observations.some(
-      (d) => d[fields?.y?.componentIri]! > 0
+      (d) => (d[fields?.y?.componentIri] as number) > 0
     );
 
     if (!somePositive) {

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -23,6 +23,8 @@ import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import { Observation } from "@/domain/data";
 import {
   DimensionMetadataFragment,
+  useComponentsQuery,
+  useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
@@ -41,20 +43,38 @@ export const ChartScatterplotVisualization = ({
   queryFilters: QueryFilters;
 }) => {
   const locale = useLocale();
-  const [queryResp] = useDataCubeObservationsQuery({
+  const [metadataQuery] = useDataCubeMetadataQuery({
     variables: {
       iri: dataSetIri,
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      dimensions: null, // FIXME: Other fields may also be measures
+    },
+  });
+  const [componentsQuery] = useComponentsQuery({
+    variables: {
+      iri: dataSetIri,
+      sourceType: dataSource.type,
+      sourceUrl: dataSource.url,
+      locale,
+    },
+  });
+  const [observationsQuery] = useDataCubeObservationsQuery({
+    variables: {
+      iri: dataSetIri,
+      sourceType: dataSource.type,
+      sourceUrl: dataSource.url,
+      locale,
+      dimensions: null,
       filters: queryFilters,
     },
   });
 
   return (
     <ChartLoadingWrapper
-      query={queryResp}
+      metadataQuery={metadataQuery}
+      componentsQuery={componentsQuery}
+      observationsQuery={observationsQuery}
       Component={ChartScatterplot}
       chartConfig={chartConfig}
     />

--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -1,7 +1,7 @@
 import { Trans } from "@lingui/macro";
 import { Box, Button, Link, Theme, Typography } from "@mui/material";
 import { makeStyles } from "@mui/styles";
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { useChartTablePreview } from "@/components/chart-table-preview";
 import { DataDownloadMenu, RunSparqlQuery } from "@/components/data-download";
@@ -11,7 +11,7 @@ import {
   useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
-import { getChartIcon, Icon } from "@/icons";
+import { Icon, getChartIcon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
 import { useEmbedOptions } from "@/utils/embed";
 import { makeOpenDataLink } from "@/utils/opendata";

--- a/app/components/data-download.tsx
+++ b/app/components/data-download.tsx
@@ -1,4 +1,4 @@
-import { Trans } from "@lingui/macro";
+import { Trans, t } from "@lingui/macro";
 import {
   Button,
   CircularProgress,
@@ -14,32 +14,34 @@ import {
   bindMenu,
   usePopupState,
 } from "material-ui-popup-state/hooks";
-import React, {
-  createContext,
+import {
   Dispatch,
-  memo,
   PropsWithChildren,
   ReactNode,
+  createContext,
+  memo,
   useCallback,
   useContext,
   useState,
 } from "react";
 import { OperationResult, useClient } from "urql";
 
+import Flex from "@/components/flex";
 import { getSortedColumns } from "@/configurator/components/datatable";
 import { DataSource, QueryFilters } from "@/configurator/config-types";
 import { Observation } from "@/domain/data";
-import { useLocale } from "@/src";
-
 import {
+  ComponentsDocument,
+  ComponentsQuery,
+  ComponentsQueryVariables,
   DataCubeObservationsDocument,
   DataCubeObservationsQuery,
   DataCubeObservationsQueryVariables,
   DimensionMetadataFragment,
-} from "../graphql/query-hooks";
-import { Icon } from "../icons";
-
-import Flex from "./flex";
+} from "@/graphql/query-hooks";
+import { Icon } from "@/icons";
+import { useLocale } from "@/src";
+import { useI18n } from "@/utils/use-i18n";
 
 type DataDownloadState = {
   isDownloading: boolean;
@@ -276,14 +278,18 @@ const DownloadMenuItem = ({
   filters?: QueryFilters;
 }) => {
   const locale = useLocale();
+  const i18n = useI18n();
   const urqlClient = useClient();
   const [state, dispatch] = useDataDownloadState();
 
   const download = useCallback(
-    (fetchedData: DataCubeObservationsQuery) => {
-      if (fetchedData?.dataCubeByIri) {
-        const { measures, dimensions, observations } =
-          fetchedData.dataCubeByIri;
+    (
+      componentsData: ComponentsQuery,
+      observationsData: DataCubeObservationsQuery
+    ) => {
+      if (componentsData?.dataCubeByIri && observationsData?.dataCubeByIri) {
+        const { dimensions, measures } = componentsData.dataCubeByIri;
+        const { observations } = observationsData.dataCubeByIri;
         const preparedData = prepareData({
           dimensions,
           measures,
@@ -318,7 +324,19 @@ const DownloadMenuItem = ({
         dispatch({ isDownloading: true });
 
         try {
-          const result: OperationResult<DataCubeObservationsQuery> =
+          const componentsResult: OperationResult<ComponentsQuery> =
+            await urqlClient
+              .query<ComponentsQuery, ComponentsQueryVariables>(
+                ComponentsDocument,
+                {
+                  iri: dataSetIri,
+                  sourceType: dataSource.type,
+                  sourceUrl: dataSource.url,
+                  locale,
+                }
+              )
+              .toPromise();
+          const observationsResult: OperationResult<DataCubeObservationsQuery> =
             await urqlClient
               .query<
                 DataCubeObservationsQuery,
@@ -333,13 +351,29 @@ const DownloadMenuItem = ({
               })
               .toPromise();
 
-          if (result.data) {
-            await download(result.data);
-          } else if (result.error) {
-            dispatch({ ...state, error: result.error.message });
+          if (componentsResult.data && observationsResult.data) {
+            await download(componentsResult.data, observationsResult.data);
+          } else if (componentsResult.error || observationsResult.error) {
+            dispatch({
+              ...state,
+              error: i18n._(
+                t({
+                  id: "hint.dataloadingerror.message",
+                  message: "The data could not be loaded.",
+                })
+              ),
+            });
           }
         } catch (e) {
-          console.error("Could not download the data!", e);
+          console.error(
+            i18n._(
+              t({
+                id: "hint.dataloadingerror.message",
+                message: "The data could not be loaded.",
+              })
+            ),
+            e
+          );
         } finally {
           dispatch({ ...state, isDownloading: false });
         }

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -83,16 +83,6 @@ export const ChartOptionsSelector = ({
 }) => {
   const { activeField, chartConfig, dataSet, dataSource } = state;
   const locale = useLocale();
-  const [{ data: observationsData }] = useDataCubeObservationsQuery({
-    variables: {
-      iri: dataSet,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-      filters: chartConfig.filters,
-    },
-  });
-
   const [{ data: metadataData }] = useDataCubeMetadataQuery({
     variables: {
       iri: dataSet,
@@ -107,6 +97,15 @@ export const ChartOptionsSelector = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
+    },
+  });
+  const [{ data: observationsData }] = useDataCubeObservationsQuery({
+    variables: {
+      iri: dataSet,
+      sourceType: dataSource.type,
+      sourceUrl: dataSource.url,
+      locale,
+      filters: chartConfig.filters,
     },
   });
 

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -363,15 +363,6 @@ query DataCubeObservations(
     locale: $locale
     latest: $latest
   ) {
-    iri
-    title
-    description
-    dimensions(sourceType: $sourceType, sourceUrl: $sourceUrl) {
-      ...dimensionMetadata
-    }
-    measures(sourceType: $sourceType, sourceUrl: $sourceUrl) {
-      ...dimensionMetadata
-    }
     observations(
       sourceType: $sourceType
       sourceUrl: $sourceUrl

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -919,34 +919,7 @@ export type DataCubeObservationsQueryVariables = Exact<{
 }>;
 
 
-export type DataCubeObservationsQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', iri: string, title: string, description?: Maybe<string>, dimensions: Array<(
-      { __typename: 'GeoCoordinatesDimension' }
-      & DimensionMetadata_GeoCoordinatesDimension_Fragment
-    ) | (
-      { __typename: 'GeoShapesDimension' }
-      & DimensionMetadata_GeoShapesDimension_Fragment
-    ) | (
-      { __typename: 'NominalDimension' }
-      & DimensionMetadata_NominalDimension_Fragment
-    ) | (
-      { __typename: 'NumericalMeasure' }
-      & DimensionMetadata_NumericalMeasure_Fragment
-    ) | (
-      { __typename: 'OrdinalDimension' }
-      & DimensionMetadata_OrdinalDimension_Fragment
-    ) | (
-      { __typename: 'OrdinalMeasure' }
-      & DimensionMetadata_OrdinalMeasure_Fragment
-    ) | (
-      { __typename: 'TemporalDimension' }
-      & DimensionMetadata_TemporalDimension_Fragment
-    )>, measures: Array<(
-      { __typename: 'NumericalMeasure' }
-      & DimensionMetadata_NumericalMeasure_Fragment
-    ) | (
-      { __typename: 'OrdinalMeasure' }
-      & DimensionMetadata_OrdinalMeasure_Fragment
-    )>, observations: { __typename: 'ObservationsQuery', data: Array<Observation>, sparqlEditorUrl?: Maybe<string> } }> };
+export type DataCubeObservationsQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', observations: { __typename: 'ObservationsQuery', data: Array<Observation>, sparqlEditorUrl?: Maybe<string> } }> };
 
 export type PossibleFiltersQueryVariables = Exact<{
   iri: Scalars['String'];
@@ -1384,15 +1357,6 @@ export const DataCubeObservationsDocument = gql`
     locale: $locale
     latest: $latest
   ) {
-    iri
-    title
-    description
-    dimensions(sourceType: $sourceType, sourceUrl: $sourceUrl) {
-      ...dimensionMetadata
-    }
-    measures(sourceType: $sourceType, sourceUrl: $sourceUrl) {
-      ...dimensionMetadata
-    }
     observations(
       sourceType: $sourceType
       sourceUrl: $sourceUrl
@@ -1405,7 +1369,7 @@ export const DataCubeObservationsDocument = gql`
     }
   }
 }
-    ${DimensionMetadataFragmentDoc}`;
+    `;
 
 export function useDataCubeObservationsQuery(options: Omit<Urql.UseQueryArgs<DataCubeObservationsQueryVariables>, 'query'> = {}) {
   return Urql.useQuery<DataCubeObservationsQuery>({ query: DataCubeObservationsDocument, ...options });

--- a/app/graphql/resolvers/rdf.ts
+++ b/app/graphql/resolvers/rdf.ts
@@ -10,7 +10,6 @@ import { Loaders } from "@/graphql/context";
 import {
   DataCubeResolvers,
   DataCubeResultOrder,
-  ObservationFilter,
   DimensionResolvers,
   QueryResolvers,
   Resolvers,
@@ -124,22 +123,25 @@ export const possibleFilters: NonNullable<QueryResolvers["possibleFilters"]> =
         dimensions: null,
         cache,
       });
+
       if (obs.length === 0) {
         continue;
       }
+
       const unversioned = await unversionObservation({
         observation: obs[0],
         cube: cube,
         sparqlClient,
       });
-      const ret = Object.keys(filters).map((f) => ({
+      const result = Object.keys(filters).map((f) => ({
         iri: f,
         type: "single",
-        // TODO figure out why I need to do the as here
-        value: unversioned[f] as ObservationFilter["value"],
+        value: unversioned[f],
       }));
-      return ret;
+
+      return result;
     }
+
     return [];
   };
 

--- a/app/rdf/query-dimension-values.ts
+++ b/app/rdf/query-dimension-values.ts
@@ -13,8 +13,8 @@ import { pragmas } from "@/rdf/create-source";
 
 import { Filters } from "../configurator";
 
-import { cube as cubeNs } from "./namespace";
 import * as ns from "./namespace";
+import { cube as cubeNs } from "./namespace";
 import { parseDimensionDatatype } from "./parse";
 import { dimensionIsVersioned } from "./queries";
 import { executeWithCache } from "./query-cache";
@@ -80,9 +80,14 @@ export async function unversionObservation({
     cube.dimensions,
     (x) => x.path?.value
   ) as Record<string, CubeDimension>;
-  const versionedDimensions = Object.keys(observation).filter((x) =>
-    dimensionIsVersioned(dimensionsByPath[x])
-  );
+  const versionedDimensions = Object.keys(observation).filter((x) => {
+    // Ignore the artificial __iri__ dimensions.
+    if (x.endsWith("/__iri__")) {
+      return false;
+    }
+
+    return dimensionIsVersioned(dimensionsByPath[x]);
+  });
   const query = SELECT.DISTINCT`?versioned ?unversioned`.WHERE`
     VALUES (?versioned) {
       ${versionedDimensions.map((x) => `(<${observation[x]}>)\n`)}

--- a/app/utils/sorting-values.spec.ts
+++ b/app/utils/sorting-values.spec.ts
@@ -1,0 +1,84 @@
+import orderBy from "lodash/orderBy";
+
+import { SortingField } from "@/configurator";
+import { DimensionMetadataWithHierarchiesFragment } from "@/graphql/query-hooks";
+import { makeDimensionValueSorters } from "@/utils/sorting-values";
+
+const dimension = {
+  hierarchy: [
+    {
+      label: "Switzerland",
+      value: "CH",
+      identifier: "CH",
+      depth: 0,
+      children: [
+        {
+          label: "Production Regions",
+          value: "CH-PROD",
+          identifier: "CH-PROD",
+          depth: 1,
+          children: [
+            {
+              label: "West Production Region",
+              value: "CH-PROD-WEST",
+              identifier: "CH-PROD-WEST",
+              depth: 2,
+            },
+            {
+              label: "East Production Region",
+              value: "CH-PROD-EAST",
+              identifier: "CH-PROD-EAST",
+              depth: 2,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      label: "Bern",
+      value: "CH-BE",
+      depth: -1,
+      children: [],
+    },
+  ],
+  values: [
+    {
+      label: "Switzerland",
+      value: "CH",
+      identifier: "CH",
+    },
+    {
+      label: "Bern",
+      value: "CH-BE",
+      identifier: "CH-BE",
+    },
+    {
+      label: "West Production Region",
+      value: "CH-PROD-WEST",
+      identifier: "CH-PROD-WEST",
+    },
+    {
+      label: "East Production Region",
+      value: "CH-PROD-EAST",
+      identifier: "CH-PROD-EAST",
+    },
+  ],
+} as unknown as DimensionMetadataWithHierarchiesFragment;
+
+describe("makeDimensionValueSorters", () => {
+  const sorting: NonNullable<SortingField["sorting"]> = {
+    sortingType: "byAuto",
+    sortingOrder: "asc",
+  };
+
+  it("should correctly sort hierarchical dimensions byAuto", () => {
+    const values = dimension.values.map((d) => d.value);
+    const sorters = makeDimensionValueSorters(dimension, { sorting });
+    expect(orderBy(values, sorters, ["asc"])).toEqual([
+      "CH",
+      "CH-PROD-EAST",
+      "CH-PROD-WEST",
+      "CH-BE",
+    ]);
+  });
+});

--- a/app/utils/sorting-values.ts
+++ b/app/utils/sorting-values.ts
@@ -1,7 +1,6 @@
 import { FilterValue, SortingField } from "@/configurator";
 import { DimensionValue } from "@/domain/data";
-
-import { DataCubeObservationsQuery } from "../graphql/query-hooks";
+import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 
 import { uniqueMapBy } from "./uniqueMapBy";
 
@@ -24,11 +23,7 @@ const maybeInt = (value?: string | number): number | string => {
 };
 
 export const makeDimensionValueSorters = (
-  dimension:
-    | NonNullable<
-        DataCubeObservationsQuery["dataCubeByIri"]
-      >["dimensions"][number]
-    | undefined,
+  dimension: DimensionMetadataFragment | undefined,
   options: {
     dimensionFilter?: FilterValue;
     sorting?:

--- a/app/utils/sorting-values.ts
+++ b/app/utils/sorting-values.ts
@@ -129,7 +129,7 @@ export const makeDimensionValueSorters = (
 
   let sorters: ((dv: string) => string | undefined | number)[] = [];
 
-  const defaultSorters = [getPosition, getIdentifier, getLabel];
+  const defaultSorters = [getHierarchy, getPosition, getIdentifier, getLabel];
 
   switch (sortingType) {
     case "byDimensionLabel":
@@ -142,7 +142,7 @@ export const makeDimensionValueSorters = (
       sorters = [getMeasure];
       break;
     case "byAuto":
-      sorters = [getHierarchy, getPosition, getIdentifier, getLabel];
+      sorters = defaultSorters;
       break;
     case "byTableSortingType":
       sorters = [getPosition, getLabel];


### PR DESCRIPTION
Fixes #1015 (sorting issue).

## Goals / Scope

The main goal of this PR is to improve sorting of hierarchical dimensions (X field) in column charts.

## Description

As mentioned in #1015, we should first sort by hierarchical values and then by non-hierarchical values (by depth). We also fall back to sorting by label in `byAuto` mode, as it seems that sometimes `identifier` and `position` are undefined.

This required us to fetch components with hierarchies, but this change is only scoped to column charts, for other charts we do not need to fetch hierarchies for this reason.

Additionally, I refactored GQL queries, so we do not fetch dimensions & measures in `DataCubeObservations` query, but we need to explicitly fetch them with `Components` query. I believe it makes it more clear (and potentially efficient) to separate this logic.

## How to test

1. Go to [/en/browse?dataset=https%3A%2F%2Fenvironment.ld.admin.ch%2Ffoen%2Fnfi%2FC-616%2Fcube%2F1&dataSource=Int](https://visualization-tool-git-feat-improve-sorting-ixt1.vercel.app/en/browse?previous=%7B%22includeDrafts%22%3Atrue%2C%22order%22%3A%22SCORE%22%2C%22search%22%3A%22target%22%7D&dataset=https%3A%2F%2Fenvironment.ld.admin.ch%2Ffoen%2Fnfi%2FC-616%2Fcube%2F1&dataSource=Int).
2. Change vertical axis to `Volume (relativ)`.
3. Change horizontal axis to `Region`.
4. See that the bars are sorted in "logical" order (by hierarchy depth) – country is first (Switzerland), followed by smaller units (production & economics regions). Cantons are occupying the last places, as they were not part of the hierarchy.