### PR TITLE
fix: Stacked column chart with missing values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 
 - Fixes
   - Dimension values are now correctly sorted is dimension is numerical dimension
+  - Stacked bar chart now doesn't render gaps in case of a missing value
 - Tests
   - Introduced load tests using k6
 

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -212,25 +212,6 @@ const useColumnsStackedState = (
     [preparedData, getX]
   );
 
-  const chartWideData = getWideData({
-    dataGroupedByX: preparedDataGroupedByX,
-    xKey,
-    getY,
-    getSegment,
-  });
-
-  const scalesDataGroupedByX = useMemo(
-    () => group(scalesData, getX),
-    [scalesData, getX]
-  );
-
-  const scalesWideData = getWideData({
-    dataGroupedByX: scalesDataGroupedByX,
-    xKey,
-    getY,
-    getSegment,
-  });
-
   const sumsBySegment = useMemo(
     () =>
       Object.fromEntries([
@@ -284,6 +265,27 @@ const useColumnsStackedState = (
     segmentFilter,
     getSegment,
   ]);
+
+  const chartWideData = getWideData({
+    dataGroupedByX: preparedDataGroupedByX,
+    xKey,
+    getY,
+    getSegment,
+    allSegments: plottableSegments,
+    imputationType: "zeros",
+  });
+
+  const scalesDataGroupedByX = useMemo(
+    () => group(scalesData, getX),
+    [scalesData, getX]
+  );
+
+  const scalesWideData = getWideData({
+    dataGroupedByX: scalesDataGroupedByX,
+    xKey,
+    getY,
+    getSegment,
+  });
 
   // Scales
   const xFilter = chartConfig.filters[xDimension.iri];


### PR DESCRIPTION
Fixes #1088.

As we use d3's `stacked` method in stacked bar chart, there can be situations similar to area chart, where we need imputation when some data point does not have some value defined in previous / following data point. We also need to impute such values, to make sure there are no NaNs returned when computing the coordinates for the chart.

I think it doesn't make sense to provide imputation options to users, as we can safely treat non-existing, imputed values as 0, as they do not have influence of how the chart is drawn, as in area chart (lines connecting the data points), and we do not show such values in the tooltip anyway.