### PR TITLE
perf: Do not sort dimensions in View

### DIFF
--- a/app/rdf/namespace.ts
+++ b/app/rdf/namespace.ts
@@ -24,5 +24,6 @@ export const adminVocabulary = namespace("https://ld.admin.ch/vocabulary/");
 export const cube = namespace("https://cube.link/");
 export const cubeView = namespace("https://cube.link/view/");
 export const cubeMeta = namespace("https://cube.link/meta/");
+export const view = namespace("https://cube.link/view/");
 
 export const visualizeAdmin = namespace("https://visualize.admin.ch/");

--- a/app/typings/rdf.d.ts
+++ b/app/typings/rdf.d.ts
@@ -97,6 +97,7 @@ declare module "rdf-cube-view-query" {
     }): Promise<Record<string, Literal | NamedNode>[]>;
     addDimension(dimension: Dimension): View;
     createDimension(options: $FixMe): Dimension;
+    setDefaultColumns(): void;
   }
   export class Source extends Node {
     constructor(


### PR DESCRIPTION
Until the appropriate change is implemented in rdf-cube-view-query library, we manually override sorting of dimensions to improve performance.

For more context see the description and discussion in #1031.

cc: @Rdataflow