### PR TITLE
feat: Make table chart type the least preferred option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 
 ## Unreleased
 
+- Features
+  - Introduced preferred chart type order, which makes the table chart the least preferred option
 - UI
   - Switched to pixel-perfect text width calculation - axes should now align correctly, without unnecessary padding that was the result of incorrect estimations
 - Fixes

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -65,8 +65,7 @@ import {
   PIE_SEGMENT_SORTING,
 } from "./chart-config-ui-options";
 
-export const enabledChartTypes: ChartType[] = [
-  // "bar",
+export const chartTypes: ChartType[] = [
   "column",
   "line",
   "area",
@@ -75,6 +74,16 @@ export const enabledChartTypes: ChartType[] = [
   "table",
   "map",
 ];
+
+export const chartTypesOrder: { [k in ChartType]: number } = {
+  column: 0,
+  line: 1,
+  area: 2,
+  scatterplot: 3,
+  pie: 4,
+  map: 5,
+  table: 6,
+};
 
 /**
  * Finds the "best" dimension based on a preferred type (e.g. TemporalDimension) and Key Dimension
@@ -1196,7 +1205,7 @@ export const getPossibleChartType = ({
   const multipleNumericalMeasuresEnabled: ChartType[] = ["scatterplot"];
   const timeEnabled: ChartType[] = ["area", "column", "line"];
 
-  let possibles: ChartType[] = ["table"];
+  const possibles: ChartType[] = ["table"];
   if (numericalMeasures.length > 0) {
     if (categoricalDimensions.length > 0) {
       possibles.push(...categoricalEnabled);
@@ -1219,7 +1228,9 @@ export const getPossibleChartType = ({
     possibles.push("map");
   }
 
-  return enabledChartTypes.filter((type) => possibles.includes(type));
+  return chartTypes
+    .filter((d) => possibles.includes(d))
+    .sort((a, b) => chartTypesOrder[a] - chartTypesOrder[b]);
 };
 
 export const getFieldComponentIris = (fields: GenericFields) => {

--- a/app/configurator/components/chart-type-selector.tsx
+++ b/app/configurator/components/chart-type-selector.tsx
@@ -4,7 +4,7 @@ import { makeStyles } from "@mui/styles";
 import clsx from "clsx";
 import { SyntheticEvent } from "react";
 
-import { enabledChartTypes, getPossibleChartType } from "@/charts";
+import { chartTypes, getPossibleChartType } from "@/charts";
 import Flex from "@/components/flex";
 import { Hint } from "@/components/hint";
 import { ControlSectionSkeleton } from "@/configurator/components/chart-controls/section";
@@ -163,7 +163,7 @@ export const ChartTypeSelector = ({
                 mx: 2,
               }}
             >
-              {enabledChartTypes.map((d) => (
+              {chartTypes.map((d) => (
                 <ChartTypeSelectionButton
                   key={d}
                   label={d}


### PR DESCRIPTION
Closes #1038.

This PR adds an object that holds the preferred chart order, which makes the table chart the least preferred option.