### PR TITLE
feat: Add a way to preview charts without saving config to database

### DIFF
--- a/app/pages/_preview_test.tsx
+++ b/app/pages/_preview_test.tsx
@@ -1,0 +1,212 @@
+import { Box, Button } from "@mui/material";
+
+const Page = () => {
+  const handleClick = async (state: any) => {
+    const response = await fetch("/preview", {
+      method: "POST",
+      body: JSON.stringify(state),
+    });
+    const data = await response.text();
+    const iframe = document.getElementById("chart") as HTMLIFrameElement;
+    const doc = iframe?.contentWindow?.document;
+    doc?.open();
+    doc?.write(data);
+    doc?.close();
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 6, p: 6 }}>
+      <Box sx={{ display: "flex", gap: 2 }}>
+        <Button
+          onClick={() => handleClick(photovoltaikanlagenState)}
+          sx={{ width: "fit-content" }}
+        >
+          ☀️ Preview a{" "}
+          <b style={{ marginLeft: 4, marginRight: 4 }}>Photovoltaikanlagen</b>{" "}
+          chart
+        </Button>
+        <Button
+          onClick={() => handleClick(nfiState)}
+          sx={{ width: "fit-content" }}
+        >
+          🎄 Preview an <b style={{ marginLeft: 4, marginRight: 4 }}>NFI</b>{" "}
+          chart
+        </Button>
+      </Box>
+      <iframe
+        id="chart"
+        style={{
+          width: 450,
+          height: 750,
+          border: "none",
+        }}
+      />
+    </Box>
+  );
+};
+
+export default Page;
+
+const photovoltaikanlagenState = {
+  state: "CONFIGURING_CHART",
+  dataSet:
+    "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/7",
+  dataSource: {
+    type: "sparql",
+    url: "https://lindas.admin.ch/query",
+  },
+  meta: {
+    title: {
+      de: "",
+      fr: "",
+      it: "",
+      en: "",
+    },
+    description: {
+      de: "",
+      fr: "",
+      it: "",
+      en: "",
+    },
+  },
+  chartConfig: {
+    version: "1.4.2",
+    chartType: "column",
+    filters: {
+      "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Kanton":
+        {
+          type: "single",
+          value: "https://ld.admin.ch/canton/1",
+        },
+    },
+    interactiveFiltersConfig: {
+      legend: {
+        active: false,
+        componentIri: "",
+      },
+      timeRange: {
+        active: false,
+        componentIri:
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr",
+        presets: {
+          type: "range",
+          from: "",
+          to: "",
+        },
+      },
+      dataFilters: {
+        active: false,
+        componentIris: [],
+      },
+      calculation: {
+        active: false,
+        type: "identity",
+      },
+    },
+    fields: {
+      x: {
+        componentIri:
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr",
+        sorting: {
+          sortingType: "byAuto",
+          sortingOrder: "asc",
+        },
+      },
+      y: {
+        componentIri:
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/AnzahlAnlagen",
+      },
+    },
+  },
+};
+
+const nfiState = {
+  state: "CONFIGURING_CHART",
+  dataSet: "https://environment.ld.admin.ch/foen/nfi/nfi_C-1266/cube/2023-1",
+  dataSource: {
+    type: "sparql",
+    url: "https://int.lindas.admin.ch/query",
+  },
+  meta: {
+    title: {
+      de: "",
+      fr: "",
+      it: "",
+      en: "",
+    },
+    description: {
+      de: "",
+      fr: "",
+      it: "",
+      en: "",
+    },
+  },
+  chartConfig: {
+    version: "1.4.2",
+    chartType: "map",
+    filters: {
+      "https://environment.ld.admin.ch/foen/nfi/evaluationType": {
+        type: "single",
+        value: "https://environment.ld.admin.ch/foen/nfi/EvaluationType/1",
+      },
+      "https://environment.ld.admin.ch/foen/nfi/grid": {
+        type: "single",
+        value: "https://environment.ld.admin.ch/foen/nfi/Grid/410",
+      },
+      "https://environment.ld.admin.ch/foen/nfi/unitOfEvaluation": {
+        type: "single",
+        value: "https://environment.ld.admin.ch/foen/nfi/UnitOfEvaluation/2382",
+      },
+      "https://environment.ld.admin.ch/foen/nfi/inventory": {
+        type: "single",
+        value: "https://environment.ld.admin.ch/foen/nfi/Inventory/250",
+      },
+      "https://environment.ld.admin.ch/foen/nfi/classificationUnit": {
+        type: "single",
+        value:
+          "https://environment.ld.admin.ch/foen/nfi/ClassificationUnit/1266/1",
+      },
+    },
+    interactiveFiltersConfig: {
+      legend: {
+        active: false,
+        componentIri: "",
+      },
+      timeRange: {
+        active: false,
+        componentIri:
+          "https://environment.ld.admin.ch/foen/nfi/classificationUnit",
+        presets: {
+          type: "range",
+          from: "",
+          to: "",
+        },
+      },
+      dataFilters: {
+        active: false,
+        componentIris: [],
+      },
+      calculation: {
+        active: false,
+        type: "identity",
+      },
+    },
+    baseLayer: {
+      show: true,
+      locked: false,
+    },
+    fields: {
+      areaLayer: {
+        componentIri:
+          "https://environment.ld.admin.ch/foen/nfi/unitOfReference",
+        color: {
+          type: "numerical",
+          componentIri: "https://environment.ld.admin.ch/foen/nfi/Topic/24r",
+          scaleType: "continuous",
+          interpolationType: "linear",
+          palette: "oranges",
+        },
+      },
+    },
+  },
+};

