### PR TITLE
refactor: Consolidate d3 rendering

### DIFF
--- a/app/charts/area/constants.ts
+++ b/app/charts/area/constants.ts
@@ -1,2 +1,0 @@
-export const BOTTOM_MARGIN_OFFSET = 10;
-export const LEFT_MARGIN_OFFSET = 16;

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -18,12 +18,7 @@ import {
   useColumnsStateData,
   useColumnsStateVariables,
 } from "@/charts/column/columns-state-props";
-import {
-  BOTTOM_MARGIN_OFFSET,
-  LEFT_MARGIN_OFFSET,
-  PADDING_INNER,
-  PADDING_OUTER,
-} from "@/charts/column/constants";
+import { PADDING_INNER, PADDING_OUTER } from "@/charts/column/constants";
 import {
   getChartBounds,
   useChartPadding,
@@ -103,6 +98,7 @@ const useColumnsState = (
   const {
     xScale,
     yScale,
+    allYScale,
     interactiveXTimeRangeScale,
     xScaleInteraction,
     bandDomainLabels,
@@ -151,12 +147,24 @@ const useColumnsState = (
       ) ?? 0,
       0
     );
-
     const yScale = scaleLinear().domain([minValue, maxValue]).nice();
+
+    const allMinValue = Math.min(
+      min(allData, (d) => (getYErrorRange ? getYErrorRange(d)[0] : getY(d))) ??
+        0,
+      0
+    );
+    const allMaxValue = Math.max(
+      max(allData, (d) => (getYErrorRange ? getYErrorRange(d)[1] : getY(d))) ??
+        0,
+      0
+    );
+    const allYScale = scaleLinear().domain([allMinValue, allMaxValue]).nice();
 
     return {
       xScale,
       yScale,
+      allYScale,
       interactiveXTimeRangeScale,
       xScaleInteraction,
       bandDomainLabels,
@@ -168,6 +176,7 @@ const useColumnsState = (
     getY,
     getYErrorRange,
     scalesData,
+    allData,
     timeRangeData,
     fields.x.sorting,
     fields.x.useAbbreviations,
@@ -177,7 +186,7 @@ const useColumnsState = (
   ]);
 
   const { left, bottom } = useChartPadding(
-    yScale,
+    allYScale,
     width,
     aspectRatio,
     interactiveFiltersConfig,
@@ -187,8 +196,8 @@ const useColumnsState = (
   const margins = {
     top: 50,
     right: 40,
-    bottom: bottom + BOTTOM_MARGIN_OFFSET,
-    left: left + LEFT_MARGIN_OFFSET,
+    bottom,
+    left,
   };
   const bounds = getChartBounds(width, margins, aspectRatio);
   const { chartWidth, chartHeight } = bounds;

--- a/app/charts/column/constants.ts
+++ b/app/charts/column/constants.ts
@@ -1,5 +1,3 @@
 export const PADDING_OUTER = 0;
 export const PADDING_INNER = 0.1;
 export const PADDING_WITHIN = 0.1;
-export const BOTTOM_MARGIN_OFFSET = 10;
-export const LEFT_MARGIN_OFFSET = 5;

--- a/app/charts/column/rendering-utils.ts
+++ b/app/charts/column/rendering-utils.ts
@@ -1,5 +1,10 @@
 import { Selection } from "d3";
 
+import {
+  RenderOptions,
+  maybeTransition,
+} from "@/charts/shared/rendering-utils";
+
 export type RenderColumnDatum = {
   key: string;
   x: number;
@@ -9,49 +14,52 @@ export type RenderColumnDatum = {
   color: string;
 };
 
-export const renderColumn = (
-  g: Selection<SVGRectElement, RenderColumnDatum, SVGGElement, unknown>,
-  y0: number,
-  transitionDuration: number
+type RenderColumnOptions = RenderOptions & {
+  y0: number;
+};
+
+export const renderColumns = (
+  g: Selection<SVGGElement, null, SVGGElement, unknown>,
+  data: RenderColumnDatum[],
+  options: RenderColumnOptions
 ) => {
-  g.join(
-    (enter) =>
-      enter
-        .append("rect")
-        .attr("data-index", (_, i) => i)
-        .attr("x", (d) => d.x)
-        .attr("y", y0)
-        .attr("width", (d) => d.width)
-        .attr("height", 0)
-        .attr("fill", (d) => d.color)
-        .call((enter) =>
-          enter
-            .transition()
-            .duration(transitionDuration)
-            .attr("y", (d) => d.y)
-            .attr("height", (d) => d.height)
-        ),
-    (update) =>
-      update.call((update) =>
-        update
-          .transition()
-          .duration(transitionDuration)
+  const { transition, y0 } = options;
+
+  g.selectAll<SVGRectElement, RenderColumnDatum>("rect")
+    .data(data, (d) => d.key)
+    .join(
+      (enter) =>
+        enter
+          .append("rect")
+          .attr("data-index", (_, i) => i)
           .attr("x", (d) => d.x)
-          .attr("y", (d) => d.y)
-          .attr("width", (d) => d.width)
-          .attr("height", (d) => d.height)
-          .attr("fill", (d) => d.color)
-      ),
-    (exit) =>
-      exit.call((exit) =>
-        exit
-          .transition()
-          .duration(transitionDuration)
           .attr("y", y0)
+          .attr("width", (d) => d.width)
           .attr("height", 0)
-          .remove()
-      )
-  );
+          .attr("fill", (d) => d.color)
+          .call((enter) =>
+            maybeTransition(enter, {
+              transition,
+              s: (g) => g.attr("y", (d) => d.y).attr("height", (d) => d.height),
+            })
+          ),
+      (update) =>
+        maybeTransition(update, {
+          s: (g) =>
+            g
+              .attr("x", (d) => d.x)
+              .attr("y", (d) => d.y)
+              .attr("width", (d) => d.width)
+              .attr("height", (d) => d.height)
+              .attr("fill", (d) => d.color),
+          transition,
+        }),
+      (exit) =>
+        maybeTransition(exit, {
+          transition,
+          s: (g) => g.attr("y", y0).attr("height", 0).remove(),
+        })
+    );
 };
 
 export type RenderWhiskerDatum = {
@@ -62,82 +70,91 @@ export type RenderWhiskerDatum = {
   width: number;
 };
 
-export const renderWhisker = (
-  g: Selection<SVGGElement, RenderWhiskerDatum, SVGGElement, unknown>,
-  transitionDuration: number
+export const renderWhiskers = (
+  g: Selection<SVGGElement, null, SVGGElement, unknown>,
+  data: RenderWhiskerDatum[],
+  options: RenderOptions
 ) => {
-  g.join(
-    (enter) =>
-      enter
-        .append("g")
-        .attr("opacity", 0)
-        .call((g) =>
-          g
-            .append("rect")
-            .attr("class", "top")
-            .attr("x", (d) => d.x)
-            .attr("y", (d) => d.y2)
-            .attr("width", (d) => d.width)
-            .attr("height", 2)
-            .attr("fill", "black")
-            .attr("stroke", "none")
-        )
-        .call((g) =>
-          g
-            .append("rect")
-            .attr("class", "middle")
-            .attr("x", (d) => d.x + d.width / 2 - 1)
-            .attr("y", (d) => d.y2)
-            .attr("width", 2)
-            .attr("height", (d) => d.y1 - d.y2)
-            .attr("fill", "black")
-            .attr("stroke", "none")
-        )
-        .call((g) =>
-          g
-            .append("rect")
-            .attr("class", "bottom")
-            .attr("x", (d) => d.x)
-            .attr("y", (d) => d.y1)
-            .attr("width", (d) => d.width)
-            .attr("height", 2)
-            .attr("fill", "black")
-            .attr("stroke", "none")
-        )
-        .call((g) =>
-          g.transition().duration(transitionDuration).attr("opacity", 1)
-        ),
-    (update) =>
-      update.call((g) =>
-        g
-          .transition()
-          .duration(transitionDuration)
-          .attr("opacity", 1)
+  const { transition } = options;
+
+  g.selectAll<SVGGElement, RenderWhiskerDatum>("g")
+    .data(data, (d) => d.key)
+    .join(
+      (enter) =>
+        enter
+          .append("g")
+          .attr("opacity", 0)
           .call((g) =>
             g
-              .select(".top")
+              .append("rect")
+              .attr("class", "top")
               .attr("x", (d) => d.x)
               .attr("y", (d) => d.y2)
               .attr("width", (d) => d.width)
+              .attr("height", 2)
+              .attr("fill", "black")
+              .attr("stroke", "none")
           )
           .call((g) =>
             g
-              .select(".middle")
+              .append("rect")
+              .attr("class", "middle")
               .attr("x", (d) => d.x + d.width / 2 - 1)
               .attr("y", (d) => d.y2)
+              .attr("width", 2)
               .attr("height", (d) => d.y1 - d.y2)
+              .attr("fill", "black")
+              .attr("stroke", "none")
           )
           .call((g) =>
             g
-              .select(".bottom")
+              .append("rect")
+              .attr("class", "bottom")
               .attr("x", (d) => d.x)
               .attr("y", (d) => d.y1)
               .attr("width", (d) => d.width)
+              .attr("height", 2)
+              .attr("fill", "black")
+              .attr("stroke", "none")
           )
-      ),
-    (exit) =>
-      exit.call((g) =>
-        g.transition().duration(transitionDuration).attr("opacity", 0).remove()
-      )
-  );
+          .call((enter) =>
+            maybeTransition(enter, {
+              s: (g) => g.attr("opacity", 1),
+              transition,
+            })
+          ),
+      (update) =>
+        maybeTransition(update, {
+          s: (g) =>
+            g
+              .attr("opacity", 1)
+              .call((g) =>
+                g
+                  .select(".top")
+                  .attr("x", (d) => d.x)
+                  .attr("y", (d) => d.y2)
+                  .attr("width", (d) => d.width)
+              )
+              .call((g) =>
+                g
+                  .select(".middle")
+                  .attr("x", (d) => d.x + d.width / 2 - 1)
+                  .attr("y", (d) => d.y2)
+                  .attr("height", (d) => d.y1 - d.y2)
+              )
+              .call((g) =>
+                g
+                  .select(".bottom")
+                  .attr("x", (d) => d.x)
+                  .attr("y", (d) => d.y1)
+                  .attr("width", (d) => d.width)
+              ),
+          transition,
+        }),
+      (exit) =>
+        maybeTransition(exit, {
+          transition,
+          s: (g) => g.attr("opacity", 0).remove(),
+        })
+    );
 };

--- a/app/charts/line/constants.ts
+++ b/app/charts/line/constants.ts
@@ -1,2 +1,0 @@
-export const BOTTOM_MARGIN_OFFSET = 10;
-export const LEFT_MARGIN_OFFSET = 16;

--- a/app/charts/pie/pie.tsx
+++ b/app/charts/pie/pie.tsx
@@ -1,18 +1,19 @@
-import { arc, PieArcDatum, select } from "d3";
+import { arc, PieArcDatum } from "d3";
 import React from "react";
 
 import { PieState } from "@/charts/pie/pie-state";
+import { RenderDatum, renderPies } from "@/charts/pie/rendering-utils";
 import { useChartState } from "@/charts/shared/chart-state";
+import { renderContainer } from "@/charts/shared/rendering-utils";
 import { useInteraction } from "@/charts/shared/use-interaction";
 import { Observation } from "@/domain/data";
 import { useTransitionStore } from "@/stores/transition";
 import useEvent from "@/utils/use-event";
 
-import { RenderDatum, renderPie } from "./rendering-utils";
-
 export const Pie = () => {
   const { chartData, getPieData, getSegment, colors, bounds, getRenderingKey } =
     useChartState() as PieState;
+  const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
   const { width, height, chartWidth, chartHeight } = bounds;
   const [, dispatch] = useInteraction();
@@ -61,23 +62,30 @@ export const Pie = () => {
   });
 
   React.useEffect(() => {
-    if (ref.current) {
-      select(ref.current).call(
-        renderPie,
-        renderData,
-        arcGenerator,
-        handleMouseEnter,
-        handleMouseLeave,
-        transitionDuration
-      );
+    if (ref.current && renderData) {
+      renderContainer(ref.current, {
+        id: "pies",
+        transform: `translate(${xTranslate} ${yTranslate})`,
+        transition: { enable: enableTransition, duration: transitionDuration },
+        render: (g, opts) =>
+          renderPies(g, renderData, {
+            ...opts,
+            arcGenerator,
+            handleMouseEnter,
+            handleMouseLeave,
+          }),
+      });
     }
   }, [
-    renderData,
     arcGenerator,
+    enableTransition,
     handleMouseEnter,
     handleMouseLeave,
+    renderData,
     transitionDuration,
+    xTranslate,
+    yTranslate,
   ]);
 
-  return <g ref={ref} transform={`translate(${xTranslate}, ${yTranslate})`} />;
+  return <g ref={ref} />;
 };

--- a/app/charts/scatterplot/constants.ts
+++ b/app/charts/scatterplot/constants.ts
@@ -1,1 +1,0 @@
-export const LEFT_MARGIN_OFFSET = 5;

--- a/app/charts/scatterplot/rendering-utils.ts
+++ b/app/charts/scatterplot/rendering-utils.ts
@@ -1,4 +1,9 @@
-import { BaseType, Selection } from "d3";
+import { Selection } from "d3";
+
+import {
+  RenderOptions,
+  maybeTransition,
+} from "@/charts/shared/rendering-utils";
 
 export type RenderDatum = {
   key: string;
@@ -8,10 +13,12 @@ export type RenderDatum = {
 };
 
 export const renderCircles = (
-  g: Selection<SVGGElement, null, BaseType, unknown>,
+  g: Selection<SVGGElement, null, SVGGElement, unknown>,
   renderData: RenderDatum[],
-  transitionDuration: number
+  options: RenderOptions
 ) => {
+  const { transition } = options;
+
   g.selectAll<SVGCircleElement, RenderDatum>("circle")
     .data(renderData, (d) => d.key)
     .join(
@@ -26,25 +33,25 @@ export const renderCircles = (
           .attr("fill", (d) => d.color)
           .attr("opacity", 0)
           .call((enter) =>
-            enter.transition().duration(transitionDuration).attr("opacity", 1)
+            maybeTransition(enter, {
+              transition,
+              s: (g) => g.attr("opacity", 1),
+            })
           ),
       (update) =>
-        update.call((update) =>
-          update
-            .transition()
-            .duration(transitionDuration)
-            .attr("cx", (d) => d.cx)
-            .attr("cy", (d) => d.cy)
-            .attr("fill", (d) => d.color)
-            .attr("opacity", 1)
-        ),
+        maybeTransition(update, {
+          transition,
+          s: (g) =>
+            g
+              .attr("cx", (d) => d.cx)
+              .attr("cy", (d) => d.cy)
+              .attr("fill", (d) => d.color)
+              .attr("opacity", 1),
+        }),
       (exit) =>
-        exit.call((exit) =>
-          exit
-            .transition()
-            .duration(transitionDuration)
-            .attr("opacity", 0)
-            .remove()
-        )
+        maybeTransition(exit, {
+          transition,
+          s: (g) => g.attr("opacity", 0).remove(),
+        })
     );
 };

--- a/app/charts/shared/axis-width-band.tsx
+++ b/app/charts/shared/axis-width-band.tsx
@@ -1,144 +1,130 @@
-import { axisBottom, select, Selection } from "d3";
+import { axisBottom } from "d3";
 import { useEffect, useRef } from "react";
 
 import { ColumnsState } from "@/charts/column/columns-state";
 import { useChartState } from "@/charts/shared/chart-state";
+import {
+  maybeTransition,
+  renderContainer,
+} from "@/charts/shared/rendering-utils";
 import { useChartTheme } from "@/charts/shared/use-chart-theme";
 import { useTimeFormatUnit } from "@/formatters";
 import { useTransitionStore } from "@/stores/transition";
 
 export const AxisWidthBand = () => {
   const ref = useRef<SVGGElement>(null);
-  const transitionDuration = useTransitionStore((state) => state.duration);
   const { xScale, yScale, bounds, xTimeUnit, getXLabel } =
     useChartState() as ColumnsState;
-
+  const enableTransition = useTransitionStore((state) => state.enable);
+  const transitionDuration = useTransitionStore((state) => state.duration);
   const formatDate = useTimeFormatUnit();
-
   const { chartHeight, margins } = bounds;
-
   const { labelColor, gridColor, labelFontSize, fontFamily, domainColor } =
     useChartTheme();
 
-  const mkAxis = (g: Selection<SVGGElement, unknown, null, undefined>) => {
-    const rotation = true;
-    const hasNegativeValues = yScale.domain()[0] < 0;
-    const fontSize =
-      xScale.bandwidth() > labelFontSize ? labelFontSize : xScale.bandwidth();
-
-    const axis = axisBottom(xScale)
-      .tickSizeOuter(0)
-      .tickSizeInner(hasNegativeValues ? -chartHeight : 6)
-      .tickPadding(rotation ? -10 : 0);
-
-    if (xTimeUnit) {
-      axis.tickFormat((d) => formatDate(d, xTimeUnit));
-    } else {
-      axis.tickFormat((d) => getXLabel(d));
-    }
-
-    g.selectAll<SVGGElement, null>(".content")
-      .data([null])
-      .join(
-        (enter) =>
-          enter
-            .append("g")
-            .attr("class", "content")
-            .attr("data-testid", "axis-width-band")
-            .attr(
-              "transform",
-              `translate(${margins.left}, ${chartHeight + margins.top})`
-            )
-            .call(axis),
-        (update) =>
-          update.call((g) =>
-            g
-              .transition()
-              .duration(transitionDuration)
-              .attr(
-                "transform",
-                `translate(${margins.left}, ${chartHeight + margins.top})`
-              )
-              .call(axis)
-          ),
-        (exit) => exit.remove()
-      );
-
-    g.select(".domain").remove();
-    g.selectAll(".tick line").attr(
-      "stroke",
-      hasNegativeValues ? gridColor : domainColor
-    );
-    g.selectAll(".tick text")
-      .attr("transform", rotation ? "rotate(90)" : "rotate(0)")
-      .attr("x", rotation ? fontSize : 0)
-      .attr("font-size", fontSize)
-      .attr("font-family", fontFamily)
-      .attr("fill", labelColor)
-      .attr("text-anchor", rotation ? "start" : "unset");
-  };
-
   useEffect(() => {
     if (ref.current) {
-      select<SVGGElement, unknown>(ref.current).call(mkAxis);
+      const rotation = true;
+      const hasNegativeValues = yScale.domain()[0] < 0;
+      const fontSize =
+        xScale.bandwidth() > labelFontSize ? labelFontSize : xScale.bandwidth();
+      const axis = axisBottom(xScale)
+        .tickSizeOuter(0)
+        .tickSizeInner(hasNegativeValues ? -chartHeight : 6)
+        .tickPadding(rotation ? -10 : 0);
+
+      if (xTimeUnit) {
+        axis.tickFormat((d) => formatDate(d, xTimeUnit));
+      } else {
+        axis.tickFormat((d) => getXLabel(d));
+      }
+
+      const g = renderContainer(ref.current, {
+        id: "axis-width-band",
+        transform: `translate(${margins.left} ${chartHeight + margins.top})`,
+        transition: { enable: enableTransition, duration: transitionDuration },
+        render: (g) => g.attr("data-testid", "axis-width-band").call(axis),
+        renderUpdate: (g, opts) =>
+          maybeTransition(g, {
+            transition: opts.transition,
+            s: (g) => g.call(axis),
+          }),
+      });
+
+      g.select(".domain").remove();
+      g.selectAll(".tick line").attr(
+        "stroke",
+        hasNegativeValues ? gridColor : domainColor
+      );
+      g.selectAll(".tick text")
+        .attr("transform", rotation ? "rotate(90)" : "rotate(0)")
+        .attr("x", rotation ? fontSize : 0)
+        .attr("font-size", fontSize)
+        .attr("font-family", fontFamily)
+        .attr("fill", labelColor)
+        .attr("text-anchor", rotation ? "start" : "unset");
     }
-  });
+  }, [
+    chartHeight,
+    domainColor,
+    enableTransition,
+    fontFamily,
+    formatDate,
+    getXLabel,
+    gridColor,
+    labelColor,
+    labelFontSize,
+    margins.left,
+    margins.top,
+    transitionDuration,
+    xScale,
+    xTimeUnit,
+    yScale,
+  ]);
 
   return <g ref={ref} />;
 };
 
 export const AxisWidthBandDomain = () => {
   const ref = useRef<SVGGElement>(null);
+  const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
   const { xScale, yScale, bounds } = useChartState() as ColumnsState;
   const { chartHeight, margins } = bounds;
   const { domainColor } = useChartTheme();
 
-  const mkAxisDomain = (
-    g: Selection<SVGGElement, unknown, null, undefined>
-  ) => {
-    g.selectAll<SVGGElement, null>(".content")
-      .data([null])
-      .join(
-        (enter) =>
-          enter
-            .append("g")
-            .attr("class", "content")
-            .attr(
-              "transform",
-              `translate(${margins.left}, ${chartHeight + margins.top})`
-            )
-            .call((g) =>
-              g
-                .transition()
-                .duration(transitionDuration)
-                .call(axisBottom(xScale).tickSizeOuter(0))
-            ),
-        (update) =>
-          update.call((g) =>
-            g
-              .transition()
-              .duration(transitionDuration)
-              .attr(
-                "transform",
-                `translate(${margins.left}, ${chartHeight + margins.top})`
-              )
-              .call(axisBottom(xScale).tickSizeOuter(0))
-          ),
-        (exit) => exit.remove()
-      );
-
-    g.selectAll(".tick line").remove();
-    g.selectAll(".tick text").remove();
-    g.select(".domain")
-      .attr("transform", `translate(0, -${bounds.chartHeight - yScale(0)})`)
-      .attr("stroke", domainColor);
-  };
-
   useEffect(() => {
-    const g = select(ref.current);
-    mkAxisDomain(g as Selection<SVGGElement, unknown, null, undefined>);
-  });
+    if (ref.current) {
+      const axis = axisBottom(xScale).tickSizeOuter(0);
+      const g = renderContainer(ref.current, {
+        id: "axis-width-band-domain",
+        transform: `translate(${margins.left} ${chartHeight + margins.top})`,
+        transition: { enable: enableTransition, duration: transitionDuration },
+        render: (g) => g.call(axis),
+        renderUpdate: (g, opts) =>
+          maybeTransition(g, {
+            transition: opts.transition,
+            s: (g) => g.call(axis),
+          }),
+      });
+
+      g.selectAll(".tick line").remove();
+      g.selectAll(".tick text").remove();
+      g.select(".domain")
+        .attr("transform", `translate(0, -${bounds.chartHeight - yScale(0)})`)
+        .attr("stroke", domainColor);
+    }
+  }, [
+    bounds.chartHeight,
+    chartHeight,
+    domainColor,
+    enableTransition,
+    margins.left,
+    margins.top,
+    transitionDuration,
+    xScale,
+    yScale,
+  ]);
 
   return <g ref={ref} />;
 };

--- a/app/charts/shared/axis-width-time.tsx
+++ b/app/charts/shared/axis-width-time.tsx
@@ -123,7 +123,6 @@ export const AxisTimeDomain = () => {
         (exit) => exit.remove()
       );
 
-    g.call(axis);
     g.selectAll(".tick line").remove();
     g.selectAll(".tick text").remove();
     g.select(".domain")

--- a/app/charts/shared/axis-width-time.tsx
+++ b/app/charts/shared/axis-width-time.tsx
@@ -1,9 +1,13 @@
-import { axisBottom, select, Selection } from "d3";
+import { axisBottom } from "d3";
 import { useEffect, useRef } from "react";
 
 import { AreasState } from "@/charts/area/areas-state";
 import { LinesState } from "@/charts/line/lines-state";
 import { useChartState } from "@/charts/shared/chart-state";
+import {
+  maybeTransition,
+  renderContainer,
+} from "@/charts/shared/rendering-utils";
 import { useChartTheme } from "@/charts/shared/use-chart-theme";
 import { useFormatShortDateAuto } from "@/formatters";
 import { useTransitionStore } from "@/stores/transition";
@@ -14,9 +18,11 @@ const MAX_DATE_LABEL_LENGHT = 70;
 
 export const AxisTime = () => {
   const ref = useRef<SVGGElement>(null);
+  const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
   const formatDateAuto = useFormatShortDateAuto();
   const { xScale, yScale, bounds } = useChartState() as LinesState | AreasState;
+  const { chartHeight, margins } = bounds;
   const { labelColor, gridColor, domainColor, labelFontSize, fontFamily } =
     useChartTheme();
 
@@ -30,109 +36,82 @@ export const AxisTime = () => {
   //     : null;
   const ticks = bounds.chartWidth / (MAX_DATE_LABEL_LENGHT + 20);
 
-  const mkAxis = (g: Selection<SVGGElement, unknown, null, undefined>) => {
-    const axis = axisBottom(xScale)
-      .ticks(ticks)
-      .tickFormat((x) => formatDateAuto(x as Date));
-
-    g.selectAll<SVGGElement, null>(".content")
-      .data([null])
-      .join(
-        (enter) =>
-          enter
-            .append("g")
-            .attr("class", "content")
-            .attr(
-              "transform",
-              `translate(${bounds.margins.left}, ${
-                bounds.chartHeight + bounds.margins.top
-              })`
-            )
-            .call(axis),
-        (update) =>
-          update.call((g) =>
-            g
-              .transition()
-              .duration(transitionDuration)
-              .attr(
-                "transform",
-                `translate(${bounds.margins.left}, ${
-                  bounds.chartHeight + bounds.margins.top
-                })`
-              )
-              .call(axis)
-          ),
-        (exit) => exit.remove()
-      );
-
-    g.select(".domain").remove();
-    g.selectAll(".tick line").attr(
-      "stroke",
-      hasNegativeValues ? gridColor : domainColor
-    );
-    g.selectAll(".tick text")
-      .attr("font-size", labelFontSize)
-      .attr("font-family", fontFamily)
-      .attr("fill", labelColor);
-  };
-
   useEffect(() => {
-    const g = select(ref.current);
-    mkAxis(g as Selection<SVGGElement, unknown, null, undefined>);
-  });
+    if (ref.current) {
+      const axis = axisBottom(xScale)
+        .ticks(ticks)
+        .tickFormat((x) => formatDateAuto(x as Date));
+      const g = renderContainer(ref.current, {
+        id: "axis-width-time",
+        transform: `translate(${margins.left} ${chartHeight + margins.top})`,
+        transition: { enable: enableTransition, duration: transitionDuration },
+        render: (g) => g.call(axis),
+        renderUpdate: (g, opts) =>
+          maybeTransition(g, {
+            transition: opts.transition,
+            s: (g) => g.call(axis),
+          }),
+      });
+
+      g.select(".domain").remove();
+      g.selectAll(".tick line").attr(
+        "stroke",
+        hasNegativeValues ? gridColor : domainColor
+      );
+      g.selectAll(".tick text")
+        .attr("font-size", labelFontSize)
+        .attr("font-family", fontFamily)
+        .attr("fill", labelColor);
+    }
+  }, [
+    chartHeight,
+    domainColor,
+    enableTransition,
+    fontFamily,
+    formatDateAuto,
+    gridColor,
+    hasNegativeValues,
+    labelColor,
+    labelFontSize,
+    margins.left,
+    margins.top,
+    ticks,
+    transitionDuration,
+    xScale,
+  ]);
 
   return <g ref={ref} />;
 };
 
 export const AxisTimeDomain = () => {
   const ref = useRef<SVGGElement>(null);
+  const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
   const { xScale, yScale, bounds } = useChartState() as LinesState | AreasState;
+  const { chartHeight, margins } = bounds;
   const { domainColor } = useChartTheme();
 
-  const mkAxis = (g: Selection<SVGGElement, unknown, null, undefined>) => {
-    const axis = axisBottom(xScale).tickSizeOuter(0);
-
-    g.selectAll<SVGGElement, null>(".content")
-      .data([null])
-      .join(
-        (enter) =>
-          enter
-            .append("g")
-            .attr("class", "content")
-            .attr(
-              "transform",
-              `translate(${bounds.margins.left}, ${
-                bounds.chartHeight + bounds.margins.top
-              })`
-            )
-            .call(axis),
-        (update) =>
-          update.call((g) =>
-            g
-              .transition()
-              .duration(transitionDuration)
-              .attr(
-                "transform",
-                `translate(${bounds.margins.left}, ${
-                  bounds.chartHeight + bounds.margins.top
-                })`
-              )
-              .call(axis)
-          ),
-        (exit) => exit.remove()
-      );
-
-    g.selectAll(".tick line").remove();
-    g.selectAll(".tick text").remove();
-    g.select(".domain")
-      .attr("transform", `translate(0, -${bounds.chartHeight - yScale(0)})`)
-      .attr("stroke", domainColor);
-  };
-
   useEffect(() => {
-    const g = select(ref.current);
-    mkAxis(g as Selection<SVGGElement, unknown, null, undefined>);
+    if (ref.current) {
+      const axis = axisBottom(xScale).tickSizeOuter(0);
+      const g = renderContainer(ref.current, {
+        id: "axis-width-time-domain",
+        transform: `translate(${margins.left} ${chartHeight + margins.top})`,
+        transition: { enable: enableTransition, duration: transitionDuration },
+        render: (g) => g.call(axis),
+        renderUpdate: (g, opts) =>
+          maybeTransition(g, {
+            transition: opts.transition,
+            s: (g) => g.call(axis),
+          }),
+      });
+
+      g.selectAll(".tick line").remove();
+      g.selectAll(".tick text").remove();
+      g.select(".domain")
+        .attr("transform", `translate(0, -${bounds.chartHeight - yScale(0)})`)
+        .attr("stroke", domainColor);
+    }
   });
 
   return <g ref={ref} />;

--- a/app/charts/shared/brush/constants.ts
+++ b/app/charts/shared/brush/constants.ts
@@ -1,2 +1,2 @@
 // Space used in chart states as bottom margin
-export const BRUSH_BOTTOM_SPACE = 100;
+export const BRUSH_BOTTOM_SPACE = 75;

--- a/app/charts/shared/brush/index.tsx
+++ b/app/charts/shared/brush/index.tsx
@@ -25,6 +25,7 @@ import { estimateTextWidth } from "@/utils/estimate-text-width";
 // Brush constants
 export const HANDLE_HEIGHT = 14;
 export const BRUSH_HEIGHT = 3;
+export const HEIGHT = HANDLE_HEIGHT + BRUSH_HEIGHT;
 
 export const BrushTime = () => {
   const ref = useRef<SVGGElement>(null);
@@ -332,13 +333,13 @@ export const BrushTime = () => {
   }, [brushWidth]);
 
   return (
-    <>
+    <g
+      transform={`translate(0, ${
+        chartHeight + margins.top + margins.bottom - HEIGHT * 1.5
+      })`}
+    >
       {/* Selected Dates */}
-      <g
-        transform={`translate(0, ${
-          chartHeight + margins.top + margins.bottom / 2
-        })`}
-      >
+      <g>
         {closestFrom && closestTo && (
           <text
             fontSize={labelFontSize}
@@ -353,11 +354,7 @@ export const BrushTime = () => {
       </g>
 
       {/* Brush */}
-      <g
-        transform={`translate(${brushLabelsWidth}, ${
-          chartHeight + margins.top + margins.bottom / 2
-        })`}
-      >
+      <g transform={`translate(${brushLabelsWidth}, 0)`}>
         {/* Visual overlay (functional overlay is managed by d3) */}
         <rect
           x={0}
@@ -368,13 +365,8 @@ export const BrushTime = () => {
         />
       </g>
       {/* actual Brush */}
-      <g
-        ref={ref}
-        transform={`translate(${brushLabelsWidth}, ${
-          chartHeight + margins.top + margins.bottom / 2
-        })`}
-      />
-    </>
+      <g ref={ref} transform={`translate(${brushLabelsWidth}, 0)`} />
+    </g>
   );
 };
 

--- a/app/charts/shared/brush/index.tsx
+++ b/app/charts/shared/brush/index.tsx
@@ -28,16 +28,10 @@ export const BRUSH_HEIGHT = 3;
 
 export const BrushTime = () => {
   const ref = useRef<SVGGElement>(null);
-  const { timeRange, setTimeRange } = useInteractiveFiltersStore((d) => ({
-    timeRange: d.timeRange,
-    setTimeRange: d.setTimeRange,
-  }));
-  const { setDefaultDuration, setInstantDuration } = useTransitionStore(
-    (d) => ({
-      setDefaultDuration: d.setDefaultDuration,
-      setInstantDuration: d.setInstantDuration,
-    })
-  );
+  const timeRange = useInteractiveFiltersStore((d) => d.timeRange);
+  const setTimeRange = useInteractiveFiltersStore((d) => d.setTimeRange);
+  const setDefaultDuration = useTransitionStore((d) => d.setDefaultDuration);
+  const setInstantDuration = useTransitionStore((d) => d.setInstantDuration);
   const formatDateAuto = useFormatFullDateAuto();
   const [brushedIsEnded, updateBrushEndedStatus] = useState(true);
   const [selectionExtent, setSelectionExtent] = useState(0);

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -49,6 +49,7 @@ export const ChartDataFilters = ({
 }) => {
   const [filtersVisible, setFiltersVisible] = React.useState(false);
   const { componentIris } = dataFiltersConfig;
+  console.log("ChartDataFilters");
 
   React.useEffect(() => {
     if (componentIris.length === 0) {
@@ -67,14 +68,14 @@ export const ChartDataFilters = ({
               minHeight: 20,
             }}
           >
-            {!filtersVisible ? (
+            {filtersVisible ? (
+              <Box />
+            ) : (
               <ChartFiltersList
                 dataSetIri={dataSet}
                 dataSource={dataSource}
                 chartConfig={chartConfig}
               />
-            ) : (
-              <Box></Box>
             )}
 
             {componentIris.length > 0 && (
@@ -127,21 +128,19 @@ export const ChartDataFilters = ({
   );
 };
 
-const DataFilter = ({
-  dimensionIri,
-  dataSetIri,
-  dataSource,
-  chartConfig,
-}: {
+type DataFilterProps = {
   dimensionIri: string;
   dataSetIri: string;
   dataSource: DataSource;
   chartConfig: ChartConfig;
-}) => {
-  const { dataFilters, updateDataFilter } = useInteractiveFiltersStore((d) => ({
-    dataFilters: d.dataFilters,
-    updateDataFilter: d.updateDataFilter,
-  }));
+};
+
+const DataFilter = (props: DataFilterProps) => {
+  const { dimensionIri, dataSetIri, dataSource, chartConfig } = props;
+  const dataFilters = useInteractiveFiltersStore((d) => d.dataFilters);
+  const updateDataFilter = useInteractiveFiltersStore(
+    (d) => d.updateDataFilter
+  );
   const locale = useLocale();
   const [{ data }] = useDimensionValuesQuery({
     variables: {

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -49,7 +49,6 @@ export const ChartDataFilters = ({
 }) => {
   const [filtersVisible, setFiltersVisible] = React.useState(false);
   const { componentIris } = dataFiltersConfig;
-  console.log("ChartDataFilters");
 
   React.useEffect(() => {
     if (componentIris.length === 0) {

--- a/app/charts/shared/chart-dimensions.tsx
+++ b/app/charts/shared/chart-dimensions.tsx
@@ -13,8 +13,7 @@ const computeChartPadding = (
   aspectRatio: number,
   interactiveFiltersConfig: ChartConfig["interactiveFiltersConfig"],
   formatNumber: (n: number) => string,
-  bandDomain?: string[],
-  normalize?: boolean
+  bandDomain?: string[]
 ) => {
   // Fake ticks to compute maximum tick length as
   // we need to take into account n between [0, 1] where numbers
@@ -23,9 +22,7 @@ const computeChartPadding = (
   // since we do not have access to chartHeight yet.
   const fakeTicks = yScale.ticks(getTickNumber(width * aspectRatio));
   const left = Math.max(
-    ...fakeTicks.map((x) =>
-      estimateTextWidth(`${formatNumber(x)}${normalize ? "%" : ""}`)
-    )
+    ...fakeTicks.map((x) => estimateTextWidth(formatNumber(x)))
   );
 
   let bottom = interactiveFiltersConfig?.timeRange.active
@@ -33,7 +30,7 @@ const computeChartPadding = (
     : 30;
 
   if (bandDomain?.length) {
-    bottom += max(bandDomain, (d) => estimateTextWidth(d) || 70)!;
+    bottom += max(bandDomain, (d) => estimateTextWidth(d)) ?? 70;
   }
 
   return { left, bottom };
@@ -45,8 +42,7 @@ export const useChartPadding = (
   aspectRatio: number,
   interactiveFiltersConfig: ChartConfig["interactiveFiltersConfig"],
   formatNumber: (n: number) => string,
-  bandDomain?: string[],
-  normalize?: boolean
+  bandDomain?: string[]
 ) => {
   return useMemo(
     () =>
@@ -56,8 +52,7 @@ export const useChartPadding = (
         aspectRatio,
         interactiveFiltersConfig,
         formatNumber,
-        bandDomain,
-        normalize
+        bandDomain
       ),
     [
       yScale,
@@ -66,7 +61,6 @@ export const useChartPadding = (
       interactiveFiltersConfig,
       formatNumber,
       bandDomain,
-      normalize,
     ]
   );
 };

--- a/app/charts/shared/chart-state.ts
+++ b/app/charts/shared/chart-state.ts
@@ -372,13 +372,9 @@ export const useChartData = (
   }
 ): Omit<ChartStateData, "allData"> => {
   const { interactiveFiltersConfig } = chartConfig;
-  const { categories, timeRange, timeSlider } = useInteractiveFiltersStore(
-    (d) => ({
-      categories: d.categories,
-      timeRange: d.timeRange,
-      timeSlider: d.timeSlider,
-    })
-  );
+  const categories = useInteractiveFiltersStore((d) => d.categories);
+  const timeRange = useInteractiveFiltersStore((d) => d.timeRange);
+  const timeSlider = useInteractiveFiltersStore((d) => d.timeSlider);
 
   // time range
   const timeRangeFilterComponentIri =

--- a/app/charts/shared/containers.tsx
+++ b/app/charts/shared/containers.tsx
@@ -8,6 +8,7 @@ import { useTransitionStore } from "@/stores/transition";
 
 export const ChartContainer = ({ children }: { children: ReactNode }) => {
   const ref = React.useRef<HTMLDivElement>(null);
+  const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
   const { bounds } = useChartState();
   const { width, height } = bounds;
@@ -19,12 +20,12 @@ export const ChartContainer = ({ children }: { children: ReactNode }) => {
         ref.current.style.height = `${height}px`;
       }
 
-      select(ref.current)
-        .transition()
-        .duration(transitionDuration)
-        .style("height", `${height}px`);
+      (enableTransition
+        ? select(ref.current).transition().duration(transitionDuration)
+        : select(ref.current)
+      ).style("height", `${height}px`);
     }
-  }, [height, transitionDuration]);
+  }, [height, enableTransition, transitionDuration]);
 
   return (
     <div ref={ref} aria-hidden="true" style={{ position: "relative", width }}>
@@ -35,6 +36,7 @@ export const ChartContainer = ({ children }: { children: ReactNode }) => {
 
 export const ChartSvg = ({ children }: { children: ReactNode }) => {
   const ref = React.useRef<SVGSVGElement>(null);
+  const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
   const { bounds, interactiveFiltersConfig } = useChartState();
   const { width, height, margins } = bounds;
@@ -46,12 +48,12 @@ export const ChartSvg = ({ children }: { children: ReactNode }) => {
         ref.current.setAttribute("height", height.toString());
       }
 
-      select(ref.current)
-        .transition()
-        .duration(transitionDuration)
-        .attr("height", height);
+      (enableTransition
+        ? select(ref.current).transition().duration(transitionDuration)
+        : select(ref.current)
+      ).attr("height", height);
     }
-  }, [height, transitionDuration]);
+  }, [height, enableTransition, transitionDuration]);
 
   return (
     <svg

--- a/app/charts/shared/interactive-filter-calculation-toggle.tsx
+++ b/app/charts/shared/interactive-filter-calculation-toggle.tsx
@@ -5,11 +5,9 @@ import { Switch } from "@/components/form";
 import { useInteractiveFiltersStore } from "@/stores/interactive-filters";
 
 export const CalculationToggle = () => {
-  const { calculation, setCalculationType } = useInteractiveFiltersStore(
-    (d) => ({
-      calculation: d.calculation,
-      setCalculationType: d.setCalculationType,
-    })
+  const calculation = useInteractiveFiltersStore((d) => d.calculation);
+  const setCalculationType = useInteractiveFiltersStore(
+    (d) => d.setCalculationType
   );
 
   const onChange = React.useCallback(() => {

--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -282,12 +282,9 @@ const LegendColorContent = (props: LegendColorContentProps) => {
   const { groups, getColor, getLabel, symbol, interactive, numberOfOptions } =
     props;
   const classes = useStyles();
-  const { categories, addCategory, removeCategory } =
-    useInteractiveFiltersStore((d) => ({
-      categories: d.categories,
-      addCategory: d.addCategory,
-      removeCategory: d.removeCategory,
-    }));
+  const categories = useInteractiveFiltersStore((d) => d.categories);
+  const addCategory = useInteractiveFiltersStore((d) => d.addCategory);
+  const removeCategory = useInteractiveFiltersStore((d) => d.removeCategory);
 
   const activeInteractiveFilters = useMemo(() => {
     return new Set(Object.keys(categories));

--- a/app/charts/shared/use-sync-interactive-filters.tsx
+++ b/app/charts/shared/use-sync-interactive-filters.tsx
@@ -104,12 +104,13 @@ const useSyncInteractiveFilters = (chartConfig: ChartConfig) => {
   );
 
   // Calculation
+  const calculationActive = interactiveFiltersConfig?.calculation.active;
   const calculationType = interactiveFiltersConfig?.calculation.type;
   React.useEffect(() => {
     if (calculationType) {
       setCalculationType(calculationType);
     }
-  }, [calculationType, setCalculationType]);
+  }, [calculationActive, calculationType, setCalculationType]);
 };
 
 export default useSyncInteractiveFilters;

--- a/app/charts/shared/use-sync-interactive-filters.tsx
+++ b/app/charts/shared/use-sync-interactive-filters.tsx
@@ -18,15 +18,17 @@ import { useInteractiveFiltersStore } from "@/stores/interactive-filters";
  *
  */
 const useSyncInteractiveFilters = (chartConfig: ChartConfig) => {
-  const {
-    resetCategories,
-    dataFilters,
-    setDataFilters,
-    updateDataFilter,
-    setTimeRange,
-    setCalculationType,
-  } = useInteractiveFiltersStore();
   const { interactiveFiltersConfig } = chartConfig;
+  const resetCategories = useInteractiveFiltersStore((d) => d.resetCategories);
+  const dataFilters = useInteractiveFiltersStore((d) => d.dataFilters);
+  const setDataFilters = useInteractiveFiltersStore((d) => d.setDataFilters);
+  const updateDataFilter = useInteractiveFiltersStore(
+    (d) => d.updateDataFilter
+  );
+  const setTimeRange = useInteractiveFiltersStore((d) => d.setTimeRange);
+  const setCalculationType = useInteractiveFiltersStore(
+    (d) => d.setCalculationType
+  );
 
   // Time range filter
   const presetFrom =

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -139,6 +139,7 @@ export const ChartPreviewInner = ({
                 sx={{
                   justifyContent: "space-between",
                   alignItems: "flex-start",
+                  gap: 2,
                 }}
               >
                 <Typography

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -9,7 +9,6 @@ import { DataSetTable } from "@/browse/datatable";
 import { ChartDataFilters } from "@/charts/shared/chart-data-filters";
 import { extractComponentIris } from "@/charts/shared/chart-helpers";
 import { isUsingImputation } from "@/charts/shared/imputation";
-import useSyncInteractiveFilters from "@/charts/shared/use-sync-interactive-filters";
 import { ChartErrorBoundary } from "@/components/chart-error-boundary";
 import { ChartFootnotes } from "@/components/chart-footnotes";
 import {
@@ -303,26 +302,12 @@ type ChartWithInteractiveFiltersProps = {
 const ChartWithInteractiveFilters = React.forwardRef(
   (props: ChartWithInteractiveFiltersProps, ref) => {
     const { dataSet, dataSource, chartConfig } = props;
-
-    useSyncInteractiveFilters(chartConfig);
-
-    const { setTimeRange, resetDataFilters } = useInteractiveFiltersStore(
-      (d) => ({
-        setTimeRange: d.setTimeRange,
-        resetDataFilters: d.resetDataFilters,
-      })
-    );
     const { interactiveFiltersConfig } = chartConfig;
+    const setTimeRange = useInteractiveFiltersStore((d) => d.setTimeRange);
     const timeRange = interactiveFiltersConfig?.timeRange;
     const presetFrom =
       timeRange?.presets.from && parseDate(timeRange.presets.from);
     const presetTo = timeRange?.presets.to && parseDate(timeRange.presets.to);
-
-    // Reset data filters if chart type changes
-    useEffect(() => {
-      resetDataFilters();
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [chartConfig.chartType]);
 
     // Editor time presets supersede interactive state
     const presetFromStr = presetFrom?.toString();
@@ -361,3 +346,4 @@ const ChartWithInteractiveFilters = React.forwardRef(
     );
   }
 );
+ChartWithInteractiveFilters.displayName = "ChartWithInteractiveFilters";

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -303,6 +303,9 @@ const ChartWithInteractiveFilters = React.forwardRef(
   (props: ChartWithInteractiveFiltersProps, ref) => {
     const { dataSet, dataSource, chartConfig } = props;
     const { interactiveFiltersConfig } = chartConfig;
+    const setCalculationType = useInteractiveFiltersStore(
+      (d) => d.setCalculationType
+    );
     const setTimeRange = useInteractiveFiltersStore((d) => d.setTimeRange);
     const timeRange = interactiveFiltersConfig?.timeRange;
     const presetFrom =
@@ -318,6 +321,16 @@ const ChartWithInteractiveFilters = React.forwardRef(
       }
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [setTimeRange, presetFromStr, presetToStr]);
+
+    useEffect(() => {
+      if (interactiveFiltersConfig?.calculation.active) {
+        setCalculationType(interactiveFiltersConfig?.calculation.type);
+      }
+    }, [
+      interactiveFiltersConfig?.calculation.active,
+      interactiveFiltersConfig?.calculation.type,
+      setCalculationType,
+    ]);
 
     return (
       <Flex

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -224,7 +224,13 @@ export const ChartPublishedInner = (props: ChartPublishInnerProps) => {
               </HintBlue>
             </Box>
           )}
-          <Flex sx={{ justifyContent: "space-between", alignItems: "center" }}>
+          <Flex
+            sx={{
+              justifyContent: "space-between",
+              alignItems: "center",
+              gap: 2,
+            }}
+          >
             <Typography component="div" variant="h2" mb={2}>
               {meta.title[locale]}
             </Typography>

--- a/app/components/data-download.tsx
+++ b/app/components/data-download.tsx
@@ -196,7 +196,7 @@ const DataDownloadInnerMenu = ({
               <Trans id="button.download">Download</Trans>
             </ListSubheader>
           ),
-          sx: { width: 200 },
+          sx: { width: 200, pt: 1, pb: 2 },
         }}
       >
         {filters && (

--- a/app/components/metadata-panel.tsx
+++ b/app/components/metadata-panel.tsx
@@ -274,7 +274,6 @@ export const MetadataPanel = (props: MetadataPanelProps) => {
     open: state.open,
     activeSection: state.activeSection,
   }));
-  const enableTransition = useTransitionStore((state) => state.enable);
   const setEnableTransition = useTransitionStore((state) => state.setEnable);
   const { setOpen, toggle, setActiveSection, reset } =
     useMetadataPanelStoreActions();

--- a/app/components/metadata-panel.tsx
+++ b/app/components/metadata-panel.tsx
@@ -274,12 +274,8 @@ export const MetadataPanel = (props: MetadataPanelProps) => {
     open: state.open,
     activeSection: state.activeSection,
   }));
-  const { setDefaultDuration, setInstantDuration } = useTransitionStore(
-    (d) => ({
-      setDefaultDuration: d.setDefaultDuration,
-      setInstantDuration: d.setInstantDuration,
-    })
-  );
+  const enableTransition = useTransitionStore((state) => state.enable);
+  const setEnableTransition = useTransitionStore((state) => state.setEnable);
   const { setOpen, toggle, setActiveSection, reset } =
     useMetadataPanelStoreActions();
   const handleToggle = useEvent(() => {
@@ -312,10 +308,10 @@ export const MetadataPanel = (props: MetadataPanelProps) => {
         ModalProps={{ container }}
         PaperProps={{ style: { position: "absolute" } }}
         SlideProps={{
-          onEnter: setInstantDuration,
-          onEntered: setDefaultDuration,
-          onExit: setInstantDuration,
-          onExited: setDefaultDuration,
+          onEnter: () => setEnableTransition(false),
+          onEntered: () => setEnableTransition(true),
+          onExit: () => setEnableTransition(false),
+          onExited: () => setEnableTransition(true),
         }}
       >
         <Header onClose={handleToggle} />

--- a/app/configurator/interactive-filters/time-slider.tsx
+++ b/app/configurator/interactive-filters/time-slider.tsx
@@ -193,10 +193,8 @@ const PlayButton = () => {
 
 const Slider = () => {
   const timeline = useTimeline();
-  const { timeSlider, setTimeSlider } = useInteractiveFiltersStore((d) => ({
-    timeSlider: d.timeSlider,
-    setTimeSlider: d.setTimeSlider,
-  }));
+  const timeSlider = useInteractiveFiltersStore((d) => d.timeSlider);
+  const setTimeSlider = useInteractiveFiltersStore((d) => d.setTimeSlider);
 
   const marks = React.useMemo(() => {
     return timeline.domain.map((d) => ({ value: d })) ?? [];

--- a/app/stores/interactive-filters.ts
+++ b/app/stores/interactive-filters.ts
@@ -53,17 +53,14 @@ export const useInteractiveFiltersStore = create<
   return {
     categories: {},
     addCategory: (category: string) => {
-      return set((state) => {
-        return {
-          ...state,
-          categories: { ...state.categories, [category]: true },
-        };
-      });
+      set((state) => ({
+        categories: { ...state.categories, [category]: true },
+      }));
     },
     removeCategory: (category: string) => {
-      return set((state) => {
+      set((state) => {
         delete state.categories[category];
-        return { ...state, categories: { ...state.categories } };
+        return { categories: { ...state.categories } };
       });
     },
     resetCategories: () => {
@@ -90,11 +87,9 @@ export const useInteractiveFiltersStore = create<
       });
     },
     resetTimeSlider: () => {
-      set((state) => {
-        return {
-          timeSlider: { ...state.timeSlider, value: undefined },
-        };
-      });
+      set((state) => ({
+        timeSlider: { ...state.timeSlider, value: undefined },
+      }));
     },
     dataFilters: {},
     setDataFilters: (dataFilters: DataFilters) => {
@@ -104,17 +99,15 @@ export const useInteractiveFiltersStore = create<
       dimensionIri: string,
       dimensionValueIri: FilterValueSingle["value"]
     ) => {
-      set((state) => {
-        return {
-          dataFilters: {
-            ...state.dataFilters,
-            [dimensionIri]: {
-              type: "single",
-              value: dimensionValueIri,
-            },
+      set((state) => ({
+        dataFilters: {
+          ...state.dataFilters,
+          [dimensionIri]: {
+            type: "single",
+            value: dimensionValueIri,
           },
-        };
-      });
+        },
+      }));
     },
     resetDataFilters: () => {
       set({ dataFilters: {} });

--- a/app/stores/transition.ts
+++ b/app/stores/transition.ts
@@ -2,16 +2,16 @@ import create from "zustand";
 
 export type TransitionStore = {
   enable: boolean;
+  setEnable: (enable: boolean) => void;
   duration: number;
   setDuration: (duration: number) => void;
   setDefaultDuration: () => void;
-  setInstantDuration: () => void;
 };
 
 export const useTransitionStore = create<TransitionStore>((set) => ({
   enable: true,
+  setEnable: (enable) => set({ enable }),
   duration: 400,
   setDuration: (duration) => set({ duration }),
   setDefaultDuration: () => set({ duration: 400 }),
-  setInstantDuration: () => set({ duration: 0 }),
 }));

--- a/app/stores/transition.ts
+++ b/app/stores/transition.ts
@@ -1,13 +1,17 @@
 import create from "zustand";
 
-type TransitionStore = {
+export type TransitionStore = {
+  enable: boolean;
   duration: number;
+  setDuration: (duration: number) => void;
   setDefaultDuration: () => void;
   setInstantDuration: () => void;
 };
 
 export const useTransitionStore = create<TransitionStore>((set) => ({
+  enable: true,
   duration: 400,
+  setDuration: (duration) => set({ duration }),
   setDefaultDuration: () => set({ duration: 400 }),
   setInstantDuration: () => set({ duration: 0 }),
 }));


### PR DESCRIPTION
This PR aims to:
- **consolidate D3 rendering** across charts and axes by adding `renderContainer` and `maybeTransition` methods,
- **properly disable transitions** with the help of `maybeTransition` function. This function makes it possible to specify the rendering logic when transitions are enabled (`t`) and disabled (`s`). I also shared the logic to base this decision on `transitionStore`,
- **fix brush disabling the transitions** when metadata panel is being toggled,
- improve performance of using Zustand stores (atomic state picks),
- **fix jumping charts** during interactions with interactive filters,
- introduce minor style adjustments.