### PR TITLE
fix: Not synced data source

### DIFF
--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/configurator/components/layout";
 import { ChartConfiguratorTable } from "@/configurator/table/table-chart-configurator";
 import SvgIcChevronLeft from "@/icons/components/IcChevronLeft";
+import { useDataSourceStore } from "@/stores/data-source";
 import useEvent from "@/utils/use-event";
 
 const BackContainer = ({ children }: { children: React.ReactNode }) => {
@@ -68,6 +69,7 @@ const isAnnotationField = (field: string | undefined) => {
 
 const ConfigureChartStep = () => {
   const [state, dispatch] = useConfiguratorState();
+  const { dataSource, setDataSource } = useDataSourceStore();
 
   const handleClosePanel = useEvent(() => {
     dispatch({
@@ -93,6 +95,15 @@ const ConfigureChartStep = () => {
       { shallow: true }
     );
   });
+
+  React.useEffect(() => {
+    if (
+      state.state === "CONFIGURING_CHART" &&
+      state.dataSource.url !== dataSource.url
+    ) {
+      setDataSource(state.dataSource);
+    }
+  }, [dataSource.url, setDataSource, state.dataSource, state.state]);
 
   if (state.state !== "CONFIGURING_CHART") {
     return null;

--- a/app/domain/datasource/index.ts
+++ b/app/domain/datasource/index.ts
@@ -61,7 +61,7 @@ export const useDataSourceState = () => {
     },
     {
       param: "dataSource",
-      deserialize: (l) => parseSourceByLabel(l) || DEFAULT_DATA_SOURCE,
+      deserialize: (l) => parseSourceByLabel(l) ?? DEFAULT_DATA_SOURCE,
       serialize: sourceToLabel,
       onValueChange: (newSource) => {
         saveDataSourceToLocalStorage(newSource);

--- a/app/domain/datasource/index.ts
+++ b/app/domain/datasource/index.ts
@@ -7,7 +7,7 @@ import useEvent from "@/utils/use-event";
 
 import { ENDPOINT } from "../env";
 
-import { SOURCES_BY_VALUE, SOURCES_BY_LABEL } from "./constants";
+import { SOURCES_BY_LABEL, SOURCES_BY_VALUE } from "./constants";
 import {
   retrieveDataSourceFromLocalStorage,
   saveDataSourceToLocalStorage,
@@ -53,11 +53,11 @@ export const useDataSourceState = () => {
       const urlParam = getURLParam("dataSource");
 
       // Priority for initial state: URL -> localStorage -> default
-      const initial =
+      return (
         (urlParam && parseSourceByLabel(urlParam)) ||
         retrieveDataSourceFromLocalStorage() ||
-        DEFAULT_DATA_SOURCE;
-      return initial;
+        DEFAULT_DATA_SOURCE
+      );
     },
     {
       param: "dataSource",
@@ -82,15 +82,7 @@ export const useDataSourceState = () => {
 };
 
 export const isDataSourceChangeable = (pathname: string) => {
-  if (
-    pathname === "/" ||
-    pathname === "/browse" ||
-    pathname === "/_cube-checker"
-  ) {
-    return true;
-  } else {
-    return false;
-  }
+  return ["/", "/browse", "/_cube-checker"].includes(pathname);
 };
 
 export const dataSourceToSparqlEditorUrl = (dataSource: DataSource): string => {

--- a/app/pages/create/[chartId].tsx
+++ b/app/pages/create/[chartId].tsx
@@ -27,10 +27,9 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
 };
 
 const ChartConfiguratorPage: NextPage<PageProps> = ({ chartId }) => {
-  const metadataPanelStore = React.useMemo(
-    () => createMetadataPanelStore(),
-    []
-  );
+  const metadataPanelStore = React.useMemo(() => {
+    return createMetadataPanelStore();
+  }, []);
 
   return (
     <>

--- a/app/rdf/sparql-client.ts
+++ b/app/rdf/sparql-client.ts
@@ -1,11 +1,4 @@
 import { DatasetCore, Quad, Stream } from "rdf-js";
-import StreamClient from "sparql-http-client";
-
-import { DEFAULT_DATA_SOURCE } from "@/domain/datasource";
-
-export const sparqlClientStream = new StreamClient({
-  endpointUrl: DEFAULT_DATA_SOURCE.url,
-});
 
 export const fromStream = (
   dataset: DatasetCore<Quad, Quad>,


### PR DESCRIPTION
This PR syncs the UI display of data source to match the one set in config in `/create` and `/v` pages and prevents setting a new data source via URL when in these modes.