### PR TITLE
fix: Infinite geographical shapes loading

### DIFF
--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -112,7 +112,6 @@ export const ChartMapVisualization = ({
 
   const ready =
     (areaDimensionIri !== "" &&
-      // Check if original, unfiltered number of shapes is bigger than 0.
       (shapes?.topology?.objects?.shapes as any)?.geometries) ||
     (symbolDimensionIri !== "" && coordinates) ||
     (shapes?.topology?.objects?.shapes as any)?.geometries ||

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -113,9 +113,9 @@ export const ChartMapVisualization = ({
   const ready =
     (areaDimensionIri !== "" &&
       // Check if original, unfiltered number of shapes is bigger than 0.
-      (shapes?.topology?.objects?.shapes as any)?.geometries?.length) ||
-    (symbolDimensionIri !== "" && coordinates?.length) ||
-    (shapes?.topology?.objects?.shapes as any)?.geometries?.length ||
+      (shapes?.topology?.objects?.shapes as any)?.geometries) ||
+    (symbolDimensionIri !== "" && coordinates) ||
+    (shapes?.topology?.objects?.shapes as any)?.geometries ||
     // Raw map without any data layer.
     (areaDimensionIri === "" && symbolDimensionIri === "");
 
@@ -123,7 +123,7 @@ export const ChartMapVisualization = ({
     ...observationsQuery,
     data:
       measures && dimensions && observations && ready
-        ? observationsQuery["data"]
+        ? observationsQuery.data
         : undefined,
     error: observationsQuery.error ?? geoCoordinatesError ?? geoShapesError,
   };

--- a/app/charts/shared/axis-height-linear.tsx
+++ b/app/charts/shared/axis-height-linear.tsx
@@ -56,9 +56,10 @@ export const AxisHeightLinear = () => {
     gridColor,
     fontFamily,
   } = useChartTheme();
-  const titleWidth = getTextWidth(yAxisLabel, {
-    fontSize: axisLabelFontSize,
-  });
+  const titleWidth =
+    getTextWidth(yAxisLabel, {
+      fontSize: axisLabelFontSize,
+    }) + TICK_PADDING;
 
   useEffect(() => {
     if (ref.current) {

--- a/app/rdf/query-geo-shapes.ts
+++ b/app/rdf/query-geo-shapes.ts
@@ -151,17 +151,17 @@ export const createGeoShapesLoader =
       );
 
       return dimensionIris.map((iri) => {
-        const geometry = groupedGeometries[iri][0]?.geometry;
         let wktString: string | undefined;
+        // There might be iris without geometries.
+        const geometry = groupedGeometries[iri]?.[0]?.geometry;
 
         if (geometry) {
-          // There might be iris without shapes.
-          wktString = groupedWktStrings[geometry]?.[0].wktString;
+          wktString = groupedWktStrings[geometry]?.[0]?.wktString;
         }
 
         return {
           iri,
-          label: groupedLabels[iri][0].label ?? iri,
+          label: groupedLabels[iri]?.[0]?.label ?? iri,
           wktString,
         };
       });


### PR DESCRIPTION
When testing #1106, I noticed that some cubes still load the data for quite long time (e.g. [this Elcom cube](https://test.visualize.admin.ch/en/browse?previous=%7B%22includeDrafts%22%3Atrue%2C%22order%22%3A%22SCORE%22%2C%22search%22%3A%22elcom%22%7D&dataset=https%3A%2F%2Fenergy.ld.admin.ch%2Felcom%2Felectricityprice&dataSource=Prod)).

After investigation, it turned out that we wrongly handle potential undefined geometries when fetching the shapes. This PR fixes that (and also removes a case of infinite loading spinner when there is an error during geo shapes fetching – now an empty map will be shown).

cc @sosiology