### PR TITLE
fix: Only show values actually present in the data in ColorLegend

### DIFF
--- a/app/charts/shared/legend-color-helpers.ts
+++ b/app/charts/shared/legend-color-helpers.ts
@@ -30,7 +30,10 @@ export const getLegendGroups = ({
 
       const parents = _parents.length === 0 ? emptyParents : _parents;
       groupsMap.set(parents, groupsMap.get(parents) || []);
-      groupsMap.get(parents)?.push(node.value);
+
+      if (values.includes(node.value)) {
+        groupsMap.get(parents)?.push(node.value);
+      }
     });
   }
 

--- a/app/charts/shared/legend-color.spec.ts
+++ b/app/charts/shared/legend-color.spec.ts
@@ -20,4 +20,16 @@ describe("getLegendGroups", () => {
     expect(groups.length).toEqual(1);
     expect(groups[0][1]).toEqual(["1", "2", "3"]);
   });
+
+  it("should only include values that are present in the data", () => {
+    const groups = getLegendGroups({
+      title: "",
+      values: ["1", "2"],
+      hierarchy,
+      sort: true,
+    });
+
+    expect(groups.length).toEqual(1);
+    expect(groups[0][1]).toEqual(["1", "2"]);
+  });
 });


### PR DESCRIPTION
Fixes #1068.

Previously, the ColorLegend would display all values present inside a hierarchical dimension, even if the chart didn't have these values. This PR fixes that by only showing values actually present in a chart.