### PR TITLE
feat: Disable stacking of non-ratio measures (Area & Column)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Nothing yet.
 
 - Features
   - Introduced preferred chart type order, which makes the table chart the least preferred option
+  - Disabled stacking of non-ratio measures (area and column charts)
 - UI
   - Switched to pixel-perfect text width calculation - axes should now align correctly, without unnecessary padding that was the result of incorrect estimations
   - Added `text-wrap: balance` to homepage title, to better wrap the text (only supported by Chrome as of now)

--- a/app/charts/chart-config-ui-options.ts
+++ b/app/charts/chart-config-ui-options.ts
@@ -114,7 +114,7 @@ export interface EncodingSpec {
   options?: EncodingOption[];
   getDisabledState?: (
     chartConfig: ChartConfig,
-    dimensions: DimensionMetadataFragment[],
+    components: DimensionMetadataFragment[],
     observations: Observation[]
   ) => {
     disabled: boolean;
@@ -208,12 +208,12 @@ export const ANIMATION_FIELD_SPEC: EncodingSpec = {
   disableInteractiveFilters: true,
   getDisabledState: (
     chartConfig,
-    dimensions
+    components
   ): {
     disabled: boolean;
     warnMessage?: string;
   } => {
-    const noTemporalDimensions = !dimensions.some((d) => {
+    const noTemporalDimensions = !components.some((d) => {
       return isTemporalDimension(d) || isTemporalOrdinalDimension(d);
     });
 

--- a/app/charts/chart-config-ui-options.ts
+++ b/app/charts/chart-config-ui-options.ts
@@ -290,7 +290,7 @@ export const chartConfigOptionsUISpec: ChartSpecs = {
           const imputationType = chartConfig.fields.y.imputationType;
           const disabled = false;
           const warnMessage =
-            missingDataPresent && imputationType === "none"
+            missingDataPresent && (!imputationType || imputationType === "none")
               ? t({
                   id: "controls.section.imputation.explanation",
                   message:

--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -47,6 +47,7 @@ import {
 import { Icon } from "@/icons";
 import SvgIcExclamation from "@/icons/components/IcExclamation";
 import { useLocale } from "@/locales/use-locale";
+import { MaybeTooltip } from "@/utils/maybe-tooltip";
 import { valueComparator } from "@/utils/sorting-values";
 
 export const Label = ({
@@ -81,9 +82,11 @@ export const Radio = ({
   checked,
   disabled,
   onChange,
+  warnMessage,
 }: {
   label: string;
   disabled?: boolean;
+  warnMessage?: string;
 } & FieldProps) => {
   const color = checked
     ? disabled
@@ -92,28 +95,30 @@ export const Radio = ({
     : "grey.500";
 
   return (
-    <FormControlLabel
-      label={label || "-"}
-      htmlFor={`${name}-${value}`}
-      componentsProps={{
-        typography: {
-          variant: "body2",
-        },
-      }}
-      control={
-        <MUIRadio
-          name={name}
-          id={`${name}-${value}`}
-          value={value}
-          onChange={onChange}
-          checked={!!checked}
-          disabled={disabled}
-          size="small"
-          sx={{ color, "> *": { fill: color } }}
-        />
-      }
-      disabled={disabled}
-    />
+    <MaybeTooltip text={warnMessage}>
+      <FormControlLabel
+        label={label || "-"}
+        htmlFor={`${name}-${value}`}
+        componentsProps={{
+          typography: {
+            variant: "body2",
+          },
+        }}
+        control={
+          <MUIRadio
+            name={name}
+            id={`${name}-${value}`}
+            value={value}
+            onChange={onChange}
+            checked={!!checked}
+            disabled={disabled}
+            size="small"
+            sx={{ color, "> *": { fill: color } }}
+          />
+        }
+        disabled={disabled}
+      />
+    </MaybeTooltip>
   );
 };
 

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -194,10 +194,13 @@ const SortingField = t.partial({
 });
 export type SortingField = t.TypeOf<typeof SortingField>;
 
+const ChartSubType = t.union([t.literal("stacked"), t.literal("grouped")]);
+export type ChartSubType = t.TypeOf<typeof ChartSubType>;
+
 const ColumnSegmentField = t.intersection([
   GenericSegmentField,
   SortingField,
-  t.type({ type: t.union([t.literal("grouped"), t.literal("stacked")]) }),
+  t.type({ type: ChartSubType }),
 ]);
 export type ColumnSegmentField = t.TypeOf<typeof ColumnSegmentField>;
 

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -817,7 +817,7 @@ const ChartFields = (props: ChartFieldsProps) => {
             }
             value={field}
             labelId={`${chartConfig.chartType}.${field}`}
-            {...getDisabledState?.(chartConfig, dimensions, observations)}
+            {...getDisabledState?.(chartConfig, components, observations)}
           />
         );
       })}

--- a/app/configurator/components/chart-controls/control-tab.tsx
+++ b/app/configurator/components/chart-controls/control-tab.tsx
@@ -81,7 +81,7 @@ const WarnIconTooltip = (props: WarnIconTooltipProps) => {
   const iconStyles = useIconStyles({ isActive: false });
 
   return (
-    <Tooltip arrow title={title}>
+    <Tooltip arrow title={<Typography variant="body2">{title}</Typography>}>
       <Typography>
         <SvgIcExclamation className={iconStyles.warn} />
       </Typography>

--- a/app/configurator/components/chart-controls/section.tsx
+++ b/app/configurator/components/chart-controls/section.tsx
@@ -311,7 +311,7 @@ const Warning = (props: WarningProps) => {
   const { title } = props;
 
   return (
-    <Tooltip arrow title={title}>
+    <Tooltip arrow title={<Typography variant="body2">{title}</Typography>}>
       <Typography color="warning.main" sx={{ mr: 2 }}>
         <SvgIcExclamation width={18} height={18} />
       </Typography>

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -785,9 +785,11 @@ const ChartFieldCalculation = (props: ChartFieldCalculationProps) => {
             <Tooltip
               enterDelay={600}
               title={
-                <Trans id="controls.filters.interactive.calculation">
-                  Allow users to change chart mode
-                </Trans>
+                <Typography variant="body2">
+                  <Trans id="controls.filters.interactive.calculation">
+                    Allow users to change chart mode
+                  </Trans>
+                </Typography>
               }
             >
               <div>

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -761,6 +761,7 @@ export const ChartOptionRadioField = ({
   value,
   defaultChecked,
   disabled = false,
+  warnMessage,
 }: {
   label: string;
   field: string | null;
@@ -768,6 +769,7 @@ export const ChartOptionRadioField = ({
   value: string | number;
   defaultChecked?: boolean;
   disabled?: boolean;
+  warnMessage?: string;
 }) => {
   const fieldProps = useChartOptionRadioField({
     path,
@@ -781,6 +783,7 @@ export const ChartOptionRadioField = ({
       label={label}
       {...fieldProps}
       checked={fieldProps.checked ?? defaultChecked}
+      warnMessage={warnMessage}
     />
   );
 };

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -5,6 +5,7 @@ fragment dimensionMetadata on Dimension {
   isNumerical
   isKeyDimension
   dataType
+  scaleType
   order
   values(sourceType: $sourceType, sourceUrl: $sourceUrl, filters: $filters)
   unit
@@ -30,6 +31,7 @@ fragment dimensionMetadataWithHierarchies on Dimension {
   description
   isNumerical
   isKeyDimension
+  scaleType
   dataType
   order
   values(sourceType: $sourceType, sourceUrl: $sourceUrl, filters: $filters)

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -558,68 +558,68 @@ export enum TimeUnit {
 
 
 
-type DimensionMetadata_GeoCoordinatesDimension_Fragment = { __typename: 'GeoCoordinatesDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetadata_GeoCoordinatesDimension_Fragment = { __typename: 'GeoCoordinatesDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
 
-type DimensionMetadata_GeoShapesDimension_Fragment = { __typename: 'GeoShapesDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetadata_GeoShapesDimension_Fragment = { __typename: 'GeoShapesDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
 
-type DimensionMetadata_NominalDimension_Fragment = { __typename: 'NominalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetadata_NominalDimension_Fragment = { __typename: 'NominalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
 
-type DimensionMetadata_NumericalMeasure_Fragment = { __typename: 'NumericalMeasure', isCurrency?: Maybe<boolean>, currencyExponent?: Maybe<number>, resolution?: Maybe<number>, isDecimal?: Maybe<boolean>, iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetadata_NumericalMeasure_Fragment = { __typename: 'NumericalMeasure', isCurrency?: Maybe<boolean>, currencyExponent?: Maybe<number>, resolution?: Maybe<number>, isDecimal?: Maybe<boolean>, iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
 
-type DimensionMetadata_OrdinalDimension_Fragment = { __typename: 'OrdinalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetadata_OrdinalDimension_Fragment = { __typename: 'OrdinalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
 
-type DimensionMetadata_OrdinalMeasure_Fragment = { __typename: 'OrdinalMeasure', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetadata_OrdinalMeasure_Fragment = { __typename: 'OrdinalMeasure', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
 
-type DimensionMetadata_StandardErrorDimension_Fragment = { __typename: 'StandardErrorDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetadata_StandardErrorDimension_Fragment = { __typename: 'StandardErrorDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
 
-type DimensionMetadata_TemporalDimension_Fragment = { __typename: 'TemporalDimension', timeUnit: TimeUnit, timeFormat: string, iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetadata_TemporalDimension_Fragment = { __typename: 'TemporalDimension', timeUnit: TimeUnit, timeFormat: string, iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
 
-type DimensionMetadata_TemporalOrdinalDimension_Fragment = { __typename: 'TemporalOrdinalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetadata_TemporalOrdinalDimension_Fragment = { __typename: 'TemporalOrdinalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
 
 export type DimensionMetadataFragment = DimensionMetadata_GeoCoordinatesDimension_Fragment | DimensionMetadata_GeoShapesDimension_Fragment | DimensionMetadata_NominalDimension_Fragment | DimensionMetadata_NumericalMeasure_Fragment | DimensionMetadata_OrdinalDimension_Fragment | DimensionMetadata_OrdinalMeasure_Fragment | DimensionMetadata_StandardErrorDimension_Fragment | DimensionMetadata_TemporalDimension_Fragment | DimensionMetadata_TemporalOrdinalDimension_Fragment;
 
 type DimensionMetadataWithHierarchies_GeoCoordinatesDimension_Fragment = (
-  { __typename: 'GeoCoordinatesDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'GeoCoordinatesDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<string>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_GeoCoordinatesDimension_Fragment
 );
 
 type DimensionMetadataWithHierarchies_GeoShapesDimension_Fragment = (
-  { __typename: 'GeoShapesDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'GeoShapesDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<string>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_GeoShapesDimension_Fragment
 );
 
 type DimensionMetadataWithHierarchies_NominalDimension_Fragment = (
-  { __typename: 'NominalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'NominalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<string>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_NominalDimension_Fragment
 );
 
 type DimensionMetadataWithHierarchies_NumericalMeasure_Fragment = (
-  { __typename: 'NumericalMeasure', isCurrency?: Maybe<boolean>, currencyExponent?: Maybe<number>, resolution?: Maybe<number>, isDecimal?: Maybe<boolean>, iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'NumericalMeasure', isCurrency?: Maybe<boolean>, currencyExponent?: Maybe<number>, resolution?: Maybe<number>, isDecimal?: Maybe<boolean>, iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<string>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_NumericalMeasure_Fragment
 );
 
 type DimensionMetadataWithHierarchies_OrdinalDimension_Fragment = (
-  { __typename: 'OrdinalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'OrdinalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<string>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_OrdinalDimension_Fragment
 );
 
 type DimensionMetadataWithHierarchies_OrdinalMeasure_Fragment = (
-  { __typename: 'OrdinalMeasure', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'OrdinalMeasure', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<string>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_OrdinalMeasure_Fragment
 );
 
 type DimensionMetadataWithHierarchies_StandardErrorDimension_Fragment = (
-  { __typename: 'StandardErrorDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'StandardErrorDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<string>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_StandardErrorDimension_Fragment
 );
 
 type DimensionMetadataWithHierarchies_TemporalDimension_Fragment = (
-  { __typename: 'TemporalDimension', timeUnit: TimeUnit, timeFormat: string, iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'TemporalDimension', timeUnit: TimeUnit, timeFormat: string, iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<string>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_TemporalDimension_Fragment
 );
 
 type DimensionMetadataWithHierarchies_TemporalOrdinalDimension_Fragment = (
-  { __typename: 'TemporalOrdinalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'TemporalOrdinalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<string>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_TemporalOrdinalDimension_Fragment
 );
 
@@ -1144,6 +1144,7 @@ export const DimensionMetadataFragmentDoc = gql`
   isNumerical
   isKeyDimension
   dataType
+  scaleType
   order
   values(sourceType: $sourceType, sourceUrl: $sourceUrl, filters: $filters)
   unit
@@ -1204,6 +1205,7 @@ export const DimensionMetadataWithHierarchiesFragmentDoc = gql`
   description
   isNumerical
   isKeyDimension
+  scaleType
   dataType
   order
   values(sourceType: $sourceType, sourceUrl: $sourceUrl, filters: $filters)

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -127,7 +127,7 @@ export type Dimension = {
   label: Scalars['String'];
   description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
-  scaleType?: Maybe<Scalars['String']>;
+  scaleType?: Maybe<ScaleType>;
   dataType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
   isNumerical: Scalars['Boolean'];
@@ -167,7 +167,7 @@ export type GeoCoordinatesDimension = Dimension & {
   label: Scalars['String'];
   description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
-  scaleType?: Maybe<Scalars['String']>;
+  scaleType?: Maybe<ScaleType>;
   dataType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
   isNumerical: Scalars['Boolean'];
@@ -198,7 +198,7 @@ export type GeoShapesDimension = Dimension & {
   label: Scalars['String'];
   description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
-  scaleType?: Maybe<Scalars['String']>;
+  scaleType?: Maybe<ScaleType>;
   dataType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
   isNumerical: Scalars['Boolean'];
@@ -243,7 +243,7 @@ export type NominalDimension = Dimension & {
   label: Scalars['String'];
   description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
-  scaleType?: Maybe<Scalars['String']>;
+  scaleType?: Maybe<ScaleType>;
   dataType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
   isNumerical: Scalars['Boolean'];
@@ -272,7 +272,7 @@ export type NumericalMeasure = Dimension & {
   label: Scalars['String'];
   description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
-  scaleType?: Maybe<Scalars['String']>;
+  scaleType?: Maybe<ScaleType>;
   dataType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
   isNumerical: Scalars['Boolean'];
@@ -325,7 +325,7 @@ export type OrdinalDimension = Dimension & {
   label: Scalars['String'];
   description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
-  scaleType?: Maybe<Scalars['String']>;
+  scaleType?: Maybe<ScaleType>;
   dataType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
   isNumerical: Scalars['Boolean'];
@@ -354,7 +354,7 @@ export type OrdinalMeasure = Dimension & {
   label: Scalars['String'];
   description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
-  scaleType?: Maybe<Scalars['String']>;
+  scaleType?: Maybe<ScaleType>;
   dataType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
   isNumerical: Scalars['Boolean'];
@@ -457,13 +457,20 @@ export type RelatedDimension = {
   iri: Scalars['String'];
 };
 
+export enum ScaleType {
+  Ordinal = 'Ordinal',
+  Nominal = 'Nominal',
+  Interval = 'Interval',
+  Ratio = 'Ratio'
+}
+
 export type StandardErrorDimension = Dimension & {
   __typename: 'StandardErrorDimension';
   iri: Scalars['String'];
   label: Scalars['String'];
   description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
-  scaleType?: Maybe<Scalars['String']>;
+  scaleType?: Maybe<ScaleType>;
   dataType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
   isNumerical: Scalars['Boolean'];
@@ -494,7 +501,7 @@ export type TemporalDimension = Dimension & {
   timeUnit: TimeUnit;
   timeFormat: Scalars['String'];
   unit?: Maybe<Scalars['String']>;
-  scaleType?: Maybe<Scalars['String']>;
+  scaleType?: Maybe<ScaleType>;
   dataType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
   isNumerical: Scalars['Boolean'];
@@ -523,7 +530,7 @@ export type TemporalOrdinalDimension = Dimension & {
   label: Scalars['String'];
   description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
-  scaleType?: Maybe<Scalars['String']>;
+  scaleType?: Maybe<ScaleType>;
   dataType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
   isNumerical: Scalars['Boolean'];
@@ -558,68 +565,68 @@ export enum TimeUnit {
 
 
 
-type DimensionMetadata_GeoCoordinatesDimension_Fragment = { __typename: 'GeoCoordinatesDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetadata_GeoCoordinatesDimension_Fragment = { __typename: 'GeoCoordinatesDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<ScaleType>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
 
-type DimensionMetadata_GeoShapesDimension_Fragment = { __typename: 'GeoShapesDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetadata_GeoShapesDimension_Fragment = { __typename: 'GeoShapesDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<ScaleType>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
 
-type DimensionMetadata_NominalDimension_Fragment = { __typename: 'NominalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetadata_NominalDimension_Fragment = { __typename: 'NominalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<ScaleType>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
 
-type DimensionMetadata_NumericalMeasure_Fragment = { __typename: 'NumericalMeasure', isCurrency?: Maybe<boolean>, currencyExponent?: Maybe<number>, resolution?: Maybe<number>, isDecimal?: Maybe<boolean>, iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetadata_NumericalMeasure_Fragment = { __typename: 'NumericalMeasure', isCurrency?: Maybe<boolean>, currencyExponent?: Maybe<number>, resolution?: Maybe<number>, isDecimal?: Maybe<boolean>, iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<ScaleType>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
 
-type DimensionMetadata_OrdinalDimension_Fragment = { __typename: 'OrdinalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetadata_OrdinalDimension_Fragment = { __typename: 'OrdinalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<ScaleType>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
 
-type DimensionMetadata_OrdinalMeasure_Fragment = { __typename: 'OrdinalMeasure', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetadata_OrdinalMeasure_Fragment = { __typename: 'OrdinalMeasure', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<ScaleType>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
 
-type DimensionMetadata_StandardErrorDimension_Fragment = { __typename: 'StandardErrorDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetadata_StandardErrorDimension_Fragment = { __typename: 'StandardErrorDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<ScaleType>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
 
-type DimensionMetadata_TemporalDimension_Fragment = { __typename: 'TemporalDimension', timeUnit: TimeUnit, timeFormat: string, iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetadata_TemporalDimension_Fragment = { __typename: 'TemporalDimension', timeUnit: TimeUnit, timeFormat: string, iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<ScaleType>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
 
-type DimensionMetadata_TemporalOrdinalDimension_Fragment = { __typename: 'TemporalOrdinalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
+type DimensionMetadata_TemporalOrdinalDimension_Fragment = { __typename: 'TemporalOrdinalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, dataType?: Maybe<string>, scaleType?: Maybe<ScaleType>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> };
 
 export type DimensionMetadataFragment = DimensionMetadata_GeoCoordinatesDimension_Fragment | DimensionMetadata_GeoShapesDimension_Fragment | DimensionMetadata_NominalDimension_Fragment | DimensionMetadata_NumericalMeasure_Fragment | DimensionMetadata_OrdinalDimension_Fragment | DimensionMetadata_OrdinalMeasure_Fragment | DimensionMetadata_StandardErrorDimension_Fragment | DimensionMetadata_TemporalDimension_Fragment | DimensionMetadata_TemporalOrdinalDimension_Fragment;
 
 type DimensionMetadataWithHierarchies_GeoCoordinatesDimension_Fragment = (
-  { __typename: 'GeoCoordinatesDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<string>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'GeoCoordinatesDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<ScaleType>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_GeoCoordinatesDimension_Fragment
 );
 
 type DimensionMetadataWithHierarchies_GeoShapesDimension_Fragment = (
-  { __typename: 'GeoShapesDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<string>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'GeoShapesDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<ScaleType>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_GeoShapesDimension_Fragment
 );
 
 type DimensionMetadataWithHierarchies_NominalDimension_Fragment = (
-  { __typename: 'NominalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<string>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'NominalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<ScaleType>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_NominalDimension_Fragment
 );
 
 type DimensionMetadataWithHierarchies_NumericalMeasure_Fragment = (
-  { __typename: 'NumericalMeasure', isCurrency?: Maybe<boolean>, currencyExponent?: Maybe<number>, resolution?: Maybe<number>, isDecimal?: Maybe<boolean>, iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<string>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'NumericalMeasure', isCurrency?: Maybe<boolean>, currencyExponent?: Maybe<number>, resolution?: Maybe<number>, isDecimal?: Maybe<boolean>, iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<ScaleType>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_NumericalMeasure_Fragment
 );
 
 type DimensionMetadataWithHierarchies_OrdinalDimension_Fragment = (
-  { __typename: 'OrdinalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<string>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'OrdinalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<ScaleType>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_OrdinalDimension_Fragment
 );
 
 type DimensionMetadataWithHierarchies_OrdinalMeasure_Fragment = (
-  { __typename: 'OrdinalMeasure', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<string>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'OrdinalMeasure', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<ScaleType>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_OrdinalMeasure_Fragment
 );
 
 type DimensionMetadataWithHierarchies_StandardErrorDimension_Fragment = (
-  { __typename: 'StandardErrorDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<string>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'StandardErrorDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<ScaleType>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_StandardErrorDimension_Fragment
 );
 
 type DimensionMetadataWithHierarchies_TemporalDimension_Fragment = (
-  { __typename: 'TemporalDimension', timeUnit: TimeUnit, timeFormat: string, iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<string>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'TemporalDimension', timeUnit: TimeUnit, timeFormat: string, iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<ScaleType>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_TemporalDimension_Fragment
 );
 
 type DimensionMetadataWithHierarchies_TemporalOrdinalDimension_Fragment = (
-  { __typename: 'TemporalOrdinalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<string>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
+  { __typename: 'TemporalOrdinalDimension', iri: string, label: string, description?: Maybe<string>, isNumerical: boolean, isKeyDimension: boolean, scaleType?: Maybe<ScaleType>, dataType?: Maybe<string>, order?: Maybe<number>, values: Array<DimensionValue>, unit?: Maybe<string>, related?: Maybe<Array<{ __typename: 'RelatedDimension', iri: string, type: string }>> }
   & HierarchyMetadata_TemporalOrdinalDimension_Fragment
 );
 

--- a/app/graphql/resolver-types.ts
+++ b/app/graphql/resolver-types.ts
@@ -129,7 +129,7 @@ export type Dimension = {
   label: Scalars['String'];
   description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
-  scaleType?: Maybe<Scalars['String']>;
+  scaleType?: Maybe<ScaleType>;
   dataType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
   isNumerical: Scalars['Boolean'];
@@ -169,7 +169,7 @@ export type GeoCoordinatesDimension = Dimension & {
   label: Scalars['String'];
   description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
-  scaleType?: Maybe<Scalars['String']>;
+  scaleType?: Maybe<ScaleType>;
   dataType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
   isNumerical: Scalars['Boolean'];
@@ -200,7 +200,7 @@ export type GeoShapesDimension = Dimension & {
   label: Scalars['String'];
   description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
-  scaleType?: Maybe<Scalars['String']>;
+  scaleType?: Maybe<ScaleType>;
   dataType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
   isNumerical: Scalars['Boolean'];
@@ -245,7 +245,7 @@ export type NominalDimension = Dimension & {
   label: Scalars['String'];
   description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
-  scaleType?: Maybe<Scalars['String']>;
+  scaleType?: Maybe<ScaleType>;
   dataType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
   isNumerical: Scalars['Boolean'];
@@ -274,7 +274,7 @@ export type NumericalMeasure = Dimension & {
   label: Scalars['String'];
   description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
-  scaleType?: Maybe<Scalars['String']>;
+  scaleType?: Maybe<ScaleType>;
   dataType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
   isNumerical: Scalars['Boolean'];
@@ -327,7 +327,7 @@ export type OrdinalDimension = Dimension & {
   label: Scalars['String'];
   description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
-  scaleType?: Maybe<Scalars['String']>;
+  scaleType?: Maybe<ScaleType>;
   dataType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
   isNumerical: Scalars['Boolean'];
@@ -356,7 +356,7 @@ export type OrdinalMeasure = Dimension & {
   label: Scalars['String'];
   description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
-  scaleType?: Maybe<Scalars['String']>;
+  scaleType?: Maybe<ScaleType>;
   dataType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
   isNumerical: Scalars['Boolean'];
@@ -459,13 +459,20 @@ export type RelatedDimension = {
   iri: Scalars['String'];
 };
 
+export enum ScaleType {
+  Ordinal = 'Ordinal',
+  Nominal = 'Nominal',
+  Interval = 'Interval',
+  Ratio = 'Ratio'
+}
+
 export type StandardErrorDimension = Dimension & {
   __typename?: 'StandardErrorDimension';
   iri: Scalars['String'];
   label: Scalars['String'];
   description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
-  scaleType?: Maybe<Scalars['String']>;
+  scaleType?: Maybe<ScaleType>;
   dataType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
   isNumerical: Scalars['Boolean'];
@@ -496,7 +503,7 @@ export type TemporalDimension = Dimension & {
   timeUnit: TimeUnit;
   timeFormat: Scalars['String'];
   unit?: Maybe<Scalars['String']>;
-  scaleType?: Maybe<Scalars['String']>;
+  scaleType?: Maybe<ScaleType>;
   dataType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
   isNumerical: Scalars['Boolean'];
@@ -525,7 +532,7 @@ export type TemporalOrdinalDimension = Dimension & {
   label: Scalars['String'];
   description?: Maybe<Scalars['String']>;
   unit?: Maybe<Scalars['String']>;
-  scaleType?: Maybe<Scalars['String']>;
+  scaleType?: Maybe<ScaleType>;
   dataType?: Maybe<Scalars['String']>;
   order?: Maybe<Scalars['Int']>;
   isNumerical: Scalars['Boolean'];
@@ -658,6 +665,7 @@ export type ResolversTypes = ResolversObject<{
   Query: ResolverTypeWrapper<{}>;
   RawObservation: ResolverTypeWrapper<Scalars['RawObservation']>;
   RelatedDimension: ResolverTypeWrapper<RelatedDimension>;
+  ScaleType: ScaleType;
   StandardErrorDimension: ResolverTypeWrapper<ResolvedDimension>;
   TemporalDimension: ResolverTypeWrapper<ResolvedDimension>;
   TemporalOrdinalDimension: ResolverTypeWrapper<ResolvedDimension>;
@@ -761,7 +769,7 @@ export type DimensionResolvers<ContextType = VisualizeGraphQLContext, ParentType
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   unit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  scaleType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  scaleType?: Resolver<Maybe<ResolversTypes['ScaleType']>, ParentType, ContextType>;
   dataType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   isNumerical?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
@@ -796,7 +804,7 @@ export type GeoCoordinatesDimensionResolvers<ContextType = VisualizeGraphQLConte
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   unit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  scaleType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  scaleType?: Resolver<Maybe<ResolversTypes['ScaleType']>, ParentType, ContextType>;
   dataType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   isNumerical?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
@@ -817,7 +825,7 @@ export type GeoShapesDimensionResolvers<ContextType = VisualizeGraphQLContext, P
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   unit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  scaleType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  scaleType?: Resolver<Maybe<ResolversTypes['ScaleType']>, ParentType, ContextType>;
   dataType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   isNumerical?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
@@ -851,7 +859,7 @@ export type NominalDimensionResolvers<ContextType = VisualizeGraphQLContext, Par
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   unit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  scaleType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  scaleType?: Resolver<Maybe<ResolversTypes['ScaleType']>, ParentType, ContextType>;
   dataType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   isNumerical?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
@@ -867,7 +875,7 @@ export type NumericalMeasureResolvers<ContextType = VisualizeGraphQLContext, Par
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   unit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  scaleType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  scaleType?: Resolver<Maybe<ResolversTypes['ScaleType']>, ParentType, ContextType>;
   dataType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   isNumerical?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
@@ -906,7 +914,7 @@ export type OrdinalDimensionResolvers<ContextType = VisualizeGraphQLContext, Par
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   unit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  scaleType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  scaleType?: Resolver<Maybe<ResolversTypes['ScaleType']>, ParentType, ContextType>;
   dataType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   isNumerical?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
@@ -922,7 +930,7 @@ export type OrdinalMeasureResolvers<ContextType = VisualizeGraphQLContext, Paren
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   unit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  scaleType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  scaleType?: Resolver<Maybe<ResolversTypes['ScaleType']>, ParentType, ContextType>;
   dataType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   isNumerical?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
@@ -958,7 +966,7 @@ export type StandardErrorDimensionResolvers<ContextType = VisualizeGraphQLContex
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   unit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  scaleType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  scaleType?: Resolver<Maybe<ResolversTypes['ScaleType']>, ParentType, ContextType>;
   dataType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   isNumerical?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
@@ -976,7 +984,7 @@ export type TemporalDimensionResolvers<ContextType = VisualizeGraphQLContext, Pa
   timeUnit?: Resolver<ResolversTypes['TimeUnit'], ParentType, ContextType>;
   timeFormat?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   unit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  scaleType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  scaleType?: Resolver<Maybe<ResolversTypes['ScaleType']>, ParentType, ContextType>;
   dataType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   isNumerical?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
@@ -992,7 +1000,7 @@ export type TemporalOrdinalDimensionResolvers<ContextType = VisualizeGraphQLCont
   label?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   description?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   unit?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  scaleType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  scaleType?: Resolver<Maybe<ResolversTypes['ScaleType']>, ParentType, ContextType>;
   dataType?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   order?: Resolver<Maybe<ResolversTypes['Int']>, ParentType, ContextType>;
   isNumerical?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -23,6 +23,13 @@ enum DataCubePublicationStatus {
   PUBLISHED
 }
 
+enum ScaleType {
+  Ordinal
+  Nominal
+  Interval
+  Ratio
+}
+
 type DataCube {
   iri: String!
   identifier: String
@@ -86,7 +93,7 @@ interface Dimension {
   label: String!
   description: String
   unit: String
-  scaleType: String
+  scaleType: ScaleType
   dataType: String
   order: Int
   isNumerical: Boolean!
@@ -112,7 +119,7 @@ type GeoCoordinatesDimension implements Dimension {
   label: String!
   description: String
   unit: String
-  scaleType: String
+  scaleType: ScaleType
   dataType: String
   order: Int
   isNumerical: Boolean!
@@ -138,7 +145,7 @@ type GeoShapesDimension implements Dimension {
   label: String!
   description: String
   unit: String
-  scaleType: String
+  scaleType: ScaleType
   dataType: String
   order: Int
   isNumerical: Boolean!
@@ -158,7 +165,7 @@ type NominalDimension implements Dimension {
   label: String!
   description: String
   unit: String
-  scaleType: String
+  scaleType: ScaleType
   dataType: String
   order: Int
   isNumerical: Boolean!
@@ -177,7 +184,7 @@ type OrdinalDimension implements Dimension {
   label: String!
   description: String
   unit: String
-  scaleType: String
+  scaleType: ScaleType
   dataType: String
   order: Int
   isNumerical: Boolean!
@@ -196,7 +203,7 @@ type StandardErrorDimension implements Dimension {
   label: String!
   description: String
   unit: String
-  scaleType: String
+  scaleType: ScaleType
   dataType: String
   order: Int
   isNumerical: Boolean!
@@ -227,7 +234,7 @@ type TemporalDimension implements Dimension {
   timeUnit: TimeUnit!
   timeFormat: String!
   unit: String
-  scaleType: String
+  scaleType: ScaleType
   dataType: String
   order: Int
   isNumerical: Boolean!
@@ -246,7 +253,7 @@ type TemporalOrdinalDimension implements Dimension {
   label: String!
   description: String
   unit: String
-  scaleType: String
+  scaleType: ScaleType
   dataType: String
   order: Int
   isNumerical: Boolean!
@@ -267,7 +274,7 @@ type NumericalMeasure implements Dimension {
   label: String!
   description: String
   unit: String
-  scaleType: String
+  scaleType: ScaleType
   dataType: String
   order: Int
   isNumerical: Boolean!
@@ -290,7 +297,7 @@ type OrdinalMeasure implements Dimension {
   label: String!
   description: String
   unit: String
-  scaleType: String
+  scaleType: ScaleType
   dataType: String
   order: Int
   isNumerical: Boolean!

--- a/app/graphql/shared-types.ts
+++ b/app/graphql/shared-types.ts
@@ -8,6 +8,7 @@ import {
   DataCubeOrganization,
   DataCubePublicationStatus,
   DataCubeTheme,
+  ScaleType,
   TimeUnit,
 } from "./resolver-types";
 
@@ -64,7 +65,7 @@ export type ResolvedDimension = {
     related: Omit<RelatedDimension, "__typename">[];
     timeUnit?: TimeUnit;
     timeFormat?: string;
-    scaleType?: "Nominal" | "Ordinal" | "Ratio" | "Interval";
+    scaleType?: ScaleType;
     hasHierarchy?: boolean;
   };
 };

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -199,10 +199,6 @@ msgstr "Horizontale Achse"
 msgid "controls.axis.vertical"
 msgstr "Vertikale Achse"
 
-#: app/configurator/components/chart-options-selector.tsx
-msgid "controls.calculation.allow-normalization"
-msgstr "Ermöglicht die Normalisierung der Daten"
-
 #: app/charts/chart-config-ui-options.ts
 msgid "controls.calculation.disabled-by-grouped"
 msgstr "Der 100%-Modus kann nicht mit einem gruppierten Layout verwendet werden."
@@ -358,6 +354,7 @@ msgid "controls.filters.interactive.color.min-1-filter"
 msgstr "Es muss mindestens ein Filter ausgewählt werden."
 
 #: app/configurator/components/chart-configurator.tsx
+#: app/configurator/components/chart-options-selector.tsx
 #: app/configurator/components/filters.tsx
 #: app/configurator/components/filters.tsx
 msgid "controls.filters.interactive.toggle"
@@ -622,6 +619,10 @@ msgstr "Fügen Sie einen Titel oder eine Beschreibung hinzu"
 #: app/configurator/components/field-i18n.ts
 msgid "controls.segment"
 msgstr "Segmentierung"
+
+#: app/charts/chart-config-ui-options.ts
+msgid "controls.segment.stacked.disabled-by-scale-type"
+msgstr "Das gestapelte Layout kann nur aktiviert werden, wenn die der vertikalen Achse zugeordnete Dimension eine Verhältnis-Skala hat."
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.select.calculation.mode"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -199,10 +199,6 @@ msgstr "Horizontal Axis"
 msgid "controls.axis.vertical"
 msgstr "Vertical Axis"
 
-#: app/configurator/components/chart-options-selector.tsx
-msgid "controls.calculation.allow-normalization"
-msgstr "Allow normalization of the data"
-
 #: app/charts/chart-config-ui-options.ts
 msgid "controls.calculation.disabled-by-grouped"
 msgstr "100% mode can't be used with grouped layout."
@@ -358,6 +354,7 @@ msgid "controls.filters.interactive.color.min-1-filter"
 msgstr "At least one filter must be selected."
 
 #: app/configurator/components/chart-configurator.tsx
+#: app/configurator/components/chart-options-selector.tsx
 #: app/configurator/components/filters.tsx
 #: app/configurator/components/filters.tsx
 msgid "controls.filters.interactive.toggle"
@@ -622,6 +619,10 @@ msgstr "Please add a title or description."
 #: app/configurator/components/field-i18n.ts
 msgid "controls.segment"
 msgstr "Segmentation"
+
+#: app/charts/chart-config-ui-options.ts
+msgid "controls.segment.stacked.disabled-by-scale-type"
+msgstr "Stacked layout can only be enabled if the dimension mapped to the vertical axis has a ratio scale."
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.select.calculation.mode"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -199,10 +199,6 @@ msgstr "Axe horizontal"
 msgid "controls.axis.vertical"
 msgstr "Axe vertical"
 
-#: app/configurator/components/chart-options-selector.tsx
-msgid "controls.calculation.allow-normalization"
-msgstr "Permettre la normalisation des données"
-
 #: app/charts/chart-config-ui-options.ts
 msgid "controls.calculation.disabled-by-grouped"
 msgstr "Le mode 100% ne peut pas être utilisé avec une mise en page groupée."
@@ -358,6 +354,7 @@ msgid "controls.filters.interactive.color.min-1-filter"
 msgstr "Au moins un filtre doit être sélectionné."
 
 #: app/configurator/components/chart-configurator.tsx
+#: app/configurator/components/chart-options-selector.tsx
 #: app/configurator/components/filters.tsx
 #: app/configurator/components/filters.tsx
 msgid "controls.filters.interactive.toggle"
@@ -622,6 +619,10 @@ msgstr "Ajoutez un titre et une description"
 #: app/configurator/components/field-i18n.ts
 msgid "controls.segment"
 msgstr "Segmentation"
+
+#: app/charts/chart-config-ui-options.ts
+msgid "controls.segment.stacked.disabled-by-scale-type"
+msgstr "La mise en page empilée ne peut être activée que si la dimension mappée sur l'axe vertical a une échelle de rapport."
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.select.calculation.mode"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -199,10 +199,6 @@ msgstr "Asse orizzontale"
 msgid "controls.axis.vertical"
 msgstr "Asse verticale"
 
-#: app/configurator/components/chart-options-selector.tsx
-msgid "controls.calculation.allow-normalization"
-msgstr "Consentire la normalizzazione dei dati"
-
 #: app/charts/chart-config-ui-options.ts
 msgid "controls.calculation.disabled-by-grouped"
 msgstr "La modalità 100% non può essere utilizzata con un layout raggruppato."
@@ -358,6 +354,7 @@ msgid "controls.filters.interactive.color.min-1-filter"
 msgstr "È necessario selezionare almeno un filtro."
 
 #: app/configurator/components/chart-configurator.tsx
+#: app/configurator/components/chart-options-selector.tsx
 #: app/configurator/components/filters.tsx
 #: app/configurator/components/filters.tsx
 msgid "controls.filters.interactive.toggle"
@@ -622,6 +619,10 @@ msgstr "Aggiungi un titolo o una descrizione"
 #: app/configurator/components/field-i18n.ts
 msgid "controls.segment"
 msgstr "Segmentazione"
+
+#: app/charts/chart-config-ui-options.ts
+msgid "controls.segment.stacked.disabled-by-scale-type"
+msgstr "Il layout impilato può essere abilitato solo se la dimensione mappata sull'asse verticale ha una scala di rapporto."
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.select.calculation.mode"

--- a/app/utils/maybe-tooltip.tsx
+++ b/app/utils/maybe-tooltip.tsx
@@ -1,5 +1,4 @@
-import { Tooltip } from "@mui/material";
-import React from "react";
+import { Tooltip, Typography } from "@mui/material";
 
 export const MaybeTooltip = ({
   text,
@@ -9,7 +8,7 @@ export const MaybeTooltip = ({
   children: JSX.Element;
 }) => {
   return text ? (
-    <Tooltip arrow title={text}>
+    <Tooltip arrow title={<Typography variant="body2">{text}</Typography>}>
       {children}
     </Tooltip>
   ) : (


### PR DESCRIPTION
Closes #1140.
Closes #1132.

This PR:
- disables stacking of non-ratio measures (for area and column charts),
- fixes missing importation warning message.

### How to test
123