### PR TITLE
fix: Import correct Sentry in Apollo plugin

### DIFF
--- a/app/graphql/apollo-sentry-plugin.ts
+++ b/app/graphql/apollo-sentry-plugin.ts
@@ -1,5 +1,6 @@
-import * as Sentry from "@sentry/nextjs";
 import { ApolloServerPlugin, GraphQLRequest } from "apollo-server-plugin-base";
+
+import { Sentry } from "@/sentry.server.config";
 
 const getDataCubeIri = (req: GraphQLRequest) => {
   const { variables, operationName } = req;
@@ -32,12 +33,15 @@ const plugin: ApolloServerPlugin = {
     }
 
     const dataCubeIri = getDataCubeIri(request);
+
     if (dataCubeIri) {
       transaction.setTag("visualize.dataCubeIri", dataCubeIri);
     }
+
     if (request.variables?.sourceUrl) {
       transaction.setTag("visualize.sourceUrl", request.variables.sourceUrl);
     }
+
     return {
       willSendResponse() {
         // hook for transaction finished

--- a/app/sentry.server.config.js
+++ b/app/sentry.server.config.js
@@ -13,3 +13,5 @@ Sentry.init({
   tracesSampleRate: 1.0,
   environment: getSentryEnv(),
 });
+
+export { Sentry };


### PR DESCRIPTION
This PR uses a correct Sentry instance in the Apollo plugin (the one with the environment already set).