### PR TITLE
perf: Only fetch necessary components

### DIFF
--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -2,9 +2,11 @@ import { memo } from "react";
 
 import { Areas } from "@/charts/area/areas";
 import { AreaChart } from "@/charts/area/areas-state";
+import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
 import { AxisHeightLinear } from "@/charts/shared/axis-height-linear";
 import { AxisTime, AxisTimeDomain } from "@/charts/shared/axis-width-time";
 import { BrushTime } from "@/charts/shared/brush";
+import { getChartConfigComponentIris } from "@/charts/shared/chart-helpers";
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { Ruler } from "@/charts/shared/interaction/ruler";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
@@ -24,18 +26,18 @@ import {
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
-import { ChartLoadingWrapper } from "../chart-loading-wrapper";
-
 export const ChartAreasVisualization = ({
   dataSetIri,
   dataSource,
   chartConfig,
   queryFilters,
+  published,
 }: {
   dataSetIri: string;
   dataSource: DataSource;
   chartConfig: AreaConfig;
   queryFilters: QueryFilters;
+  published: boolean;
 }) => {
   const locale = useLocale();
   const [metadataQuery] = useDataCubeMetadataQuery({
@@ -51,6 +53,9 @@ export const ChartAreasVisualization = ({
       iri: dataSetIri,
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
+      componentIris: published
+        ? getChartConfigComponentIris(chartConfig)
+        : undefined,
       locale,
     },
   });

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -40,6 +40,9 @@ export const ChartAreasVisualization = ({
   published: boolean;
 }) => {
   const locale = useLocale();
+  const componentIrisToFilterBy = published
+    ? getChartConfigComponentIris(chartConfig)
+    : undefined;
   const [metadataQuery] = useDataCubeMetadataQuery({
     variables: {
       iri: dataSetIri,
@@ -53,9 +56,7 @@ export const ChartAreasVisualization = ({
       iri: dataSetIri,
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
-      componentIris: published
-        ? getChartConfigComponentIris(chartConfig)
-        : undefined,
+      componentIris: componentIrisToFilterBy,
       locale,
     },
   });
@@ -65,7 +66,7 @@ export const ChartAreasVisualization = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      dimensions: null,
+      componentIris: componentIrisToFilterBy,
       filters: queryFilters,
     },
   });

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -41,11 +41,13 @@ export const ChartColumnsVisualization = ({
   dataSource,
   chartConfig,
   queryFilters,
+  published,
 }: {
   dataSetIri: string;
   dataSource: DataSource;
   chartConfig: ColumnConfig;
   queryFilters: QueryFilters;
+  published: boolean;
 }) => {
   const locale = useLocale();
   const [metadataQuery] = useDataCubeMetadataQuery({
@@ -62,7 +64,9 @@ export const ChartColumnsVisualization = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      componentIris: getChartConfigComponents(chartConfig),
+      componentIris: published
+        ? getChartConfigComponents(chartConfig)
+        : undefined,
     },
   });
 

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -1,5 +1,6 @@
 import { memo } from "react";
 
+import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
 import {
   ColumnsGrouped,
   ErrorWhiskers as ErrorWhiskersGrouped,
@@ -16,6 +17,7 @@ import {
   AxisWidthBandDomain,
 } from "@/charts/shared/axis-width-band";
 import { BrushTime } from "@/charts/shared/brush";
+import { getChartConfigComponents } from "@/charts/shared/chart-helpers";
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
@@ -33,8 +35,6 @@ import {
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
-
-import { ChartLoadingWrapper } from "../chart-loading-wrapper";
 
 export const ChartColumnsVisualization = ({
   dataSetIri,
@@ -62,8 +62,10 @@ export const ChartColumnsVisualization = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
+      componentIris: getChartConfigComponents(chartConfig),
     },
   });
+
   const [observationsQuery] = useDataCubeObservationsQuery({
     variables: {
       iri: dataSetIri,

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -17,7 +17,7 @@ import {
   AxisWidthBandDomain,
 } from "@/charts/shared/axis-width-band";
 import { BrushTime } from "@/charts/shared/brush";
-import { getChartConfigComponents } from "@/charts/shared/chart-helpers";
+import { getChartConfigComponentIris } from "@/charts/shared/chart-helpers";
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
@@ -65,7 +65,7 @@ export const ChartColumnsVisualization = ({
       sourceUrl: dataSource.url,
       locale,
       componentIris: published
-        ? getChartConfigComponents(chartConfig)
+        ? getChartConfigComponentIris(chartConfig)
         : undefined,
     },
   });

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -50,6 +50,9 @@ export const ChartColumnsVisualization = ({
   published: boolean;
 }) => {
   const locale = useLocale();
+  const componentIrisToFilterBy = published
+    ? getChartConfigComponentIris(chartConfig)
+    : undefined;
   const [metadataQuery] = useDataCubeMetadataQuery({
     variables: {
       iri: dataSetIri,
@@ -64,19 +67,16 @@ export const ChartColumnsVisualization = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      componentIris: published
-        ? getChartConfigComponentIris(chartConfig)
-        : undefined,
+      componentIris: componentIrisToFilterBy,
     },
   });
-
   const [observationsQuery] = useDataCubeObservationsQuery({
     variables: {
       iri: dataSetIri,
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      dimensions: null,
+      componentIris: componentIrisToFilterBy,
       filters: queryFilters,
     },
   });

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -41,6 +41,9 @@ export const ChartLinesVisualization = ({
   published: boolean;
 }) => {
   const locale = useLocale();
+  const componentIrisToFilterBy = published
+    ? getChartConfigComponentIris(chartConfig)
+    : undefined;
   const [metadataQuery] = useDataCubeMetadataQuery({
     variables: {
       iri: dataSetIri,
@@ -55,9 +58,7 @@ export const ChartLinesVisualization = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      componentIris: published
-        ? getChartConfigComponentIris(chartConfig)
-        : undefined,
+      componentIris: componentIrisToFilterBy,
     },
   });
   const [observationsQuery] = useDataCubeObservationsQuery({
@@ -66,7 +67,7 @@ export const ChartLinesVisualization = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      dimensions: null,
+      componentIris: componentIrisToFilterBy,
       filters: queryFilters,
     },
   });

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -6,7 +6,7 @@ import { LineChart } from "@/charts/line/lines-state";
 import { AxisHeightLinear } from "@/charts/shared/axis-height-linear";
 import { AxisTime, AxisTimeDomain } from "@/charts/shared/axis-width-time";
 import { BrushTime } from "@/charts/shared/brush";
-import { getChartConfigComponents } from "@/charts/shared/chart-helpers";
+import { getChartConfigComponentIris } from "@/charts/shared/chart-helpers";
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { HoverDotMultiple } from "@/charts/shared/interaction/hover-dots-multiple";
 import { Ruler } from "@/charts/shared/interaction/ruler";
@@ -56,7 +56,7 @@ export const ChartLinesVisualization = ({
       sourceUrl: dataSource.url,
       locale,
       componentIris: published
-        ? getChartConfigComponents(chartConfig)
+        ? getChartConfigComponentIris(chartConfig)
         : undefined,
     },
   });

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -32,11 +32,13 @@ export const ChartLinesVisualization = ({
   dataSource,
   chartConfig,
   queryFilters,
+  published,
 }: {
   dataSetIri: string;
   dataSource: DataSource;
   chartConfig: LineConfig;
   queryFilters: QueryFilters;
+  published: boolean;
 }) => {
   const locale = useLocale();
   const [metadataQuery] = useDataCubeMetadataQuery({
@@ -53,7 +55,9 @@ export const ChartLinesVisualization = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      componentIris: getChartConfigComponents(chartConfig),
+      componentIris: published
+        ? getChartConfigComponents(chartConfig)
+        : undefined,
     },
   });
   const [observationsQuery] = useDataCubeObservationsQuery({

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -1,10 +1,12 @@
 import { memo } from "react";
 
+import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
 import { Lines } from "@/charts/line/lines";
 import { LineChart } from "@/charts/line/lines-state";
 import { AxisHeightLinear } from "@/charts/shared/axis-height-linear";
 import { AxisTime, AxisTimeDomain } from "@/charts/shared/axis-width-time";
 import { BrushTime } from "@/charts/shared/brush";
+import { getChartConfigComponents } from "@/charts/shared/chart-helpers";
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { HoverDotMultiple } from "@/charts/shared/interaction/hover-dots-multiple";
 import { Ruler } from "@/charts/shared/interaction/ruler";
@@ -24,8 +26,6 @@ import {
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
-
-import { ChartLoadingWrapper } from "../chart-loading-wrapper";
 
 export const ChartLinesVisualization = ({
   dataSetIri,
@@ -53,6 +53,7 @@ export const ChartLinesVisualization = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
+      componentIris: getChartConfigComponents(chartConfig),
     },
   });
   const [observationsQuery] = useDataCubeObservationsQuery({

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -3,10 +3,13 @@ import keyBy from "lodash/keyBy";
 import { useMemo } from "react";
 import { mesh as topojsonMesh } from "topojson-client";
 
+import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
+import { prepareTopojson } from "@/charts/map/helpers";
 import { MapComponent } from "@/charts/map/map";
 import { MapLegend } from "@/charts/map/map-legend";
 import { MapChart } from "@/charts/map/map-state";
 import { MapTooltip } from "@/charts/map/map-tooltip";
+import { getChartConfigComponents } from "@/charts/shared/chart-helpers";
 import { ChartContainer } from "@/charts/shared/containers";
 import {
   BaseLayer,
@@ -33,10 +36,6 @@ import {
   useGeoShapesByDimensionIriQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
-
-import { ChartLoadingWrapper } from "../chart-loading-wrapper";
-
-import { prepareTopojson } from "./helpers";
 
 export const ChartMapVisualization = ({
   dataSetIri,
@@ -66,6 +65,7 @@ export const ChartMapVisualization = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
+      componentIris: getChartConfigComponents(chartConfig),
     },
   });
   const [observationsQuery] = useDataCubeObservationsQuery({

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -53,6 +53,9 @@ export const ChartMapVisualization = ({
   const locale = useLocale();
   const areaDimensionIri = chartConfig.fields.areaLayer?.componentIri || "";
   const symbolDimensionIri = chartConfig.fields.symbolLayer?.componentIri || "";
+  const componentIrisToFilterBy = published
+    ? getChartConfigComponentIris(chartConfig)
+    : undefined;
   const [metadataQuery] = useDataCubeMetadataQuery({
     variables: {
       iri: dataSetIri,
@@ -67,9 +70,7 @@ export const ChartMapVisualization = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      componentIris: published
-        ? getChartConfigComponentIris(chartConfig)
-        : undefined,
+      componentIris: componentIrisToFilterBy,
     },
   });
   const [observationsQuery] = useDataCubeObservationsQuery({
@@ -78,7 +79,7 @@ export const ChartMapVisualization = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      dimensions: null, // FIXME: Try to load less dimensions
+      componentIris: componentIrisToFilterBy,
       filters: queryFilters,
     },
   });

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -9,7 +9,7 @@ import { MapComponent } from "@/charts/map/map";
 import { MapLegend } from "@/charts/map/map-legend";
 import { MapChart } from "@/charts/map/map-state";
 import { MapTooltip } from "@/charts/map/map-tooltip";
-import { getChartConfigComponents } from "@/charts/shared/chart-helpers";
+import { getChartConfigComponentIris } from "@/charts/shared/chart-helpers";
 import { ChartContainer } from "@/charts/shared/containers";
 import {
   BaseLayer,
@@ -68,7 +68,7 @@ export const ChartMapVisualization = ({
       sourceUrl: dataSource.url,
       locale,
       componentIris: published
-        ? getChartConfigComponents(chartConfig)
+        ? getChartConfigComponentIris(chartConfig)
         : undefined,
     },
   });

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -42,11 +42,13 @@ export const ChartMapVisualization = ({
   dataSource,
   chartConfig,
   queryFilters,
+  published,
 }: {
   dataSetIri: string;
   dataSource: DataSource;
   chartConfig: MapConfig;
   queryFilters: QueryFilters;
+  published: boolean;
 }) => {
   const locale = useLocale();
   const areaDimensionIri = chartConfig.fields.areaLayer?.componentIri || "";
@@ -65,7 +67,9 @@ export const ChartMapVisualization = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      componentIris: getChartConfigComponents(chartConfig),
+      componentIris: published
+        ? getChartConfigComponents(chartConfig)
+        : undefined,
     },
   });
   const [observationsQuery] = useDataCubeObservationsQuery({

--- a/app/charts/map/map.tsx
+++ b/app/charts/map/map.tsx
@@ -365,7 +365,7 @@ export const MapComponent = () => {
             setLoaded(true);
           }}
           onLoad={(e) => {
-            setMap(e.target);
+            setMap(e.target as mapboxgl.Map);
             currentBBox.current = e.target.getBounds().toArray() as BBox;
 
             /**

--- a/app/charts/map/ref.ts
+++ b/app/charts/map/ref.ts
@@ -1,16 +1,14 @@
-import { Map } from "mapbox-gl";
-
 /**
  * We need to access the map from the map controls. Until we have a good solution
  * for sibling components, we use a global non-observable ref.
  */
-let map: Map | null = null;
+let map: mapboxgl.Map | null = null;
 
 const getMap = () => {
   return map;
 };
 
-const setMap = (d: Map) => {
+const setMap = (d: mapboxgl.Map) => {
   map = d;
 };
 

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -3,7 +3,7 @@ import { memo } from "react";
 import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
 import { Pie } from "@/charts/pie/pie";
 import { PieChart } from "@/charts/pie/pie-state";
-import { getChartConfigComponents } from "@/charts/shared/chart-helpers";
+import { getChartConfigComponentIris } from "@/charts/shared/chart-helpers";
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
@@ -52,7 +52,7 @@ export const ChartPieVisualization = ({
       sourceUrl: dataSource.url,
       locale,
       componentIris: published
-        ? getChartConfigComponents(chartConfig)
+        ? getChartConfigComponentIris(chartConfig)
         : undefined,
     },
   });

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -37,6 +37,9 @@ export const ChartPieVisualization = ({
   published: boolean;
 }) => {
   const locale = useLocale();
+  const componentIrisToFilterBy = published
+    ? getChartConfigComponentIris(chartConfig)
+    : undefined;
   const [metadataQuery] = useDataCubeMetadataQuery({
     variables: {
       iri: dataSetIri,
@@ -51,9 +54,7 @@ export const ChartPieVisualization = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      componentIris: published
-        ? getChartConfigComponentIris(chartConfig)
-        : undefined,
+      componentIris: componentIrisToFilterBy,
     },
   });
   const [observationsQuery] = useDataCubeObservationsQuery({
@@ -62,7 +63,7 @@ export const ChartPieVisualization = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      dimensions: null,
+      componentIris: componentIrisToFilterBy,
       filters: queryFilters,
     },
   });

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -28,11 +28,13 @@ export const ChartPieVisualization = ({
   dataSource,
   chartConfig,
   queryFilters,
+  published,
 }: {
   dataSetIri: string;
   dataSource: DataSource;
   chartConfig: PieConfig;
   queryFilters: QueryFilters;
+  published: boolean;
 }) => {
   const locale = useLocale();
   const [metadataQuery] = useDataCubeMetadataQuery({
@@ -49,7 +51,9 @@ export const ChartPieVisualization = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      componentIris: getChartConfigComponents(chartConfig),
+      componentIris: published
+        ? getChartConfigComponents(chartConfig)
+        : undefined,
     },
   });
   const [observationsQuery] = useDataCubeObservationsQuery({

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -3,6 +3,7 @@ import { memo } from "react";
 import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
 import { Pie } from "@/charts/pie/pie";
 import { PieChart } from "@/charts/pie/pie-state";
+import { getChartConfigComponents } from "@/charts/shared/chart-helpers";
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
@@ -48,6 +49,7 @@ export const ChartPieVisualization = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
+      componentIris: getChartConfigComponents(chartConfig),
     },
   });
   const [observationsQuery] = useDataCubeObservationsQuery({

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -45,6 +45,9 @@ export const ChartScatterplotVisualization = ({
   published: boolean;
 }) => {
   const locale = useLocale();
+  const componentIrisToFilterBy = published
+    ? getChartConfigComponentIris(chartConfig)
+    : undefined;
   const [metadataQuery] = useDataCubeMetadataQuery({
     variables: {
       iri: dataSetIri,
@@ -59,9 +62,7 @@ export const ChartScatterplotVisualization = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      componentIris: published
-        ? getChartConfigComponentIris(chartConfig)
-        : undefined,
+      componentIris: componentIrisToFilterBy,
     },
   });
   const [observationsQuery] = useDataCubeObservationsQuery({
@@ -70,7 +71,7 @@ export const ChartScatterplotVisualization = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      dimensions: null,
+      componentIris: componentIrisToFilterBy,
       filters: queryFilters,
     },
   });

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -36,11 +36,13 @@ export const ChartScatterplotVisualization = ({
   dataSource,
   chartConfig,
   queryFilters,
+  published,
 }: {
   dataSetIri: string;
   dataSource: DataSource;
   chartConfig: ScatterPlotConfig;
   queryFilters: QueryFilters;
+  published: boolean;
 }) => {
   const locale = useLocale();
   const [metadataQuery] = useDataCubeMetadataQuery({
@@ -57,7 +59,9 @@ export const ChartScatterplotVisualization = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      componentIris: getChartConfigComponents(chartConfig),
+      componentIris: published
+        ? getChartConfigComponents(chartConfig)
+        : undefined,
     },
   });
   const [observationsQuery] = useDataCubeObservationsQuery({

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -1,5 +1,6 @@
 import { memo } from "react";
 
+import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
 import { Scatterplot } from "@/charts/scatterplot/scatterplot-simple";
 import { ScatterplotChart } from "@/charts/scatterplot/scatterplot-state";
 import {
@@ -10,6 +11,7 @@ import {
   AxisWidthLinear,
   AxisWidthLinearDomain,
 } from "@/charts/shared/axis-width-linear";
+import { getChartConfigComponents } from "@/charts/shared/chart-helpers";
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
@@ -28,8 +30,6 @@ import {
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
-
-import { ChartLoadingWrapper } from "../chart-loading-wrapper";
 
 export const ChartScatterplotVisualization = ({
   dataSetIri,
@@ -57,6 +57,7 @@ export const ChartScatterplotVisualization = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
+      componentIris: getChartConfigComponents(chartConfig),
     },
   });
   const [observationsQuery] = useDataCubeObservationsQuery({

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -11,7 +11,7 @@ import {
   AxisWidthLinear,
   AxisWidthLinearDomain,
 } from "@/charts/shared/axis-width-linear";
-import { getChartConfigComponents } from "@/charts/shared/chart-helpers";
+import { getChartConfigComponentIris } from "@/charts/shared/chart-helpers";
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
@@ -60,7 +60,7 @@ export const ChartScatterplotVisualization = ({
       sourceUrl: dataSource.url,
       locale,
       componentIris: published
-        ? getChartConfigComponents(chartConfig)
+        ? getChartConfigComponentIris(chartConfig)
         : undefined,
     },
   });

--- a/app/charts/shared/chart-helpers.spec.tsx
+++ b/app/charts/shared/chart-helpers.spec.tsx
@@ -5,12 +5,20 @@ import {
   getWideData,
   prepareQueryFilters,
   getMaybeTemporalDimensionValues,
+  getChartConfigComponentIris,
 } from "@/charts/shared/chart-helpers";
 import { InteractiveFiltersState } from "@/charts/shared/use-interactive-filters";
-import { ChartType, Filters, InteractiveFiltersConfig } from "@/configurator";
+import {
+  ChartType,
+  Filters,
+  InteractiveFiltersConfig,
+  LineConfig,
+  MapConfig,
+} from "@/configurator";
 import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import { Observation } from "@/domain/data";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
+import map1Fixture from "@/test/__fixtures/config/int/map-waldflasche.json";
 import line1Fixture from "@/test/__fixtures/config/prod/line-1.json";
 
 const makeCubeNsGetters = (cubeIri: string) => ({
@@ -180,5 +188,35 @@ describe("getMaybeTemporalDimensionValues", () => {
     const result = getMaybeTemporalDimensionValues(dimension, data);
 
     expect(result).toEqual(dimension.values);
+  });
+});
+
+describe("getChartConfigComponentIris", () => {
+  const lineConfig = line1Fixture.data.chartConfig as unknown as LineConfig;
+  const mapConfig = map1Fixture.data.chartConfig as unknown as MapConfig;
+
+  it("should return correct componentIris for line chart", () => {
+    const componentsIris = getChartConfigComponentIris(lineConfig);
+    expect(componentsIris).toEqual([
+      "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/0",
+      "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/0",
+      "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/1",
+      "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2",
+      "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/3",
+      "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/4",
+    ]);
+  });
+
+  it("should return correct componentIris for map chart", () => {
+    const componentsIris = getChartConfigComponentIris(mapConfig);
+    console.log(componentsIris);
+    expect(componentsIris).toEqual([
+      "https://environment.ld.admin.ch/foen/nfi/unitOfReference",
+      "https://environment.ld.admin.ch/foen/nfi/forestArea",
+      "https://environment.ld.admin.ch/foen/nfi/inventory",
+      "https://environment.ld.admin.ch/foen/nfi/struk",
+      "https://environment.ld.admin.ch/foen/nfi/grid",
+      "https://environment.ld.admin.ch/foen/nfi/unitOfEvaluation",
+    ]);
   });
 });

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -82,13 +82,14 @@ export const useQueryFilters = ({
 
 type IFKey = keyof NonNullable<InteractiveFiltersConfig>;
 
-export const getChartConfigComponents = ({
-  fields,
-  filters,
-  interactiveFiltersConfig: IFConfig,
-}: ChartConfig) => {
+export const getChartConfigFilterComponentIris = ({ filters }: ChartConfig) => {
+  return Object.keys(filters);
+};
+
+export const getChartConfigComponentIris = (chartConfig: ChartConfig) => {
+  const { fields, interactiveFiltersConfig: IFConfig } = chartConfig;
   const fieldIris = Object.values(fields).map((d) => d.componentIri);
-  const filterIris = Object.keys(filters);
+  const filterIris = getChartConfigFilterComponentIris(chartConfig);
   const IFKeys = IFConfig ? (Object.keys(IFConfig) as IFKey[]) : [];
   const IFIris: string[] = [];
 

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -150,7 +150,11 @@ export const getChartConfigComponentIris = (chartConfig: ChartConfig) => {
     });
   }
 
-  return uniq([...fieldIris, ...additionalFieldIris, ...filterIris, ...IFIris]);
+  return uniq(
+    [...fieldIris, ...additionalFieldIris, ...filterIris, ...IFIris].filter(
+      Boolean
+    )
+  );
 };
 
 export const usePlottableData = ({

--- a/app/charts/table/chart-table.tsx
+++ b/app/charts/table/chart-table.tsx
@@ -1,6 +1,7 @@
 import { memo } from "react";
 
 import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
+import { getChartConfigComponents } from "@/charts/shared/chart-helpers";
 import { Table } from "@/charts/table/table";
 import { TableChart } from "@/charts/table/table-state";
 import { DataSource, TableConfig } from "@/configurator";
@@ -37,6 +38,7 @@ export const ChartTableVisualization = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
+      componentIris: getChartConfigComponents(chartConfig),
     },
   });
   const [observationsQuery] = useDataCubeObservationsQuery({

--- a/app/charts/table/chart-table.tsx
+++ b/app/charts/table/chart-table.tsx
@@ -18,10 +18,12 @@ export const ChartTableVisualization = ({
   dataSetIri,
   dataSource,
   chartConfig,
+  published,
 }: {
   dataSetIri: string;
   dataSource: DataSource;
   chartConfig: TableConfig;
+  published: boolean;
 }) => {
   const locale = useLocale();
   const [metadataQuery] = useDataCubeMetadataQuery({
@@ -38,7 +40,9 @@ export const ChartTableVisualization = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      componentIris: getChartConfigComponents(chartConfig),
+      componentIris: published
+        ? getChartConfigComponents(chartConfig)
+        : undefined,
     },
   });
   const [observationsQuery] = useDataCubeObservationsQuery({

--- a/app/charts/table/chart-table.tsx
+++ b/app/charts/table/chart-table.tsx
@@ -1,7 +1,7 @@
 import { memo } from "react";
 
 import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
-import { getChartConfigComponents } from "@/charts/shared/chart-helpers";
+import { getChartConfigComponentIris } from "@/charts/shared/chart-helpers";
 import { Table } from "@/charts/table/table";
 import { TableChart } from "@/charts/table/table-state";
 import { DataSource, TableConfig } from "@/configurator";
@@ -41,7 +41,7 @@ export const ChartTableVisualization = ({
       sourceUrl: dataSource.url,
       locale,
       componentIris: published
-        ? getChartConfigComponents(chartConfig)
+        ? getChartConfigComponentIris(chartConfig)
         : undefined,
     },
   });

--- a/app/charts/table/chart-table.tsx
+++ b/app/charts/table/chart-table.tsx
@@ -26,6 +26,9 @@ export const ChartTableVisualization = ({
   published: boolean;
 }) => {
   const locale = useLocale();
+  const componentIrisToFilterBy = published
+    ? getChartConfigComponentIris(chartConfig)
+    : undefined;
   const [metadataQuery] = useDataCubeMetadataQuery({
     variables: {
       iri: dataSetIri,
@@ -40,9 +43,7 @@ export const ChartTableVisualization = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      componentIris: published
-        ? getChartConfigComponentIris(chartConfig)
-        : undefined,
+      componentIris: componentIrisToFilterBy,
     },
   });
   const [observationsQuery] = useDataCubeObservationsQuery({
@@ -51,7 +52,7 @@ export const ChartTableVisualization = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      dimensions: null,
+      componentIris: componentIrisToFilterBy,
       filters: chartConfig.filters,
     },
   });

--- a/app/components/chart-filters-list.tsx
+++ b/app/components/chart-filters-list.tsx
@@ -2,6 +2,7 @@ import { Box, Typography } from "@mui/material";
 import { Fragment } from "react";
 
 import { useQueryFilters } from "@/charts/shared/chart-helpers";
+import { getChartConfigFilterComponentIris } from "@/charts/shared/chart-helpers";
 import { OpenMetadataPanelWrapper } from "@/components/metadata-panel";
 import { ChartConfig, DataSource } from "@/configurator";
 import { isTemporalDimension } from "@/domain/data";
@@ -27,6 +28,7 @@ export const ChartFiltersList = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
+      componentIris: getChartConfigFilterComponentIris(chartConfig),
     },
   });
 

--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -3,6 +3,10 @@ import { Box, Button, Link, Theme, Typography } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import { PropsWithChildren, useEffect, useMemo, useState } from "react";
 
+import {
+  getChartConfigComponentIris,
+  useQueryFilters,
+} from "@/charts/shared/chart-helpers";
 import { useChartTablePreview } from "@/components/chart-table-preview";
 import { DataDownloadMenu, RunSparqlQuery } from "@/components/data-download";
 import { ChartConfig, DataSource } from "@/configurator";
@@ -15,8 +19,6 @@ import { Icon, getChartIcon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
 import { useEmbedOptions } from "@/utils/embed";
 import { makeOpenDataLink } from "@/utils/opendata";
-
-import { useQueryFilters } from "../charts/shared/chart-helpers";
 
 export const useFootnotesStyles = makeStyles<Theme, { useMarginTop: boolean }>(
   (theme) => ({
@@ -92,13 +94,14 @@ export const ChartFootnotes = ({
 
   // Data for data download
   const filters = useQueryFilters({ chartConfig });
+  const componentIrisToFilterBy = getChartConfigComponentIris(chartConfig);
   const [{ data: visibleData }] = useDataCubeObservationsQuery({
     variables: {
       iri: dataSetIri,
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      dimensions: null,
+      componentIris: componentIrisToFilterBy,
       filters,
     },
   });
@@ -189,6 +192,7 @@ export const ChartFootnotes = ({
               dataSetIri={dataSetIri}
               dataSource={dataSource}
               title={dataCubeByIri.title}
+              componentIris={componentIrisToFilterBy}
               filters={filters}
             />
           ) : null}

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -21,12 +21,7 @@ import DebugPanel from "@/components/debug-panel";
 import Flex from "@/components/flex";
 import { HintYellow } from "@/components/hint";
 import { MetadataPanel } from "@/components/metadata-panel";
-import {
-  ChartConfig,
-  DataSource,
-  isConfiguring,
-  useConfiguratorState,
-} from "@/configurator";
+import { ChartConfig, DataSource, useConfiguratorState } from "@/configurator";
 import { DataSetTable } from "@/configurator/components/datatable";
 import {
   useComponentsQuery,
@@ -74,7 +69,7 @@ export const ChartPreviewInner = ({
   dataSetIri: string;
   dataSource: DataSource;
 }) => {
-  const [state, dispatch] = useConfiguratorState(isConfiguring);
+  const [state, dispatch] = useConfiguratorState();
   const locale = useLocale();
   const classes = useStyles();
   const [{ data: metadata }] = useDataCubeMetadataQuery({

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -6,10 +6,7 @@ import * as React from "react";
 import { useMemo } from "react";
 
 import { ChartDataFilters } from "@/charts/shared/chart-data-filters";
-import {
-  getChartConfigComponents,
-  useQueryFilters,
-} from "@/charts/shared/chart-helpers";
+import { useQueryFilters } from "@/charts/shared/chart-helpers";
 import { InteractiveFiltersProvider } from "@/charts/shared/use-interactive-filters";
 import useSyncInteractiveFilters from "@/charts/shared/use-sync-interactive-filters";
 import { ChartErrorBoundary } from "@/components/chart-error-boundary";
@@ -94,7 +91,6 @@ export const ChartPreviewInner = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      componentIris: getChartConfigComponents(state.chartConfig),
     },
   });
   const {
@@ -225,6 +221,7 @@ export const ChartPreviewInner = ({
                     dataSet={dataSetIri}
                     dataSource={dataSource}
                     chartConfig={state.chartConfig}
+                    published={false}
                   />
                 )}
               </Box>
@@ -251,10 +248,12 @@ const ChartWithInteractiveFilters = React.forwardRef(
       dataSet,
       dataSource,
       chartConfig,
+      published,
     }: {
       dataSet: string;
       dataSource: DataSource;
       chartConfig: ChartConfig;
+      published: boolean;
     },
     ref
   ) => {
@@ -290,6 +289,7 @@ const ChartWithInteractiveFilters = React.forwardRef(
           dataSet={dataSet}
           dataSource={dataSource}
           chartConfig={chartConfig}
+          published={published}
         />
       </Flex>
     );
@@ -300,21 +300,20 @@ const Chart = ({
   dataSet,
   dataSource,
   chartConfig,
+  published,
 }: {
   dataSet: string;
   dataSource: DataSource;
   chartConfig: ChartConfig;
+  published: boolean;
 }) => {
-  // Combine filters from config + interactive filters
-  const queryFilters = useQueryFilters({
-    chartConfig,
-  });
-
+  const queryFilters = useQueryFilters({ chartConfig });
   const props = {
     dataSet,
     dataSource,
-    chartConfig: chartConfig,
-    queryFilters: queryFilters,
+    chartConfig,
+    queryFilters,
+    published,
   };
 
   return <GenericChart {...props} />;

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -6,7 +6,10 @@ import * as React from "react";
 import { useMemo } from "react";
 
 import { ChartDataFilters } from "@/charts/shared/chart-data-filters";
-import { useQueryFilters } from "@/charts/shared/chart-helpers";
+import {
+  getChartConfigComponents,
+  useQueryFilters,
+} from "@/charts/shared/chart-helpers";
 import { InteractiveFiltersProvider } from "@/charts/shared/use-interactive-filters";
 import useSyncInteractiveFilters from "@/charts/shared/use-sync-interactive-filters";
 import { ChartErrorBoundary } from "@/components/chart-error-boundary";
@@ -21,7 +24,12 @@ import DebugPanel from "@/components/debug-panel";
 import Flex from "@/components/flex";
 import { HintYellow } from "@/components/hint";
 import { MetadataPanel } from "@/components/metadata-panel";
-import { ChartConfig, DataSource, useConfiguratorState } from "@/configurator";
+import {
+  ChartConfig,
+  DataSource,
+  isConfiguring,
+  useConfiguratorState,
+} from "@/configurator";
 import { DataSetTable } from "@/configurator/components/datatable";
 import {
   useComponentsQuery,
@@ -69,7 +77,7 @@ export const ChartPreviewInner = ({
   dataSetIri: string;
   dataSource: DataSource;
 }) => {
-  const [state, dispatch] = useConfiguratorState();
+  const [state, dispatch] = useConfiguratorState(isConfiguring);
   const locale = useLocale();
   const classes = useStyles();
   const [{ data: metadata }] = useDataCubeMetadataQuery({
@@ -86,6 +94,7 @@ export const ChartPreviewInner = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
+      componentIris: getChartConfigComponents(state.chartConfig),
     },
   });
   const {

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -6,7 +6,7 @@ import { useEffect, useMemo, useRef } from "react";
 import { useStore } from "zustand";
 
 import { ChartDataFilters } from "@/charts/shared/chart-data-filters";
-import { getChartConfigComponents } from "@/charts/shared/chart-helpers";
+import { getChartConfigComponentIris } from "@/charts/shared/chart-helpers";
 import { isUsingImputation } from "@/charts/shared/imputation";
 import {
   InteractiveFiltersProvider,
@@ -154,7 +154,7 @@ export const ChartPublishedInner = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      componentIris: getChartConfigComponents(chartConfig),
+      componentIris: getChartConfigComponentIris(chartConfig),
     },
   });
 

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useRef } from "react";
 import { useStore } from "zustand";
 
 import { ChartDataFilters } from "@/charts/shared/chart-data-filters";
+import { getChartConfigComponents } from "@/charts/shared/chart-helpers";
 import { isUsingImputation } from "@/charts/shared/imputation";
 import {
   InteractiveFiltersProvider,
@@ -153,6 +154,7 @@ export const ChartPublishedInner = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
+      componentIris: getChartConfigComponents(chartConfig),
     },
   });
 

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -358,6 +358,7 @@ const ChartWithInteractiveFilters = React.forwardRef(
           dataSet={dataSet}
           dataSource={dataSource}
           chartConfig={chartConfig}
+          published
         />
       </Flex>
     );

--- a/app/components/common-chart.tsx
+++ b/app/components/common-chart.tsx
@@ -50,21 +50,19 @@ const GenericChart = ({
   dataSet,
   dataSource,
   chartConfig,
+  published,
 }: {
   dataSet: string;
   dataSource: DataSource;
   chartConfig: ChartConfig;
+  published: boolean;
 }) => {
-  // Combine filters from config + interactive filters
-  const queryFilters = useQueryFilters({
-    chartConfig,
-  });
-
+  const queryFilters = useQueryFilters({ chartConfig });
   const props = {
     dataSetIri: dataSet,
     dataSource,
-    chartConfig,
     queryFilters,
+    published,
   };
 
   switch (chartConfig.chartType) {

--- a/app/components/data-download.tsx
+++ b/app/components/data-download.tsx
@@ -132,11 +132,13 @@ export const DataDownloadMenu = memo(
     dataSetIri,
     dataSource,
     filters,
+    componentIris,
     title,
   }: {
     dataSetIri: string;
     dataSource: DataSource;
     filters?: QueryFilters;
+    componentIris?: string[];
     title: string;
   }) => {
     return (
@@ -145,6 +147,7 @@ export const DataDownloadMenu = memo(
           dataSetIri={dataSetIri}
           dataSource={dataSource}
           fileName={title}
+          componentIris={componentIris}
           filters={filters}
         />
       </DataDownloadStateProvider>
@@ -156,11 +159,13 @@ const DataDownloadInnerMenu = ({
   dataSetIri,
   dataSource,
   fileName,
+  componentIris,
   filters,
 }: {
   dataSetIri: string;
   dataSource: DataSource;
   fileName: string;
+  componentIris?: string[];
   filters?: QueryFilters;
 }) => {
   const [state] = useDataDownloadState();
@@ -207,6 +212,7 @@ const DataDownloadInnerMenu = ({
               <Trans id="button.download.data.visible">Chart dataset</Trans>
             }
             fileName={fileName}
+            componentIris={componentIris}
             filters={filters}
           />
         )}
@@ -215,6 +221,7 @@ const DataDownloadInnerMenu = ({
           dataSource={dataSource}
           subheader={<Trans id="button.download.data.all">Full dataset</Trans>}
           fileName={fileName}
+          componentIris={componentIris}
         />
         {state.error && (
           <RawMenuItem>
@@ -233,12 +240,14 @@ const DataDownloadMenuSection = ({
   dataSource,
   subheader,
   fileName,
+  componentIris,
   filters,
 }: {
   dataSetIri: string;
   dataSource: DataSource;
   subheader: ReactNode;
   fileName: string;
+  componentIris?: string[];
   filters?: QueryFilters;
 }) => {
   return (
@@ -255,6 +264,7 @@ const DataDownloadMenuSection = ({
               dataSource={dataSource}
               fileName={fileName}
               fileFormat={fileFormat}
+              componentIris={componentIris}
               filters={filters}
             />
           ))}
@@ -269,12 +279,14 @@ const DownloadMenuItem = ({
   dataSource,
   fileName,
   fileFormat,
+  componentIris,
   filters,
 }: {
   dataSetIri: string;
   dataSource: DataSource;
   fileName: string;
   fileFormat: FileFormat;
+  componentIris?: string[];
   filters?: QueryFilters;
 }) => {
   const locale = useLocale();
@@ -333,6 +345,7 @@ const DownloadMenuItem = ({
                   sourceType: dataSource.type,
                   sourceUrl: dataSource.url,
                   locale,
+                  componentIris,
                 }
               )
               .toPromise();
@@ -346,7 +359,7 @@ const DownloadMenuItem = ({
                 sourceType: dataSource.type,
                 sourceUrl: dataSource.url,
                 locale,
-                dimensions: null,
+                componentIris,
                 filters,
               })
               .toPromise();

--- a/app/configurator/components/datatable.tsx
+++ b/app/configurator/components/datatable.tsx
@@ -14,7 +14,10 @@ import {
 import { ascending, descending } from "d3";
 import { useMemo, useRef, useState } from "react";
 
-import { useQueryFilters } from "@/charts/shared/chart-helpers";
+import {
+  getChartConfigComponentIris,
+  useQueryFilters,
+} from "@/charts/shared/chart-helpers";
 import { Loading } from "@/components/hint";
 import { OpenMetadataPanelWrapper } from "@/components/metadata-panel";
 import { ChartConfig, DataSource } from "@/configurator/config-types";
@@ -242,6 +245,7 @@ export const DataSetTable = ({
   sx?: SxProps<Theme>;
 }) => {
   const locale = useLocale();
+  const componentIrisToFilterBy = getChartConfigComponentIris(chartConfig);
   const filters = useQueryFilters({ chartConfig });
   const [{ data: metadataData }] = useDataCubeMetadataQuery({
     variables: {
@@ -257,6 +261,7 @@ export const DataSetTable = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
+      componentIris: componentIrisToFilterBy,
     },
   });
   const [{ data: observationsData }] = useDataCubeObservationsQuery({
@@ -265,7 +270,7 @@ export const DataSetTable = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      dimensions: null,
+      componentIris: componentIrisToFilterBy,
       filters,
     },
   });

--- a/app/configurator/config-types.ts
+++ b/app/configurator/config-types.ts
@@ -528,13 +528,13 @@ export type MapFields = t.TypeOf<typeof MapFields>;
 export type MapConfig = t.TypeOf<typeof MapConfig>;
 
 export type ChartFields =
+  | AreaFields
   | ColumnFields
   | LineFields
-  | AreaFields
-  | ScatterPlotFields
+  | MapFields
   | PieFields
-  | TableFields
-  | MapFields;
+  | ScatterPlotFields
+  | TableFields;
 
 export type ChartSegmentField =
   | AreaSegmentField
@@ -547,12 +547,11 @@ const ChartConfig = t.union([
   AreaConfig,
   ColumnConfig,
   LineConfig,
-  ScatterPlotConfig,
-  PieConfig,
-  TableConfig,
   MapConfig,
+  PieConfig,
+  ScatterPlotConfig,
+  TableConfig,
 ]);
-// t.record(t.string, t.any)
 export type ChartConfig = t.TypeOf<typeof ChartConfig>;
 
 export const decodeChartConfig = (

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -190,6 +190,7 @@ query Components(
   $locale: String!
   $latest: Boolean
   $filters: Filters
+  $componentIris: [String!]
 ) {
   dataCubeByIri(
     iri: $iri
@@ -198,10 +199,18 @@ query Components(
     locale: $locale
     latest: $latest
   ) {
-    dimensions(sourceType: $sourceType, sourceUrl: $sourceUrl) {
+    dimensions(
+      sourceType: $sourceType
+      sourceUrl: $sourceUrl
+      componentIris: $componentIris
+    ) {
       ...dimensionMetadata
     }
-    measures(sourceType: $sourceType, sourceUrl: $sourceUrl) {
+    measures(
+      sourceType: $sourceType
+      sourceUrl: $sourceUrl
+      componentIris: $componentIris
+    ) {
       ...dimensionMetadata
     }
   }
@@ -214,6 +223,7 @@ query ComponentsWithHierarchies(
   $locale: String!
   $latest: Boolean
   $filters: Filters
+  $componentIris: [String!]
 ) {
   dataCubeByIri(
     iri: $iri
@@ -222,10 +232,18 @@ query ComponentsWithHierarchies(
     locale: $locale
     latest: $latest
   ) {
-    dimensions(sourceType: $sourceType, sourceUrl: $sourceUrl) {
+    dimensions(
+      sourceType: $sourceType
+      sourceUrl: $sourceUrl
+      componentIris: $componentIris
+    ) {
       ...dimensionMetadataWithHierarchies
     }
-    measures(sourceType: $sourceType, sourceUrl: $sourceUrl) {
+    measures(
+      sourceType: $sourceType
+      sourceUrl: $sourceUrl
+      componentIris: $componentIris
+    ) {
       ...dimensionMetadataWithHierarchies
     }
   }

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -369,7 +369,7 @@ query DataCubeObservations(
   $sourceType: String!
   $sourceUrl: String!
   $locale: String!
-  $dimensions: [String!]
+  $componentIris: [String!]
   $filters: Filters
   $latest: Boolean
   $limit: Int
@@ -384,7 +384,7 @@ query DataCubeObservations(
     observations(
       sourceType: $sourceType
       sourceUrl: $sourceUrl
-      dimensions: $dimensions
+      componentIris: $componentIris
       filters: $filters
       limit: $limit
     ) {

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -55,7 +55,7 @@ export type DataCubeObservationsArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   limit?: Maybe<Scalars['Int']>;
-  dimensions?: Maybe<Array<Scalars['String']>>;
+  componentIris?: Maybe<Array<Scalars['String']>>;
   filters?: Maybe<Scalars['Filters']>;
 };
 
@@ -917,7 +917,7 @@ export type DataCubeObservationsQueryVariables = Exact<{
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
-  dimensions?: Maybe<Array<Scalars['String']> | Scalars['String']>;
+  componentIris?: Maybe<Array<Scalars['String']> | Scalars['String']>;
   filters?: Maybe<Scalars['Filters']>;
   latest?: Maybe<Scalars['Boolean']>;
   limit?: Maybe<Scalars['Int']>;
@@ -1370,7 +1370,7 @@ export function useTemporalDimensionValuesQuery(options: Omit<Urql.UseQueryArgs<
   return Urql.useQuery<TemporalDimensionValuesQuery>({ query: TemporalDimensionValuesDocument, ...options });
 };
 export const DataCubeObservationsDocument = gql`
-    query DataCubeObservations($iri: String!, $sourceType: String!, $sourceUrl: String!, $locale: String!, $dimensions: [String!], $filters: Filters, $latest: Boolean, $limit: Int) {
+    query DataCubeObservations($iri: String!, $sourceType: String!, $sourceUrl: String!, $locale: String!, $componentIris: [String!], $filters: Filters, $latest: Boolean, $limit: Int) {
   dataCubeByIri(
     iri: $iri
     sourceType: $sourceType
@@ -1381,7 +1381,7 @@ export const DataCubeObservationsDocument = gql`
     observations(
       sourceType: $sourceType
       sourceUrl: $sourceUrl
-      dimensions: $dimensions
+      componentIris: $componentIris
       filters: $filters
       limit: $limit
     ) {

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -63,6 +63,7 @@ export type DataCubeObservationsArgs = {
 export type DataCubeDimensionsArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
+  componentIris?: Maybe<Array<Scalars['String']>>;
 };
 
 
@@ -76,6 +77,7 @@ export type DataCubeDimensionByIriArgs = {
 export type DataCubeMeasuresArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
+  componentIris?: Maybe<Array<Scalars['String']>>;
 };
 
 export type DataCubeOrganization = {
@@ -394,6 +396,7 @@ export type QueryDataCubeByIriArgs = {
   iri: Scalars['String'];
   latest?: Maybe<Scalars['Boolean']>;
   filters?: Maybe<Scalars['Filters']>;
+  componentIris?: Maybe<Array<Scalars['String']>>;
 };
 
 
@@ -762,6 +765,7 @@ export type ComponentsQueryVariables = Exact<{
   locale: Scalars['String'];
   latest?: Maybe<Scalars['Boolean']>;
   filters?: Maybe<Scalars['Filters']>;
+  componentIris?: Maybe<Array<Scalars['String']> | Scalars['String']>;
 }>;
 
 
@@ -801,6 +805,7 @@ export type ComponentsWithHierarchiesQueryVariables = Exact<{
   locale: Scalars['String'];
   latest?: Maybe<Scalars['Boolean']>;
   filters?: Maybe<Scalars['Filters']>;
+  componentIris?: Maybe<Array<Scalars['String']> | Scalars['String']>;
 }>;
 
 
@@ -1200,7 +1205,7 @@ export function useDataCubeMetadataQuery(options: Omit<Urql.UseQueryArgs<DataCub
   return Urql.useQuery<DataCubeMetadataQuery>({ query: DataCubeMetadataDocument, ...options });
 };
 export const ComponentsDocument = gql`
-    query Components($iri: String!, $sourceType: String!, $sourceUrl: String!, $locale: String!, $latest: Boolean, $filters: Filters) {
+    query Components($iri: String!, $sourceType: String!, $sourceUrl: String!, $locale: String!, $latest: Boolean, $filters: Filters, $componentIris: [String!]) {
   dataCubeByIri(
     iri: $iri
     sourceType: $sourceType
@@ -1208,10 +1213,18 @@ export const ComponentsDocument = gql`
     locale: $locale
     latest: $latest
   ) {
-    dimensions(sourceType: $sourceType, sourceUrl: $sourceUrl) {
+    dimensions(
+      sourceType: $sourceType
+      sourceUrl: $sourceUrl
+      componentIris: $componentIris
+    ) {
       ...dimensionMetadata
     }
-    measures(sourceType: $sourceType, sourceUrl: $sourceUrl) {
+    measures(
+      sourceType: $sourceType
+      sourceUrl: $sourceUrl
+      componentIris: $componentIris
+    ) {
       ...dimensionMetadata
     }
   }
@@ -1222,7 +1235,7 @@ export function useComponentsQuery(options: Omit<Urql.UseQueryArgs<ComponentsQue
   return Urql.useQuery<ComponentsQuery>({ query: ComponentsDocument, ...options });
 };
 export const ComponentsWithHierarchiesDocument = gql`
-    query ComponentsWithHierarchies($iri: String!, $sourceType: String!, $sourceUrl: String!, $locale: String!, $latest: Boolean, $filters: Filters) {
+    query ComponentsWithHierarchies($iri: String!, $sourceType: String!, $sourceUrl: String!, $locale: String!, $latest: Boolean, $filters: Filters, $componentIris: [String!]) {
   dataCubeByIri(
     iri: $iri
     sourceType: $sourceType
@@ -1230,10 +1243,18 @@ export const ComponentsWithHierarchiesDocument = gql`
     locale: $locale
     latest: $latest
   ) {
-    dimensions(sourceType: $sourceType, sourceUrl: $sourceUrl) {
+    dimensions(
+      sourceType: $sourceType
+      sourceUrl: $sourceUrl
+      componentIris: $componentIris
+    ) {
       ...dimensionMetadataWithHierarchies
     }
-    measures(sourceType: $sourceType, sourceUrl: $sourceUrl) {
+    measures(
+      sourceType: $sourceType
+      sourceUrl: $sourceUrl
+      componentIris: $componentIris
+    ) {
       ...dimensionMetadataWithHierarchies
     }
   }

--- a/app/graphql/resolver-types.ts
+++ b/app/graphql/resolver-types.ts
@@ -57,7 +57,7 @@ export type DataCubeObservationsArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   limit?: Maybe<Scalars['Int']>;
-  dimensions?: Maybe<Array<Scalars['String']>>;
+  componentIris?: Maybe<Array<Scalars['String']>>;
   filters?: Maybe<Scalars['Filters']>;
 };
 

--- a/app/graphql/resolver-types.ts
+++ b/app/graphql/resolver-types.ts
@@ -65,6 +65,7 @@ export type DataCubeObservationsArgs = {
 export type DataCubeDimensionsArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
+  componentIris?: Maybe<Array<Scalars['String']>>;
 };
 
 
@@ -78,6 +79,7 @@ export type DataCubeDimensionByIriArgs = {
 export type DataCubeMeasuresArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
+  componentIris?: Maybe<Array<Scalars['String']>>;
 };
 
 export type DataCubeOrganization = {
@@ -396,6 +398,7 @@ export type QueryDataCubeByIriArgs = {
   iri: Scalars['String'];
   latest?: Maybe<Scalars['Boolean']>;
   filters?: Maybe<Scalars['Filters']>;
+  componentIris?: Maybe<Array<Scalars['String']>>;
 };
 
 

--- a/app/graphql/resolvers/rdf.ts
+++ b/app/graphql/resolvers/rdf.ts
@@ -200,26 +200,30 @@ export const datasetcount: NonNullable<QueryResolvers["datasetcount"]> = async (
 };
 
 export const dataCubeDimensions: NonNullable<DataCubeResolvers["dimensions"]> =
-  async ({ cube, locale }, _, { setup }, info) => {
+  async ({ cube, locale }, { componentIris }, { setup }, info) => {
     const { sparqlClient, cache } = await setup(info);
     const dimensions = await getCubeDimensions({
       cube,
       locale,
       sparqlClient,
+      componentIris,
       cache,
     });
+
     return dimensions.filter((d) => !d.data.isMeasureDimension);
   };
 
 export const dataCubeMeasures: NonNullable<DataCubeResolvers["measures"]> =
-  async ({ cube, locale }, _, { setup }, info) => {
+  async ({ cube, locale }, { componentIris }, { setup }, info) => {
     const { sparqlClient, cache } = await setup(info);
     const dimensions = await getCubeDimensions({
       cube,
       locale,
       sparqlClient,
+      componentIris,
       cache,
     });
+
     return dimensions.filter((d) => d.data.isMeasureDimension);
   };
 
@@ -231,7 +235,7 @@ export const dataCubeDimensionByIri: NonNullable<
     cube,
     locale,
     sparqlClient,
-    dimensionIris: [iri],
+    componentIris: [iri],
     cache,
   });
   const dimension = dimensions.find((d) => iri === d.data.iri);

--- a/app/graphql/resolvers/rdf.ts
+++ b/app/graphql/resolvers/rdf.ts
@@ -120,7 +120,6 @@ export const possibleFilters: NonNullable<QueryResolvers["possibleFilters"]> =
         filters: queryFilters,
         limit: 1,
         raw: true,
-        dimensions: null,
         cache,
       });
 
@@ -254,7 +253,7 @@ export const dataCubeObservations: NonNullable<
   DataCubeResolvers["observations"]
 > = async (
   { cube, locale },
-  { limit, filters, dimensions },
+  { limit, filters, componentIris },
   { setup },
   info
 ) => {
@@ -265,7 +264,7 @@ export const dataCubeObservations: NonNullable<
     sparqlClient,
     filters: filters ?? undefined,
     limit: limit ?? undefined,
-    dimensions,
+    componentIris,
     cache,
   });
 

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -46,13 +46,21 @@ type DataCube {
     dimensions: [String!]
     filters: Filters
   ): ObservationsQuery!
-  dimensions(sourceType: String!, sourceUrl: String!): [Dimension!]!
+  dimensions(
+    sourceType: String!
+    sourceUrl: String!
+    componentIris: [String!]
+  ): [Dimension!]!
   dimensionByIri(
     iri: String!
     sourceType: String!
     sourceUrl: String!
   ): Dimension
-  measures(sourceType: String!, sourceUrl: String!): [Measure!]!
+  measures(
+    sourceType: String!
+    sourceUrl: String!
+    componentIris: [String!]
+  ): [Measure!]!
   themes: [DataCubeTheme!]!
 }
 
@@ -301,6 +309,7 @@ type Query {
     iri: String!
     latest: Boolean = true
     filters: Filters
+    componentIris: [String!]
   ): DataCube
   possibleFilters(
     iri: String!

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -43,7 +43,7 @@ type DataCube {
     sourceType: String!
     sourceUrl: String!
     limit: Int
-    dimensions: [String!]
+    componentIris: [String!]
     filters: Filters
   ): ObservationsQuery!
   dimensions(

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -466,7 +466,7 @@ export const getCubeObservations = async ({
   filters,
   limit,
   raw,
-  dimensions,
+  componentIris,
   cache,
 }: {
   cube: Cube;
@@ -478,7 +478,7 @@ export const getCubeObservations = async ({
   limit?: number;
   /** Returns IRIs instead of labels for NamedNodes  */
   raw?: boolean;
-  dimensions: Maybe<string[]> | undefined;
+  componentIris?: Maybe<string[]>;
   cache: LRUCache | undefined;
 }): Promise<{
   query: string;
@@ -495,7 +495,7 @@ export const getCubeObservations = async ({
   });
 
   const cubeDimensions = allResolvedDimensions.filter((d) =>
-    dimensions ? dimensions.includes(d.data.iri) : true
+    componentIris ? componentIris.includes(d.data.iri) : true
   );
 
   const serverFilters: typeof filters = {};
@@ -521,10 +521,9 @@ export const getCubeObservations = async ({
     ? buildFilters({ cube, view: cubeView, filters: dbFilters, locale })
     : [];
 
-  // Only choose dimensions that we really want
   const observationDimensions = buildDimensions({
     cubeView,
-    dimensions,
+    dimensions: componentIris,
     cubeDimensions,
     cube,
     locale,

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -129,20 +129,20 @@ export const getCubeDimensions = async ({
   cube,
   locale,
   sparqlClient,
-  dimensionIris,
+  componentIris,
   cache,
 }: {
   cube: Cube;
   locale: string;
   sparqlClient: ParsingClient;
-  dimensionIris?: string[];
+  componentIris?: Maybe<string[]>;
   cache: LRUCache | undefined;
 }): Promise<ResolvedDimension[]> => {
   try {
     const dimensions = cube.dimensions
       .filter(isObservationDimension)
       .filter((x) =>
-        dimensionIris ? dimensionIris.includes(x.path.value) : true
+        componentIris ? componentIris.includes(x.path.value) : true
       );
     const dimensionUnits = dimensions.flatMap(getDimensionUnits);
 


### PR DESCRIPTION
Contributes towards fixing #1028.

## Goals / Scope

This PR aims to improve data loading performance for published charts.

## Description

The main change from this PR is about fetching only the dimensions that are actually used in the chart (for the published chart) to reduce the need to fetch values for them, which can lead to unnecessary fetch of dozens of dimensions and their values for some datasets. It means that we only show the dimensions that are actually used in chart in the metadata panel, table preview and data download. I think that from the end user perspective it makes sense, as what we see on the chart is reflected in all the other places. Let me know about your opinions here @RDataflow @ptbrowne.

## Comments

Additionally to the change described above, I also tried to understand what causes the time difference described in #1028. I ran 20 tests focusing on observations fetching using the chart from https://int.visualize.admin.ch/v/hKkUyBpGpWPl?dataSource=Int. [The function to fetch the observations](https://github.com/visualize-admin/visualization-tool/blob/e231b68e7b0e075ee3d1daa4eb173590bdd98e6d/app/rdf/queries.ts#L462-L566) consists of five main parts, which were measured and visualised below. The average time to run the function was 1.045s.

<img width="1181" alt="Screenshot 2023-05-10 at 17 06 44" src="https://github.com/visualize-admin/visualization-tool/assets/52032047/e2e1bdac-0e51-494b-8779-6af02f560177">

As can be seen, the fetching of the observations took only 0.145s on average, compared to 0.930s to build the query itself (filters, dimensions, etc). I hope that this at least partially explains why it takes longer to fetch data from LINDAS using Visualize than direct calls to the API.