### PR TITLE
fix: Hierarchical interactive filter language switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 
 ## Unreleased
 
-Nothing yet.
+- Fixes
+  - Changing a language in published mode now correctly updates options in hierarchical select element (Interactive Filters)
 
 # [3.21.0] - 2023-08-15
 

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -60,6 +60,7 @@ export const ChartDataFilters = (props: ChartDataFiltersProps) => {
             sx={{
               justifyContent: "space-between",
               alignItems: "flex-start",
+              gap: 3,
               minHeight: 20,
             }}
           >

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -12,8 +12,6 @@ import {
   ChartConfig,
   DataSource,
   InteractiveFiltersDataConfig,
-  Option,
-  OptionGroup,
 } from "@/configurator";
 import { TimeInput } from "@/configurator/components/field";
 import {
@@ -36,17 +34,15 @@ import { useLocale } from "@/locales/use-locale";
 import { useInteractiveFiltersStore } from "@/stores/interactive-filters";
 import { hierarchyToOptions } from "@/utils/hierarchy";
 
-export const ChartDataFilters = ({
-  dataSet,
-  dataSource,
-  chartConfig,
-  dataFiltersConfig,
-}: {
+type ChartDataFiltersProps = {
   dataSet: string;
   dataSource: DataSource;
   chartConfig: ChartConfig;
   dataFiltersConfig: InteractiveFiltersDataConfig;
-}) => {
+};
+
+export const ChartDataFilters = (props: ChartDataFiltersProps) => {
+  const { dataSet, dataSource, chartConfig, dataFiltersConfig } = props;
   const [filtersVisible, setFiltersVisible] = React.useState(false);
   const { componentIris } = dataFiltersConfig;
 
@@ -213,26 +209,21 @@ const DataFilter = (props: DataFilterProps) => {
   }
 };
 
-const DataFilterGenericDimension = ({
-  dimension,
-  value,
-  onChange,
-  options: propOptions,
-}: {
+type DataFilterGenericDimensionProps = {
   dimension: Dimension;
   value: string;
   onChange: (e: SelectChangeEvent<unknown>) => void;
   options?: Array<{ label: string; value: string }>;
-  optionGroups?: [OptionGroup, Option[]][];
-}) => {
+};
+
+const DataFilterGenericDimension = (props: DataFilterGenericDimensionProps) => {
+  const { dimension, value, onChange, options: propOptions } = props;
+  const { label, isKeyDimension } = dimension;
   const noneLabel = t({
     id: "controls.dimensionvalue.none",
     message: `No Filter`,
   });
-
-  const { label, isKeyDimension } = dimension;
-  const options = propOptions || dimension.values;
-
+  const options = propOptions ?? dimension.values;
   const allOptions = React.useMemo(() => {
     return isKeyDimension
       ? options
@@ -261,23 +252,22 @@ const DataFilterGenericDimension = ({
   );
 };
 
-const DataFilterHierarchyDimension = ({
-  dimension,
-  value,
-  onChange,
-  hierarchy,
-}: {
+type DataFilterHierarchyDimensionProps = {
   dimension: Dimension;
   value: string;
   onChange: (e: { target: { value: string } }) => void;
   hierarchy?: HierarchyValue[];
-}) => {
+};
+
+const DataFilterHierarchyDimension = (
+  props: DataFilterHierarchyDimensionProps
+) => {
+  const { dimension, value, onChange, hierarchy } = props;
+  const { label, isKeyDimension, values: dimensionValues } = dimension;
   const noneLabel = t({
     id: "controls.dimensionvalue.none",
     message: `No Filter`,
   });
-
-  const { label, isKeyDimension, values: dimensionValues } = dimension;
   const options = React.useMemo(() => {
     let opts = [] as { label: string; value: string; isNoneValue?: boolean }[];
     if (hierarchy) {
@@ -286,6 +276,7 @@ const DataFilterHierarchyDimension = ({
       // @ts-ignore
       opts = dimensionValues;
     }
+
     if (!isKeyDimension) {
       opts.unshift({
         value: FIELD_VALUE_NONE,
@@ -293,6 +284,7 @@ const DataFilterHierarchyDimension = ({
         isNoneValue: true,
       });
     }
+
     return opts;
   }, [hierarchy, isKeyDimension, dimensionValues, noneLabel]);
 

--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -276,6 +276,7 @@ const LoadingMenuPaperContext = React.createContext(
 const LoadingMenuPaper = forwardRef<HTMLDivElement>(
   (props: PaperProps, ref) => {
     const loading = useContext(LoadingMenuPaperContext);
+
     return (
       <MenuPaper {...props} ref={ref}>
         {loading ? (
@@ -323,7 +324,6 @@ export const Select = ({
   loading?: boolean;
 } & SelectProps) => {
   const locale = useLocale();
-
   const sortedOptions = useMemo(() => {
     if (optionGroups) {
       return flatten(
@@ -370,6 +370,7 @@ export const Select = ({
             if (!opt.value) {
               return null;
             }
+
             return opt.type === "group" ? (
               <ListSubheader key={opt.label}>{opt.label}</ListSubheader>
             ) : (

--- a/app/components/select-tree.tsx
+++ b/app/components/select-tree.tsx
@@ -8,23 +8,22 @@ import MUITreeItem, {
 } from "@mui/lab/TreeItem";
 import TreeView, { TreeViewProps } from "@mui/lab/TreeView";
 import {
-  Theme,
+  Collapse,
+  IconButton,
+  OutlinedInput,
   Popover,
   PopoverActions,
-  useEventCallback,
-  OutlinedInput,
-  Typography,
-  Collapse,
   TextField,
   TextFieldProps,
-  IconButton,
+  Theme,
+  Typography,
+  useEventCallback,
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import useId from "@mui/utils/useId";
 import clsx from "clsx";
-import { useCallback, useMemo, useRef, useState } from "react";
 import * as React from "react";
-import { useEffect } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Label } from "@/components/form";
 import { HierarchyValue } from "@/graphql/resolver-types";
@@ -296,7 +295,11 @@ function SelectTree({
   const [minMenuWidth, setMinMenuWidth] = useState<number>();
   const [inputValue, setInputValue] = useState("");
   const classes = useStyles({ disabled, open });
-  const [filteredOptions, setFilteredOptions] = useState(options);
+  const [filteredOptions, setFilteredOptions] = useState<Tree>([]);
+
+  React.useEffect(() => {
+    setFilteredOptions(options);
+  }, [options]);
 
   const parentsRef = React.useRef({} as Record<NodeId, NodeId>);
   const menuRef = React.useRef<PopoverActions>(null);
@@ -307,17 +310,19 @@ function SelectTree({
     if (!value && options.length > 0) {
       return options[0].value ? [options[0].value] : [];
     }
+
     const res = value ? [value] : [];
     let cur = value;
     const parents = parentsRef.current;
+
     while (cur && parents[cur]) {
       res.push(parents[cur]);
       cur = parents[cur];
     }
+
     return res;
   }, [value, options]);
   const [expanded, setExpanded] = useState(defaultExpanded);
-
   const labelsByValue = useMemo(() => {
     parentsRef.current = {} as Record<NodeId, NodeId>;
     const res: Record<string, string> = {};
@@ -382,7 +387,7 @@ function SelectTree({
   );
 
   const handleNodeSelect = useEventCallback((_ev, value: NodeId) => {
-    onChange({ target: { value: value } });
+    onChange({ target: { value } });
     handleClose();
   });
 


### PR DESCRIPTION
Closes #1104.

It turned out we didn't refresh the `filteredOptions` in the `SelectTree` component when `options` property changed. This PR fixes this, which means users can now switch the language in the published mode and see correctly updated select values.

It also adds some space between list of filters and button to activate interactive filters.