### PR TITLE
feat: Update Prisma configuration

### DIFF
--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -4,7 +4,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_URL")
+  url      = env("DATABASE_PRISMA_URL")
 }
 
 model Config {


### PR DESCRIPTION
Closes #1035.

## Goals / Scope

This PR updates Prisma schema to pick up correct environmental variable for database connection string (due to the set up of Vercel Postgres for preview environments).

## Description

There is a need to update the Prisma schema to use `DATABASE_PRISMA_URL` instead of `DATABASE_URL`. This is due to the fact that Vercel automatically creates environmental variables and we do not have a way to change their names.

Technically, Vercel also creates a `DATABASE_URL` variable, but it lacks `pgbouncer=true` param at the end of the connection string [which is required for the connection to work](https://github.com/prisma/prisma/issues/11643).

## Comments

The information about database for preview deployments has been also included in https://www.notion.so/interactivethings/Deployment-Environments-e813d77550a14ee8a8ffe1f0405516e1.

## How to test

1. Go to [Vercel Postgres](https://vercel.com/ixt/visualization-tool/stores/postgres/store_PH3NomM8zT9FWd82/data).
2. Browse `config` table.
3. See that `MjlYpoOfUpU6` is there.
4. Go to [/v/MjlYpoOfUpU6](https://visualization-tool-git-feat-connect-to-vercel-postgres-ixt1.vercel.app/en/v/MjlYpoOfUpU6?dataSource=Int) and see that the chart loads.

## TODO

If the PR is approved, we need to rename the `DATABASE_URL` variable into `DATABASE_PRISMA_URL` for every environment:
- [ ] Test – immediately after merging the PR,
- [ ] Int – after publishing a new release,
- [ ] Prod – in the email to Jan when asking for a new release.