### PR TITLE
fix: Temporal values in X axis in column charts

### DIFF
--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -115,7 +115,8 @@ const useAreasState = (
     abbreviationOrLabelLookup: segmentsByAbbreviationOrLabel,
   } = useMaybeAbbreviations({
     useAbbreviations: fields.segment?.useAbbreviations,
-    dimension: segmentDimension,
+    dimensionIri: segmentDimension?.iri,
+    dimensionValues: segmentDimension?.values,
   });
 
   const { getValue: getSegment, getLabel: getSegmentLabel } =

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -109,7 +109,8 @@ const useGroupedColumnsState = (
   const { getAbbreviationOrLabelByValue: getXAbbreviationOrLabel } =
     useMaybeAbbreviations({
       useAbbreviations: fields.x.useAbbreviations,
-      dimension: xDimension,
+      dimensionIri: xDimension.iri,
+      dimensionValues: xDimension.values,
     });
 
   const { getValue: getX, getLabel: getXLabel } = useObservationLabels(

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -29,7 +29,7 @@ import {
 import {
   getLabelWithUnit,
   useDataAfterInteractiveFilters,
-  useMaybeTemporalDimensionValues,
+  getMaybeTemporalDimensionValues,
   useOptionalNumericVariable,
   usePlottableData,
   useTemporalVariable,
@@ -106,7 +106,9 @@ const useGroupedColumnsState = (
   }
 
   const xIsTime = isTemporalDimension(xDimension);
-  const xDimensionValues = useMaybeTemporalDimensionValues(xDimension, data);
+  const xDimensionValues = useMemo(() => {
+    return getMaybeTemporalDimensionValues(xDimension, data);
+  }, [xDimension, data]);
 
   const { getAbbreviationOrLabelByValue: getXAbbreviationOrLabel } =
     useMaybeAbbreviations({

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -29,6 +29,7 @@ import {
 import {
   getLabelWithUnit,
   useDataAfterInteractiveFilters,
+  useMaybeTemporalDimensionValues,
   useOptionalNumericVariable,
   usePlottableData,
   useTemporalVariable,
@@ -105,12 +106,13 @@ const useGroupedColumnsState = (
   }
 
   const xIsTime = isTemporalDimension(xDimension);
+  const xDimensionValues = useMaybeTemporalDimensionValues(xDimension, data);
 
   const { getAbbreviationOrLabelByValue: getXAbbreviationOrLabel } =
     useMaybeAbbreviations({
       useAbbreviations: fields.x.useAbbreviations,
       dimensionIri: xDimension.iri,
-      dimensionValues: xDimension.values,
+      dimensionValues: xDimensionValues,
     });
 
   const { getValue: getX, getLabel: getXLabel } = useObservationLabels(
@@ -133,7 +135,8 @@ const useGroupedColumnsState = (
     abbreviationOrLabelLookup: segmentsByAbbreviationOrLabel,
   } = useMaybeAbbreviations({
     useAbbreviations: fields.segment?.useAbbreviations,
-    dimension: segmentDimension,
+    dimensionIri: segmentDimension?.iri,
+    dimensionValues: segmentDimension?.values,
   });
 
   const { getValue: getSegment, getLabel: getSegmentLabel } =

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -34,7 +34,7 @@ import {
   getLabelWithUnit,
   getWideData,
   useDataAfterInteractiveFilters,
-  useMaybeTemporalDimensionValues,
+  getMaybeTemporalDimensionValues,
   useOptionalNumericVariable,
   usePlottableData,
   useTemporalVariable,
@@ -109,7 +109,9 @@ const useColumnsStackedState = (
   }
 
   const xIsTime = isTemporalDimension(xDimension);
-  const xDimensionValues = useMaybeTemporalDimensionValues(xDimension, data);
+  const xDimensionValues = useMemo(() => {
+    return getMaybeTemporalDimensionValues(xDimension, data);
+  }, [xDimension, data]);
 
   const { getAbbreviationOrLabelByValue: getXAbbreviationOrLabel } =
     useMaybeAbbreviations({

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -34,6 +34,7 @@ import {
   getLabelWithUnit,
   getWideData,
   useDataAfterInteractiveFilters,
+  useMaybeTemporalDimensionValues,
   useOptionalNumericVariable,
   usePlottableData,
   useTemporalVariable,
@@ -108,12 +109,13 @@ const useColumnsStackedState = (
   }
 
   const xIsTime = isTemporalDimension(xDimension);
+  const xDimensionValues = useMaybeTemporalDimensionValues(xDimension, data);
 
   const { getAbbreviationOrLabelByValue: getXAbbreviationOrLabel } =
     useMaybeAbbreviations({
       useAbbreviations: fields.x.useAbbreviations,
       dimensionIri: xDimension.iri,
-      dimensionValues: xDimension.values,
+      dimensionValues: xDimensionValues,
     });
 
   const { getValue: getX, getLabel: getXLabel } = useObservationLabels(
@@ -134,7 +136,8 @@ const useColumnsStackedState = (
     abbreviationOrLabelLookup: segmentsByAbbreviationOrLabel,
   } = useMaybeAbbreviations({
     useAbbreviations: fields.segment?.useAbbreviations,
-    dimension: segmentDimension,
+    dimensionIri: segmentDimension?.iri,
+    dimensionValues: segmentDimension?.values,
   });
 
   const { getValue: getSegment, getLabel: getSegmentLabel } =

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -112,7 +112,8 @@ const useColumnsStackedState = (
   const { getAbbreviationOrLabelByValue: getXAbbreviationOrLabel } =
     useMaybeAbbreviations({
       useAbbreviations: fields.x.useAbbreviations,
-      dimension: xDimension,
+      dimensionIri: xDimension.iri,
+      dimensionValues: xDimension.values,
     });
 
   const { getValue: getX, getLabel: getXLabel } = useObservationLabels(

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -26,7 +26,7 @@ import {
 import {
   getLabelWithUnit,
   useDataAfterInteractiveFilters,
-  useMaybeTemporalDimensionValues,
+  getMaybeTemporalDimensionValues,
   useOptionalNumericVariable,
   usePlottableData,
   useSegment,
@@ -113,7 +113,9 @@ const useColumnsState = (
   const timeUnit = xIsTime
     ? (xDimension as TemporalDimension).timeUnit
     : undefined;
-  const xDimensionValues = useMaybeTemporalDimensionValues(xDimension, data);
+  const xDimensionValues = useMemo(() => {
+    return getMaybeTemporalDimensionValues(xDimension, data);
+  }, [xDimension, data]);
 
   const { getAbbreviationOrLabelByValue: getXAbbreviationOrLabel } =
     useMaybeAbbreviations({

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -116,7 +116,8 @@ const useColumnsState = (
   const { getAbbreviationOrLabelByValue: getXAbbreviationOrLabel } =
     useMaybeAbbreviations({
       useAbbreviations: fields.x.useAbbreviations,
-      dimension: xDimension,
+      dimensionIri: xDimension.iri,
+      dimensionValues: xDimension.values,
     });
 
   const { getValue: getX, getLabel: getXLabel } = useObservationLabels(

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -26,6 +26,7 @@ import {
 import {
   getLabelWithUnit,
   useDataAfterInteractiveFilters,
+  useMaybeTemporalDimensionValues,
   useOptionalNumericVariable,
   usePlottableData,
   useSegment,
@@ -112,12 +113,13 @@ const useColumnsState = (
   const timeUnit = xIsTime
     ? (xDimension as TemporalDimension).timeUnit
     : undefined;
+  const xDimensionValues = useMaybeTemporalDimensionValues(xDimension, data);
 
   const { getAbbreviationOrLabelByValue: getXAbbreviationOrLabel } =
     useMaybeAbbreviations({
       useAbbreviations: fields.x.useAbbreviations,
       dimensionIri: xDimension.iri,
-      dimensionValues: xDimension.values,
+      dimensionValues: xDimensionValues,
     });
 
   const { getValue: getX, getLabel: getXLabel } = useObservationLabels(

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -111,7 +111,8 @@ const useLinesState = (
     abbreviationOrLabelLookup: segmentsByAbbreviationOrLabel,
   } = useMaybeAbbreviations({
     useAbbreviations: fields.segment?.useAbbreviations,
-    dimension: segmentDimension,
+    dimensionIri: segmentDimension?.iri,
+    dimensionValues: segmentDimension?.values,
   });
 
   const { getValue: getSegment, getLabel: getSegmentLabel } =

--- a/app/charts/pie/pie-state.tsx
+++ b/app/charts/pie/pie-state.tsx
@@ -72,7 +72,8 @@ const usePieState = (
     abbreviationOrLabelLookup: segmentsByAbbreviationOrLabel,
   } = useMaybeAbbreviations({
     useAbbreviations: fields.segment?.useAbbreviations,
-    dimension: segmentDimension,
+    dimensionIri: segmentDimension?.iri,
+    dimensionValues: segmentDimension?.values,
   });
 
   const { getValue: getSegment, getLabel: getSegmentLabel } =

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -76,7 +76,8 @@ const useScatterplotState = ({
     abbreviationOrLabelLookup: segmentsByAbbreviationOrLabel,
   } = useMaybeAbbreviations({
     useAbbreviations: fields.segment?.useAbbreviations,
-    dimension: segmentDimension,
+    dimensionIri: segmentDimension?.iri,
+    dimensionValues: segmentDimension?.values,
   });
 
   const { getValue: getSegment, getLabel: getSegmentLabel } =

--- a/app/charts/shared/chart-helpers.spec.tsx
+++ b/app/charts/shared/chart-helpers.spec.tsx
@@ -1,11 +1,10 @@
-import { renderHook } from "@testing-library/react-hooks";
 import { InternMap } from "d3";
 import merge from "lodash/merge";
 
 import {
   getWideData,
   prepareQueryFilters,
-  useMaybeTemporalDimensionValues,
+  getMaybeTemporalDimensionValues,
 } from "@/charts/shared/chart-helpers";
 import { InteractiveFiltersState } from "@/charts/shared/use-interactive-filters";
 import { ChartType, Filters, InteractiveFiltersConfig } from "@/configurator";
@@ -141,7 +140,7 @@ describe("getWideData", () => {
   });
 });
 
-describe("useMaybeTemporalDimensionValues", () => {
+describe("getMaybeTemporalDimensionValues", () => {
   it("should return data values if dimension is temporal", () => {
     const temporalDimension = {
       __typename: "TemporalDimension",
@@ -157,11 +156,9 @@ describe("useMaybeTemporalDimensionValues", () => {
       { [temporalDimension.iri]: "2023" },
     ];
 
-    const { result } = renderHook(() => {
-      return useMaybeTemporalDimensionValues(temporalDimension, data);
-    });
+    const result = getMaybeTemporalDimensionValues(temporalDimension, data);
 
-    expect(result.current).toEqual([
+    expect(result).toEqual([
       { label: "1997", value: "1997" },
       { label: "2002", value: "2002" },
       { label: "2023", value: "2023" },
@@ -180,10 +177,8 @@ describe("useMaybeTemporalDimensionValues", () => {
     } as DimensionMetadataFragment;
     const data: Observation[] = [];
 
-    const { result } = renderHook(() => {
-      return useMaybeTemporalDimensionValues(dimension, data);
-    });
+    const result = getMaybeTemporalDimensionValues(dimension, data);
 
-    expect(result.current).toEqual(dimension.values);
+    expect(result).toEqual(dimension.values);
   });
 });

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -23,11 +23,7 @@ import {
   QueryFilters,
 } from "@/configurator/config-types";
 import { FIELD_VALUE_NONE } from "@/configurator/constants";
-import {
-  DimensionValue,
-  isTemporalDimension,
-  Observation,
-} from "@/domain/data";
+import { isTemporalDimension, Observation } from "@/domain/data";
 import { truthy } from "@/domain/types";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 
@@ -421,18 +417,14 @@ export const useImputationNeeded = ({
  * column charts, where the temporal dimension is used as X axis (and we
  * do not fetch all values for temporal dimensions, only the min and max).
  */
-export const useMaybeTemporalDimensionValues = (
+export const getMaybeTemporalDimensionValues = (
   dimension: DimensionMetadataFragment,
   data: Observation[]
 ) => {
-  const maybeTemporalDimensionValues: DimensionValue[] = useMemo(() => {
-    if (isTemporalDimension(dimension)) {
-      const dates = data.map((d) => d[dimension.iri] as string);
-      return uniq(dates).map((d) => ({ label: d, value: d }));
-    } else {
-      return dimension.values;
-    }
-  }, [dimension, data]);
-
-  return maybeTemporalDimensionValues;
+  if (isTemporalDimension(dimension)) {
+    const dates = data.map((d) => d[dimension.iri] as string);
+    return uniq(dates).map((d) => ({ label: d, value: d }));
+  } else {
+    return dimension.values;
+  }
 };

--- a/app/charts/shared/use-abbreviations.ts
+++ b/app/charts/shared/use-abbreviations.ts
@@ -1,18 +1,19 @@
 import React from "react";
 
 import { DimensionValue, Observation, ObservationValue } from "@/domain/data";
-import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 
 export const useMaybeAbbreviations = ({
   useAbbreviations,
-  dimension,
+  dimensionIri,
+  dimensionValues,
 }: {
   useAbbreviations: boolean | undefined;
-  dimension: DimensionMetadataFragment | undefined;
+  dimensionIri: string | undefined;
+  dimensionValues: DimensionValue[] | undefined;
 }) => {
   const { valueLookup, labelLookup, abbreviationOrLabelLookup } =
     React.useMemo(() => {
-      const values = dimension?.values ?? [];
+      const values = dimensionValues ?? [];
 
       const valueLookup = new Map<
         NonNullable<ObservationValue>,
@@ -37,16 +38,16 @@ export const useMaybeAbbreviations = ({
         labelLookup,
         abbreviationOrLabelLookup,
       };
-    }, [dimension?.values, useAbbreviations]);
+    }, [dimensionValues, useAbbreviations]);
 
   const getAbbreviationOrLabelByValue = React.useCallback(
     (d: Observation) => {
-      if (!dimension) {
+      if (!dimensionIri) {
         return "";
       }
 
-      const value = d[`${dimension.iri}/__iri__`] as string | undefined;
-      const label = d[dimension.iri] as string | undefined;
+      const value = d[`${dimensionIri}/__iri__`] as string | undefined;
+      const label = d[dimensionIri] as string | undefined;
 
       if (value === undefined && label === undefined) {
         return "";
@@ -55,13 +56,14 @@ export const useMaybeAbbreviations = ({
       const lookedUpObservation =
         (value ? valueLookup.get(value) : null) ??
         (label ? labelLookup.get(label) : null);
+
       const lookedUpLabel = lookedUpObservation?.label ?? "";
 
       return useAbbreviations
         ? lookedUpObservation?.alternateName ?? lookedUpLabel
         : lookedUpLabel;
     },
-    [dimension, valueLookup, labelLookup, useAbbreviations]
+    [dimensionIri, valueLookup, labelLookup, useAbbreviations]
   );
 
   return {


### PR DESCRIPTION
Fixes #1024.

We were creating the lookups in `useMaybeAbbreviations` by using dimension values. While it's not a problem for most dimensions, we only fetch min and max values for temporal dimensions which leads to problems described in #1024.

This PR fixes that by passing "fake" dimension values (based on the ones that appear in the data) for column charts (X axis).