--- a/app/pages/api/preview.tsx
+++ b/app/pages/api/preview.tsx
@@ -1,0 +1,18 @@
+import ReactDOMServer from "react-dom/server";
+
+import { api } from "../../server/nextkit";
+import Preview from "../preview";
+
+const route = api({
+  POST: async ({ req }) => {
+    const state = JSON.parse(req.body);
+
+    try {
+      return ReactDOMServer.renderToString(<Preview state={state} />);
+    } catch (e) {
+      console.error(e);
+    }
+  },
+});
+
+export default route;

--- a/app/pages/preview.tsx
+++ b/app/pages/preview.tsx
@@ -1,0 +1,57 @@
+import "core-js/features/array/flat-map";
+
+import { I18nProvider } from "@lingui/react";
+import { ThemeProvider } from "@mui/material";
+import { GetServerSideProps } from "next";
+
+import { ChartPublished } from "@/components/chart-published";
+import { GraphqlProvider } from "@/graphql/GraphqlProvider";
+import { Locale, i18n } from "@/locales/locales";
+import { LocaleProvider } from "@/locales/use-locale";
+import * as federalTheme from "@/themes/federal";
+
+const streamToString = async (stream: any) => {
+  if (stream) {
+    const chunks = [];
+
+    for await (const chunk of stream) {
+      chunks.push(Buffer.from(chunk));
+    }
+
+    return Buffer.concat(chunks).toString("utf-8");
+  }
+
+  return null;
+};
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  let state: any | null = null;
+
+  if (req.method === "POST") {
+    const body = (await streamToString(req)) as string;
+    state = JSON.parse(body);
+  }
+
+  return {
+    props: {
+      ...state,
+    },
+  };
+};
+
+export default function Preview(props: any) {
+  const locale: Locale = "en";
+  i18n.activate(locale);
+
+  return (
+    <LocaleProvider value={locale}>
+      <I18nProvider i18n={i18n}>
+        <GraphqlProvider>
+          <ThemeProvider theme={federalTheme.theme}>
+            <ChartPublished configKey="preview" {...props} />
+          </ThemeProvider>
+        </GraphqlProvider>
+      </I18nProvider>
+    </LocaleProvider>
+  );
+}


### PR DESCRIPTION
Contributes to #1095.
Contributes to #1102.

This PR adds an experimental way to call up a chart in a "preview" mode, without saving the config to a database.

It works by rendering a special published chart component to string on the server side – it essentially works by allowing to read POST data by `getServerSideProps`. The resulting DOM is then written to an iframe which displays a chart.

In order to create a chart in preview mode:
1. Send a POST request with chart state to `/api/preview`.
2. Covert received data to text.
3. Write the text to iframe.

The feature can be also tested by accessing a `/_preview_test` page.

cc @adintegra