### PR TITLE
refactor: Consolidate chart logic

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,28 +1,42 @@
 {
   "extends": "next",
-  "plugins": ["unused-imports", "import", "visualize-admin"],
+  "plugins": ["import", "visualize-admin"],
   "rules": {
-    "no-restricted-imports": ["error", {
-      "name": "lodash",
-      "message": "Please use direct imports instead, ex: lodash/mapValues, lodash/groupBy."
-    }],
-    "react/display-name": "off", 
+    "no-restricted-imports": [
+      "error",
+      {
+        "name": "lodash",
+        "message": "Please use direct imports instead, ex: lodash/mapValues, lodash/groupBy."
+      }
+    ],
+    "react/display-name": "off",
     "visualize-admin/no-large-sx": "error",
     "visualize-admin/make-styles": "error",
-    "unused-imports/no-unused-imports-ts": "error",
     "@next/next/no-html-link-for-pages": ["error", "app/pages/"],
-    "import/order": [2, {
-      "alphabetize": { "order": "asc" },
-      "newlines-between": "always",
-      "groups": ["builtin", "external", "internal", "parent", "sibling", "index", "object", "type"],
-      "pathGroups": [
-        {
-          "pattern": "@/**",
-          "group": "internal"
-        }
-      ],
-      "pathGroupsExcludedImportTypes": ["builtin"]
-    }]
+    "import/order": [
+      2,
+      {
+        "alphabetize": { "order": "asc" },
+        "newlines-between": "always",
+        "groups": [
+          "builtin",
+          "external",
+          "internal",
+          "parent",
+          "sibling",
+          "index",
+          "object",
+          "type"
+        ],
+        "pathGroups": [
+          {
+            "pattern": "@/**",
+            "group": "internal"
+          }
+        ],
+        "pathGroupsExcludedImportTypes": ["builtin"]
+      }
+    ]
   },
   "overrides": [
     {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,14 @@
 {
   "typescript.tsdk": "node_modules/typescript/lib",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true,
+    "source.organizeImports": true
+  },
   "eslint.validate": [
     "javascript",
     "javascriptreact",
-    { "language": "typescript", "autoFix": true },
-    { "language": "typescriptreact", "autoFix": true }
+    "typescript",
+    "typescriptreact"
   ],
   "files.exclude": {
     "**/.next": true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 ## Unreleased
 
 - Fixes
+  - Scales now adapt to color legend filter when using time slider
+  - Columns now properly animate out, instead of disappearing
+- Tests
+  - Unit tests that import `rdf-js` library now run without errors
+- Refactors:
+  - Consolidated data calculation and sorting for all charts in one place to prepare for app-wide time slider implementation
+
+# [3.20.3] - 2023-07-04
+
+- Fixes
   - Dimension values are now correctly sorted is dimension is numerical dimension
   - Stacked bar chart now doesn't render gaps in case of a missing value
 - Tests

--- a/app/browse/datatable.tsx
+++ b/app/browse/datatable.tsx
@@ -15,7 +15,7 @@ import { ascending, descending } from "d3";
 import { useMemo, useRef, useState } from "react";
 
 import {
-  getChartConfigComponentIris,
+  extractComponentIris,
   useQueryFilters,
 } from "@/charts/shared/chart-helpers";
 import { Loading } from "@/components/hint";
@@ -246,32 +246,27 @@ export const DataSetTable = ({
   sx?: SxProps<Theme>;
 }) => {
   const locale = useLocale();
-  const componentIrisToFilterBy = getChartConfigComponentIris(chartConfig);
+  const componentIris = extractComponentIris(chartConfig);
   const filters = useQueryFilters({ chartConfig });
+  const commonQueryVariables = {
+    iri: dataSetIri,
+    sourceType: dataSource.type,
+    sourceUrl: dataSource.url,
+    locale,
+  };
   const [{ data: metadataData }] = useDataCubeMetadataQuery({
-    variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-    },
+    variables: commonQueryVariables,
   });
   const [{ data: componentsData }] = useComponentsQuery({
     variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-      componentIris: componentIrisToFilterBy,
+      ...commonQueryVariables,
+      componentIris,
     },
   });
   const [{ data: observationsData }] = useDataCubeObservationsQuery({
     variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-      componentIris: componentIrisToFilterBy,
+      ...commonQueryVariables,
+      componentIris,
       filters,
     },
   });

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -18,7 +18,7 @@ import {
   sum,
 } from "d3";
 import orderBy from "lodash/orderBy";
-import { ReactNode, useMemo } from "react";
+import { useMemo } from "react";
 
 import { LEFT_MARGIN_OFFSET } from "@/charts/area/constants";
 import { BRUSH_BOTTOM_SPACE } from "@/charts/shared/brush/constants";
@@ -40,7 +40,7 @@ import { ChartContext } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useObservationLabels } from "@/charts/shared/use-observation-labels";
 import { Observer, useWidth } from "@/charts/shared/use-width";
-import { AreaConfig, AreaFields } from "@/configurator";
+import { AreaConfig } from "@/configurator";
 import { isTemporalDimension, Observation } from "@/domain/data";
 import {
   formatNumberWithUnit,
@@ -81,15 +81,10 @@ export interface AreasState extends CommonChartState {
 }
 
 const useAreasState = (
-  chartProps: Pick<
-    ChartProps,
-    "data" | "dimensions" | "measures" | "chartConfig"
-  > & {
-    aspectRatio: number;
-  }
+  props: ChartProps<AreaConfig> & { aspectRatio: number }
 ): AreasState => {
-  const { data, dimensions, measures, chartConfig, aspectRatio } = chartProps;
-  const { fields, interactiveFiltersConfig } = chartConfig as AreaConfig;
+  const { data, dimensions, measures, chartConfig, aspectRatio } = props;
+  const { fields, interactiveFiltersConfig } = chartConfig;
   const width = useWidth();
   const formatNumber = useFormatNumber({ decimals: "auto" });
   const estimateNumberWidth = (d: number) => estimateTextWidth(formatNumber(d));
@@ -357,7 +352,7 @@ const useAreasState = (
   xEntireScale.range([0, chartWidth]);
   yScale.range([chartHeight, 0]);
 
-  const formatters = useChartFormatters(chartProps);
+  const formatters = useChartFormatters(props);
 
   /** Tooltip */
   const getAnnotationInfo = (datum: Observation): TooltipInfo => {
@@ -428,48 +423,46 @@ const useAreasState = (
 };
 
 const AreaChartProvider = ({
-  data,
-  measures,
-  dimensions,
   chartConfig,
+  data,
+  dimensions,
+  measures,
   aspectRatio,
   children,
-}: Pick<ChartProps, "data" | "dimensions" | "measures" | "chartConfig"> & {
-  children: ReactNode;
-  aspectRatio: number;
-}) => {
+}: React.PropsWithChildren<
+  ChartProps<AreaConfig> & { aspectRatio: number }
+>) => {
   const state = useAreasState({
+    chartConfig,
     data,
     dimensions,
     measures,
-    chartConfig,
     aspectRatio,
   });
+
   return (
     <ChartContext.Provider value={state}>{children}</ChartContext.Provider>
   );
 };
 
 export const AreaChart = ({
+  chartConfig,
   data,
   measures,
   dimensions,
-  chartConfig,
   aspectRatio,
   children,
-}: Pick<ChartProps, "data" | "dimensions" | "measures" | "chartConfig"> & {
-  children: ReactNode;
-  fields: AreaFields;
-  aspectRatio: number;
-}) => {
+}: React.PropsWithChildren<
+  ChartProps<AreaConfig> & { aspectRatio: number }
+>) => {
   return (
     <Observer>
       <InteractionProvider>
         <AreaChartProvider
+          chartConfig={chartConfig}
           data={data}
           dimensions={dimensions}
           measures={measures}
-          chartConfig={chartConfig}
           aspectRatio={aspectRatio}
         >
           {children}

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -462,7 +462,8 @@ export const getAreasStateMetadata = (
 
 const AreaChartProvider = ({
   chartConfig,
-  data,
+  chartData,
+  scalesData,
   dimensions,
   measures,
   aspectRatio,
@@ -472,7 +473,8 @@ const AreaChartProvider = ({
 >) => {
   const state = useAreasState({
     chartConfig,
-    data,
+    chartData,
+    scalesData,
     dimensions,
     measures,
     aspectRatio,
@@ -485,7 +487,8 @@ const AreaChartProvider = ({
 
 export const AreaChart = ({
   chartConfig,
-  data,
+  chartData,
+  scalesData,
   measures,
   dimensions,
   aspectRatio,
@@ -498,7 +501,8 @@ export const AreaChart = ({
       <InteractionProvider>
         <AreaChartProvider
           chartConfig={chartConfig}
-          data={data}
+          chartData={chartData}
+          scalesData={scalesData}
           dimensions={dimensions}
           measures={measures}
           aspectRatio={aspectRatio}

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -174,7 +174,7 @@ const useAreasState = (
 
   // Data for chart
   const { preparedData, scalesData } = useDataAfterInteractiveFilters({
-    sortedData: plottableSortedData,
+    observations: plottableSortedData,
     interactiveFiltersConfig,
     // No animation yet for areas
     animationField: undefined,

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -21,6 +21,7 @@ import orderBy from "lodash/orderBy";
 import { useMemo } from "react";
 
 import { LEFT_MARGIN_OFFSET } from "@/charts/area/constants";
+import { useMaybeAbbreviations } from "@/charts/shared/abbreviations";
 import { BRUSH_BOTTOM_SPACE } from "@/charts/shared/brush/constants";
 import {
   getLabelWithUnit,
@@ -37,11 +38,10 @@ import {
   CommonChartState,
 } from "@/charts/shared/chart-state";
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
-import { useMaybeAbbreviations } from "@/charts/shared/use-abbreviations";
+import { useObservationLabels } from "@/charts/shared/observation-labels";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { ChartContext } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
-import { useObservationLabels } from "@/charts/shared/use-observation-labels";
 import { Observer, useWidth } from "@/charts/shared/use-width";
 import { AreaConfig } from "@/configurator";
 import { parseDate } from "@/configurator/components/ui-helpers";
@@ -357,7 +357,7 @@ const useAreasState = (
       data: tooltipValues,
       order: segments,
       getCategory: getSegment,
-      sortOrder: "asc",
+      sortingOrder: "asc",
     });
 
     const yAnchor = 0;
@@ -419,14 +419,14 @@ export const getAreasStateMetadata = (
 ): ChartStateMetadata => {
   const { fields } = chartConfig;
   const x = fields.x.componentIri;
-  const getSortValue = (d: Observation) => {
+  const getX = (d: Observation) => {
     return parseDate(`${d[x]}`);
   };
 
   return {
     sortData: (data) => {
       return [...data].sort((a, b) => {
-        return ascending(getSortValue(a), getSortValue(b));
+        return ascending(getX(a), getX(b));
       });
     },
   };

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -74,13 +74,14 @@ export const ChartAreasVisualization = ({
 };
 
 export const ChartAreas = memo((props: ChartProps<AreaConfig>) => {
-  const { data, dimensions, measures, chartConfig } = props;
+  const { chartConfig, chartData, scalesData, dimensions, measures } = props;
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   return (
     <AreaChart
       chartConfig={chartConfig}
-      data={data}
+      chartData={chartData}
+      scalesData={scalesData}
       dimensions={dimensions}
       measures={measures}
       aspectRatio={0.4}

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -6,7 +6,7 @@ import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
 import { AxisHeightLinear } from "@/charts/shared/axis-height-linear";
 import { AxisTime, AxisTimeDomain } from "@/charts/shared/axis-width-time";
 import { BrushTime } from "@/charts/shared/brush";
-import { getChartConfigComponentIris } from "@/charts/shared/chart-helpers";
+import { extractComponentIris } from "@/charts/shared/chart-helpers";
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { Ruler } from "@/charts/shared/interaction/ruler";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
@@ -36,33 +36,28 @@ export const ChartAreasVisualization = ({
   published: boolean;
 }) => {
   const locale = useLocale();
-  const componentIrisToFilterBy = published
-    ? getChartConfigComponentIris(chartConfig)
+  const componentIris = published
+    ? extractComponentIris(chartConfig)
     : undefined;
+  const commonQueryVariables = {
+    iri: dataSetIri,
+    sourceType: dataSource.type,
+    sourceUrl: dataSource.url,
+    locale,
+  };
   const [metadataQuery] = useDataCubeMetadataQuery({
-    variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-    },
+    variables: commonQueryVariables,
   });
   const [componentsQuery] = useComponentsQuery({
     variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      componentIris: componentIrisToFilterBy,
-      locale,
+      ...commonQueryVariables,
+      componentIris,
     },
   });
   const [observationsQuery] = useDataCubeObservationsQuery({
     variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-      componentIris: componentIrisToFilterBy,
+      ...commonQueryVariables,
+      componentIris,
       filters: queryFilters,
     },
   });

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -74,7 +74,8 @@ export const ChartAreasVisualization = ({
 };
 
 export const ChartAreas = memo((props: ChartProps<AreaConfig>) => {
-  const { chartConfig, chartData, scalesData, dimensions, measures } = props;
+  const { chartConfig, chartData, allData, scalesData, dimensions, measures } =
+    props;
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   return (
@@ -82,6 +83,7 @@ export const ChartAreas = memo((props: ChartProps<AreaConfig>) => {
       chartConfig={chartConfig}
       chartData={chartData}
       scalesData={scalesData}
+      allData={allData}
       dimensions={dimensions}
       measures={measures}
       aspectRatio={0.4}

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -13,14 +13,14 @@ import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import { AreaConfig, DataSource, QueryFilters } from "@/config-types";
-import { Observation } from "@/domain/data";
 import {
-  DimensionMetadataFragment,
   useComponentsQuery,
   useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
+
+import { ChartProps } from "../shared/ChartProps";
 
 export const ChartAreasVisualization = ({
   dataSetIri,
@@ -73,48 +73,35 @@ export const ChartAreasVisualization = ({
   );
 };
 
-export const ChartAreas = memo(
-  ({
-    observations,
-    dimensions,
-    measures,
-    chartConfig,
-  }: {
-    observations: Observation[];
-    dimensions: DimensionMetadataFragment[];
-    measures: DimensionMetadataFragment[];
-    chartConfig: AreaConfig;
-  }) => {
-    const { fields, interactiveFiltersConfig } = chartConfig;
-    return (
-      <AreaChart
-        data={observations}
-        fields={fields}
-        dimensions={dimensions}
-        measures={measures}
-        chartConfig={chartConfig}
-        aspectRatio={0.4}
-      >
-        <ChartContainer>
-          <ChartSvg>
-            <AxisTime /> <AxisHeightLinear />
-            <Areas /> <AxisTimeDomain />
-            <InteractionHorizontal />
-            {interactiveFiltersConfig?.timeRange.active === true && (
-              <BrushTime />
-            )}
-          </ChartSvg>
-          <Tooltip type={fields.segment ? "multiple" : "single"} />
-          <Ruler />
-        </ChartContainer>
+export const ChartAreas = memo((props: ChartProps<AreaConfig>) => {
+  const { data, dimensions, measures, chartConfig } = props;
+  const { fields, interactiveFiltersConfig } = chartConfig;
 
-        <LegendColor
-          symbol="square"
-          interactive={
-            fields.segment && interactiveFiltersConfig?.legend.active === true
-          }
-        />
-      </AreaChart>
-    );
-  }
-);
+  return (
+    <AreaChart
+      chartConfig={chartConfig}
+      data={data}
+      dimensions={dimensions}
+      measures={measures}
+      aspectRatio={0.4}
+    >
+      <ChartContainer>
+        <ChartSvg>
+          <AxisTime /> <AxisHeightLinear />
+          <Areas /> <AxisTimeDomain />
+          <InteractionHorizontal />
+          {interactiveFiltersConfig?.timeRange.active === true && <BrushTime />}
+        </ChartSvg>
+        <Tooltip type={fields.segment ? "multiple" : "single"} />
+        <Ruler />
+      </ChartContainer>
+
+      <LegendColor
+        symbol="square"
+        interactive={
+          fields.segment && interactiveFiltersConfig?.legend.active === true
+        }
+      />
+    </AreaChart>
+  );
+});

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -74,20 +74,11 @@ export const ChartAreasVisualization = ({
 };
 
 export const ChartAreas = memo((props: ChartProps<AreaConfig>) => {
-  const { chartConfig, chartData, allData, scalesData, dimensions, measures } =
-    props;
+  const { chartConfig } = props;
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   return (
-    <AreaChart
-      chartConfig={chartConfig}
-      chartData={chartData}
-      scalesData={scalesData}
-      allData={allData}
-      dimensions={dimensions}
-      measures={measures}
-      aspectRatio={0.4}
-    >
+    <AreaChart aspectRatio={0.4} {...props}>
       <ChartContainer>
         <ChartSvg>
           <AxisTime /> <AxisHeightLinear />

--- a/app/charts/chart-loading-wrapper.tsx
+++ b/app/charts/chart-loading-wrapper.tsx
@@ -4,7 +4,7 @@ import { UseQueryResponse } from "urql";
 
 import { ChartProps } from "@/charts/shared/ChartProps";
 import { A11yTable } from "@/charts/shared/a11y-table";
-import { usePlottableData } from "@/charts/shared/chart-helpers";
+import { useChartData, usePlottableData } from "@/charts/shared/chart-helpers";
 import { getChartStateMetadata } from "@/charts/shared/chart-state";
 import Flex from "@/components/flex";
 import {
@@ -13,7 +13,7 @@ import {
   LoadingOverlay,
   NoDataHint,
 } from "@/components/hint";
-import { ChartConfig, isAnimationInConfig } from "@/configurator";
+import { ChartConfig } from "@/configurator";
 import {
   ComponentsQuery,
   DataCubeMetadataQuery,
@@ -94,6 +94,12 @@ export const ChartLoadingWrapper = <
     getY: chartStateMetadata?.assureDefined.getY,
   });
 
+  const { chartData, scalesData } = useChartData(plottableData, {
+    chartConfig,
+    getXDate: chartStateMetadata?.getXDate,
+    getSegment: chartStateMetadata?.getSegment,
+  });
+
   if (metadata && dimensions && measures && data) {
     const { title } = metadata;
 
@@ -111,7 +117,8 @@ export const ChartLoadingWrapper = <
           measures={measures}
         />
         {React.createElement(Component, {
-          data: plottableData,
+          chartData,
+          scalesData,
           dimensions,
           measures,
           chartConfig,

--- a/app/charts/chart-loading-wrapper.tsx
+++ b/app/charts/chart-loading-wrapper.tsx
@@ -119,6 +119,7 @@ export const ChartLoadingWrapper = <
         {React.createElement(Component, {
           chartData,
           scalesData,
+          allData: plottableData,
           dimensions,
           measures,
           chartConfig,

--- a/app/charts/chart-loading-wrapper.tsx
+++ b/app/charts/chart-loading-wrapper.tsx
@@ -2,6 +2,7 @@ import { Box } from "@mui/material";
 import React from "react";
 import { UseQueryResponse } from "urql";
 
+import { ChartProps } from "@/charts/shared/ChartProps";
 import { A11yTable } from "@/charts/shared/a11y-table";
 import { getChartStateMetadata } from "@/charts/shared/chart-state";
 import Flex from "@/components/flex";
@@ -17,8 +18,6 @@ import {
   DataCubeMetadataQuery,
   DataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
-
-import { ChartProps } from "./shared/ChartProps";
 
 type ElementProps<RE> = RE extends React.ElementType<infer P> ? P : never;
 
@@ -69,6 +68,7 @@ export const ChartLoadingWrapper = <
     error: observationsError,
   } = observationsQuery;
 
+  const metadata = metadataData?.dataCubeByIri;
   const observations = observationsData?.dataCubeByIri?.observations.data;
   const dimensions = componentsData?.dataCubeByIri?.dimensions;
   const measures = componentsData?.dataCubeByIri?.measures;
@@ -87,8 +87,17 @@ export const ChartLoadingWrapper = <
     return observations;
   }, [chartStateMetadata, observations]);
 
-  if (metadataData?.dataCubeByIri && dimensions && measures && data) {
-    const { title } = metadataData.dataCubeByIri;
+  // const { chartData, scalesData } = useChartData(data ?? [], {
+  //   interactiveFiltersConfig: chartConfig.interactiveFiltersConfig,
+  //   animationField: isAnimationInConfig(chartConfig)
+  //     ? chartConfig.fields.animation
+  //     : undefined,
+  //   getXDate: chartStateMetadata?.getXDate,
+  //   getSegment: chartStateMetadata?.getSegment,
+  // });
+
+  if (metadata && dimensions && measures && data) {
+    const { title } = metadata;
 
     return data.length > 0 ? (
       <Box

--- a/app/charts/chart-loading-wrapper.tsx
+++ b/app/charts/chart-loading-wrapper.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { UseQueryResponse } from "urql";
 
 import { A11yTable } from "@/charts/shared/a11y-table";
+import { getChartStateMetadata } from "@/charts/shared/chart-state";
 import Flex from "@/components/flex";
 import {
   Loading,
@@ -68,16 +69,29 @@ export const ChartLoadingWrapper = <
     error: observationsError,
   } = observationsQuery;
 
+  const chartStateMetadata = React.useMemo(() => {
+    return getChartStateMetadata(chartConfig);
+  }, [chartConfig]);
+
+  const observations = React.useMemo(() => {
+    const observations = observationsData?.dataCubeByIri?.observations.data;
+
+    if (observations && chartStateMetadata) {
+      return chartStateMetadata.sortData(observations);
+    }
+
+    return observations;
+  }, [chartStateMetadata, observationsData?.dataCubeByIri?.observations.data]);
+
   if (
     metadataData?.dataCubeByIri &&
     componentsData?.dataCubeByIri &&
-    observationsData?.dataCubeByIri
+    observations
   ) {
     const { title } = metadataData.dataCubeByIri;
     const { dimensions, measures } = componentsData.dataCubeByIri;
-    const { observations } = observationsData.dataCubeByIri;
 
-    return observations.data.length > 0 ? (
+    return observations.length > 0 ? (
       <Box
         data-chart-loaded={
           !(fetchingMetadata && fetchingComponents && fetchingObservations)
@@ -86,12 +100,12 @@ export const ChartLoadingWrapper = <
       >
         <A11yTable
           title={title}
-          observations={observations.data}
+          observations={observations}
           dimensions={dimensions}
           measures={measures}
         />
         {React.createElement(Component, {
-          data: observations.data,
+          data: observations,
           dimensions,
           measures,
           chartConfig,

--- a/app/charts/chart-loading-wrapper.tsx
+++ b/app/charts/chart-loading-wrapper.tsx
@@ -11,21 +11,13 @@ import {
   NoDataHint,
 } from "@/components/hint";
 import { ChartConfig } from "@/configurator";
-import { Observation } from "@/domain/data";
 import {
   ComponentsQuery,
   DataCubeMetadataQuery,
   DataCubeObservationsQuery,
-  DimensionMetadataFragment,
 } from "@/graphql/query-hooks";
 
-type ChartCommonProps<TChartConfig extends ChartConfig> = {
-  fields: TChartConfig["fields"];
-  observations: Observation[];
-  measures: DimensionMetadataFragment[];
-  dimensions: DimensionMetadataFragment[];
-  chartConfig: TChartConfig;
-};
+import { ChartProps } from "./shared/ChartProps";
 
 type ElementProps<RE> = RE extends React.ElementType<infer P> ? P : never;
 
@@ -57,7 +49,7 @@ export const ChartLoadingWrapper = <
   Component: TChartComponent;
   ComponentProps?: Omit<
     ElementProps<TChartComponent>,
-    keyof ChartCommonProps<TChartConfig>
+    keyof ChartProps<TChartConfig>
   >;
 }) => {
   const {
@@ -99,12 +91,12 @@ export const ChartLoadingWrapper = <
           measures={measures}
         />
         {React.createElement(Component, {
-          observations: observations.data,
+          data: observations.data,
           dimensions,
           measures,
           chartConfig,
           ...ComponentProps,
-        } as ChartCommonProps<TChartConfig> & TOtherProps)}
+        } as ChartProps<TChartConfig> & TOtherProps)}
         {(fetchingMetadata || fetchingComponents || fetchingObservations) && (
           <LoadingOverlay />
         )}

--- a/app/charts/chart-loading-wrapper.tsx
+++ b/app/charts/chart-loading-wrapper.tsx
@@ -94,7 +94,7 @@ export const ChartLoadingWrapper = <
     getY: chartStateMetadata?.assureDefined.getY,
   });
 
-  const { chartData, scalesData } = useChartData(plottableData, {
+  const { chartData, scalesData, segmentData } = useChartData(plottableData, {
     chartConfig,
     getXDate: chartStateMetadata?.getXDate,
     getSegment: chartStateMetadata?.getSegment,
@@ -119,6 +119,7 @@ export const ChartLoadingWrapper = <
         {React.createElement(Component, {
           chartData,
           scalesData,
+          segmentData,
           allData: plottableData,
           dimensions,
           measures,

--- a/app/charts/chart-loading-wrapper.tsx
+++ b/app/charts/chart-loading-wrapper.tsx
@@ -4,6 +4,7 @@ import { UseQueryResponse } from "urql";
 
 import { ChartProps } from "@/charts/shared/ChartProps";
 import { A11yTable } from "@/charts/shared/a11y-table";
+import { usePlottableData } from "@/charts/shared/chart-helpers";
 import { getChartStateMetadata } from "@/charts/shared/chart-state";
 import Flex from "@/components/flex";
 import {
@@ -12,7 +13,7 @@ import {
   LoadingOverlay,
   NoDataHint,
 } from "@/components/hint";
-import { ChartConfig } from "@/configurator";
+import { ChartConfig, isAnimationInConfig } from "@/configurator";
 import {
   ComponentsQuery,
   DataCubeMetadataQuery,
@@ -87,14 +88,11 @@ export const ChartLoadingWrapper = <
     return observations;
   }, [chartStateMetadata, observations]);
 
-  // const { chartData, scalesData } = useChartData(data ?? [], {
-  //   interactiveFiltersConfig: chartConfig.interactiveFiltersConfig,
-  //   animationField: isAnimationInConfig(chartConfig)
-  //     ? chartConfig.fields.animation
-  //     : undefined,
-  //   getXDate: chartStateMetadata?.getXDate,
-  //   getSegment: chartStateMetadata?.getSegment,
-  // });
+  const plottableData = usePlottableData({
+    data: data ?? [],
+    getX: chartStateMetadata?.assureDefined.getX,
+    getY: chartStateMetadata?.assureDefined.getY,
+  });
 
   if (metadata && dimensions && measures && data) {
     const { title } = metadata;
@@ -113,7 +111,7 @@ export const ChartLoadingWrapper = <
           measures={measures}
         />
         {React.createElement(Component, {
-          data,
+          data: plottableData,
           dimensions,
           measures,
           chartConfig,

--- a/app/charts/chart-loading-wrapper.tsx
+++ b/app/charts/chart-loading-wrapper.tsx
@@ -69,29 +69,28 @@ export const ChartLoadingWrapper = <
     error: observationsError,
   } = observationsQuery;
 
+  const observations = observationsData?.dataCubeByIri?.observations.data;
+  const dimensions = componentsData?.dataCubeByIri?.dimensions;
+  const measures = componentsData?.dataCubeByIri?.measures;
+
   const chartStateMetadata = React.useMemo(() => {
-    return getChartStateMetadata(chartConfig);
-  }, [chartConfig]);
+    if (observations && dimensions) {
+      return getChartStateMetadata({ chartConfig, observations, dimensions });
+    }
+  }, [chartConfig, observations, dimensions]);
 
-  const observations = React.useMemo(() => {
-    const observations = observationsData?.dataCubeByIri?.observations.data;
-
+  const data = React.useMemo(() => {
     if (observations && chartStateMetadata) {
       return chartStateMetadata.sortData(observations);
     }
 
     return observations;
-  }, [chartStateMetadata, observationsData?.dataCubeByIri?.observations.data]);
+  }, [chartStateMetadata, observations]);
 
-  if (
-    metadataData?.dataCubeByIri &&
-    componentsData?.dataCubeByIri &&
-    observations
-  ) {
+  if (metadataData?.dataCubeByIri && dimensions && measures && data) {
     const { title } = metadataData.dataCubeByIri;
-    const { dimensions, measures } = componentsData.dataCubeByIri;
 
-    return observations.length > 0 ? (
+    return data.length > 0 ? (
       <Box
         data-chart-loaded={
           !(fetchingMetadata && fetchingComponents && fetchingObservations)
@@ -100,12 +99,12 @@ export const ChartLoadingWrapper = <
       >
         <A11yTable
           title={title}
-          observations={observations}
+          observations={data}
           dimensions={dimensions}
           measures={measures}
         />
         {React.createElement(Component, {
-          data: observations,
+          data,
           dimensions,
           measures,
           chartConfig,

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -84,22 +84,13 @@ export const ChartColumnsVisualization = ({
 };
 
 export const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
-  const { chartConfig, chartData, scalesData, allData, dimensions, measures } =
-    props;
+  const { chartConfig, dimensions } = props;
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   return (
     <>
       {fields.segment?.componentIri && fields.segment.type === "stacked" ? (
-        <StackedColumnsChart
-          chartConfig={chartConfig}
-          chartData={chartData}
-          scalesData={scalesData}
-          allData={allData}
-          dimensions={dimensions}
-          measures={measures}
-          aspectRatio={0.4}
-        >
+        <StackedColumnsChart aspectRatio={0.4} {...props}>
           <ChartContainer>
             <ChartSvg>
               <AxisHeightLinear /> <AxisWidthBand />
@@ -126,15 +117,7 @@ export const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
           )}
         </StackedColumnsChart>
       ) : fields.segment?.componentIri && fields.segment.type === "grouped" ? (
-        <GroupedColumnChart
-          chartConfig={chartConfig}
-          chartData={chartData}
-          scalesData={scalesData}
-          allData={allData}
-          dimensions={dimensions}
-          measures={measures}
-          aspectRatio={0.4}
-        >
+        <GroupedColumnChart aspectRatio={0.4} {...props}>
           <ChartContainer>
             <ChartSvg>
               <AxisHeightLinear />
@@ -164,15 +147,7 @@ export const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
           )}
         </GroupedColumnChart>
       ) : (
-        <ColumnChart
-          chartConfig={chartConfig}
-          chartData={chartData}
-          scalesData={scalesData}
-          allData={allData}
-          measures={measures}
-          dimensions={dimensions}
-          aspectRatio={0.4}
-        >
+        <ColumnChart aspectRatio={0.4} {...props}>
           <ChartContainer>
             <ChartSvg>
               <AxisHeightLinear />

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -17,7 +17,7 @@ import {
   AxisWidthBandDomain,
 } from "@/charts/shared/axis-width-band";
 import { BrushTime } from "@/charts/shared/brush";
-import { getChartConfigComponentIris } from "@/charts/shared/chart-helpers";
+import { extractComponentIris } from "@/charts/shared/chart-helpers";
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
@@ -46,33 +46,28 @@ export const ChartColumnsVisualization = ({
   published: boolean;
 }) => {
   const locale = useLocale();
-  const componentIrisToFilterBy = published
-    ? getChartConfigComponentIris(chartConfig)
+  const componentIris = published
+    ? extractComponentIris(chartConfig)
     : undefined;
+  const commonQueryVariables = {
+    iri: dataSetIri,
+    sourceType: dataSource.type,
+    sourceUrl: dataSource.url,
+    locale,
+  };
   const [metadataQuery] = useDataCubeMetadataQuery({
-    variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-    },
+    variables: commonQueryVariables,
   });
   const [componentsWithHierarchiesQuery] = useComponentsWithHierarchiesQuery({
     variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-      componentIris: componentIrisToFilterBy,
+      ...commonQueryVariables,
+      componentIris,
     },
   });
   const [observationsQuery] = useDataCubeObservationsQuery({
     variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-      componentIris: componentIrisToFilterBy,
+      ...commonQueryVariables,
+      componentIris,
       filters: queryFilters,
     },
   });

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -23,14 +23,14 @@ import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { ColumnConfig, DataSource, QueryFilters } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
-import { Observation } from "@/domain/data";
 import {
-  DimensionMetadataFragment,
   useComponentsWithHierarchiesQuery,
   useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
+
+import { ChartProps } from "../shared/ChartProps";
 
 export const ChartColumnsVisualization = ({
   dataSetIri,
@@ -83,126 +83,112 @@ export const ChartColumnsVisualization = ({
   );
 };
 
-export const ChartColumns = memo(
-  ({
-    observations,
-    dimensions,
-    measures,
-    chartConfig,
-  }: {
-    observations: Observation[];
-    dimensions: DimensionMetadataFragment[];
-    measures: DimensionMetadataFragment[];
-    chartConfig: ColumnConfig;
-  }) => {
-    const { fields, interactiveFiltersConfig } = chartConfig;
-    return (
-      <>
-        {/* FIXME: These checks should probably be handled somewhere else */}
-        {fields.segment?.componentIri && fields.segment.type === "stacked" ? (
-          <StackedColumnsChart
-            data={observations}
-            fields={fields}
-            dimensions={dimensions}
-            measures={measures}
-            aspectRatio={0.4}
-            chartConfig={chartConfig}
-          >
-            <ChartContainer>
-              <ChartSvg>
-                <AxisHeightLinear /> <AxisWidthBand />
-                <ColumnsStacked /> <AxisWidthBandDomain />
-                <InteractionColumns />
-                {interactiveFiltersConfig?.timeRange.active && <BrushTime />}
-              </ChartSvg>
-              <Tooltip type="multiple" />
-            </ChartContainer>
-            <LegendColor
-              symbol="square"
-              interactive={
-                fields.segment && interactiveFiltersConfig?.legend.active
-              }
+export const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
+  const { chartConfig, data, dimensions, measures } = props;
+  const { fields, interactiveFiltersConfig } = chartConfig;
+
+  return (
+    <>
+      {fields.segment?.componentIri && fields.segment.type === "stacked" ? (
+        <StackedColumnsChart
+          chartConfig={chartConfig}
+          data={data}
+          dimensions={dimensions}
+          measures={measures}
+          aspectRatio={0.4}
+        >
+          <ChartContainer>
+            <ChartSvg>
+              <AxisHeightLinear /> <AxisWidthBand />
+              <ColumnsStacked /> <AxisWidthBandDomain />
+              <InteractionColumns />
+              {interactiveFiltersConfig?.timeRange.active && <BrushTime />}
+            </ChartSvg>
+            <Tooltip type="multiple" />
+          </ChartContainer>
+          <LegendColor
+            symbol="square"
+            interactive={
+              fields.segment && interactiveFiltersConfig?.legend.active
+            }
+          />
+          {fields.animation && (
+            <TimeSlider
+              componentIri={fields.animation.componentIri}
+              dimensions={dimensions}
+              showPlayButton={fields.animation.showPlayButton}
+              animationDuration={fields.animation.duration}
+              animationType={fields.animation.type}
             />
-            {fields.animation && (
-              <TimeSlider
-                componentIri={fields.animation.componentIri}
-                dimensions={dimensions}
-                showPlayButton={fields.animation.showPlayButton}
-                animationDuration={fields.animation.duration}
-                animationType={fields.animation.type}
-              />
-            )}
-          </StackedColumnsChart>
-        ) : fields.segment?.componentIri &&
-          fields.segment.type === "grouped" ? (
-          <GroupedColumnChart
-            data={observations}
-            fields={fields}
-            dimensions={dimensions}
-            measures={measures}
-            aspectRatio={0.4}
-            chartConfig={chartConfig}
-          >
-            <ChartContainer>
-              <ChartSvg>
-                <AxisHeightLinear />
-                <AxisWidthBand />
-                <ColumnsGrouped />
-                <ErrorWhiskersGrouped />
-                <AxisWidthBandDomain />
-                <InteractionColumns />
-                {interactiveFiltersConfig?.timeRange.active && <BrushTime />}
-              </ChartSvg>
-              <Tooltip type="multiple" />
-            </ChartContainer>
-            <LegendColor
-              symbol="square"
-              interactive={
-                fields.segment && interactiveFiltersConfig?.legend.active
-              }
+          )}
+        </StackedColumnsChart>
+      ) : fields.segment?.componentIri && fields.segment.type === "grouped" ? (
+        <GroupedColumnChart
+          chartConfig={chartConfig}
+          data={data}
+          dimensions={dimensions}
+          measures={measures}
+          aspectRatio={0.4}
+        >
+          <ChartContainer>
+            <ChartSvg>
+              <AxisHeightLinear />
+              <AxisWidthBand />
+              <ColumnsGrouped />
+              <ErrorWhiskersGrouped />
+              <AxisWidthBandDomain />
+              <InteractionColumns />
+              {interactiveFiltersConfig?.timeRange.active && <BrushTime />}
+            </ChartSvg>
+            <Tooltip type="multiple" />
+          </ChartContainer>
+          <LegendColor
+            symbol="square"
+            interactive={
+              fields.segment && interactiveFiltersConfig?.legend.active
+            }
+          />
+          {fields.animation && (
+            <TimeSlider
+              componentIri={fields.animation.componentIri}
+              dimensions={dimensions}
+              showPlayButton={fields.animation.showPlayButton}
+              animationDuration={fields.animation.duration}
+              animationType={fields.animation.type}
             />
-            {fields.animation && (
-              <TimeSlider
-                componentIri={fields.animation.componentIri}
-                dimensions={dimensions}
-                showPlayButton={fields.animation.showPlayButton}
-                animationDuration={fields.animation.duration}
-                animationType={fields.animation.type}
-              />
-            )}
-          </GroupedColumnChart>
-        ) : (
-          <ColumnChart
-            data={observations}
-            measures={measures}
-            dimensions={dimensions}
-            aspectRatio={0.4}
-            chartConfig={chartConfig}
-          >
-            <ChartContainer>
-              <ChartSvg>
-                <AxisHeightLinear />
-                <AxisWidthBand />
-                <Columns />
-                <ErrorWhiskers />
-                <AxisWidthBandDomain />
-                <InteractionColumns />
-                {interactiveFiltersConfig?.timeRange.active && <BrushTime />}
-              </ChartSvg>
-              <Tooltip type="single" />
-            </ChartContainer>
-            {fields.animation && (
-              <TimeSlider
-                componentIri={fields.animation.componentIri}
-                dimensions={dimensions}
-                showPlayButton={fields.animation.showPlayButton}
-                animationDuration={fields.animation.duration}
-                animationType={fields.animation.type}
-              />
-            )}
-          </ColumnChart>
-        )}
-      </>
-    );
-  }
-);
+          )}
+        </GroupedColumnChart>
+      ) : (
+        <ColumnChart
+          chartConfig={chartConfig}
+          data={data}
+          measures={measures}
+          dimensions={dimensions}
+          aspectRatio={0.4}
+        >
+          <ChartContainer>
+            <ChartSvg>
+              <AxisHeightLinear />
+              <AxisWidthBand />
+              <Columns />
+              <ErrorWhiskers />
+              <AxisWidthBandDomain />
+              <InteractionColumns />
+              {interactiveFiltersConfig?.timeRange.active && <BrushTime />}
+            </ChartSvg>
+            <Tooltip type="single" />
+          </ChartContainer>
+          {fields.animation && (
+            <TimeSlider
+              componentIri={fields.animation.componentIri}
+              dimensions={dimensions}
+              showPlayButton={fields.animation.showPlayButton}
+              animationDuration={fields.animation.duration}
+              animationType={fields.animation.type}
+            />
+          )}
+        </ColumnChart>
+      )}
+    </>
+  );
+});

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -84,7 +84,8 @@ export const ChartColumnsVisualization = ({
 };
 
 export const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
-  const { chartConfig, chartData, scalesData, dimensions, measures } = props;
+  const { chartConfig, chartData, scalesData, allData, dimensions, measures } =
+    props;
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   return (
@@ -94,6 +95,7 @@ export const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
           chartConfig={chartConfig}
           chartData={chartData}
           scalesData={scalesData}
+          allData={allData}
           dimensions={dimensions}
           measures={measures}
           aspectRatio={0.4}
@@ -128,6 +130,7 @@ export const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
           chartConfig={chartConfig}
           chartData={chartData}
           scalesData={scalesData}
+          allData={allData}
           dimensions={dimensions}
           measures={measures}
           aspectRatio={0.4}
@@ -165,6 +168,7 @@ export const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
           chartConfig={chartConfig}
           chartData={chartData}
           scalesData={scalesData}
+          allData={allData}
           measures={measures}
           dimensions={dimensions}
           aspectRatio={0.4}

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -84,7 +84,7 @@ export const ChartColumnsVisualization = ({
 };
 
 export const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
-  const { chartConfig, data, dimensions, measures } = props;
+  const { chartConfig, chartData, scalesData, dimensions, measures } = props;
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   return (
@@ -92,7 +92,8 @@ export const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
       {fields.segment?.componentIri && fields.segment.type === "stacked" ? (
         <StackedColumnsChart
           chartConfig={chartConfig}
-          data={data}
+          chartData={chartData}
+          scalesData={scalesData}
           dimensions={dimensions}
           measures={measures}
           aspectRatio={0.4}
@@ -125,7 +126,8 @@ export const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
       ) : fields.segment?.componentIri && fields.segment.type === "grouped" ? (
         <GroupedColumnChart
           chartConfig={chartConfig}
-          data={data}
+          chartData={chartData}
+          scalesData={scalesData}
           dimensions={dimensions}
           measures={measures}
           aspectRatio={0.4}
@@ -161,7 +163,8 @@ export const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
       ) : (
         <ColumnChart
           chartConfig={chartConfig}
-          data={data}
+          chartData={chartData}
+          scalesData={scalesData}
           measures={measures}
           dimensions={dimensions}
           aspectRatio={0.4}

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -187,7 +187,7 @@ const useGroupedColumnsState = (
 
   // Data for chart
   const { preparedData, scalesData } = useDataAfterInteractiveFilters({
-    sortedData: plottableSortedData,
+    observations: plottableSortedData,
     interactiveFiltersConfig,
     animationField: fields.animation,
     getX: getXAsDate,

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -349,25 +349,24 @@ const useGroupedColumnsState = (
   const yAxisLabel = getLabelWithUnit(yMeasure);
 
   // Group
-  const grouped = useMemo(() => {
+  const grouped: [string, Observation[]][] = useMemo(() => {
+    const xKeys = xScale.domain();
     const groupedMap = group(chartData, getX);
-    const grouped = [...groupedMap];
+    const grouped: [string, Observation[]][] =
+      groupedMap.size > 0 ? [...groupedMap] : xKeys.map((d) => [d, []]);
 
-    // sort by segments
-    grouped.forEach((group) => {
+    return grouped.map(([key, data]) => {
       return [
-        group[0],
+        key,
         sortByIndex({
-          data: group[1],
+          data,
           order: segments,
           getCategory: getSegment,
           sortingOrder: segmentSortingOrder,
         }),
       ];
     });
-
-    return grouped;
-  }, [getSegment, getX, chartData, segmentSortingOrder, segments]);
+  }, [getSegment, getX, chartData, segmentSortingOrder, segments, xScale]);
 
   const { left, bottom } = useChartPadding(
     yScale,

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -17,7 +17,7 @@ import {
 } from "d3";
 import get from "lodash/get";
 import orderBy from "lodash/orderBy";
-import { ReactNode, useMemo } from "react";
+import { useMemo } from "react";
 
 import {
   BOTTOM_MARGIN_OFFSET,
@@ -43,7 +43,7 @@ import { ChartContext } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useObservationLabels } from "@/charts/shared/use-observation-labels";
 import { Observer, useWidth } from "@/charts/shared/use-width";
-import { ColumnFields, SortingField } from "@/configurator";
+import { ColumnConfig, SortingField } from "@/configurator";
 import {
   useErrorMeasure,
   useErrorRange,
@@ -87,17 +87,10 @@ export interface GroupedColumnsState extends CommonChartState {
 }
 
 const useGroupedColumnsState = (
-  chartProps: Pick<
-    ChartProps,
-    "data" | "dimensions" | "measures" | "chartConfig"
-  > & {
-    fields: ColumnFields;
-    aspectRatio: number;
-  }
+  props: ChartProps<ColumnConfig> & { aspectRatio: number }
 ): GroupedColumnsState => {
-  const { data, fields, dimensions, measures, chartConfig, aspectRatio } =
-    chartProps;
-  const { interactiveFiltersConfig } = chartConfig;
+  const { data, dimensions, measures, chartConfig, aspectRatio } = props;
+  const { fields, interactiveFiltersConfig } = chartConfig;
   const width = useWidth();
   const formatNumber = useFormatNumber({ decimals: "auto" });
 
@@ -127,7 +120,7 @@ const useGroupedColumnsState = (
 
   const getXAsDate = useTemporalVariable(fields.x.componentIri);
   const getY = useOptionalNumericVariable(fields.y.componentIri);
-  const errorMeasure = useErrorMeasure(chartProps, fields.y.componentIri);
+  const errorMeasure = useErrorMeasure(props, fields.y.componentIri);
   const getYErrorRange = useErrorRange(errorMeasure, getY);
 
   const segmentDimension = dimensions.find(
@@ -417,7 +410,7 @@ const useGroupedColumnsState = (
   xEntireScale.range([0, chartWidth]);
   yScale.range([chartHeight, 0]);
 
-  const formatters = useChartFormatters(chartProps);
+  const formatters = useChartFormatters(props);
 
   // Tooltip
   const getAnnotationInfo = (datum: Observation): TooltipInfo => {
@@ -514,53 +507,48 @@ const useGroupedColumnsState = (
 };
 
 const GroupedColumnChartProvider = ({
+  chartConfig,
   data,
-  fields,
   dimensions,
   measures,
-  chartConfig,
   aspectRatio,
   children,
-}: Pick<ChartProps, "data" | "dimensions" | "measures" | "chartConfig"> & {
-  children: ReactNode;
-  fields: ColumnFields;
-  aspectRatio: number;
-}) => {
+}: React.PropsWithChildren<
+  ChartProps<ColumnConfig> & {
+    aspectRatio: number;
+  }
+>) => {
   const state = useGroupedColumnsState({
+    chartConfig,
     data,
-    fields,
     dimensions,
     measures,
-    chartConfig,
     aspectRatio,
   });
+
   return (
     <ChartContext.Provider value={state}>{children}</ChartContext.Provider>
   );
 };
 
 export const GroupedColumnChart = ({
+  chartConfig,
   data,
-  fields,
   dimensions,
   measures,
-  chartConfig,
   aspectRatio,
   children,
-}: Pick<ChartProps, "data" | "dimensions" | "measures" | "chartConfig"> & {
-  aspectRatio: number;
-  children: ReactNode;
-  fields: ColumnFields;
-}) => {
+}: React.PropsWithChildren<
+  ChartProps<ColumnConfig> & { aspectRatio: number }
+>) => {
   return (
     <Observer>
       <InteractionProvider>
         <GroupedColumnChartProvider
+          chartConfig={chartConfig}
           data={data}
-          fields={fields}
           dimensions={dimensions}
           measures={measures}
-          chartConfig={chartConfig}
           aspectRatio={aspectRatio}
         >
           {children}

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -532,7 +532,25 @@ export const getColumnsGroupedStateMetadata = (
 
   const { sortingOrder, sortingType } = fields.x.sorting ?? {};
 
+  const segmentDimension = dimensions.find(
+    (d) => d.iri === fields.segment?.componentIri
+  );
+
+  const { getAbbreviationOrLabelByValue: getSegmentAbbreviationOrLabel } =
+    getMaybeAbbreviations({
+      useAbbreviations: fields.segment?.useAbbreviations,
+      dimensionIri: segmentDimension?.iri,
+      dimensionValues: segmentDimension?.values,
+    });
+
+  const { getValue: getSegment } = getObservationLabels(
+    observations,
+    getSegmentAbbreviationOrLabel,
+    fields.segment?.componentIri
+  );
+
   return {
+    getSegment,
     sortData: (data) => {
       const order = [
         ...rollup(

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -571,7 +571,8 @@ export const getColumnsGroupedStateMetadata = (
 
 const GroupedColumnChartProvider = ({
   chartConfig,
-  data,
+  chartData,
+  scalesData,
   dimensions,
   measures,
   aspectRatio,
@@ -583,7 +584,8 @@ const GroupedColumnChartProvider = ({
 >) => {
   const state = useGroupedColumnsState({
     chartConfig,
-    data,
+    chartData,
+    scalesData,
     dimensions,
     measures,
     aspectRatio,
@@ -596,7 +598,8 @@ const GroupedColumnChartProvider = ({
 
 export const GroupedColumnChart = ({
   chartConfig,
-  data,
+  chartData,
+  scalesData,
   dimensions,
   measures,
   aspectRatio,
@@ -609,7 +612,8 @@ export const GroupedColumnChart = ({
       <InteractionProvider>
         <GroupedColumnChartProvider
           chartConfig={chartConfig}
-          data={data}
+          chartData={chartData}
+          scalesData={scalesData}
           dimensions={dimensions}
           measures={measures}
           aspectRatio={aspectRatio}

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -98,6 +98,7 @@ const useGroupedColumnsState = (
   const {
     chartData,
     scalesData,
+    segmentData,
     allData,
     dimensions,
     measures,
@@ -171,22 +172,22 @@ const useGroupedColumnsState = (
   const sumsBySegment = useMemo(() => {
     return Object.fromEntries([
       ...rollup(
-        scalesData,
+        segmentData,
         (v) => sum(v, (x) => getY(x)),
         (x) => getSegment(x)
       ),
     ]);
-  }, [scalesData, getY, getSegment]);
+  }, [segmentData, getY, getSegment]);
 
   const segmentFilter = segmentDimension?.iri
     ? chartConfig.filters[segmentDimension.iri]
     : undefined;
   const { allSegments, segments } = useMemo(() => {
     const allUniqueSegments = Array.from(
-      new Set(scalesData.map((d) => getSegment(d)))
+      new Set(segmentData.map((d) => getSegment(d)))
     );
     const uniqueSegments = Array.from(
-      new Set(chartData.map((d) => getSegment(d)))
+      new Set(scalesData.map((d) => getSegment(d)))
     );
     const sorting = fields?.segment?.sorting;
     const sorters = makeDimensionValueSorters(segmentDimension, {
@@ -206,8 +207,8 @@ const useGroupedColumnsState = (
       segments: allSegments.filter((d) => uniqueSegments.includes(d)),
     };
   }, [
-    chartData,
     scalesData,
+    segmentData,
     segmentDimension,
     fields.segment?.sorting,
     fields.segment?.useAbbreviations,
@@ -578,61 +579,28 @@ export const getColumnsGroupedStateMetadata = (
   };
 };
 
-const GroupedColumnChartProvider = ({
-  chartConfig,
-  chartData,
-  scalesData,
-  allData,
-  dimensions,
-  measures,
-  aspectRatio,
-  children,
-}: React.PropsWithChildren<
-  ChartProps<ColumnConfig> & {
-    aspectRatio: number;
-  }
->) => {
-  const state = useGroupedColumnsState({
-    chartConfig,
-    chartData,
-    scalesData,
-    allData,
-    dimensions,
-    measures,
-    aspectRatio,
-  });
+const GroupedColumnChartProvider = (
+  props: React.PropsWithChildren<
+    ChartProps<ColumnConfig> & { aspectRatio: number }
+  >
+) => {
+  const { children, ...rest } = props;
+  const state = useGroupedColumnsState(rest);
 
   return (
     <ChartContext.Provider value={state}>{children}</ChartContext.Provider>
   );
 };
 
-export const GroupedColumnChart = ({
-  chartConfig,
-  chartData,
-  scalesData,
-  allData,
-  dimensions,
-  measures,
-  aspectRatio,
-  children,
-}: React.PropsWithChildren<
-  ChartProps<ColumnConfig> & { aspectRatio: number }
->) => {
+export const GroupedColumnChart = (
+  props: React.PropsWithChildren<
+    ChartProps<ColumnConfig> & { aspectRatio: number }
+  >
+) => {
   return (
     <Observer>
       <InteractionProvider>
-        <GroupedColumnChartProvider
-          chartConfig={chartConfig}
-          chartData={chartData}
-          scalesData={scalesData}
-          allData={allData}
-          dimensions={dimensions}
-          measures={measures}
-          aspectRatio={aspectRatio}
-        >
-          {children}
-        </GroupedColumnChartProvider>
+        <GroupedColumnChartProvider {...props} />
       </InteractionProvider>
     </Observer>
   );

--- a/app/charts/column/columns-simple.tsx
+++ b/app/charts/column/columns-simple.tsx
@@ -9,14 +9,8 @@ import { useTheme } from "@/themes";
 
 export const ErrorWhiskers = () => {
   const state = useChartState() as ColumnsState;
-  const {
-    getX,
-    getYErrorRange,
-    preparedData,
-    yScale,
-    xScale,
-    showStandardError,
-  } = state;
+  const { getX, getYErrorRange, chartData, yScale, xScale, showStandardError } =
+    state;
   const { margins } = state.bounds;
 
   if (!getYErrorRange || !showStandardError) {
@@ -25,7 +19,7 @@ export const ErrorWhiskers = () => {
 
   return (
     <g transform={`translate(${margins.left} ${margins.top})`}>
-      {preparedData.map((d, i) => {
+      {chartData.map((d, i) => {
         const x0 = xScale(getX(d)) as number;
         const bandwidth = xScale.bandwidth();
         const barwidth = Math.min(bandwidth, 15);
@@ -46,7 +40,7 @@ export const ErrorWhiskers = () => {
 
 export const Columns = () => {
   const ref = React.useRef<SVGGElement>(null);
-  const { preparedData, bounds, getX, xScale, getY, yScale } =
+  const { chartData, bounds, getX, xScale, getY, yScale } =
     useChartState() as ColumnsState;
   const theme = useTheme();
   const { margins } = bounds;
@@ -58,7 +52,7 @@ export const Columns = () => {
       return d <= 0 ? theme.palette.secondary.main : theme.palette.primary.main;
     };
 
-    return preparedData.map((d) => {
+    return chartData.map((d) => {
       const x = getX(d);
       const xScaled = xScale(x) as number;
       const y = getY(d) ?? NaN;
@@ -77,7 +71,7 @@ export const Columns = () => {
       };
     });
   }, [
-    preparedData,
+    chartData,
     bandwidth,
     getX,
     getY,

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -200,7 +200,7 @@ const useColumnsStackedState = (
 
   // Data for chart
   const { preparedData, scalesData } = useDataAfterInteractiveFilters({
-    sortedData: plottableSortedData,
+    observations: plottableSortedData,
     interactiveFiltersConfig,
     animationField: fields.animation,
     getX: getXAsDate,

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -40,7 +40,6 @@ import {
   getWideData,
   useDataAfterInteractiveFilters,
   useOptionalNumericVariable,
-  usePlottableData,
   useTemporalVariable,
 } from "@/charts/shared/chart-helpers";
 import {
@@ -171,14 +170,9 @@ const useColumnsStackedState = (
     [allDataGroupedByX, xKey, getY, getSegment]
   );
 
-  const plottableData = usePlottableData({
-    data,
-    plotters: [getXAsDate, getY],
-  });
-
   // Data for chart
   const { preparedData, scalesData } = useDataAfterInteractiveFilters({
-    observations: plottableData,
+    observations: data,
     interactiveFiltersConfig,
     animationField: fields.animation,
     getX: getXAsDate,
@@ -194,21 +188,19 @@ const useColumnsStackedState = (
     () =>
       Object.fromEntries([
         ...rollup(
-          plottableData,
+          data,
           (v) => sum(v, (x) => getY(x)),
           (x) => getSegment(x)
         ),
       ]),
-    [getSegment, getY, plottableData]
+    [getSegment, getY, data]
   );
 
   const segmentFilter = segmentDimension?.iri
     ? chartConfig.filters[segmentDimension?.iri]
     : undefined;
   const { segments, plottableSegments } = useMemo(() => {
-    const allUniqueSegments = Array.from(
-      new Set(plottableData.map(getSegment))
-    );
+    const allUniqueSegments = Array.from(new Set(data.map(getSegment)));
     const allPlottableSegments = Array.from(
       new Set(preparedData.map(getSegment))
     );
@@ -234,7 +226,7 @@ const useColumnsStackedState = (
       ),
     };
   }, [
-    plottableData,
+    data,
     preparedData,
     segmentDimension,
     fields.segment?.sorting,
@@ -271,12 +263,12 @@ const useColumnsStackedState = (
     () =>
       Object.fromEntries([
         ...rollup(
-          plottableData,
+          data,
           (v) => sum(v, (x) => getY(x)),
           (x) => getX(x)
         ),
       ]),
-    [plottableData, getX, getY]
+    [data, getX, getY]
   );
   // Map ordered segments labels to colors
   const {
@@ -346,7 +338,7 @@ const useColumnsStackedState = (
       .paddingOuter(0);
 
     // x as time, needs to be memoized!
-    const xEntireDomainAsTime = extent(plottableData, (d) => getXAsDate(d)) as [
+    const xEntireDomainAsTime = extent(data, (d) => getXAsDate(d)) as [
       Date,
       Date
     ];
@@ -386,7 +378,7 @@ const useColumnsStackedState = (
     getX,
     getXLabel,
     getXAsDate,
-    plottableData,
+    data,
     scalesData,
     segmentsByAbbreviationOrLabel,
     segmentsByValue,
@@ -562,7 +554,7 @@ const useColumnsStackedState = (
     chartType: "column",
     bounds,
     preparedData,
-    allData: plottableData,
+    allData: data,
     getX,
     getXLabel,
     getXAsDate,
@@ -654,6 +646,9 @@ export const getColumnsStackedStateMetadata = (
   const { sortingOrder, sortingType } = fields.x.sorting ?? {};
 
   return {
+    assureDefined: {
+      getY,
+    },
     getSegment,
     sortData: (data) => {
       if (sortingOrder === "desc" && sortingType === "byDimensionLabel") {

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -99,6 +99,7 @@ const useColumnsStackedState = (
   const {
     chartData,
     scalesData,
+    segmentData,
     allData,
     measures,
     dimensions,
@@ -200,8 +201,8 @@ const useColumnsStackedState = (
     ? chartConfig.filters[segmentDimension?.iri]
     : undefined;
   const { allSegments, segments } = useMemo(() => {
-    const allUniqueSegments = Array.from(new Set(scalesData.map(getSegment)));
-    const uniqueSegments = Array.from(new Set(chartData.map(getSegment)));
+    const allUniqueSegments = Array.from(new Set(segmentData.map(getSegment)));
+    const uniqueSegments = Array.from(new Set(scalesData.map(getSegment)));
     const sorting = fields?.segment?.sorting;
     const sorters = makeDimensionValueSorters(segmentDimension, {
       sorting,
@@ -221,7 +222,7 @@ const useColumnsStackedState = (
     };
   }, [
     scalesData,
-    chartData,
+    segmentData,
     segmentDimension,
     fields.segment?.sorting,
     fields.segment?.useAbbreviations,
@@ -666,6 +667,7 @@ const StackedColumnsChartProvider = ({
   chartConfig,
   chartData,
   scalesData,
+  segmentData,
   allData,
   dimensions,
   measures,
@@ -678,6 +680,7 @@ const StackedColumnsChartProvider = ({
     chartConfig,
     chartData,
     scalesData,
+    segmentData,
     allData,
     dimensions,
     measures,
@@ -689,32 +692,15 @@ const StackedColumnsChartProvider = ({
   );
 };
 
-export const StackedColumnsChart = ({
-  chartConfig,
-  chartData,
-  scalesData,
-  allData,
-  dimensions,
-  measures,
-  aspectRatio,
-  children,
-}: React.PropsWithChildren<
-  ChartProps<ColumnConfig> & { aspectRatio: number }
->) => {
+export const StackedColumnsChart = (
+  props: React.PropsWithChildren<
+    ChartProps<ColumnConfig> & { aspectRatio: number }
+  >
+) => {
   return (
     <Observer>
       <InteractionProvider>
-        <StackedColumnsChartProvider
-          chartConfig={chartConfig}
-          chartData={chartData}
-          scalesData={scalesData}
-          allData={allData}
-          dimensions={dimensions}
-          measures={measures}
-          aspectRatio={aspectRatio}
-        >
-          {children}
-        </StackedColumnsChartProvider>
+        <StackedColumnsChartProvider {...props} />
       </InteractionProvider>
     </Observer>
   );

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -671,7 +671,8 @@ export const getColumnsStackedStateMetadata = (
 
 const StackedColumnsChartProvider = ({
   chartConfig,
-  data,
+  chartData,
+  scalesData,
   dimensions,
   measures,
   aspectRatio,
@@ -681,7 +682,8 @@ const StackedColumnsChartProvider = ({
 >) => {
   const state = useColumnsStackedState({
     chartConfig,
-    data,
+    chartData,
+    scalesData,
     dimensions,
     measures,
     aspectRatio,
@@ -694,7 +696,8 @@ const StackedColumnsChartProvider = ({
 
 export const StackedColumnsChart = ({
   chartConfig,
-  data,
+  chartData,
+  scalesData,
   dimensions,
   measures,
   aspectRatio,
@@ -707,7 +710,8 @@ export const StackedColumnsChart = ({
       <InteractionProvider>
         <StackedColumnsChartProvider
           chartConfig={chartConfig}
-          data={data}
+          chartData={chartData}
+          scalesData={scalesData}
           dimensions={dimensions}
           measures={measures}
           aspectRatio={aspectRatio}

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -22,7 +22,7 @@ import {
   sum,
 } from "d3";
 import orderBy from "lodash/orderBy";
-import { ReactNode, useCallback, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 import {
   BOTTOM_MARGIN_OFFSET,
@@ -48,7 +48,7 @@ import { ChartContext } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useObservationLabels } from "@/charts/shared/use-observation-labels";
 import { Observer, useWidth } from "@/charts/shared/use-width";
-import { ColumnFields, SortingOrder, SortingType } from "@/configurator";
+import { ColumnConfig, SortingOrder, SortingType } from "@/configurator";
 import { isTemporalDimension, Observation } from "@/domain/data";
 import { formatNumberWithUnit, useFormatNumber } from "@/formatters";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
@@ -88,17 +88,10 @@ export interface StackedColumnsState extends CommonChartState {
 }
 
 const useColumnsStackedState = (
-  chartProps: Pick<
-    ChartProps,
-    "data" | "dimensions" | "measures" | "chartConfig"
-  > & {
-    fields: ColumnFields;
-    aspectRatio: number;
-  }
+  props: ChartProps<ColumnConfig> & { aspectRatio: number }
 ): StackedColumnsState => {
-  const { data, fields, measures, dimensions, chartConfig, aspectRatio } =
-    chartProps;
-  const { interactiveFiltersConfig } = chartConfig;
+  const { data, measures, dimensions, chartConfig, aspectRatio } = props;
+  const { fields, interactiveFiltersConfig } = chartConfig;
   const width = useWidth();
   const formatNumber = useFormatNumber({ decimals: "auto" });
 
@@ -481,7 +474,7 @@ const useColumnsStackedState = (
   xEntireScale.range([0, chartWidth]);
   yScale.range([chartHeight, 0]);
 
-  const formatters = useChartFormatters(chartProps);
+  const formatters = useChartFormatters(props);
 
   // Tooltips
   const getAnnotationInfo = useCallback(
@@ -608,53 +601,46 @@ const useColumnsStackedState = (
 };
 
 const StackedColumnsChartProvider = ({
-  data,
-  fields,
-  measures,
-  dimensions,
   chartConfig,
+  data,
+  dimensions,
+  measures,
   aspectRatio,
   children,
-}: Pick<ChartProps, "data" | "dimensions" | "measures" | "chartConfig"> & {
-  children: ReactNode;
-  fields: ColumnFields;
-  aspectRatio: number;
-}) => {
+}: React.PropsWithChildren<
+  ChartProps<ColumnConfig> & { aspectRatio: number }
+>) => {
   const state = useColumnsStackedState({
-    data,
-    fields,
-    dimensions,
     chartConfig,
+    data,
+    dimensions,
     measures,
     aspectRatio,
   });
+
   return (
     <ChartContext.Provider value={state}>{children}</ChartContext.Provider>
   );
 };
 
 export const StackedColumnsChart = ({
-  data,
-  fields,
-  measures,
-  dimensions,
   chartConfig,
+  data,
+  dimensions,
+  measures,
   aspectRatio,
   children,
-}: Pick<ChartProps, "data" | "dimensions" | "measures" | "chartConfig"> & {
-  aspectRatio: number;
-  children: ReactNode;
-  fields: ColumnFields;
-}) => {
+}: React.PropsWithChildren<
+  ChartProps<ColumnConfig> & { aspectRatio: number }
+>) => {
   return (
     <Observer>
       <InteractionProvider>
         <StackedColumnsChartProvider
+          chartConfig={chartConfig}
           data={data}
-          fields={fields}
           dimensions={dimensions}
           measures={measures}
-          chartConfig={chartConfig}
           aspectRatio={aspectRatio}
         >
           {children}

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -592,9 +592,7 @@ export const getColumnsStackedStateMetadata = (
   dimensions: DimensionMetadataFragment[]
 ): ChartStateMetadata => {
   const { fields } = chartConfig;
-
   const xKey = fields.x.componentIri;
-
   const xDimension = dimensions.find((d) => d.iri === xKey);
 
   if (!xDimension) {
@@ -656,6 +654,7 @@ export const getColumnsStackedStateMetadata = (
   const { sortingOrder, sortingType } = fields.x.sorting ?? {};
 
   return {
+    getSegment,
     sortData: (data) => {
       if (sortingOrder === "desc" && sortingType === "byDimensionLabel") {
         return [...data].sort((a, b) => descending(getX(a), getX(b)));

--- a/app/charts/column/columns-stacked.tsx
+++ b/app/charts/column/columns-stacked.tsx
@@ -5,11 +5,6 @@ import { StackedColumnsState } from "@/charts/column/columns-stacked-state";
 import { RenderDatum, renderColumn } from "@/charts/column/rendering-utils";
 import { useChartState } from "@/charts/shared/use-chart-state";
 
-type StackedRenderDatum = {
-  key: string;
-  data: RenderDatum[];
-};
-
 export const ColumnsStacked = () => {
   const ref = React.useRef<SVGGElement>(null);
   const { bounds, getX, xScale, yScale, colors, series } =
@@ -18,40 +13,32 @@ export const ColumnsStacked = () => {
 
   const bandwidth = xScale.bandwidth();
   const y0 = yScale(0);
-  const renderData: StackedRenderDatum[] = React.useMemo(() => {
-    return series.map((d) => {
+  const renderData: RenderDatum[] = React.useMemo(() => {
+    return series.flatMap((d) => {
       const key = d.key;
       const color = colors(key);
 
-      return {
-        key,
-        data: d.map((segment: $FixMe) => {
-          const x = getX(segment.data);
+      return d.map((segment: $FixMe) => {
+        const x = getX(segment.data);
 
-          return {
-            key: `${key}-${x}`,
-            x: xScale(x) as number,
-            y: yScale(segment[1]),
-            width: bandwidth,
-            height: yScale(segment[0]) - yScale(segment[1]),
-            color,
-          };
-        }),
-      };
+        return {
+          key: `${key}-${x}`,
+          x: xScale(x) as number,
+          y: yScale(segment[1]),
+          width: bandwidth,
+          height: yScale(segment[0]) - yScale(segment[1]),
+          color,
+        };
+      });
     });
   }, [bandwidth, colors, getX, series, xScale, yScale]);
 
   React.useEffect(() => {
+    console.log("rendering columns", renderData);
     if (ref.current) {
       select(ref.current)
-        .selectAll<SVGGElement, StackedRenderDatum>("g")
-        .data(renderData, (d) => d.key)
-        .join("g")
         .selectAll<SVGRectElement, RenderDatum>("rect")
-        .data(
-          (d) => d.data,
-          (d) => d.key
-        )
+        .data(renderData, (d) => d.key)
         .call(renderColumn, y0);
     }
   }, [renderData, y0]);

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -15,7 +15,7 @@ import {
 } from "d3";
 import get from "lodash/get";
 import orderBy from "lodash/orderBy";
-import { ReactNode, useMemo } from "react";
+import { useMemo } from "react";
 
 import {
   BOTTOM_MARGIN_OFFSET,
@@ -91,13 +91,10 @@ export interface ColumnsState extends CommonChartState {
 }
 
 const useColumnsState = (
-  chartProps: Pick<ChartProps, "data" | "measures" | "dimensions"> & {
-    chartConfig: ColumnConfig;
-    aspectRatio: number;
-  }
+  props: ChartProps<ColumnConfig> & { aspectRatio: number }
 ): ColumnsState => {
-  const { data, measures, dimensions, aspectRatio, chartConfig } = chartProps;
-  const { interactiveFiltersConfig, fields } = chartConfig;
+  const { data, measures, dimensions, aspectRatio, chartConfig } = props;
+  const { fields, interactiveFiltersConfig } = chartConfig;
   const width = useWidth();
   const formatNumber = useFormatNumber({ decimals: "auto" });
   const timeFormatUnit = useTimeFormatUnit();
@@ -134,7 +131,7 @@ const useColumnsState = (
 
   const getXAsDate = useTemporalVariable(fields.x.componentIri);
   const getY = useOptionalNumericVariable(fields.y.componentIri);
-  const errorMeasure = useErrorMeasure(chartProps, fields.y.componentIri);
+  const errorMeasure = useErrorMeasure(props, fields.y.componentIri);
   const getYErrorRange = useErrorRange(errorMeasure, getY);
   const getYError = useErrorVariable(errorMeasure);
   const getSegment = useSegment(fields.segment?.componentIri);
@@ -240,7 +237,7 @@ const useColumnsState = (
     ]);
 
   const yMeasure = measures.find((d) => d.iri === fields.y.componentIri);
-  const formatters = useChartFormatters(chartProps);
+  const formatters = useChartFormatters(props);
 
   if (!yMeasure) {
     throw Error(`No dimension <${fields.y.componentIri}> in cube!`);
@@ -375,18 +372,17 @@ const ColumnChartProvider = ({
   aspectRatio,
   children,
   chartConfig,
-}: Pick<ChartProps, "data" | "measures" | "dimensions"> & {
-  children: ReactNode;
-  aspectRatio: number;
-  chartConfig: ColumnConfig;
-}) => {
+}: React.PropsWithChildren<
+  ChartProps<ColumnConfig> & { aspectRatio: number }
+>) => {
   const state = useColumnsState({
-    data,
-    measures,
-    dimensions,
-    aspectRatio,
     chartConfig,
+    data,
+    dimensions,
+    measures,
+    aspectRatio,
   });
+
   return (
     <ChartContext.Provider value={state}>{children}</ChartContext.Provider>
   );
@@ -399,20 +395,18 @@ export const ColumnChart = ({
   chartConfig,
   aspectRatio,
   children,
-}: Pick<ChartProps, "data" | "measures" | "dimensions"> & {
-  aspectRatio: number;
-  children: ReactNode;
-  chartConfig: ColumnConfig;
-}) => {
+}: React.PropsWithChildren<
+  ChartProps<ColumnConfig> & { aspectRatio: number }
+>) => {
   return (
     <Observer>
       <InteractionProvider>
         <ColumnChartProvider
+          chartConfig={chartConfig}
+          dimensions={dimensions}
           data={data}
           measures={measures}
-          dimensions={dimensions}
           aspectRatio={aspectRatio}
-          chartConfig={chartConfig}
         >
           {children}
         </ColumnChartProvider>

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -419,18 +419,20 @@ export const getColumnsStateMetadata = (
 };
 
 const ColumnChartProvider = ({
-  data,
-  measures,
+  chartConfig,
+  chartData,
+  scalesData,
   dimensions,
+  measures,
   aspectRatio,
   children,
-  chartConfig,
 }: React.PropsWithChildren<
   ChartProps<ColumnConfig> & { aspectRatio: number }
 >) => {
   const state = useColumnsState({
     chartConfig,
-    data,
+    chartData,
+    scalesData,
     dimensions,
     measures,
     aspectRatio,
@@ -442,10 +444,11 @@ const ColumnChartProvider = ({
 };
 
 export const ColumnChart = ({
-  data,
-  measures,
-  dimensions,
   chartConfig,
+  chartData,
+  scalesData,
+  dimensions,
+  measures,
   aspectRatio,
   children,
 }: React.PropsWithChildren<
@@ -456,8 +459,9 @@ export const ColumnChart = ({
       <InteractionProvider>
         <ColumnChartProvider
           chartConfig={chartConfig}
+          chartData={chartData}
+          scalesData={scalesData}
           dimensions={dimensions}
-          data={data}
           measures={measures}
           aspectRatio={aspectRatio}
         >

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -32,7 +32,6 @@ import {
   getMaybeTemporalDimensionValues,
   useDataAfterInteractiveFilters,
   useOptionalNumericVariable,
-  usePlottableData,
   useSegment,
   useTemporalVariable,
 } from "@/charts/shared/chart-helpers";
@@ -146,14 +145,9 @@ const useColumnsState = (
   const getSegment = useSegment(fields.segment?.componentIri);
   const showStandardError = get(fields, ["y", "showStandardError"], true);
 
-  const plottableData = usePlottableData({
-    data,
-    plotters: [getXAsDate, getY],
-  });
-
   // Data for chart
   const { preparedData, scalesData } = useDataAfterInteractiveFilters({
-    observations: plottableData,
+    observations: data,
     interactiveFiltersConfig,
     animationField: fields.animation,
     getX: getXAsDate,
@@ -187,9 +181,10 @@ const useColumnsState = (
         .paddingOuter(0);
 
       // x as time, needs to be memoized!
-      const xEntireDomainAsTime = extent(plottableData, (d) =>
-        getXAsDate(d)
-      ) as [Date, Date];
+      const xEntireDomainAsTime = extent(data, (d) => getXAsDate(d)) as [
+        Date,
+        Date
+      ];
 
       const xEntireScale = scaleTime().domain(xEntireDomainAsTime);
 
@@ -222,7 +217,7 @@ const useColumnsState = (
       getXAsDate,
       getY,
       getYErrorRange,
-      plottableData,
+      data,
       scalesData,
       fields.x.sorting,
       fields.x.useAbbreviations,
@@ -336,7 +331,7 @@ const useColumnsState = (
     chartType: "column",
     bounds,
     preparedData,
-    allData: plottableData,
+    allData: data,
     getX,
     getXLabel,
     getXAsDate,
@@ -400,6 +395,9 @@ export const getColumnsStateMetadata = (
   const sortingOrder = fields.x.sorting?.sortingOrder;
 
   return {
+    assureDefined: {
+      getY,
+    },
     sortData: (data) => {
       if (sortingOrder === "desc" && sortingType === "byDimensionLabel") {
         return [...data].sort((a, b) => descending(getX(a), getX(b)));

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -415,59 +415,28 @@ export const getColumnsStateMetadata = (
   };
 };
 
-const ColumnChartProvider = ({
-  chartConfig,
-  chartData,
-  scalesData,
-  allData,
-  dimensions,
-  measures,
-  aspectRatio,
-  children,
-}: React.PropsWithChildren<
-  ChartProps<ColumnConfig> & { aspectRatio: number }
->) => {
-  const state = useColumnsState({
-    chartConfig,
-    chartData,
-    scalesData,
-    allData,
-    dimensions,
-    measures,
-    aspectRatio,
-  });
+const ColumnChartProvider = (
+  props: React.PropsWithChildren<
+    ChartProps<ColumnConfig> & { aspectRatio: number }
+  >
+) => {
+  const { children, ...rest } = props;
+  const state = useColumnsState(rest);
 
   return (
     <ChartContext.Provider value={state}>{children}</ChartContext.Provider>
   );
 };
 
-export const ColumnChart = ({
-  chartConfig,
-  chartData,
-  scalesData,
-  allData,
-  dimensions,
-  measures,
-  aspectRatio,
-  children,
-}: React.PropsWithChildren<
-  ChartProps<ColumnConfig> & { aspectRatio: number }
->) => {
+export const ColumnChart = (
+  props: React.PropsWithChildren<
+    ChartProps<ColumnConfig> & { aspectRatio: number }
+  >
+) => {
   return (
     <Observer>
       <InteractionProvider>
-        <ColumnChartProvider
-          chartConfig={chartConfig}
-          chartData={chartData}
-          scalesData={scalesData}
-          allData={allData}
-          dimensions={dimensions}
-          measures={measures}
-          aspectRatio={aspectRatio}
-        >
-          {children}
-        </ColumnChartProvider>
+        <ColumnChartProvider {...props} />
       </InteractionProvider>
     </Observer>
   );

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -25,8 +25,8 @@ import {
 } from "@/charts/column/constants";
 import {
   getLabelWithUnit,
-  useDataAfterInteractiveFilters,
   getMaybeTemporalDimensionValues,
+  useDataAfterInteractiveFilters,
   useOptionalNumericVariable,
   usePlottableData,
   useSegment,
@@ -162,7 +162,7 @@ const useColumnsState = (
 
   // Data for chart
   const { preparedData, scalesData } = useDataAfterInteractiveFilters({
-    sortedData: plottableSortedData,
+    observations: plottableSortedData,
     interactiveFiltersConfig,
     animationField: fields.animation,
     getX: getXAsDate,

--- a/app/charts/column/overlay-columns.tsx
+++ b/app/charts/column/overlay-columns.tsx
@@ -6,7 +6,7 @@ import { Observation } from "@/domain/data";
 export const InteractionColumns = () => {
   const [, dispatch] = useInteraction();
 
-  const { preparedData, bounds, getX, xScaleInteraction } =
+  const { chartData, bounds, getX, xScaleInteraction } =
     useChartState() as ColumnsState;
   const { margins, chartHeight } = bounds;
 
@@ -23,7 +23,7 @@ export const InteractionColumns = () => {
   };
   return (
     <g transform={`translate(${margins.left} ${margins.top})`}>
-      {preparedData.map((d, i) => (
+      {chartData.map((d, i) => (
         <rect
           key={i}
           x={xScaleInteraction(getX(d)) as number}

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -75,13 +75,14 @@ export const ChartLinesVisualization = ({
 };
 
 export const ChartLines = memo((props: ChartProps<LineConfig>) => {
-  const { chartConfig, data, dimensions, measures } = props;
+  const { chartConfig, chartData, scalesData, dimensions, measures } = props;
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   return (
     <LineChart
       chartConfig={chartConfig}
-      data={data}
+      chartData={chartData}
+      scalesData={scalesData}
       dimensions={dimensions}
       measures={measures}
       aspectRatio={0.4}

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -14,14 +14,14 @@ import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import { DataSource, LineConfig, QueryFilters } from "@/config-types";
-import { Observation } from "@/domain/data";
 import {
-  DimensionMetadataFragment,
   useComponentsQuery,
   useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
+
+import { ChartProps } from "../shared/ChartProps";
 
 export const ChartLinesVisualization = ({
   dataSetIri,
@@ -74,25 +74,16 @@ export const ChartLinesVisualization = ({
   );
 };
 
-export const ChartLines = memo(function ChartLines({
-  observations,
-  dimensions,
-  measures,
+export const ChartLines = memo((props: ChartProps<LineConfig>) => {
+  const { chartConfig, data, dimensions, measures } = props;
+  const { fields, interactiveFiltersConfig } = chartConfig;
 
-  chartConfig,
-}: {
-  observations: Observation[];
-  dimensions: DimensionMetadataFragment[];
-  measures: DimensionMetadataFragment[];
-  chartConfig: LineConfig;
-}) {
-  const { interactiveFiltersConfig, fields } = chartConfig;
   return (
     <LineChart
-      data={observations}
+      chartConfig={chartConfig}
+      data={data}
       dimensions={dimensions}
       measures={measures}
-      chartConfig={chartConfig}
       aspectRatio={0.4}
     >
       <ChartContainer>

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -75,20 +75,11 @@ export const ChartLinesVisualization = ({
 };
 
 export const ChartLines = memo((props: ChartProps<LineConfig>) => {
-  const { chartConfig, chartData, scalesData, allData, dimensions, measures } =
-    props;
+  const { chartConfig } = props;
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   return (
-    <LineChart
-      chartConfig={chartConfig}
-      chartData={chartData}
-      scalesData={scalesData}
-      allData={allData}
-      dimensions={dimensions}
-      measures={measures}
-      aspectRatio={0.4}
-    >
+    <LineChart aspectRatio={0.4} {...props}>
       <ChartContainer>
         <ChartSvg>
           <AxisHeightLinear /> <AxisTime /> <AxisTimeDomain />

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -75,7 +75,8 @@ export const ChartLinesVisualization = ({
 };
 
 export const ChartLines = memo((props: ChartProps<LineConfig>) => {
-  const { chartConfig, chartData, scalesData, dimensions, measures } = props;
+  const { chartConfig, chartData, scalesData, allData, dimensions, measures } =
+    props;
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   return (
@@ -83,6 +84,7 @@ export const ChartLines = memo((props: ChartProps<LineConfig>) => {
       chartConfig={chartConfig}
       chartData={chartData}
       scalesData={scalesData}
+      allData={allData}
       dimensions={dimensions}
       measures={measures}
       aspectRatio={0.4}

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -6,7 +6,7 @@ import { LineChart } from "@/charts/line/lines-state";
 import { AxisHeightLinear } from "@/charts/shared/axis-height-linear";
 import { AxisTime, AxisTimeDomain } from "@/charts/shared/axis-width-time";
 import { BrushTime } from "@/charts/shared/brush";
-import { getChartConfigComponentIris } from "@/charts/shared/chart-helpers";
+import { extractComponentIris } from "@/charts/shared/chart-helpers";
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { HoverDotMultiple } from "@/charts/shared/interaction/hover-dots-multiple";
 import { Ruler } from "@/charts/shared/interaction/ruler";
@@ -37,33 +37,28 @@ export const ChartLinesVisualization = ({
   published: boolean;
 }) => {
   const locale = useLocale();
-  const componentIrisToFilterBy = published
-    ? getChartConfigComponentIris(chartConfig)
+  const componentIris = published
+    ? extractComponentIris(chartConfig)
     : undefined;
+  const commonQueryVariables = {
+    iri: dataSetIri,
+    sourceType: dataSource.type,
+    sourceUrl: dataSource.url,
+    locale,
+  };
   const [metadataQuery] = useDataCubeMetadataQuery({
-    variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-    },
+    variables: commonQueryVariables,
   });
   const [componentsQuery] = useComponentsQuery({
     variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-      componentIris: componentIrisToFilterBy,
+      ...commonQueryVariables,
+      componentIris,
     },
   });
   const [observationsQuery] = useDataCubeObservationsQuery({
     variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-      componentIris: componentIrisToFilterBy,
+      ...commonQueryVariables,
+      componentIris,
       filters: queryFilters,
     },
   });

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -12,7 +12,7 @@ import {
   scaleTime,
 } from "d3";
 import orderBy from "lodash/orderBy";
-import { ReactNode, useMemo } from "react";
+import { useMemo } from "react";
 
 import { LEFT_MARGIN_OFFSET } from "@/charts/line/constants";
 import { BRUSH_BOTTOM_SPACE } from "@/charts/shared/brush/constants";
@@ -77,15 +77,9 @@ export interface LinesState extends CommonChartState {
 }
 
 const useLinesState = (
-  chartProps: Pick<
-    ChartProps,
-    "data" | "dimensions" | "measures" | "chartConfig"
-  > & {
-    chartConfig: LineConfig;
-    aspectRatio: number;
-  }
+  props: ChartProps<LineConfig> & { aspectRatio: number }
 ): LinesState => {
-  const { data, dimensions, measures, chartConfig, aspectRatio } = chartProps;
+  const { data, dimensions, measures, chartConfig, aspectRatio } = props;
   const { fields, interactiveFiltersConfig } = chartConfig;
   const width = useWidth();
   const formatNumber = useFormatNumber({ decimals: "auto" });
@@ -289,7 +283,7 @@ const useLinesState = (
   xEntireScale.range([0, chartWidth]);
   yScale.range([chartHeight, 0]);
 
-  const formatters = useChartFormatters(chartProps);
+  const formatters = useChartFormatters(props);
 
   // Tooltip
   const getAnnotationInfo = (datum: Observation): TooltipInfo => {
@@ -364,49 +358,46 @@ const useLinesState = (
 };
 
 const LineChartProvider = ({
+  chartConfig,
   data,
   dimensions,
   measures,
-  chartConfig,
   aspectRatio,
   children,
-}: Pick<ChartProps, "data" | "dimensions" | "measures"> & {
-  children: ReactNode;
-  chartConfig: LineConfig;
-  aspectRatio: number;
-}) => {
+}: React.PropsWithChildren<
+  ChartProps<LineConfig> & { aspectRatio: number }
+>) => {
   const state = useLinesState({
+    chartConfig,
     data,
     dimensions,
     measures,
-    chartConfig,
     aspectRatio,
   });
+
   return (
     <ChartContext.Provider value={state}>{children}</ChartContext.Provider>
   );
 };
 
 export const LineChart = ({
+  chartConfig,
   data,
   dimensions,
   measures,
-  chartConfig,
   aspectRatio,
   children,
-}: Pick<ChartProps, "data" | "dimensions" | "measures"> & {
-  aspectRatio: number;
-  chartConfig: LineConfig;
-  children: ReactNode;
-}) => {
+}: React.PropsWithChildren<
+  ChartProps<LineConfig> & { aspectRatio: number }
+>) => {
   return (
     <Observer>
       <InteractionProvider>
         <LineChartProvider
+          chartConfig={chartConfig}
           data={data}
           dimensions={dimensions}
           measures={measures}
-          chartConfig={chartConfig}
           aspectRatio={aspectRatio}
         >
           {children}

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -157,7 +157,7 @@ const useLinesState = (
 
   // Data for chart
   const { preparedData, scalesData } = useDataAfterInteractiveFilters({
-    sortedData: plottableSortedData,
+    observations: plottableSortedData,
     interactiveFiltersConfig,
     // No animation yet for lines
     animationField: undefined,

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -15,7 +15,10 @@ import orderBy from "lodash/orderBy";
 import { useMemo } from "react";
 
 import { LEFT_MARGIN_OFFSET } from "@/charts/line/constants";
-import { useMaybeAbbreviations } from "@/charts/shared/abbreviations";
+import {
+  getMaybeAbbreviations,
+  useMaybeAbbreviations,
+} from "@/charts/shared/abbreviations";
 import { BRUSH_BOTTOM_SPACE } from "@/charts/shared/brush/constants";
 import {
   getLabelWithUnit,
@@ -31,7 +34,10 @@ import {
   CommonChartState,
 } from "@/charts/shared/chart-state";
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
-import { useObservationLabels } from "@/charts/shared/observation-labels";
+import {
+  getObservationLabels,
+  useObservationLabels,
+} from "@/charts/shared/observation-labels";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { ChartContext } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
@@ -357,18 +363,39 @@ const useLinesState = (
 };
 
 export const getLinesStateMetadata = (
-  chartConfig: LineConfig
+  chartConfig: LineConfig,
+  observations: Observation[],
+  dimensions: DimensionMetadataFragment[]
 ): ChartStateMetadata => {
   const { fields } = chartConfig;
   const x = fields.x.componentIri;
-  const getSortValue = (d: Observation) => {
+  const getXDate = (d: Observation) => {
     return parseDate(`${d[x]}`);
   };
 
+  const segmentDimension = dimensions.find(
+    (d) => d.iri === fields.segment?.componentIri
+  );
+
+  const { getAbbreviationOrLabelByValue: getSegmentAbbreviationOrLabel } =
+    getMaybeAbbreviations({
+      useAbbreviations: fields.segment?.useAbbreviations,
+      dimensionIri: segmentDimension?.iri,
+      dimensionValues: segmentDimension?.values,
+    });
+
+  const { getValue: getSegment } = getObservationLabels(
+    observations,
+    getSegmentAbbreviationOrLabel,
+    fields.segment?.componentIri
+  );
+
   return {
+    getXDate,
+    getSegment,
     sortData: (data) => {
       return [...data].sort((a, b) => {
-        return ascending(getSortValue(a), getSortValue(b));
+        return ascending(getXDate(a), getXDate(b));
       });
     },
   };

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -88,7 +88,7 @@ export interface LinesState extends CommonChartState {
 const useLinesState = (
   props: ChartProps<LineConfig> & { aspectRatio: number }
 ): LinesState => {
-  const { data, dimensions, measures, chartConfig, aspectRatio } = props;
+  const { chartConfig, data, dimensions, measures, aspectRatio } = props;
   const { fields, interactiveFiltersConfig } = chartConfig;
   const width = useWidth();
   const formatNumber = useFormatNumber({ decimals: "auto" });
@@ -405,7 +405,8 @@ export const getLinesStateMetadata = (
 
 const LineChartProvider = ({
   chartConfig,
-  data,
+  chartData,
+  scalesData,
   dimensions,
   measures,
   aspectRatio,
@@ -415,7 +416,8 @@ const LineChartProvider = ({
 >) => {
   const state = useLinesState({
     chartConfig,
-    data,
+    chartData,
+    scalesData,
     dimensions,
     measures,
     aspectRatio,
@@ -428,7 +430,8 @@ const LineChartProvider = ({
 
 export const LineChart = ({
   chartConfig,
-  data,
+  chartData,
+  scalesData,
   dimensions,
   measures,
   aspectRatio,
@@ -441,7 +444,8 @@ export const LineChart = ({
       <InteractionProvider>
         <LineChartProvider
           chartConfig={chartConfig}
-          data={data}
+          chartData={chartData}
+          scalesData={scalesData}
           dimensions={dimensions}
           measures={measures}
           aspectRatio={aspectRatio}

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -89,6 +89,7 @@ const useLinesState = (
     chartConfig,
     chartData,
     scalesData,
+    segmentData,
     allData,
     dimensions,
     measures,
@@ -204,8 +205,8 @@ const useLinesState = (
     ? chartConfig.filters[segmentDimension?.iri]
     : undefined;
   const { allSegments, segments } = useMemo(() => {
-    const allUniqueSegments = [...new Set(scalesData.map(getSegment))];
-    const uniqueSegments = [...new Set(chartData.map(getSegment))];
+    const allUniqueSegments = Array.from(new Set(segmentData.map(getSegment)));
+    const uniqueSegments = Array.from(new Set(scalesData.map(getSegment)));
     const sorting = fields?.segment?.sorting;
     const sorters = makeDimensionValueSorters(segmentDimension, {
       sorting,
@@ -227,8 +228,8 @@ const useLinesState = (
     getSegment,
     fields.segment?.sorting,
     fields.segment?.useAbbreviations,
+    segmentData,
     scalesData,
-    chartData,
     segmentFilter,
   ]);
 
@@ -404,59 +405,28 @@ export const getLinesStateMetadata = (
   };
 };
 
-const LineChartProvider = ({
-  chartConfig,
-  chartData,
-  scalesData,
-  allData,
-  dimensions,
-  measures,
-  aspectRatio,
-  children,
-}: React.PropsWithChildren<
-  ChartProps<LineConfig> & { aspectRatio: number }
->) => {
-  const state = useLinesState({
-    chartConfig,
-    chartData,
-    scalesData,
-    allData,
-    dimensions,
-    measures,
-    aspectRatio,
-  });
+const LineChartProvider = (
+  props: React.PropsWithChildren<
+    ChartProps<LineConfig> & { aspectRatio: number }
+  >
+) => {
+  const { children, ...rest } = props;
+  const state = useLinesState(rest);
 
   return (
     <ChartContext.Provider value={state}>{children}</ChartContext.Provider>
   );
 };
 
-export const LineChart = ({
-  chartConfig,
-  chartData,
-  scalesData,
-  allData,
-  dimensions,
-  measures,
-  aspectRatio,
-  children,
-}: React.PropsWithChildren<
-  ChartProps<LineConfig> & { aspectRatio: number }
->) => {
+export const LineChart = (
+  props: React.PropsWithChildren<
+    ChartProps<LineConfig> & { aspectRatio: number }
+  >
+) => {
   return (
     <Observer>
       <InteractionProvider>
-        <LineChartProvider
-          chartConfig={chartConfig}
-          chartData={chartData}
-          scalesData={scalesData}
-          allData={allData}
-          dimensions={dimensions}
-          measures={measures}
-          aspectRatio={aspectRatio}
-        >
-          {children}
-        </LineChartProvider>
+        <LineChartProvider {...props} />
       </InteractionProvider>
     </Observer>
   );

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -251,13 +251,21 @@ export const ChartMap = (
     baseLayer: BaseLayer;
   }
 ) => {
-  const { chartConfig, data, dimensions, measures, features, baseLayer } =
-    props;
+  const {
+    chartConfig,
+    chartData,
+    scalesData,
+    dimensions,
+    measures,
+    features,
+    baseLayer,
+  } = props;
 
   return (
     <MapChart
       chartConfig={chartConfig}
-      data={data}
+      chartData={chartData}
+      scalesData={scalesData}
       dimensions={dimensions}
       measures={measures}
       features={features}

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -246,33 +246,12 @@ export const ChartMapVisualization = ({
 };
 
 export const ChartMap = (
-  props: ChartProps<MapConfig> & {
-    features: GeoData;
-    baseLayer: BaseLayer;
-  }
+  props: ChartProps<MapConfig> & { features: GeoData; baseLayer: BaseLayer }
 ) => {
-  const {
-    chartConfig,
-    chartData,
-    scalesData,
-    allData,
-    dimensions,
-    measures,
-    features,
-    baseLayer,
-  } = props;
+  const { chartConfig } = props;
 
   return (
-    <MapChart
-      chartConfig={chartConfig}
-      chartData={chartData}
-      scalesData={scalesData}
-      allData={allData}
-      dimensions={dimensions}
-      measures={measures}
-      features={features}
-      baseLayer={baseLayer}
-    >
+    <MapChart {...props}>
       <ChartContainer>
         <MapComponent />
         <MapTooltip />

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -9,7 +9,10 @@ import { MapComponent } from "@/charts/map/map";
 import { MapLegend } from "@/charts/map/map-legend";
 import { MapChart } from "@/charts/map/map-state";
 import { MapTooltip } from "@/charts/map/map-tooltip";
-import { getChartConfigComponentIris } from "@/charts/shared/chart-helpers";
+import {
+  extractComponentIris,
+  useDataAfterInteractiveFilters,
+} from "@/charts/shared/chart-helpers";
 import { ChartContainer } from "@/charts/shared/containers";
 import { BaseLayer, DataSource, MapConfig, QueryFilters } from "@/config-types";
 import {

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -9,10 +9,7 @@ import { MapComponent } from "@/charts/map/map";
 import { MapLegend } from "@/charts/map/map-legend";
 import { MapChart } from "@/charts/map/map-state";
 import { MapTooltip } from "@/charts/map/map-tooltip";
-import {
-  extractComponentIris,
-  useDataAfterInteractiveFilters,
-} from "@/charts/shared/chart-helpers";
+import { extractComponentIris } from "@/charts/shared/chart-helpers";
 import { ChartContainer } from "@/charts/shared/containers";
 import { BaseLayer, DataSource, MapConfig, QueryFilters } from "@/config-types";
 import {
@@ -20,13 +17,11 @@ import {
   GeoData,
   GeoPoint,
   GeoShapes,
-  Observation,
   SymbolLayer,
   isGeoCoordinatesDimension,
   isGeoShapesDimension,
 } from "@/domain/data";
 import {
-  DimensionMetadataFragment,
   useComponentsQuery,
   useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
@@ -34,6 +29,8 @@ import {
   useGeoShapesByDimensionIriQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
+
+import { ChartProps } from "../shared/ChartProps";
 
 export const ChartMapVisualization = ({
   dataSetIri,
@@ -51,33 +48,28 @@ export const ChartMapVisualization = ({
   const locale = useLocale();
   const areaDimensionIri = chartConfig.fields.areaLayer?.componentIri || "";
   const symbolDimensionIri = chartConfig.fields.symbolLayer?.componentIri || "";
-  const componentIrisToFilterBy = published
-    ? getChartConfigComponentIris(chartConfig)
+  const commonQueryVariables = {
+    iri: dataSetIri,
+    sourceType: dataSource.type,
+    sourceUrl: dataSource.url,
+    locale,
+  };
+  const componentIris = published
+    ? extractComponentIris(chartConfig)
     : undefined;
   const [metadataQuery] = useDataCubeMetadataQuery({
-    variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-    },
+    variables: commonQueryVariables,
   });
   const [componentsQuery] = useComponentsQuery({
     variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-      componentIris: componentIrisToFilterBy,
+      ...commonQueryVariables,
+      componentIris,
     },
   });
   const [observationsQuery] = useDataCubeObservationsQuery({
     variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-      componentIris: componentIrisToFilterBy,
+      ...commonQueryVariables,
+      componentIris,
       filters: queryFilters,
     },
   });
@@ -253,29 +245,23 @@ export const ChartMapVisualization = ({
   );
 };
 
-export const ChartMap = ({
-  observations,
-  features,
-  chartConfig,
-  measures,
-  dimensions,
-  baseLayer,
-}: {
-  features: GeoData;
-  observations: Observation[];
-  measures: DimensionMetadataFragment[];
-  dimensions: DimensionMetadataFragment[];
-  chartConfig: MapConfig;
-  baseLayer: BaseLayer;
-}) => {
+export const ChartMap = (
+  props: ChartProps<MapConfig> & {
+    features: GeoData;
+    baseLayer: BaseLayer;
+  }
+) => {
+  const { chartConfig, data, dimensions, measures, features, baseLayer } =
+    props;
+
   return (
     <MapChart
-      data={observations}
-      features={features}
-      measures={measures}
-      dimensions={dimensions}
-      baseLayer={baseLayer}
       chartConfig={chartConfig}
+      data={data}
+      dimensions={dimensions}
+      measures={measures}
+      features={features}
+      baseLayer={baseLayer}
     >
       <ChartContainer>
         <MapComponent />

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -255,6 +255,7 @@ export const ChartMap = (
     chartConfig,
     chartData,
     scalesData,
+    allData,
     dimensions,
     measures,
     features,
@@ -266,6 +267,7 @@ export const ChartMap = (
       chartConfig={chartConfig}
       chartData={chartData}
       scalesData={scalesData}
+      allData={allData}
       dimensions={dimensions}
       measures={measures}
       features={features}

--- a/app/charts/map/map-state.tsx
+++ b/app/charts/map/map-state.tsx
@@ -29,7 +29,10 @@ import {
   useOptionalNumericVariable,
   useStringVariable,
 } from "@/charts/shared/chart-helpers";
-import { CommonChartState } from "@/charts/shared/chart-state";
+import {
+  ChartStateMetadata,
+  CommonChartState,
+} from "@/charts/shared/chart-state";
 import { colorToRgbArray } from "@/charts/shared/colors";
 import { ChartContext } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
@@ -575,6 +578,14 @@ const useMapState = (
     identicalLayerComponentIris,
     areaLayer: preparedAreaLayerState,
     symbolLayer: preparedSymbolLayerState,
+  };
+};
+
+export const getMapStateMetadata = (): ChartStateMetadata => {
+  return {
+    sortData: (data) => {
+      return data;
+    },
   };
 };
 

--- a/app/charts/map/map-state.tsx
+++ b/app/charts/map/map-state.tsx
@@ -583,6 +583,7 @@ const useMapState = (
 
 export const getMapStateMetadata = (): ChartStateMetadata => {
   return {
+    assureDefined: {},
     sortData: (data) => {
       return data;
     },
@@ -590,11 +591,12 @@ export const getMapStateMetadata = (): ChartStateMetadata => {
 };
 
 const MapChartProvider = ({
-  data,
-  features,
   chartConfig,
-  measures,
+  chartData,
+  scalesData,
   dimensions,
+  measures,
+  features,
   baseLayer,
   children,
 }: React.PropsWithChildren<
@@ -602,7 +604,8 @@ const MapChartProvider = ({
 >) => {
   const state = useMapState({
     chartConfig,
-    data,
+    chartData,
+    scalesData,
     dimensions,
     measures,
     features,
@@ -615,11 +618,12 @@ const MapChartProvider = ({
 };
 
 export const MapChart = ({
-  data,
-  features,
-  measures,
   chartConfig,
+  chartData,
+  scalesData,
   dimensions,
+  measures,
+  features,
   baseLayer,
   children,
 }: React.PropsWithChildren<
@@ -629,11 +633,12 @@ export const MapChart = ({
     <Observer>
       <InteractionProvider>
         <MapChartProvider
-          data={data}
-          features={features}
           chartConfig={chartConfig}
-          measures={measures}
+          chartData={chartData}
+          scalesData={scalesData}
+          features={features}
           dimensions={dimensions}
+          measures={measures}
           baseLayer={baseLayer}
         >
           <MapTooltipProvider>{children}</MapTooltipProvider>

--- a/app/charts/map/map-state.tsx
+++ b/app/charts/map/map-state.tsx
@@ -466,6 +466,7 @@ const useMapState = (
   const { fields } = chartConfig;
   const { areaLayer, symbolLayer } = fields;
 
+  // FIXME: use scales data for colors.
   const areaLayerState = useLayerState({
     componentIri: areaLayer?.componentIri,
     measureIri: areaLayer?.color.componentIri,
@@ -598,61 +599,30 @@ export const getMapStateMetadata = (): ChartStateMetadata => {
   };
 };
 
-const MapChartProvider = ({
-  chartConfig,
-  chartData,
-  scalesData,
-  allData,
-  dimensions,
-  measures,
-  features,
-  baseLayer,
-  children,
-}: React.PropsWithChildren<
-  ChartProps<MapConfig> & { features: GeoData; baseLayer: BaseLayer }
->) => {
-  const state = useMapState({
-    chartConfig,
-    chartData,
-    scalesData,
-    allData,
-    dimensions,
-    measures,
-    features,
-    baseLayer,
-  });
+const MapChartProvider = (
+  props: React.PropsWithChildren<
+    ChartProps<MapConfig> & { features: GeoData; baseLayer: BaseLayer }
+  >
+) => {
+  const { children, ...rest } = props;
+  const state = useMapState(rest);
 
   return (
     <ChartContext.Provider value={state}>{children}</ChartContext.Provider>
   );
 };
 
-export const MapChart = ({
-  chartConfig,
-  chartData,
-  scalesData,
-  allData,
-  dimensions,
-  measures,
-  features,
-  baseLayer,
-  children,
-}: React.PropsWithChildren<
-  ChartProps<MapConfig> & { features: GeoData; baseLayer: BaseLayer }
->) => {
+export const MapChart = (
+  props: React.PropsWithChildren<
+    ChartProps<MapConfig> & { features: GeoData; baseLayer: BaseLayer }
+  >
+) => {
+  const { children, ...rest } = props;
+
   return (
     <Observer>
       <InteractionProvider>
-        <MapChartProvider
-          chartConfig={chartConfig}
-          chartData={chartData}
-          scalesData={scalesData}
-          allData={allData}
-          features={features}
-          dimensions={dimensions}
-          measures={measures}
-          baseLayer={baseLayer}
-        >
+        <MapChartProvider {...rest}>
           <MapTooltipProvider>{children}</MapTooltipProvider>
         </MapChartProvider>
       </InteractionProvider>

--- a/app/charts/map/map-state.tsx
+++ b/app/charts/map/map-state.tsx
@@ -454,15 +454,22 @@ const useMapState = (
   props: ChartProps<MapConfig> & { features: GeoData; baseLayer: BaseLayer }
 ): MapState => {
   const width = useWidth();
-  const { data, features, chartConfig, measures, dimensions, baseLayer } =
-    props;
+  const {
+    chartData,
+    allData,
+    features,
+    chartConfig,
+    measures,
+    dimensions,
+    baseLayer,
+  } = props;
   const { fields } = chartConfig;
   const { areaLayer, symbolLayer } = fields;
 
   const areaLayerState = useLayerState({
     componentIri: areaLayer?.componentIri,
     measureIri: areaLayer?.color.componentIri,
-    data,
+    data: chartData,
     features,
     dimensions,
     measures,
@@ -491,7 +498,7 @@ const useMapState = (
   const symbolLayerState = useLayerState({
     componentIri: symbolLayer?.componentIri,
     measureIri: symbolLayer?.measureIri,
-    data,
+    data: chartData,
     features,
     dimensions,
     measures,
@@ -569,6 +576,7 @@ const useMapState = (
 
   return {
     chartType: "map",
+    allData,
     bounds,
     features,
     showBaseLayer: baseLayer.show,
@@ -594,6 +602,7 @@ const MapChartProvider = ({
   chartConfig,
   chartData,
   scalesData,
+  allData,
   dimensions,
   measures,
   features,
@@ -606,6 +615,7 @@ const MapChartProvider = ({
     chartConfig,
     chartData,
     scalesData,
+    allData,
     dimensions,
     measures,
     features,
@@ -621,6 +631,7 @@ export const MapChart = ({
   chartConfig,
   chartData,
   scalesData,
+  allData,
   dimensions,
   measures,
   features,
@@ -636,6 +647,7 @@ export const MapChart = ({
           chartConfig={chartConfig}
           chartData={chartData}
           scalesData={scalesData}
+          allData={allData}
           features={features}
           dimensions={dimensions}
           measures={measures}

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -71,9 +71,9 @@ export const ChartPieVisualization = ({
 };
 
 export const ChartPie = memo((props: ChartProps<PieConfig>) => {
-  const { chartConfig, data, dimensions, measures } = props;
+  const { chartConfig, chartData, scalesData, dimensions, measures } = props;
   const { fields, interactiveFiltersConfig } = chartConfig;
-  const somePositive = data.some(
+  const somePositive = chartData.some(
     (d) => (d[fields?.y?.componentIri] as number) > 0
   );
 
@@ -84,7 +84,8 @@ export const ChartPie = memo((props: ChartProps<PieConfig>) => {
   return (
     <PieChart
       chartConfig={chartConfig}
-      data={data}
+      chartData={chartData}
+      scalesData={scalesData}
       dimensions={dimensions}
       measures={measures}
       aspectRatio={0.5}

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -10,14 +10,14 @@ import { LegendColor } from "@/charts/shared/legend-color";
 import { OnlyNegativeDataHint } from "@/components/hint";
 import { DataSource, PieConfig, QueryFilters } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
-import { Observation } from "@/domain/data";
 import {
-  DimensionMetadataFragment,
   useComponentsQuery,
   useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
+
+import { ChartProps } from "../shared/ChartProps";
 
 export const ChartPieVisualization = ({
   dataSetIri,
@@ -70,59 +70,47 @@ export const ChartPieVisualization = ({
   );
 };
 
-export const ChartPie = memo(
-  ({
-    observations,
-    dimensions,
-    measures,
-    chartConfig,
-  }: {
-    observations: Observation[];
-    dimensions: DimensionMetadataFragment[];
-    measures: DimensionMetadataFragment[];
-    chartConfig: PieConfig;
-  }) => {
-    const { fields } = chartConfig;
-    const somePositive = observations.some(
-      (d) => (d[fields?.y?.componentIri] as number) > 0
-    );
+export const ChartPie = memo((props: ChartProps<PieConfig>) => {
+  const { chartConfig, data, dimensions, measures } = props;
+  const { fields, interactiveFiltersConfig } = chartConfig;
+  const somePositive = data.some(
+    (d) => (d[fields?.y?.componentIri] as number) > 0
+  );
 
-    if (!somePositive) {
-      return <OnlyNegativeDataHint />;
-    }
-
-    const { interactiveFiltersConfig } = chartConfig;
-    return (
-      <PieChart
-        data={observations}
-        dimensions={dimensions}
-        measures={measures}
-        chartConfig={chartConfig}
-        aspectRatio={0.5}
-      >
-        <ChartContainer>
-          <ChartSvg>
-            <Pie />
-          </ChartSvg>
-          <Tooltip type="single" />
-        </ChartContainer>
-        <LegendColor
-          symbol="square"
-          interactive={
-            fields.segment && interactiveFiltersConfig?.legend.active === true
-          }
-        />
-
-        {fields.animation && (
-          <TimeSlider
-            componentIri={fields.animation.componentIri}
-            dimensions={dimensions}
-            showPlayButton={fields.animation.showPlayButton}
-            animationDuration={fields.animation.duration}
-            animationType={fields.animation.type}
-          />
-        )}
-      </PieChart>
-    );
+  if (!somePositive) {
+    return <OnlyNegativeDataHint />;
   }
-);
+
+  return (
+    <PieChart
+      chartConfig={chartConfig}
+      data={data}
+      dimensions={dimensions}
+      measures={measures}
+      aspectRatio={0.5}
+    >
+      <ChartContainer>
+        <ChartSvg>
+          <Pie />
+        </ChartSvg>
+        <Tooltip type="single" />
+      </ChartContainer>
+      <LegendColor
+        symbol="square"
+        interactive={
+          fields.segment && interactiveFiltersConfig?.legend.active === true
+        }
+      />
+
+      {fields.animation && (
+        <TimeSlider
+          componentIri={fields.animation.componentIri}
+          dimensions={dimensions}
+          showPlayButton={fields.animation.showPlayButton}
+          animationDuration={fields.animation.duration}
+          animationType={fields.animation.type}
+        />
+      )}
+    </PieChart>
+  );
+});

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -71,7 +71,8 @@ export const ChartPieVisualization = ({
 };
 
 export const ChartPie = memo((props: ChartProps<PieConfig>) => {
-  const { chartConfig, chartData, scalesData, dimensions, measures } = props;
+  const { chartConfig, chartData, scalesData, allData, dimensions, measures } =
+    props;
   const { fields, interactiveFiltersConfig } = chartConfig;
   const somePositive = chartData.some(
     (d) => (d[fields?.y?.componentIri] as number) > 0
@@ -86,6 +87,7 @@ export const ChartPie = memo((props: ChartProps<PieConfig>) => {
       chartConfig={chartConfig}
       chartData={chartData}
       scalesData={scalesData}
+      allData={allData}
       dimensions={dimensions}
       measures={measures}
       aspectRatio={0.5}

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -3,7 +3,7 @@ import { memo } from "react";
 import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
 import { Pie } from "@/charts/pie/pie";
 import { PieChart } from "@/charts/pie/pie-state";
-import { getChartConfigComponentIris } from "@/charts/shared/chart-helpers";
+import { extractComponentIris } from "@/charts/shared/chart-helpers";
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
@@ -33,33 +33,28 @@ export const ChartPieVisualization = ({
   published: boolean;
 }) => {
   const locale = useLocale();
-  const componentIrisToFilterBy = published
-    ? getChartConfigComponentIris(chartConfig)
+  const componentIris = published
+    ? extractComponentIris(chartConfig)
     : undefined;
+  const commonQueryVariables = {
+    iri: dataSetIri,
+    sourceType: dataSource.type,
+    sourceUrl: dataSource.url,
+    locale,
+  };
   const [metadataQuery] = useDataCubeMetadataQuery({
-    variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-    },
+    variables: commonQueryVariables,
   });
   const [componentsQuery] = useComponentsQuery({
     variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-      componentIris: componentIrisToFilterBy,
+      ...commonQueryVariables,
+      componentIris,
     },
   });
   const [observationsQuery] = useDataCubeObservationsQuery({
     variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-      componentIris: componentIrisToFilterBy,
+      ...commonQueryVariables,
+      componentIris,
       filters: queryFilters,
     },
   });

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -71,27 +71,21 @@ export const ChartPieVisualization = ({
 };
 
 export const ChartPie = memo((props: ChartProps<PieConfig>) => {
-  const { chartConfig, chartData, scalesData, allData, dimensions, measures } =
-    props;
+  const { chartConfig, chartData, dimensions } = props;
   const { fields, interactiveFiltersConfig } = chartConfig;
-  const somePositive = chartData.some(
-    (d) => (d[fields?.y?.componentIri] as number) > 0
-  );
+  // Allow displaying empty chart, which might be the case when animating
+  // by time and there is no data for a given step.
+  const somePositive =
+    chartData.length > 0
+      ? chartData.some((d) => (d[fields?.y?.componentIri] as number) > 0)
+      : true;
 
   if (!somePositive) {
     return <OnlyNegativeDataHint />;
   }
 
   return (
-    <PieChart
-      chartConfig={chartConfig}
-      chartData={chartData}
-      scalesData={scalesData}
-      allData={allData}
-      dimensions={dimensions}
-      measures={measures}
-      aspectRatio={0.5}
-    >
+    <PieChart aspectRatio={0.5} {...props}>
       <ChartContainer>
         <ChartSvg>
           <Pie />

--- a/app/charts/pie/pie-state.tsx
+++ b/app/charts/pie/pie-state.tsx
@@ -99,7 +99,7 @@ const usePieState = (
 
   // Data for chart
   const { preparedData } = useDataAfterInteractiveFilters({
-    sortedData: plottableData,
+    observations: plottableData,
     interactiveFiltersConfig,
     animationField: fields.animation,
     getSegment: getSegmentAbbreviationOrLabel,

--- a/app/charts/pie/pie-state.tsx
+++ b/app/charts/pie/pie-state.tsx
@@ -10,18 +10,21 @@ import {
 import orderBy from "lodash/orderBy";
 import { useMemo } from "react";
 
+import { useMaybeAbbreviations } from "@/charts/shared/abbreviations";
 import {
   useDataAfterInteractiveFilters,
   useOptionalNumericVariable,
   usePlottableData,
 } from "@/charts/shared/chart-helpers";
-import { CommonChartState } from "@/charts/shared/chart-state";
+import {
+  ChartStateMetadata,
+  CommonChartState,
+} from "@/charts/shared/chart-state";
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
-import { useMaybeAbbreviations } from "@/charts/shared/use-abbreviations";
+import { useObservationLabels } from "@/charts/shared/observation-labels";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { ChartContext } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
-import { useObservationLabels } from "@/charts/shared/use-observation-labels";
 import { Observer, useWidth } from "@/charts/shared/use-width";
 import { PieConfig } from "@/configurator";
 import { Observation } from "@/domain/data";
@@ -262,6 +265,14 @@ const usePieState = (
     colors,
     getAnnotationInfo,
     getSegmentLabel,
+  };
+};
+
+export const getPieStateMetadata = (): ChartStateMetadata => {
+  return {
+    sortData: (data) => {
+      return data;
+    },
   };
 };
 

--- a/app/charts/pie/pie-state.tsx
+++ b/app/charts/pie/pie-state.tsx
@@ -309,10 +309,11 @@ export const getPieStateMetadata = (
 };
 
 const PieChartProvider = ({
-  data,
+  chartConfig,
+  chartData,
+  scalesData,
   dimensions,
   measures,
-  chartConfig,
   aspectRatio,
   children,
 }: React.PropsWithChildren<
@@ -320,7 +321,8 @@ const PieChartProvider = ({
 >) => {
   const state = usePieState({
     chartConfig,
-    data,
+    chartData,
+    scalesData,
     dimensions,
     measures,
     aspectRatio,
@@ -333,7 +335,8 @@ const PieChartProvider = ({
 
 export const PieChart = ({
   chartConfig,
-  data,
+  chartData,
+  scalesData,
   dimensions,
   measures,
   aspectRatio,
@@ -345,10 +348,11 @@ export const PieChart = ({
     <Observer>
       <InteractionProvider>
         <PieChartProvider
-          data={data}
+          chartConfig={chartConfig}
+          chartData={chartData}
+          scalesData={scalesData}
           dimensions={dimensions}
           measures={measures}
-          chartConfig={chartConfig}
           aspectRatio={aspectRatio}
         >
           {children}

--- a/app/charts/pie/pie-state.tsx
+++ b/app/charts/pie/pie-state.tsx
@@ -57,6 +57,7 @@ const usePieState = (
   const {
     chartData,
     scalesData,
+    segmentData,
     allData,
     dimensions,
     measures,
@@ -108,7 +109,7 @@ const usePieState = (
   const colors = useMemo(() => {
     const colors = scaleOrdinal<string, string>();
     const measureBySegment = Object.fromEntries(
-      scalesData.map((d) => [getSegment(d), getY(d)])
+      segmentData.map((d) => [getSegment(d), getY(d)])
     );
     const allUniqueSegments = Object.entries(measureBySegment)
       .filter((x) => typeof x[1] === "number")
@@ -156,7 +157,7 @@ const usePieState = (
     fields.segment,
     getSegment,
     getY,
-    scalesData,
+    segmentData,
     segmentDimension,
     segmentsByAbbreviationOrLabel,
     segmentsByValue,
@@ -305,59 +306,28 @@ export const getPieStateMetadata = (
   };
 };
 
-const PieChartProvider = ({
-  chartConfig,
-  chartData,
-  scalesData,
-  allData,
-  dimensions,
-  measures,
-  aspectRatio,
-  children,
-}: React.PropsWithChildren<
-  ChartProps<PieConfig> & { aspectRatio: number }
->) => {
-  const state = usePieState({
-    chartConfig,
-    chartData,
-    scalesData,
-    allData,
-    dimensions,
-    measures,
-    aspectRatio,
-  });
+const PieChartProvider = (
+  props: React.PropsWithChildren<
+    ChartProps<PieConfig> & { aspectRatio: number }
+  >
+) => {
+  const { children, ...rest } = props;
+  const state = usePieState(rest);
 
   return (
     <ChartContext.Provider value={state}>{children}</ChartContext.Provider>
   );
 };
 
-export const PieChart = ({
-  chartConfig,
-  chartData,
-  scalesData,
-  allData,
-  dimensions,
-  measures,
-  aspectRatio,
-  children,
-}: React.PropsWithChildren<
-  ChartProps<PieConfig> & { aspectRatio: number }
->) => {
+export const PieChart = (
+  props: React.PropsWithChildren<
+    ChartProps<PieConfig> & { aspectRatio: number }
+  >
+) => {
   return (
     <Observer>
       <InteractionProvider>
-        <PieChartProvider
-          chartConfig={chartConfig}
-          chartData={chartData}
-          scalesData={scalesData}
-          allData={allData}
-          dimensions={dimensions}
-          measures={measures}
-          aspectRatio={aspectRatio}
-        >
-          {children}
-        </PieChartProvider>
+        <PieChartProvider {...props} />
       </InteractionProvider>
     </Observer>
   );

--- a/app/charts/pie/pie-state.tsx
+++ b/app/charts/pie/pie-state.tsx
@@ -8,7 +8,7 @@ import {
   scaleOrdinal,
 } from "d3";
 import orderBy from "lodash/orderBy";
-import { ReactNode, useMemo } from "react";
+import { useMemo } from "react";
 
 import {
   useDataAfterInteractiveFilters,
@@ -47,13 +47,10 @@ export interface PieState extends CommonChartState {
 }
 
 const usePieState = (
-  chartProps: Pick<ChartProps, "data" | "dimensions" | "measures"> & {
-    chartConfig: PieConfig;
-    aspectRatio: number;
-  }
+  props: ChartProps<PieConfig> & { aspectRatio: number }
 ): PieState => {
-  const { data, dimensions, measures, chartConfig, aspectRatio } = chartProps;
-  const { interactiveFiltersConfig, fields } = chartConfig;
+  const { data, dimensions, measures, chartConfig, aspectRatio } = props;
+  const { fields, interactiveFiltersConfig } = chartConfig;
   const width = useWidth();
   const formatNumber = useFormatNumber();
 
@@ -211,7 +208,7 @@ const usePieState = (
     .value((d) => getY(d) ?? NaN)
     .sort(pieSorter);
 
-  const formatters = useChartFormatters(chartProps);
+  const formatters = useChartFormatters(props);
   const valueFormatter = (value: number | null) =>
     formatNumberWithUnit(
       value,
@@ -275,35 +272,32 @@ const PieChartProvider = ({
   chartConfig,
   aspectRatio,
   children,
-}: Pick<ChartProps, "data" | "dimensions" | "measures"> & {
-  children: ReactNode;
-  chartConfig: PieConfig;
-  aspectRatio: number;
-}) => {
+}: React.PropsWithChildren<
+  ChartProps<PieConfig> & { aspectRatio: number }
+>) => {
   const state = usePieState({
+    chartConfig,
     data,
     dimensions,
     measures,
-    chartConfig,
     aspectRatio,
   });
+
   return (
     <ChartContext.Provider value={state}>{children}</ChartContext.Provider>
   );
 };
 
 export const PieChart = ({
-  data,
-  measures,
-  dimensions,
-  aspectRatio,
   chartConfig,
+  data,
+  dimensions,
+  measures,
+  aspectRatio,
   children,
-}: Pick<ChartProps, "data" | "dimensions" | "measures"> & {
-  aspectRatio: number;
-  chartConfig: PieConfig;
-  children: ReactNode;
-}) => {
+}: React.PropsWithChildren<
+  ChartProps<PieConfig> & { aspectRatio: number }
+>) => {
   return (
     <Observer>
       <InteractionProvider>

--- a/app/charts/pie/pie.tsx
+++ b/app/charts/pie/pie.tsx
@@ -6,11 +6,11 @@ import { useInteraction } from "@/charts/shared/use-interaction";
 import { Observation } from "@/domain/data";
 
 export const Pie = () => {
-  const { preparedData, getPieData, getX, colors, bounds } =
+  const { chartData, getPieData, getX, colors, bounds } =
     useChartState() as PieState;
   const { width, height, chartWidth, chartHeight } = bounds;
 
-  const arcs = getPieData(preparedData);
+  const arcs = getPieData(chartData);
 
   const maxSide = Math.min(chartWidth, chartHeight) / 2;
 

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -79,15 +79,16 @@ export const ChartScatterplotVisualization = ({
 };
 
 export const ChartScatterplot = memo((props: ChartProps<ScatterPlotConfig>) => {
-  const { chartConfig, data, dimensions, measures } = props;
+  const { chartConfig, chartData, scalesData, dimensions, measures } = props;
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   return (
     <ScatterplotChart
-      data={data}
+      chartConfig={chartConfig}
+      chartData={chartData}
+      scalesData={scalesData}
       dimensions={dimensions}
       measures={measures}
-      chartConfig={chartConfig}
       aspectRatio={1}
     >
       <ChartContainer>

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -79,7 +79,8 @@ export const ChartScatterplotVisualization = ({
 };
 
 export const ChartScatterplot = memo((props: ChartProps<ScatterPlotConfig>) => {
-  const { chartConfig, chartData, scalesData, dimensions, measures } = props;
+  const { chartConfig, chartData, scalesData, allData, dimensions, measures } =
+    props;
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   return (
@@ -87,6 +88,7 @@ export const ChartScatterplot = memo((props: ChartProps<ScatterPlotConfig>) => {
       chartConfig={chartConfig}
       chartData={chartData}
       scalesData={scalesData}
+      allData={allData}
       dimensions={dimensions}
       measures={measures}
       aspectRatio={1}

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -11,7 +11,7 @@ import {
   AxisWidthLinear,
   AxisWidthLinearDomain,
 } from "@/charts/shared/axis-width-linear";
-import { getChartConfigComponentIris } from "@/charts/shared/chart-helpers";
+import { extractComponentIris } from "@/charts/shared/chart-helpers";
 import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
@@ -41,33 +41,28 @@ export const ChartScatterplotVisualization = ({
   published: boolean;
 }) => {
   const locale = useLocale();
-  const componentIrisToFilterBy = published
-    ? getChartConfigComponentIris(chartConfig)
+  const componentIris = published
+    ? extractComponentIris(chartConfig)
     : undefined;
+  const commonQueryVariables = {
+    iri: dataSetIri,
+    sourceType: dataSource.type,
+    sourceUrl: dataSource.url,
+    locale,
+  };
   const [metadataQuery] = useDataCubeMetadataQuery({
-    variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-    },
+    variables: commonQueryVariables,
   });
   const [componentsQuery] = useComponentsQuery({
     variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-      componentIris: componentIrisToFilterBy,
+      ...commonQueryVariables,
+      componentIris,
     },
   });
   const [observationsQuery] = useDataCubeObservationsQuery({
     variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-      componentIris: componentIrisToFilterBy,
+      ...commonQueryVariables,
+      componentIris,
       filters: queryFilters,
     },
   });

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -18,14 +18,14 @@ import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionVoronoi } from "@/charts/shared/overlay-voronoi";
 import { DataSource, QueryFilters, ScatterPlotConfig } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
-import { Observation } from "@/domain/data";
 import {
-  DimensionMetadataFragment,
   useComponentsQuery,
   useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
+
+import { ChartProps } from "../shared/ChartProps";
 
 export const ChartScatterplotVisualization = ({
   dataSetIri,
@@ -78,56 +78,46 @@ export const ChartScatterplotVisualization = ({
   );
 };
 
-export const ChartScatterplot = memo(
-  ({
-    observations,
-    dimensions,
-    measures,
-    chartConfig,
-  }: {
-    observations: Observation[];
-    dimensions: DimensionMetadataFragment[];
-    measures: DimensionMetadataFragment[];
-    chartConfig: ScatterPlotConfig;
-  }) => {
-    const { interactiveFiltersConfig, fields } = chartConfig;
-    return (
-      <ScatterplotChart
-        data={observations}
-        dimensions={dimensions}
-        measures={measures}
-        chartConfig={chartConfig}
-        aspectRatio={1}
-      >
-        <ChartContainer>
-          <ChartSvg>
-            <AxisWidthLinear />
-            <AxisHeightLinear />
-            <AxisWidthLinearDomain />
-            <AxisHeightLinearDomain />
-            <Scatterplot />
-            <InteractionVoronoi />
-          </ChartSvg>
-          <Tooltip type="single" />
-        </ChartContainer>
+export const ChartScatterplot = memo((props: ChartProps<ScatterPlotConfig>) => {
+  const { chartConfig, data, dimensions, measures } = props;
+  const { fields, interactiveFiltersConfig } = chartConfig;
 
-        <LegendColor
-          symbol="circle"
-          interactive={
-            fields.segment && interactiveFiltersConfig?.legend.active === true
-          }
+  return (
+    <ScatterplotChart
+      data={data}
+      dimensions={dimensions}
+      measures={measures}
+      chartConfig={chartConfig}
+      aspectRatio={1}
+    >
+      <ChartContainer>
+        <ChartSvg>
+          <AxisWidthLinear />
+          <AxisHeightLinear />
+          <AxisWidthLinearDomain />
+          <AxisHeightLinearDomain />
+          <Scatterplot />
+          <InteractionVoronoi />
+        </ChartSvg>
+        <Tooltip type="single" />
+      </ChartContainer>
+
+      <LegendColor
+        symbol="circle"
+        interactive={
+          fields.segment && interactiveFiltersConfig?.legend.active === true
+        }
+      />
+
+      {fields.animation && (
+        <TimeSlider
+          componentIri={fields.animation.componentIri}
+          dimensions={dimensions}
+          showPlayButton={fields.animation.showPlayButton}
+          animationDuration={fields.animation.duration}
+          animationType={fields.animation.type}
         />
-
-        {fields.animation && (
-          <TimeSlider
-            componentIri={fields.animation.componentIri}
-            dimensions={dimensions}
-            showPlayButton={fields.animation.showPlayButton}
-            animationDuration={fields.animation.duration}
-            animationType={fields.animation.type}
-          />
-        )}
-      </ScatterplotChart>
-    );
-  }
-);
+      )}
+    </ScatterplotChart>
+  );
+});

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -79,20 +79,11 @@ export const ChartScatterplotVisualization = ({
 };
 
 export const ChartScatterplot = memo((props: ChartProps<ScatterPlotConfig>) => {
-  const { chartConfig, chartData, scalesData, allData, dimensions, measures } =
-    props;
+  const { chartConfig, dimensions } = props;
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   return (
-    <ScatterplotChart
-      chartConfig={chartConfig}
-      chartData={chartData}
-      scalesData={scalesData}
-      allData={allData}
-      dimensions={dimensions}
-      measures={measures}
-      aspectRatio={1}
-    >
+    <ScatterplotChart aspectRatio={1} {...props}>
       <ChartContainer>
         <ChartSvg>
           <AxisWidthLinear />

--- a/app/charts/scatterplot/scatterplot-simple.tsx
+++ b/app/charts/scatterplot/scatterplot-simple.tsx
@@ -6,7 +6,7 @@ import { useTheme } from "@/themes";
 
 export const Scatterplot = () => {
   const {
-    preparedData,
+    chartData,
     bounds,
     getX,
     xScale,
@@ -22,7 +22,7 @@ export const Scatterplot = () => {
 
   return (
     <g transform={`translate(${margins.left} ${margins.top})`}>
-      {preparedData.map((d, i) => {
+      {chartData.map((d, i) => {
         return (
           <Dot
             key={i}

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -303,10 +303,11 @@ export const getScatterplotStateMetadata = (
 };
 
 const ScatterplotChartProvider = ({
-  data,
+  chartConfig,
+  chartData,
+  scalesData,
   dimensions,
   measures,
-  chartConfig,
   aspectRatio,
   children,
 }: React.PropsWithChildren<
@@ -314,7 +315,8 @@ const ScatterplotChartProvider = ({
 >) => {
   const state = useScatterplotState({
     chartConfig,
-    data,
+    chartData,
+    scalesData,
     dimensions,
     measures,
     aspectRatio,
@@ -327,7 +329,8 @@ const ScatterplotChartProvider = ({
 
 export const ScatterplotChart = ({
   chartConfig,
-  data,
+  chartData,
+  scalesData,
   dimensions,
   measures,
   aspectRatio,
@@ -339,10 +342,11 @@ export const ScatterplotChart = ({
     <Observer>
       <InteractionProvider>
         <ScatterplotChartProvider
-          data={data}
+          chartConfig={chartConfig}
+          chartData={chartData}
+          scalesData={scalesData}
           dimensions={dimensions}
           measures={measures}
-          chartConfig={chartConfig}
           aspectRatio={aspectRatio}
         >
           {children}

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -107,7 +107,7 @@ const useScatterplotState = ({
   // Data for chart
   const { interactiveFiltersConfig } = chartConfig;
   const { preparedData, scalesData } = useDataAfterInteractiveFilters({
-    sortedData: plottableSortedData,
+    observations: plottableSortedData,
     interactiveFiltersConfig,
     // No animation yet for scatterplot
     animationField: undefined,

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -7,7 +7,7 @@ import {
   ScaleOrdinal,
   scaleOrdinal,
 } from "d3";
-import { ReactNode, useMemo } from "react";
+import { useMemo } from "react";
 
 import { LEFT_MARGIN_OFFSET } from "@/charts/scatterplot/constants";
 import {
@@ -52,17 +52,11 @@ export interface ScatterplotState extends CommonChartState {
   getAnnotationInfo: (d: Observation, values: Observation[]) => TooltipInfo;
 }
 
-const useScatterplotState = ({
-  data,
-  dimensions,
-  measures,
-  chartConfig,
-  aspectRatio,
-}: Pick<ChartProps, "data" | "dimensions" | "measures"> & {
-  aspectRatio: number;
-  chartConfig: ScatterPlotConfig;
-}): ScatterplotState => {
+const useScatterplotState = (
+  props: ChartProps<ScatterPlotConfig> & { aspectRatio: number }
+): ScatterplotState => {
   const width = useWidth();
+  const { chartConfig, data, dimensions, measures, aspectRatio } = props;
   const { fields } = chartConfig;
   const formatNumber = useFormatNumber({ decimals: "auto" });
 
@@ -271,35 +265,32 @@ const ScatterplotChartProvider = ({
   chartConfig,
   aspectRatio,
   children,
-}: Pick<ChartProps, "data" | "dimensions" | "measures"> & {
-  children: ReactNode;
-  aspectRatio: number;
-  chartConfig: ScatterPlotConfig;
-}) => {
+}: React.PropsWithChildren<
+  ChartProps<ScatterPlotConfig> & { aspectRatio: number }
+>) => {
   const state = useScatterplotState({
+    chartConfig,
     data,
     dimensions,
     measures,
-    chartConfig,
     aspectRatio,
   });
+
   return (
     <ChartContext.Provider value={state}>{children}</ChartContext.Provider>
   );
 };
 
 export const ScatterplotChart = ({
+  chartConfig,
   data,
   dimensions,
   measures,
-  chartConfig,
   aspectRatio,
   children,
-}: Pick<ChartProps, "data" | "dimensions" | "measures"> & {
-  aspectRatio: number;
-  children: ReactNode;
-  chartConfig: ScatterPlotConfig;
-}) => {
+}: React.PropsWithChildren<
+  ChartProps<ScatterPlotConfig> & { aspectRatio: number }
+>) => {
   return (
     <Observer>
       <InteractionProvider>

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -70,6 +70,7 @@ const useScatterplotState = (
     chartConfig,
     chartData,
     scalesData,
+    segmentData,
     allData,
     dimensions,
     measures,
@@ -138,7 +139,7 @@ const useScatterplotState = (
     ? chartConfig.filters[segmentDimension.iri]
     : undefined;
   const allSegments = useMemo(() => {
-    const allUniqueSegments = [...new Set(scalesData.map(getSegment))];
+    const allUniqueSegments = Array.from(new Set(segmentData.map(getSegment)));
     const sorting = {
       sortingType: "byAuto",
       sortingOrder: "asc",
@@ -157,7 +158,7 @@ const useScatterplotState = (
   }, [
     fields.segment?.useAbbreviations,
     getSegment,
-    scalesData,
+    segmentData,
     segmentDimension,
     segmentFilter,
   ]);
@@ -328,59 +329,28 @@ export const getScatterplotStateMetadata = (
   };
 };
 
-const ScatterplotChartProvider = ({
-  chartConfig,
-  chartData,
-  scalesData,
-  allData,
-  dimensions,
-  measures,
-  aspectRatio,
-  children,
-}: React.PropsWithChildren<
-  ChartProps<ScatterPlotConfig> & { aspectRatio: number }
->) => {
-  const state = useScatterplotState({
-    chartConfig,
-    chartData,
-    scalesData,
-    allData,
-    dimensions,
-    measures,
-    aspectRatio,
-  });
+const ScatterplotChartProvider = (
+  props: React.PropsWithChildren<
+    ChartProps<ScatterPlotConfig> & { aspectRatio: number }
+  >
+) => {
+  const { children, ...rest } = props;
+  const state = useScatterplotState(rest);
 
   return (
     <ChartContext.Provider value={state}>{children}</ChartContext.Provider>
   );
 };
 
-export const ScatterplotChart = ({
-  chartConfig,
-  chartData,
-  scalesData,
-  allData,
-  dimensions,
-  measures,
-  aspectRatio,
-  children,
-}: React.PropsWithChildren<
-  ChartProps<ScatterPlotConfig> & { aspectRatio: number }
->) => {
+export const ScatterplotChart = (
+  props: React.PropsWithChildren<
+    ChartProps<ScatterPlotConfig> & { aspectRatio: number }
+  >
+) => {
   return (
     <Observer>
       <InteractionProvider>
-        <ScatterplotChartProvider
-          chartConfig={chartConfig}
-          chartData={chartData}
-          scalesData={scalesData}
-          allData={allData}
-          dimensions={dimensions}
-          measures={measures}
-          aspectRatio={aspectRatio}
-        >
-          {children}
-        </ScatterplotChartProvider>
+        <ScatterplotChartProvider {...props} />
       </InteractionProvider>
     </Observer>
   );

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -9,7 +9,10 @@ import {
 import { useMemo } from "react";
 
 import { LEFT_MARGIN_OFFSET } from "@/charts/scatterplot/constants";
-import { useMaybeAbbreviations } from "@/charts/shared/abbreviations";
+import {
+  getMaybeAbbreviations,
+  useMaybeAbbreviations,
+} from "@/charts/shared/abbreviations";
 import {
   getLabelWithUnit,
   useDataAfterInteractiveFilters,
@@ -22,7 +25,10 @@ import {
 } from "@/charts/shared/chart-state";
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
 import { TooltipScatterplot } from "@/charts/shared/interaction/tooltip-content";
-import { useObservationLabels } from "@/charts/shared/observation-labels";
+import {
+  getObservationLabels,
+  useObservationLabels,
+} from "@/charts/shared/observation-labels";
 import { ChartContext } from "@/charts/shared/use-chart-state";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { Observer, useWidth } from "@/charts/shared/use-width";
@@ -256,8 +262,31 @@ const useScatterplotState = (
   };
 };
 
-export const getScatterplotStateMetadata = (): ChartStateMetadata => {
+export const getScatterplotStateMetadata = (
+  chartConfig: ScatterPlotConfig,
+  observations: Observation[],
+  dimensions: DimensionMetadataFragment[]
+): ChartStateMetadata => {
+  const { fields } = chartConfig;
+  const segmentDimension = dimensions.find(
+    (d) => d.iri === fields.segment?.componentIri
+  );
+
+  const { getAbbreviationOrLabelByValue: getSegmentAbbreviationOrLabel } =
+    getMaybeAbbreviations({
+      useAbbreviations: fields.segment?.useAbbreviations,
+      dimensionIri: segmentDimension?.iri,
+      dimensionValues: segmentDimension?.values,
+    });
+
+  const { getValue: getSegment } = getObservationLabels(
+    observations,
+    getSegmentAbbreviationOrLabel,
+    fields.segment?.componentIri
+  );
+
   return {
+    getSegment,
     sortData: (data) => {
       return data;
     },

--- a/app/charts/shared/ChartProps.tsx
+++ b/app/charts/shared/ChartProps.tsx
@@ -3,8 +3,12 @@ import { Observation } from "@/domain/data";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 
 export type BaseChartProps = {
+  /** Data used to draw the shapes. */
   chartData: Observation[];
+  /** Data used to compute the scales. */
   scalesData: Observation[];
+  /** Non-filtered data used e.g. in timeline. */
+  allData: Observation[];
   dimensions: DimensionMetadataFragment[];
   measures: DimensionMetadataFragment[];
 };

--- a/app/charts/shared/ChartProps.tsx
+++ b/app/charts/shared/ChartProps.tsx
@@ -7,6 +7,8 @@ export type BaseChartProps = {
   chartData: Observation[];
   /** Data used to compute the scales. */
   scalesData: Observation[];
+  /** Data used for color scales. */
+  segmentData: Observation[];
   /** Non-filtered data used e.g. in timeline. */
   allData: Observation[];
   dimensions: DimensionMetadataFragment[];

--- a/app/charts/shared/ChartProps.tsx
+++ b/app/charts/shared/ChartProps.tsx
@@ -2,9 +2,12 @@ import { ChartConfig } from "@/configurator";
 import { Observation } from "@/domain/data";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 
-export interface ChartProps {
+export type BaseChartProps = {
   data: Observation[];
   dimensions: DimensionMetadataFragment[];
   measures: DimensionMetadataFragment[];
-  chartConfig: ChartConfig;
-}
+};
+
+export type ChartProps<TChartConfig extends ChartConfig> = BaseChartProps & {
+  chartConfig: TChartConfig;
+};

--- a/app/charts/shared/ChartProps.tsx
+++ b/app/charts/shared/ChartProps.tsx
@@ -3,7 +3,8 @@ import { Observation } from "@/domain/data";
 import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 
 export type BaseChartProps = {
-  data: Observation[];
+  chartData: Observation[];
+  scalesData: Observation[];
   dimensions: DimensionMetadataFragment[];
   measures: DimensionMetadataFragment[];
 };

--- a/app/charts/shared/abbreviations.ts
+++ b/app/charts/shared/abbreviations.ts
@@ -2,6 +2,61 @@ import React from "react";
 
 import { DimensionValue, Observation, ObservationValue } from "@/domain/data";
 
+export const getMaybeAbbreviations = ({
+  useAbbreviations,
+  dimensionIri,
+  dimensionValues,
+}: {
+  useAbbreviations: boolean | undefined;
+  dimensionIri: string | undefined;
+  dimensionValues: DimensionValue[] | undefined;
+}) => {
+  const values = dimensionValues ?? [];
+
+  const valueLookup = new Map<NonNullable<ObservationValue>, DimensionValue>();
+  const labelLookup = new Map<string, DimensionValue>();
+
+  for (const d of values) {
+    valueLookup.set(d.value, d);
+    labelLookup.set(d.label, d);
+  }
+
+  const abbreviationOrLabelLookup = new Map(
+    Array.from(labelLookup, ([k, v]) => [
+      useAbbreviations ? v.alternateName ?? k : k,
+      v,
+    ])
+  );
+
+  const getAbbreviationOrLabelByValue = (d: Observation) => {
+    if (!dimensionIri) {
+      return "";
+    }
+
+    const value = d[`${dimensionIri}/__iri__`] as string | undefined;
+    const label = d[dimensionIri] as string | undefined;
+
+    if (value === undefined && label === undefined) {
+      return "";
+    }
+
+    const lookedUpObservation =
+      (value ? valueLookup.get(value) : null) ??
+      (label ? labelLookup.get(label) : null);
+
+    const lookedUpLabel = lookedUpObservation?.label ?? "";
+
+    return useAbbreviations
+      ? lookedUpObservation?.alternateName ?? lookedUpLabel
+      : lookedUpLabel;
+  };
+
+  return {
+    abbreviationOrLabelLookup,
+    getAbbreviationOrLabelByValue,
+  };
+};
+
 export const useMaybeAbbreviations = ({
   useAbbreviations,
   dimensionIri,

--- a/app/charts/shared/chart-helpers.spec.tsx
+++ b/app/charts/shared/chart-helpers.spec.tsx
@@ -2,7 +2,7 @@ import { InternMap } from "d3";
 import merge from "lodash/merge";
 
 import {
-  getChartConfigComponentIris,
+  extractComponentIris,
   getMaybeTemporalDimensionValues,
   getWideData,
   prepareQueryFilters,
@@ -193,7 +193,7 @@ describe("getChartConfigComponentIris", () => {
   const mapConfig = map1Fixture.data.chartConfig as unknown as MapConfig;
 
   it("should return correct componentIris for line chart", () => {
-    const componentsIris = getChartConfigComponentIris(lineConfig);
+    const componentsIris = extractComponentIris(lineConfig);
     expect(componentsIris).toEqual([
       "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/0",
       "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/0",
@@ -205,7 +205,7 @@ describe("getChartConfigComponentIris", () => {
   });
 
   it("should return correct componentIris for map chart", () => {
-    const componentsIris = getChartConfigComponentIris(mapConfig);
+    const componentsIris = extractComponentIris(mapConfig);
     expect(componentsIris).toEqual([
       "https://environment.ld.admin.ch/foen/nfi/unitOfReference",
       "https://environment.ld.admin.ch/foen/nfi/Topic/3r",

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -149,14 +149,16 @@ export const extractComponentIris = (chartConfig: ChartConfig) => {
 
 export const usePlottableData = ({
   data,
-  plotters,
+  getX,
+  getY,
 }: {
   data: Observation[];
-  plotters: ((d: Observation) => unknown | null)[];
+  getX?: (d: Observation) => unknown | null;
+  getY?: (d: Observation) => unknown | null;
 }) => {
   const isPlottable = useCallback(
     (d: Observation) => {
-      for (let p of plotters) {
+      for (let p of [getX, getY].filter(truthy)) {
         const v = p(d);
         if (v === undefined || v === null) {
           return false;
@@ -164,8 +166,7 @@ export const usePlottableData = ({
       }
       return true;
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    plotters
+    [getX, getY]
   );
 
   return useMemo(() => data.filter(isPlottable), [data, isPlottable]);

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -175,13 +175,13 @@ type ValuePredicate = (v: any) => boolean;
 
 /** Prepares the data to be used in charts, taking interactive filters into account. */
 export const useDataAfterInteractiveFilters = ({
-  sortedData,
+  observations,
   interactiveFiltersConfig,
   animationField,
   getX,
   getSegment,
 }: {
-  sortedData: Observation[];
+  observations: Observation[];
   interactiveFiltersConfig: InteractiveFiltersConfig;
   animationField: AnimationField | undefined;
   getX?: (d: Observation) => Date;
@@ -253,16 +253,19 @@ export const useDataAfterInteractiveFilters = ({
   ]);
 
   const preparedData = useMemo(() => {
-    return sortedData.filter(allFilters);
-  }, [allFilters, sortedData]);
+    return observations.filter(allFilters);
+  }, [allFilters, observations]);
 
   const timeSliderFilterPresent = !!(
     animationField?.componentIri && timeSliderValue
   );
 
-  const scalesData = timeSliderFilterPresent ? sortedData : preparedData;
+  const scalesData = timeSliderFilterPresent ? observations : preparedData;
 
-  return { preparedData, scalesData };
+  return {
+    preparedData,
+    scalesData,
+  };
 };
 
 export const makeUseParsedVariable =

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -108,7 +108,7 @@ const getMapChartConfigAdditionalFields = ({ fields }: MapConfig) => {
   return additionalFields;
 };
 
-export const getChartConfigComponentIris = (chartConfig: ChartConfig) => {
+export const extractComponentIris = (chartConfig: ChartConfig) => {
   const { fields, interactiveFiltersConfig: IFConfig } = chartConfig;
   const fieldIris = Object.values(fields).map((d) => d.componentIri);
   const additionalFieldIris =

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -367,20 +367,8 @@ export const useChartData = (
   }, [allFilters, observations]);
 
   const scalesData = useMemo(() => {
-    const timeSliderActive = !!(
-      animationField?.componentIri && timeSliderValue
-    );
-
-    return timeSliderActive
-      ? observations.filter(overEvery(timeFilters))
-      : chartData;
-  }, [
-    animationField?.componentIri,
-    chartData,
-    observations,
-    timeFilters,
-    timeSliderValue,
-  ]);
+    return observations.filter(overEvery(timeFilters));
+  }, [observations, timeFilters]);
 
   return {
     chartData,

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -26,7 +26,11 @@ import {
   MapConfig,
   QueryFilters,
 } from "@/config-types";
-import { CategoricalColorField, NumericalColorField } from "@/configurator";
+import {
+  CategoricalColorField,
+  isAnimationInConfig,
+  NumericalColorField,
+} from "@/configurator";
 import { parseDate } from "@/configurator/components/ui-helpers";
 import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import { isTemporalDimension, Observation } from "@/domain/data";
@@ -273,13 +277,11 @@ export const useDataAfterInteractiveFilters = ({
 export const useChartData = (
   observations: Observation[],
   {
-    interactiveFiltersConfig,
-    animationField,
+    chartConfig,
     getXDate,
     getSegment,
   }: {
-    interactiveFiltersConfig: InteractiveFiltersConfig;
-    animationField?: AnimationField;
+    chartConfig: ChartConfig;
     getXDate?: (d: Observation) => Date;
     getSegment?: (d: Observation) => string;
   }
@@ -293,6 +295,7 @@ export const useChartData = (
    * corresponding to the selected time.*/
   scalesData: Observation[];
 } => {
+  const { interactiveFiltersConfig } = chartConfig;
   const [IFState] = useInteractiveFilters();
 
   // time range
@@ -301,11 +304,14 @@ export const useChartData = (
   const toTime = IFState.timeRange.to?.getTime();
 
   // time slider
-  const legend = interactiveFiltersConfig?.legend;
+  const animationField = isAnimationInConfig(chartConfig)
+    ? chartConfig.fields.animation
+    : undefined;
   const getTime = useTemporalVariable(animationField?.componentIri ?? "");
   const timeSliderValue = IFState.timeSlider.value;
 
   // legend
+  const legend = interactiveFiltersConfig?.legend;
   const legendItems = Object.keys(IFState.categories);
 
   const { allFilters, timeFilters } = useMemo(() => {

--- a/app/charts/shared/chart-state.ts
+++ b/app/charts/shared/chart-state.ts
@@ -1,8 +1,16 @@
+import { getAreasStateMetadata } from "@/charts/area/areas-state";
+import { getColumnsGroupedStateMetadata } from "@/charts/column/columns-grouped-state";
+import { getColumnsStackedStateMetadata } from "@/charts/column/columns-stacked-state";
+import { getColumnsStateMetadata } from "@/charts/column/columns-state";
+import { getLinesStateMetadata } from "@/charts/line/lines-state";
+import { getMapStateMetadata } from "@/charts/map/map-state";
+import { getPieStateMetadata } from "@/charts/pie/pie-state";
+import { getScatterplotStateMetadata } from "@/charts/scatterplot/scatterplot-state";
 import { Bounds } from "@/charts/shared/use-width";
+import { getTableStateMetadata } from "@/charts/table/table-state";
 import { ChartConfig, ChartType } from "@/configurator";
 import { Observation } from "@/domain/data";
-
-import { getAreasStateMetadata } from "../area/areas-state";
+import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 
 export interface CommonChartState {
   chartType: ChartType;
@@ -13,11 +21,46 @@ export type ChartStateMetadata = {
   sortData: (data: Observation[]) => Observation[];
 };
 
+type ChartStateMetadataProps = {
+  chartConfig: ChartConfig;
+  observations: Observation[];
+  dimensions: DimensionMetadataFragment[];
+};
+
 export const getChartStateMetadata = (
-  chartConfig: ChartConfig
-): ChartStateMetadata | undefined => {
+  props: ChartStateMetadataProps
+): ChartStateMetadata => {
+  const { chartConfig, observations, dimensions } = props;
+
   switch (chartConfig.chartType) {
     case "area":
       return getAreasStateMetadata(chartConfig);
+    case "column":
+      switch (chartConfig.fields.segment?.type) {
+        case undefined:
+          return getColumnsStateMetadata(chartConfig, observations, dimensions);
+        case "grouped":
+          return getColumnsGroupedStateMetadata(
+            chartConfig,
+            observations,
+            dimensions
+          );
+        case "stacked":
+          return getColumnsStackedStateMetadata(
+            chartConfig,
+            observations,
+            dimensions
+          );
+      }
+    case "line":
+      return getLinesStateMetadata(chartConfig);
+    case "map":
+      return getMapStateMetadata();
+    case "pie":
+      return getPieStateMetadata();
+    case "scatterplot":
+      return getScatterplotStateMetadata();
+    case "table":
+      return getTableStateMetadata();
   }
 };

--- a/app/charts/shared/chart-state.ts
+++ b/app/charts/shared/chart-state.ts
@@ -18,6 +18,8 @@ export interface CommonChartState {
 }
 
 export type ChartStateMetadata = {
+  getXDate?: (d: Observation) => Date;
+  getSegment?: (d: Observation) => string;
   sortData: (data: Observation[]) => Observation[];
 };
 
@@ -34,7 +36,7 @@ export const getChartStateMetadata = (
 
   switch (chartConfig.chartType) {
     case "area":
-      return getAreasStateMetadata(chartConfig);
+      return getAreasStateMetadata(chartConfig, observations, dimensions);
     case "column":
       switch (chartConfig.fields.segment?.type) {
         case undefined:
@@ -53,13 +55,13 @@ export const getChartStateMetadata = (
           );
       }
     case "line":
-      return getLinesStateMetadata(chartConfig);
+      return getLinesStateMetadata(chartConfig, observations, dimensions);
     case "map":
       return getMapStateMetadata();
     case "pie":
-      return getPieStateMetadata();
+      return getPieStateMetadata(chartConfig, observations, dimensions);
     case "scatterplot":
-      return getScatterplotStateMetadata();
+      return getScatterplotStateMetadata(chartConfig, observations, dimensions);
     case "table":
       return getTableStateMetadata();
   }

--- a/app/charts/shared/chart-state.ts
+++ b/app/charts/shared/chart-state.ts
@@ -18,6 +18,10 @@ export interface CommonChartState {
 }
 
 export type ChartStateMetadata = {
+  assureDefined: {
+    getX?: (d: Observation) => unknown | null;
+    getY?: (d: Observation) => unknown | null;
+  };
   getXDate?: (d: Observation) => Date;
   getSegment?: (d: Observation) => string;
   sortData: (data: Observation[]) => Observation[];

--- a/app/charts/shared/chart-state.ts
+++ b/app/charts/shared/chart-state.ts
@@ -14,6 +14,7 @@ import { DimensionMetadataFragment } from "@/graphql/query-hooks";
 
 export interface CommonChartState {
   chartType: ChartType;
+  allData: Observation[];
   bounds: Bounds;
 }
 

--- a/app/charts/shared/chart-state.ts
+++ b/app/charts/shared/chart-state.ts
@@ -1,8 +1,23 @@
-import { ChartType } from "@/configurator";
+import { Bounds } from "@/charts/shared/use-width";
+import { ChartConfig, ChartType } from "@/configurator";
+import { Observation } from "@/domain/data";
 
-import { Bounds } from "./use-width";
+import { getAreasStateMetadata } from "../area/areas-state";
 
 export interface CommonChartState {
   chartType: ChartType;
   bounds: Bounds;
 }
+
+export type ChartStateMetadata = {
+  sortData: (data: Observation[]) => Observation[];
+};
+
+export const getChartStateMetadata = (
+  chartConfig: ChartConfig
+): ChartStateMetadata | undefined => {
+  switch (chartConfig.chartType) {
+    case "area":
+      return getAreasStateMetadata(chartConfig);
+  }
+};

--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -65,10 +65,12 @@ const useStyles = makeStyles<Theme>((theme) => ({
   },
 }));
 
-const useItemStyles = makeStyles<
-  Theme,
-  { symbol: LegendSymbol; color: string }
->((theme) => ({
+type ItemStyleProps = {
+  symbol: LegendSymbol;
+  color: string;
+};
+
+const useItemStyles = makeStyles<Theme, ItemStyleProps>((theme) => ({
   legendItem: {
     position: "relative",
     justifyContent: "flex-start",
@@ -82,13 +84,15 @@ const useItemStyles = makeStyles<
       position: "relative",
       display: "block",
       width: ".5rem",
-      marginTop: ({ symbol }) => (symbol === "line" ? "0.75rem" : "0.5rem"),
+      marginTop: ({ symbol }: ItemStyleProps) =>
+        symbol === "line" ? "0.75rem" : "0.5rem",
       marginRight: "0.5rem",
       flexShrink: 0,
-      backgroundColor: ({ color }) => color,
-      height: ({ symbol }) =>
+      backgroundColor: ({ color }: ItemStyleProps) => color,
+      height: ({ symbol }: ItemStyleProps) =>
         symbol === "square" || symbol === "circle" ? `.5rem` : 2,
-      borderRadius: ({ symbol }) => (symbol === "circle" ? "50%" : 0),
+      borderRadius: ({ symbol }: ItemStyleProps) =>
+        symbol === "circle" ? "50%" : 0,
     },
   },
 
@@ -199,7 +203,8 @@ export const LegendColor = memo(function LegendColor({
   interactive?: boolean;
 }) {
   const { colors, getSegmentLabel } = useChartState() as ColorsChartState;
-  const groups = useLegendGroups({ values: colors.domain() });
+  const values = colors.domain();
+  const groups = useLegendGroups({ values });
 
   return (
     <LegendColorContent
@@ -208,6 +213,7 @@ export const LegendColor = memo(function LegendColor({
       getLabel={getSegmentLabel}
       symbol={symbol}
       interactive={interactive}
+      numberOfOptions={values.length}
     />
   );
 });
@@ -261,6 +267,7 @@ export const MapLegendColor = memo(function LegendColor({
       }}
       getLabel={getLabel}
       symbol="circle"
+      numberOfOptions={sortedValues.length}
     />
   );
 });
@@ -271,12 +278,14 @@ const LegendColorContent = ({
   getLabel,
   symbol,
   interactive,
+  numberOfOptions,
 }: {
   groups: ReturnType<typeof useLegendGroups>;
   getColor: (d: string) => string;
   getLabel: (d: string) => string;
   symbol: LegendSymbol;
   interactive?: boolean;
+  numberOfOptions: number;
 }) => {
   const classes = useStyles();
   const [state, dispatch] = useInteractiveFilters();
@@ -294,7 +303,7 @@ const LegendColorContent = ({
         type: "REMOVE_INTERACTIVE_FILTER",
         value: item,
       });
-    } else {
+    } else if (activeInteractiveFilters.size < numberOfOptions - 1) {
       dispatch({
         type: "ADD_INTERACTIVE_FILTER",
         value: item,

--- a/app/charts/shared/observation-labels.ts
+++ b/app/charts/shared/observation-labels.ts
@@ -2,6 +2,37 @@ import React from "react";
 
 import { Observation } from "@/domain/data";
 
+export const getObservationLabels = (
+  data: Observation[],
+  getLabel: (d: Observation) => string,
+  componentIri?: string
+) => {
+  const getIri = (d: Observation) => {
+    const iri = d[`${componentIri}/__iri__`] as string | undefined;
+    return iri;
+  };
+
+  const lookup = new Map<string, string>();
+  data.forEach((d) => {
+    const iri = getIri(d);
+    const label = getLabel(d);
+    lookup.set(iri ?? label, label);
+  });
+
+  const getValue = (d: Observation) => {
+    return getIri(d) ?? getLabel(d);
+  };
+
+  const getLookupLabel = (d: string) => {
+    return lookup.get(d) ?? d;
+  };
+
+  return {
+    getValue,
+    getLabel: getLookupLabel,
+  };
+};
+
 /** Use this hook to be able to retrieve observation values and labels,
  * where the value is the iri if present, otherwise the label.
  *

--- a/app/charts/shared/overlay-horizontal.tsx
+++ b/app/charts/shared/overlay-horizontal.tsx
@@ -1,6 +1,5 @@
-import { bisector } from "d3";
-import { pointer } from "d3";
-import { memo, useRef, MouseEvent } from "react";
+import { bisector, pointer } from "d3";
+import { MouseEvent, memo, useRef } from "react";
 
 import { AreasState } from "@/charts/area/areas-state";
 import { LinesState } from "@/charts/line/lines-state";
@@ -12,7 +11,7 @@ export const InteractionHorizontal = memo(function InteractionHorizontal() {
   const [state, dispatch] = useInteraction();
   const ref = useRef<SVGGElement>(null);
 
-  const { data, bounds, getX, xScale, chartWideData } = useChartState() as
+  const { chartData, bounds, getX, xScale, chartWideData } = useChartState() as
     | AreasState
     | LinesState;
 
@@ -38,7 +37,7 @@ export const InteractionHorizontal = memo(function InteractionHorizontal() {
 
     if (closestDatum) {
       const closestDatumTime = getX(closestDatum).getTime();
-      const datumToUpdate = data.find(
+      const datumToUpdate = chartData.find(
         (d) => closestDatumTime === getX(d).getTime()
       ) as Observation;
 

--- a/app/charts/shared/overlay-voronoi.tsx
+++ b/app/charts/shared/overlay-voronoi.tsx
@@ -1,6 +1,5 @@
-import { Delaunay } from "d3";
-import { pointer } from "d3";
-import { memo, useRef, MouseEvent as ReactMouseEvent } from "react";
+import { Delaunay, pointer } from "d3";
+import { MouseEvent as ReactMouseEvent, memo, useRef } from "react";
 
 import { AreasState } from "@/charts/area/areas-state";
 import { LinesState } from "@/charts/line/lines-state";
@@ -15,22 +14,14 @@ export const InteractionVoronoi = memo(function InteractionVoronoi({
 }) {
   const [, dispatch] = useInteraction();
   const ref = useRef<SVGGElement>(null);
-  const {
-    preparedData,
-    getX,
-    xScale,
-    getY,
-    yScale,
-    getSegment,
-    colors,
-    bounds,
-  } = useChartState() as LinesState | AreasState | ScatterplotState;
+  const { chartData, getX, xScale, getY, yScale, getSegment, colors, bounds } =
+    useChartState() as LinesState | AreasState | ScatterplotState;
 
   const { chartWidth, chartHeight, margins } = bounds;
 
   // FIXME: delaunay/voronoi calculation could be memoized
   const delaunay = Delaunay.from(
-    preparedData,
+    chartData,
     (d) => xScale(getX(d) ?? NaN),
     (d) => yScale(getY(d) ?? NaN)
   );
@@ -40,7 +31,7 @@ export const InteractionVoronoi = memo(function InteractionVoronoi({
     const [x, y] = pointer(e, ref.current!);
 
     const location = delaunay.find(x, y);
-    const d = preparedData[location];
+    const d = chartData[location];
 
     if (typeof location !== "undefined") {
       dispatch({
@@ -63,7 +54,7 @@ export const InteractionVoronoi = memo(function InteractionVoronoi({
   return (
     <g ref={ref} transform={`translate(${margins.left} ${margins.top})`}>
       {debug &&
-        preparedData.map((d, i) => (
+        chartData.map((d, i) => (
           <path
             key={i}
             d={voronoi.renderCell(i)}

--- a/app/charts/shared/use-chart-formatters.ts
+++ b/app/charts/shared/use-chart-formatters.ts
@@ -2,17 +2,18 @@ import { useMemo } from "react";
 
 import { useDimensionFormatters } from "@/formatters";
 
-import { ChartProps } from "./ChartProps";
+import { BaseChartProps } from "./ChartProps";
 
 const useChartFormatters = (
-  chartProps: Pick<ChartProps, "measures" | "dimensions">
+  chartProps: Pick<BaseChartProps, "dimensions" | "measures">
 ) => {
-  const { measures, dimensions } = chartProps;
-  const allDimensions = useMemo(
-    () => [...measures, ...dimensions],
-    [measures, dimensions]
+  const { dimensions, measures } = chartProps;
+  const components = useMemo(
+    () => [...dimensions, ...measures],
+    [dimensions, measures]
   );
-  const formatters = useDimensionFormatters(allDimensions);
+  const formatters = useDimensionFormatters(components);
+
   return formatters;
 };
 

--- a/app/charts/shared/use-observation-labels.spec.ts
+++ b/app/charts/shared/use-observation-labels.spec.ts
@@ -1,6 +1,6 @@
 import { renderHook } from "@testing-library/react-hooks";
 
-import { useObservationLabels } from "@/charts/shared/use-observation-labels";
+import { useObservationLabels } from "@/charts/shared/observation-labels";
 import { Observation } from "@/domain/data";
 
 const data: Observation[] = [

--- a/app/charts/table/chart-table.tsx
+++ b/app/charts/table/chart-table.tsx
@@ -1,7 +1,7 @@
 import { memo } from "react";
 
 import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
-import { getChartConfigComponentIris } from "@/charts/shared/chart-helpers";
+import { extractComponentIris } from "@/charts/shared/chart-helpers";
 import { Table } from "@/charts/table/table";
 import { TableChart } from "@/charts/table/table-state";
 import { DataSource, TableConfig } from "@/configurator";
@@ -26,33 +26,28 @@ export const ChartTableVisualization = ({
   published: boolean;
 }) => {
   const locale = useLocale();
-  const componentIrisToFilterBy = published
-    ? getChartConfigComponentIris(chartConfig)
+  const componentIris = published
+    ? extractComponentIris(chartConfig)
     : undefined;
+  const commonQueryVariables = {
+    iri: dataSetIri,
+    sourceType: dataSource.type,
+    sourceUrl: dataSource.url,
+    locale,
+  };
   const [metadataQuery] = useDataCubeMetadataQuery({
-    variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-    },
+    variables: commonQueryVariables,
   });
   const [componentsQuery] = useComponentsQuery({
     variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-      componentIris: componentIrisToFilterBy,
+      ...commonQueryVariables,
+      componentIris,
     },
   });
   const [observationsQuery] = useDataCubeObservationsQuery({
     variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-      componentIris: componentIrisToFilterBy,
+      ...commonQueryVariables,
+      componentIris,
       filters: chartConfig.filters,
     },
   });

--- a/app/charts/table/chart-table.tsx
+++ b/app/charts/table/chart-table.tsx
@@ -64,13 +64,15 @@ export const ChartTableVisualization = ({
 };
 
 const ChartTable = memo(function ChartTable(props: ChartProps<TableConfig>) {
-  const { chartConfig, chartData, scalesData, dimensions, measures } = props;
+  const { chartConfig, chartData, scalesData, allData, dimensions, measures } =
+    props;
 
   return (
     <TableChart
       chartConfig={chartConfig}
       chartData={chartData}
       scalesData={scalesData}
+      allData={allData}
       dimensions={dimensions}
       measures={measures}
     >

--- a/app/charts/table/chart-table.tsx
+++ b/app/charts/table/chart-table.tsx
@@ -5,14 +5,14 @@ import { extractComponentIris } from "@/charts/shared/chart-helpers";
 import { Table } from "@/charts/table/table";
 import { TableChart } from "@/charts/table/table-state";
 import { DataSource, TableConfig } from "@/configurator";
-import { Observation } from "@/domain/data";
 import {
-  DimensionMetadataFragment,
   useComponentsQuery,
   useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
+
+import { ChartProps } from "../shared/ChartProps";
 
 export const ChartTableVisualization = ({
   dataSetIri,
@@ -63,23 +63,15 @@ export const ChartTableVisualization = ({
   );
 };
 
-const ChartTable = memo(function ChartTable({
-  observations,
-  dimensions,
-  measures,
-  chartConfig,
-}: {
-  observations: Observation[];
-  dimensions: DimensionMetadataFragment[];
-  measures: DimensionMetadataFragment[];
-  chartConfig: TableConfig;
-}) {
+const ChartTable = memo(function ChartTable(props: ChartProps<TableConfig>) {
+  const { chartConfig, data, dimensions, measures } = props;
+
   return (
     <TableChart
-      data={observations}
+      chartConfig={chartConfig}
+      data={data}
       dimensions={dimensions}
       measures={measures}
-      chartConfig={chartConfig}
     >
       <Table />
     </TableChart>

--- a/app/charts/table/chart-table.tsx
+++ b/app/charts/table/chart-table.tsx
@@ -64,12 +64,13 @@ export const ChartTableVisualization = ({
 };
 
 const ChartTable = memo(function ChartTable(props: ChartProps<TableConfig>) {
-  const { chartConfig, data, dimensions, measures } = props;
+  const { chartConfig, chartData, scalesData, dimensions, measures } = props;
 
   return (
     <TableChart
       chartConfig={chartConfig}
-      data={data}
+      chartData={chartData}
+      scalesData={scalesData}
       dimensions={dimensions}
       measures={measures}
     >

--- a/app/charts/table/chart-table.tsx
+++ b/app/charts/table/chart-table.tsx
@@ -64,18 +64,8 @@ export const ChartTableVisualization = ({
 };
 
 const ChartTable = memo(function ChartTable(props: ChartProps<TableConfig>) {
-  const { chartConfig, chartData, scalesData, allData, dimensions, measures } =
-    props;
-
   return (
-    <TableChart
-      chartConfig={chartConfig}
-      chartData={chartData}
-      scalesData={scalesData}
-      allData={allData}
-      dimensions={dimensions}
-      measures={measures}
-    >
+    <TableChart {...props}>
       <Table />
     </TableChart>
   );

--- a/app/charts/table/table-state.tsx
+++ b/app/charts/table/table-state.tsx
@@ -404,6 +404,7 @@ const useTableState = (props: ChartProps<TableConfig>): TableChartState => {
 
 export const getTableStateMetadata = (): ChartStateMetadata => {
   return {
+    assureDefined: {},
     sortData: (data) => {
       return data;
     },
@@ -412,7 +413,8 @@ export const getTableStateMetadata = (): ChartStateMetadata => {
 
 const TableChartProvider = ({
   chartConfig,
-  data,
+  chartData,
+  scalesData,
   dimensions,
   measures,
   children,
@@ -423,7 +425,8 @@ const TableChartProvider = ({
 >) => {
   const state = useTableState({
     chartConfig,
-    data,
+    chartData,
+    scalesData,
     dimensions,
     measures,
   });
@@ -434,17 +437,19 @@ const TableChartProvider = ({
 };
 
 export const TableChart = ({
-  data,
+  chartConfig,
+  chartData,
+  scalesData,
   dimensions,
   measures,
-  chartConfig,
   children,
 }: React.PropsWithChildren<ChartProps<TableConfig>>) => {
   return (
     <Observer>
       <TableChartProvider
         chartConfig={chartConfig}
-        data={data}
+        chartData={chartData}
+        scalesData={scalesData}
         dimensions={dimensions}
         measures={measures}
       >

--- a/app/charts/table/table-state.tsx
+++ b/app/charts/table/table-state.tsx
@@ -20,7 +20,10 @@ import {
   getLabelWithUnit,
   getSlugifiedIri,
 } from "@/charts/shared/chart-helpers";
-import { CommonChartState } from "@/charts/shared/chart-state";
+import {
+  ChartStateMetadata,
+  CommonChartState,
+} from "@/charts/shared/chart-state";
 import { ChartContext } from "@/charts/shared/use-chart-state";
 import { Observer, useWidth } from "@/charts/shared/use-width";
 import { BAR_CELL_PADDING, TABLE_HEIGHT } from "@/charts/table/constants";
@@ -399,8 +402,13 @@ const useTableState = (props: ChartProps<TableConfig>): TableChartState => {
   };
 };
 
-//  ------------------------------------------------------------------------------------ //
-//  ------------------------------------------------------------------------------------ //
+export const getTableStateMetadata = (): ChartStateMetadata => {
+  return {
+    sortData: (data) => {
+      return data;
+    },
+  };
+};
 
 const TableChartProvider = ({
   chartConfig,

--- a/app/charts/table/table-state.tsx
+++ b/app/charts/table/table-state.tsx
@@ -13,7 +13,7 @@ import {
 } from "d3";
 import mapKeys from "lodash/mapKeys";
 import mapValues from "lodash/mapValues";
-import { ReactNode, useMemo } from "react";
+import { useMemo } from "react";
 import { Cell, Column, Row } from "react-table";
 
 import {
@@ -101,14 +101,8 @@ export interface TableChartState extends CommonChartState {
   sortingIris: { id: string; desc: boolean }[];
 }
 
-const useTableState = ({
-  data,
-  dimensions,
-  measures,
-  chartConfig,
-}: Pick<ChartProps, "data" | "dimensions" | "measures"> & {
-  chartConfig: TableConfig;
-}): TableChartState => {
+const useTableState = (props: ChartProps<TableConfig>): TableChartState => {
+  const { chartConfig, data, dimensions, measures } = props;
   const theme = useTheme();
   const { fields, settings, sorting } = chartConfig;
   const formatNumber = useFormatNumber();
@@ -409,21 +403,23 @@ const useTableState = ({
 //  ------------------------------------------------------------------------------------ //
 
 const TableChartProvider = ({
+  chartConfig,
   data,
   dimensions,
   measures,
   children,
-  chartConfig,
-}: Pick<ChartProps, "data" | "dimensions" | "measures"> & {
-  children: ReactNode;
-  chartConfig: TableConfig;
-}) => {
+}: React.PropsWithChildren<
+  ChartProps<TableConfig> & {
+    chartConfig: TableConfig;
+  }
+>) => {
   const state = useTableState({
+    chartConfig,
     data,
     dimensions,
     measures,
-    chartConfig,
   });
+
   return (
     <ChartContext.Provider value={state}>{children}</ChartContext.Provider>
   );
@@ -435,17 +431,14 @@ export const TableChart = ({
   measures,
   chartConfig,
   children,
-}: Pick<ChartProps, "data" | "dimensions" | "measures"> & {
-  children: ReactNode;
-  chartConfig: TableConfig;
-}) => {
+}: React.PropsWithChildren<ChartProps<TableConfig>>) => {
   return (
     <Observer>
       <TableChartProvider
+        chartConfig={chartConfig}
         data={data}
         dimensions={dimensions}
         measures={measures}
-        chartConfig={chartConfig}
       >
         {children}
       </TableChartProvider>

--- a/app/charts/table/table-state.tsx
+++ b/app/charts/table/table-state.tsx
@@ -105,7 +105,7 @@ export interface TableChartState extends CommonChartState {
 }
 
 const useTableState = (props: ChartProps<TableConfig>): TableChartState => {
-  const { chartConfig, data, dimensions, measures } = props;
+  const { chartConfig, chartData, allData, dimensions, measures } = props;
   const theme = useTheme();
   const { fields, settings, sorting } = chartConfig;
   const formatNumber = useFormatNumber();
@@ -124,7 +124,7 @@ const useTableState = (props: ChartProps<TableConfig>): TableChartState => {
     left: 10,
   };
   const chartWidth = width - margins.left - margins.right; // We probably don't need this
-  const chartHeight = Math.min(TABLE_HEIGHT, data.length * rowHeight);
+  const chartHeight = Math.min(TABLE_HEIGHT, chartData.length * rowHeight);
   const bounds = {
     width,
     height: chartHeight + margins.top + margins.bottom,
@@ -149,10 +149,10 @@ const useTableState = (props: ChartProps<TableConfig>): TableChartState => {
   const memoizedData = useMemo(
     function replaceKeys() {
       // Only read keys once
-      const keys = Object.keys(data[0]);
+      const keys = Object.keys(chartData[0]);
       const slugifiedKeys = keys.map(getSlugifiedIri);
 
-      return data.map((d, index) => {
+      return chartData.map((d, index) => {
         let o = { id: index } as $IntentionalAny;
         // This is run often, so let's optimize it
         for (let i = 0; i < keys.length; i++) {
@@ -166,7 +166,7 @@ const useTableState = (props: ChartProps<TableConfig>): TableChartState => {
         return o;
       });
     },
-    [data, types]
+    [chartData, types]
   );
 
   // Columns used by react-table
@@ -190,7 +190,7 @@ const useTableState = (props: ChartProps<TableConfig>): TableChartState => {
 
       // The column width depends on the estimated width of the
       // longest value in the column, with a minimum of 150px.
-      const columnItems = [...new Set(data.map((d) => d[c.componentIri]))];
+      const columnItems = [...new Set(chartData.map((d) => d[c.componentIri]))];
       const columnItemSizes = [
         ...columnItems.map((item) => {
           const itemAsString =
@@ -233,7 +233,7 @@ const useTableState = (props: ChartProps<TableConfig>): TableChartState => {
         },
       };
     });
-  }, [orderedTableColumns, data, dimensions, measures, formatNumber]);
+  }, [orderedTableColumns, chartData, dimensions, measures, formatNumber]);
 
   // Groupings used by react-table
   const groupingIris = useMemo(
@@ -337,11 +337,11 @@ const useTableState = (props: ChartProps<TableConfig>): TableChartState => {
           } as CategoryColumnMeta;
         } else if (columnStyleType === "heatmap") {
           const absMinValue =
-            min(data, (d) =>
+            min(chartData, (d) =>
               d[iri] !== null ? Math.abs(d[iri] as number) : 0
             ) || 0;
           const absMaxValue =
-            max(data, (d) =>
+            max(chartData, (d) =>
               d[iri] !== null ? Math.abs(d[iri] as number) : 1
             ) || 1;
           const maxAbsoluteValue = Math.max(absMinValue, absMaxValue);
@@ -357,7 +357,7 @@ const useTableState = (props: ChartProps<TableConfig>): TableChartState => {
           // longest value in the column, with a minimum of 150px.
           const columnItems = [
             ...new Set(
-              data.map((d) =>
+              chartData.map((d) =>
                 d !== null && d[iri] !== null ? mkNumber(d[iri]) : NaN
               )
             ),
@@ -380,7 +380,7 @@ const useTableState = (props: ChartProps<TableConfig>): TableChartState => {
       (v) => v.slugifiedIri
     );
   }, [
-    data,
+    chartData,
     dimensions,
     fields,
     formatters,
@@ -390,6 +390,7 @@ const useTableState = (props: ChartProps<TableConfig>): TableChartState => {
 
   return {
     chartType: "table",
+    allData,
     bounds,
     rowHeight,
     showSearch: settings.showSearch,
@@ -415,6 +416,7 @@ const TableChartProvider = ({
   chartConfig,
   chartData,
   scalesData,
+  allData,
   dimensions,
   measures,
   children,
@@ -427,6 +429,7 @@ const TableChartProvider = ({
     chartConfig,
     chartData,
     scalesData,
+    allData,
     dimensions,
     measures,
   });
@@ -440,6 +443,7 @@ export const TableChart = ({
   chartConfig,
   chartData,
   scalesData,
+  allData,
   dimensions,
   measures,
   children,
@@ -450,6 +454,7 @@ export const TableChart = ({
         chartConfig={chartConfig}
         chartData={chartData}
         scalesData={scalesData}
+        allData={allData}
         dimensions={dimensions}
         measures={measures}
       >

--- a/app/charts/table/table-state.tsx
+++ b/app/charts/table/table-state.tsx
@@ -412,54 +412,27 @@ export const getTableStateMetadata = (): ChartStateMetadata => {
   };
 };
 
-const TableChartProvider = ({
-  chartConfig,
-  chartData,
-  scalesData,
-  allData,
-  dimensions,
-  measures,
-  children,
-}: React.PropsWithChildren<
-  ChartProps<TableConfig> & {
-    chartConfig: TableConfig;
-  }
->) => {
-  const state = useTableState({
-    chartConfig,
-    chartData,
-    scalesData,
-    allData,
-    dimensions,
-    measures,
-  });
+const TableChartProvider = (
+  props: React.PropsWithChildren<
+    ChartProps<TableConfig> & {
+      chartConfig: TableConfig;
+    }
+  >
+) => {
+  const { children, ...rest } = props;
+  const state = useTableState(rest);
 
   return (
     <ChartContext.Provider value={state}>{children}</ChartContext.Provider>
   );
 };
 
-export const TableChart = ({
-  chartConfig,
-  chartData,
-  scalesData,
-  allData,
-  dimensions,
-  measures,
-  children,
-}: React.PropsWithChildren<ChartProps<TableConfig>>) => {
+export const TableChart = (
+  props: React.PropsWithChildren<ChartProps<TableConfig>>
+) => {
   return (
     <Observer>
-      <TableChartProvider
-        chartConfig={chartConfig}
-        chartData={chartData}
-        scalesData={scalesData}
-        allData={allData}
-        dimensions={dimensions}
-        measures={measures}
-      >
-        {children}
-      </TableChartProvider>
+      <TableChartProvider {...props} />
     </Observer>
   );
 };

--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -43,9 +43,8 @@ export const useFootnotesStyles = makeStyles<Theme, { useMarginTop: boolean }>(
           content: '" "',
           display: "block",
           height: "3px",
-          width: "3px ",
+          width: "3px",
           borderRadius: "3px",
-          position: "relative",
           left: "calc(-1 * var(--column-gap) / 2)",
           backgroundColor: theme.palette.grey[600],
         },
@@ -83,25 +82,23 @@ export const ChartFootnotes = ({
     setShareUrl(`${window.location.origin}/${locale}/v/${configKey}`);
   }, [configKey, locale]);
 
+  const commonQueryVariables = {
+    iri: dataSetIri,
+    sourceType: dataSource.type,
+    sourceUrl: dataSource.url,
+    locale,
+  };
   const [{ data }] = useDataCubeMetadataQuery({
-    variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-    },
+    variables: commonQueryVariables,
   });
 
   // Data for data download
   const filters = useQueryFilters({ chartConfig });
-  const componentIrisToFilterBy = extractComponentIris(chartConfig);
+  const componentIris = extractComponentIris(chartConfig);
   const [{ data: visibleData }] = useDataCubeObservationsQuery({
     variables: {
-      iri: dataSetIri,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-      componentIris: componentIrisToFilterBy,
+      ...commonQueryVariables,
+      componentIris,
       filters,
     },
   });

--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -4,7 +4,7 @@ import { makeStyles } from "@mui/styles";
 import { PropsWithChildren, useEffect, useMemo, useState } from "react";
 
 import {
-  getChartConfigComponentIris,
+  extractComponentIris,
   useQueryFilters,
 } from "@/charts/shared/chart-helpers";
 import { useChartTablePreview } from "@/components/chart-table-preview";
@@ -94,7 +94,7 @@ export const ChartFootnotes = ({
 
   // Data for data download
   const filters = useQueryFilters({ chartConfig });
-  const componentIrisToFilterBy = getChartConfigComponentIris(chartConfig);
+  const componentIrisToFilterBy = extractComponentIris(chartConfig);
   const [{ data: visibleData }] = useDataCubeObservationsQuery({
     variables: {
       iri: dataSetIri,

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -7,7 +7,7 @@ import { useStore } from "zustand";
 
 import { DataSetTable } from "@/browse/datatable";
 import { ChartDataFilters } from "@/charts/shared/chart-data-filters";
-import { getChartConfigComponentIris } from "@/charts/shared/chart-helpers";
+import { extractComponentIris } from "@/charts/shared/chart-helpers";
 import { isUsingImputation } from "@/charts/shared/imputation";
 import {
   InteractiveFiltersProvider,

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -139,22 +139,20 @@ export const ChartPublishedInner = ({
   });
   const locale = useLocale();
   const isTrustedDataSource = useIsTrustedDataSource(dataSource);
+  const commonQueryVariables = {
+    iri: dataSet,
+    sourceType: dataSource.type,
+    sourceUrl: dataSource.url,
+    locale,
+  };
 
   const [{ data: metadata }] = useDataCubeMetadataQuery({
-    variables: {
-      iri: dataSet,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-    },
+    variables: commonQueryVariables,
   });
   const [{ data: components }] = useComponentsQuery({
     variables: {
-      iri: dataSet,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-      componentIris: getChartConfigComponentIris(chartConfig),
+      ...commonQueryVariables,
+      componentIris: extractComponentIris(chartConfig),
     },
   });
 

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -91,7 +91,6 @@ const DataFilterSelectGeneric = ({
   onRemove,
 }: {
   dimension: DataCubeMetadata["dimensions"][number];
-  isOptional?: boolean;
   index: number;
   disabled?: boolean;
   onRemove: () => void;
@@ -448,12 +447,7 @@ const useFilterReorder = ({
   };
 };
 
-const useStyles = makeStyles<
-  Theme,
-  {
-    fetching: boolean;
-  }
->((theme) => ({
+const useStyles = makeStyles<Theme, { fetching: boolean }>((theme) => ({
   loadingIndicator: {
     color: theme.palette.grey[700],
     display: "inline-block",
@@ -477,7 +471,9 @@ const useStyles = makeStyles<
       color: theme.palette.secondary.active,
     },
     "& .buttons:hover": {
-      opacity: ({ fetching }) => (fetching ? undefined : 1),
+      // Type inheritance is broken when one level of nesting is added
+      opacity: ({ fetching }: { fetching: boolean }) =>
+        fetching ? undefined : 1,
     },
     "& > *": {
       overflow: "hidden",

--- a/app/configurator/components/ui-helpers.ts
+++ b/app/configurator/components/ui-helpers.ts
@@ -7,7 +7,7 @@ import {
 } from "d3";
 import { useMemo } from "react";
 
-import type { ChartProps } from "@/charts/shared/ChartProps";
+import type { BaseChartProps } from "@/charts/shared/ChartProps";
 import { getTimeInterval } from "@/intervals";
 
 import { TableColumn, TableFields } from "../../config-types";
@@ -80,10 +80,10 @@ export const getTimeIntervalFormattedSelectOptions = ({
 };
 
 export const getErrorMeasure = (
-  { measures, dimensions }: Pick<ChartProps, "measures" | "dimensions">,
+  { dimensions, measures }: Pick<BaseChartProps, "dimensions" | "measures">,
   valueIri: string
 ) => {
-  return [...measures, ...dimensions].find((m) => {
+  return [...dimensions, ...measures].find((m) => {
     return m.related?.some(
       (r) => r.type === "StandardError" && r.iri === valueIri
     );
@@ -91,12 +91,13 @@ export const getErrorMeasure = (
 };
 
 export const useErrorMeasure = (
-  chartState: Pick<ChartProps, "measures" | "dimensions">,
+  chartState: Pick<BaseChartProps, "dimensions" | "measures">,
   valueIri: string
 ) => {
-  const { measures, dimensions } = chartState;
+  const { dimensions, measures } = chartState;
+
   return useMemo(() => {
-    return getErrorMeasure({ measures, dimensions }, valueIri);
+    return getErrorMeasure({ dimensions, measures }, valueIri);
   }, [dimensions, measures, valueIri]);
 };
 

--- a/app/docs/annotations.docs.tsx
+++ b/app/docs/annotations.docs.tsx
@@ -34,7 +34,9 @@ ${(
   <ReactSpecimen>
     <InteractiveFiltersProvider>
       <ColumnChart
-        data={observations}
+        chartData={observations}
+        scalesData={observations}
+        allData={observations}
         measures={measures}
         dimensions={dimensions}
         chartConfig={
@@ -181,7 +183,9 @@ ${(
   <ReactSpecimen span={2}>
     <InteractiveFiltersProvider>
       <ColumnChart
-        data={observations}
+        chartData={observations}
+        scalesData={observations}
+        allData={observations}
         measures={measures}
         dimensions={dimensions}
         chartConfig={
@@ -224,7 +228,9 @@ ${(
   <ReactSpecimen span={2}>
     <InteractiveFiltersProvider>
       <ColumnChart
-        data={observations}
+        chartData={observations}
+        scalesData={observations}
+        allData={observations}
         measures={measures}
         dimensions={dimensions}
         chartConfig={

--- a/app/docs/annotations.docs.tsx
+++ b/app/docs/annotations.docs.tsx
@@ -36,6 +36,7 @@ ${(
       <ColumnChart
         chartData={observations}
         scalesData={observations}
+        segmentData={observations}
         allData={observations}
         measures={measures}
         dimensions={dimensions}
@@ -185,6 +186,7 @@ ${(
       <ColumnChart
         chartData={observations}
         scalesData={observations}
+        segmentData={observations}
         allData={observations}
         measures={measures}
         dimensions={dimensions}
@@ -230,6 +232,7 @@ ${(
       <ColumnChart
         chartData={observations}
         scalesData={observations}
+        segmentData={observations}
         allData={observations}
         measures={measures}
         dimensions={dimensions}

--- a/app/docs/columns.docs.tsx
+++ b/app/docs/columns.docs.tsx
@@ -23,6 +23,7 @@ ${(
       <ColumnChart
         chartData={columnObservations}
         scalesData={columnObservations}
+        segmentData={columnObservations}
         allData={columnObservations}
         dimensions={columnDimensions}
         chartConfig={

--- a/app/docs/columns.docs.tsx
+++ b/app/docs/columns.docs.tsx
@@ -21,7 +21,9 @@ ${(
   <ReactSpecimen span={6}>
     <InteractiveFiltersProvider>
       <ColumnChart
-        data={columnObservations}
+        chartData={columnObservations}
+        scalesData={columnObservations}
+        allData={columnObservations}
         dimensions={columnDimensions}
         chartConfig={
           {

--- a/app/docs/data-table.docs.tsx
+++ b/app/docs/data-table.docs.tsx
@@ -1,5 +1,4 @@
 import { markdown, ReactSpecimen } from "catalog";
-import * as React from "react";
 
 import { ChartContainer } from "@/charts/shared/containers";
 import { Table } from "@/charts/table/table";
@@ -19,7 +18,9 @@ export const Docs = () => markdown`
 ${(
   <ReactSpecimen span={6}>
     <TableChart
-      data={tableObservations}
+      chartData={tableObservations}
+      scalesData={tableObservations}
+      allData={tableObservations}
       dimensions={tableDimensions as DimensionMetadataFragment[]}
       measures={tableMeasures as DimensionMetadataFragment[]}
       chartConfig={tableConfig}

--- a/app/docs/data-table.docs.tsx
+++ b/app/docs/data-table.docs.tsx
@@ -20,6 +20,7 @@ ${(
     <TableChart
       chartData={tableObservations}
       scalesData={tableObservations}
+      segmentData={tableObservations}
       allData={tableObservations}
       dimensions={tableDimensions as DimensionMetadataFragment[]}
       measures={tableMeasures as DimensionMetadataFragment[]}

--- a/app/docs/lines.docs.tsx
+++ b/app/docs/lines.docs.tsx
@@ -59,6 +59,7 @@ ${(
         <LineChart
           chartData={observations}
           scalesData={observations}
+          segmentData={observations}
           allData={observations}
           dimensions={dimensions}
           measures={measures}

--- a/app/docs/lines.docs.tsx
+++ b/app/docs/lines.docs.tsx
@@ -57,7 +57,9 @@ ${(
     >
       <InteractiveFiltersProvider>
         <LineChart
-          data={observations}
+          chartData={observations}
+          scalesData={observations}
+          allData={observations}
           dimensions={dimensions}
           measures={measures}
           chartConfig={{ interactiveFiltersConfig } as unknown as LineConfig}

--- a/app/docs/scatterplot.docs.tsx
+++ b/app/docs/scatterplot.docs.tsx
@@ -62,6 +62,7 @@ ${(
         <ScatterplotChart
           chartData={scatterplotObservations}
           scalesData={scatterplotObservations}
+          segmentData={scatterplotObservations}
           allData={scatterplotObservations}
           dimensions={scatterplotDimensions}
           measures={scatterplotMeasures}

--- a/app/docs/scatterplot.docs.tsx
+++ b/app/docs/scatterplot.docs.tsx
@@ -60,7 +60,9 @@ ${(
     >
       <InteractiveFiltersProvider>
         <ScatterplotChart
-          data={scatterplotObservations}
+          chartData={scatterplotObservations}
+          scalesData={scatterplotObservations}
+          allData={scatterplotObservations}
           dimensions={scatterplotDimensions}
           measures={scatterplotMeasures}
           chartConfig={

--- a/app/domain/data.ts
+++ b/app/domain/data.ts
@@ -228,31 +228,31 @@ export const isGeoDimension = (
 };
 
 export const isGeoCoordinatesDimension = (
-  dimension?: DimensionMetadataFragment
+  dimension?: { __typename?: string } | null
 ): dimension is GeoCoordinatesDimension => {
   return dimension?.__typename === "GeoCoordinatesDimension";
 };
 
 export const isGeoShapesDimension = (
-  dimension?: DimensionMetadataFragment
+  dimension?: { __typename?: string } | null
 ): dimension is GeoShapesDimension => {
   return dimension?.__typename === "GeoShapesDimension";
 };
 
 export const isNumericalMeasure = (
-  dimension?: DimensionMetadataFragment
+  dimension?: { __typename?: string } | null
 ): dimension is NumericalMeasure => {
   return dimension?.__typename === "NumericalMeasure";
 };
 
 export const isOrdinalMeasure = (
-  dimension?: DimensionMetadataFragment
+  dimension?: { __typename?: string } | null
 ): dimension is OrdinalMeasure => {
   return dimension?.__typename === "OrdinalMeasure";
 };
 
 export const isTemporalDimension = (
-  dimension?: DimensionMetadataFragment | null
+  dimension?: { __typename?: string } | null
 ): dimension is TemporalDimension => {
   return dimension?.__typename === "TemporalDimension";
 };

--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -12,6 +12,10 @@ const config = {
     "^@/(.*)$": "<rootDir>/$1",
     "\\.(css)$": "<rootDir>/test/style-mock.js",
   },
+  transform: {
+    "node_modules/@rdf*": "ts-jest",
+  },
+  transformIgnorePatterns: ["node_modules/!@rdf*"],
 };
 
 module.exports = config;

--- a/app/utils/array.ts
+++ b/app/utils/array.ts
@@ -2,20 +2,20 @@ export const sortByIndex = <T>({
   data,
   order,
   getCategory,
-  sortOrder,
+  sortingOrder,
 }: {
   data: T[];
   order: string[];
   getCategory: (datum: T) => string;
-  sortOrder?: "asc" | "desc";
+  sortingOrder?: "asc" | "desc";
 }) => {
   data.sort((a, b) => {
     const A = getCategory(a);
     const B = getCategory(b);
     if (order.indexOf(A) > order.indexOf(B)) {
-      return sortOrder === "asc" ? 1 : -1;
+      return sortingOrder === "asc" ? 1 : -1;
     } else {
-      return sortOrder === "asc" ? -1 : 1;
+      return sortingOrder === "asc" ? -1 : 1;
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "babel-plugin-macros": "^3.0.0",
     "eslint": "^7.29.0",
     "eslint-config-next": "^11.0.1",
-    "eslint-plugin-unused-imports": "^2.0.0",
     "eslint-plugin-visualize-admin": "link:./eslint/visualize-admin",
     "fs-extra": "^10.0.0",
     "import-move-codemod": "^0.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8700,21 +8700,9 @@ eslint-plugin-react@^7.23.1:
     resolve "^2.0.0-next.3"
     string.prototype.matchall "^4.0.5"
 
-eslint-plugin-unused-imports@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz"
-  integrity sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==
-  dependencies:
-    eslint-rule-composer "^0.3.0"
-
 "eslint-plugin-visualize-admin@link:./eslint/visualize-admin":
   version "0.0.0"
   uid ""
-
-eslint-rule-composer@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz"
-  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
 
 eslint-scope@^5.1.1:
   version "5.1.1"


### PR DESCRIPTION
This PR consolidates common chart-state-computing logic by extracting some chart logic outside of individual chart states:
- computation of data needed by charts (`chartData`, `scalesData`, `segmentData`, `allData`). I introduced this distinction to make all charts "ready for interactive filters" (e.g. maps do not have them yet) and to have one place to "fix" things, instead of needing to go to every chart,
- sorting the data. Right now every chart type defines its own sorting / missing values filtering logic and this information is used when computing the data upfront, before it's passed to the chart.

It also fixes some minor things:
- column exit animations,
- inner band scale when toggling interactive legend filters,
- tests with dependencies that import `rdf-js` modules (_SyntaxError: Cannot use import statement outside a module_),
- scales now adapt to color legend filter when using time slider,
- it's now not possible to remove all color legend filters to prevent showing no chart.

### Reference: Interactive filters
- Time range
- Time slider
- Color legend

### New chart data structure
- `chartData`: data with all interactive filters applied, used to draw the shapes,
- `scalesData`: data with color legend and time range filters applied, used to compute the scales. As time slider filter is not applied to it, it holds the information about all potential scale values and makes it possible to fix the scales when animating the charts,
- `segmentData`: data with time range filter applied. Needed to hold the information about all color values that can be used in a chart, to save unchecked color legend items from being removed,
- `allData`: full dataset, needed to show the timeline when using time slider. We can't use `scalesData` here, due to the fact the the `useChartData` hook gets re-rendered and prevents the timeline from working it such case.

### Next steps
- Consolidate segments computation logic.