### PR TITLE
fix: Interactive color legend

### DIFF
--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -177,7 +177,7 @@ const useAreasState = (
     // No animation yet for areas
     animationField: undefined,
     getX,
-    getSegment,
+    getSegment: getSegmentAbbreviationOrLabel,
   });
 
   const chartWideData = useMemo(() => {

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -28,8 +28,8 @@ import {
 } from "@/charts/column/constants";
 import {
   getLabelWithUnit,
-  useDataAfterInteractiveFilters,
   getMaybeTemporalDimensionValues,
+  useDataAfterInteractiveFilters,
   useOptionalNumericVariable,
   usePlottableData,
   useTemporalVariable,
@@ -189,7 +189,7 @@ const useGroupedColumnsState = (
     interactiveFiltersConfig,
     animationField: fields.animation,
     getX: getXAsDate,
-    getSegment,
+    getSegment: getSegmentAbbreviationOrLabel,
   });
 
   // segments

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -202,7 +202,7 @@ const useColumnsStackedState = (
     interactiveFiltersConfig,
     animationField: fields.animation,
     getX: getXAsDate,
-    getSegment,
+    getSegment: getSegmentAbbreviationOrLabel,
   });
 
   const preparedDataGroupedByX = useMemo(

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -157,7 +157,7 @@ const useLinesState = (
     // No animation yet for lines
     animationField: undefined,
     getX,
-    getSegment,
+    getSegment: getSegmentAbbreviationOrLabel,
   });
 
   const preparedDataGroupedBySegment = useMemo(

--- a/app/charts/pie/pie-state.tsx
+++ b/app/charts/pie/pie-state.tsx
@@ -100,7 +100,7 @@ const usePieState = (
     sortedData: plottableData,
     interactiveFiltersConfig,
     animationField: fields.animation,
-    getSegment,
+    getSegment: getSegmentAbbreviationOrLabel,
   });
 
   // Map ordered segments to colors

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -109,7 +109,7 @@ const useScatterplotState = ({
     interactiveFiltersConfig,
     // No animation yet for scatterplot
     animationField: undefined,
-    getSegment,
+    getSegment: getSegmentAbbreviationOrLabel,
   });
   const xMeasure = measures.find((d) => d.iri === fields.x.componentIri);
 

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -25,8 +25,8 @@ import {
   InteractiveFiltersLegend,
   InteractiveFiltersTimeRange,
   isAreaConfig,
-  QueryFilters,
   MapConfig,
+  QueryFilters,
 } from "@/configurator/config-types";
 import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import { isTemporalDimension, Observation } from "@/domain/data";


### PR DESCRIPTION
Fixes #1058.

This PR fixes two problems with interactive color legend issues.

1. Stacked bar chart was using all segments defined in the data to construct series (coordinates to draw the chart) – when one segment was de-selected using interactive color legend, it would introduce NaNs and thus break the chart. Now we use plottable segments to create series.
2. Interactive color legend not affecting the chart – as we store abbreviations / labels inside interactive filters state, we need to also get segment abbreviation / label when applying interactive filters to the data (previously we would try to access segment value).