### PR TITLE
perf: Improve performance of fetching geoShapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
   - Switched to pixel-perfect text width calculation - axes should now align correctly, without unnecessary padding that was the result of incorrect estimations
 - Fixes
   - Changing a language in published mode now correctly updates options in hierarchical select element (Interactive Filters)
+- Performance
+  - Vastly improved the performance of fetching geographical shapes when fetching more than 100 at once
 
 # [3.21.0] - 2023-08-15
 

--- a/app/graphql/resolvers/index.ts
+++ b/app/graphql/resolvers/index.ts
@@ -263,6 +263,7 @@ export const resolvers: Resolvers = {
           } as GeoJSON.FeatureCollection<GeoJSON.Geometry, GeoProperties>,
         }) as GeoShapes["topology"],
       };
+
       return resolved;
     },
   },


### PR DESCRIPTION
Closes #1106.

This PR drops the usage of a federated SPARQL query and adds a dedicated `geoSparqlClient` instead, to vastly improve the performance of fetching geographical shapes.

When testing the cube from #1106, we **went down from around 120 to 1.5 seconds**.