### PR TITLE
fix: Server-side filtering for versioned dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 ## Unreleased
 
 - Fixes
+  - Server-side filtering of large dimensions (more than 100 filter values) now works for versioned dimensions
+
+# [3.20.3] - 2023-07-04
+
+- Fixes
   - Dimension values are now correctly sorted is dimension is numerical dimension
   - Stacked bar chart now doesn't render gaps in case of a missing value
 - Tests

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -563,12 +563,11 @@ export const getCubeObservations = async ({
   });
 
   const serverFilter =
-    Object.keys(serverFilters).length > 0
-      ? makeServerFilter(serverFilters)
-      : null;
+    Object.keys(dbFilters).length > 0 ? makeServerFilter(dbFilters) : null;
   const filteredObservationsRaw: typeof observationsRaw = [];
   const observations: Observation[] = [];
   const observationParser = parseObservation(cubeDimensions, raw);
+
   for (let or of observationsRaw) {
     if (!serverFilter || serverFilter(or)) {
       const obs = observationParser(or);


### PR DESCRIPTION
This PR fixes the server-side filtering of versioned dimensions.

It turns out that the server-side filtering didn't work when dimension was a versioned dimension – we were comparing unversioned filter values with versioned filter values.

### How to test
1. Open `Bathing water quality` dataset.
2. Add coloring by Bathing site.
3. See that the chart works.
4. Follow above steps on other environments (e.g. Prod) to see that no data is returned.