### PR TITLE
fix: Interactive cascading filters

### DIFF
--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -596,7 +596,7 @@ const useEnsurePossibleInteractiveFilters = (
         mappedFilters
       );
 
-      if (!isEqual(filters, chartConfig.filters) && !isEmpty(filters)) {
+      if (!isEqual(filters, interactiveFilters) && !isEmpty(filters)) {
         for (const [k, v] of Object.entries(filters)) {
           if (k in dataFilters && v.type === "single") {
             dataFilters[k] = v;

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -44,7 +44,8 @@ export const prepareQueryFilters = (
   chartType: ChartType,
   filters: Filters,
   interactiveFiltersConfig: InteractiveFiltersConfig,
-  dataFilters: InteractiveFiltersState["dataFilters"]
+  dataFilters: InteractiveFiltersState["dataFilters"],
+  allowNoneValues = false
 ): Filters => {
   const queryFilters = { ...filters };
 
@@ -54,15 +55,19 @@ export const prepareQueryFilters = (
     }
   }
 
-  return omitBy(queryFilters, (v) => {
-    return v.type === "single" && v.value === FIELD_VALUE_NONE;
-  });
+  return allowNoneValues
+    ? queryFilters
+    : omitBy(queryFilters, (v) => {
+        return v.type === "single" && v.value === FIELD_VALUE_NONE;
+      });
 };
 
 export const useQueryFilters = ({
   chartConfig,
+  allowNoneValues,
 }: {
   chartConfig: ChartConfig;
+  allowNoneValues?: boolean;
 }): QueryFilters => {
   const dataFilters = useInteractiveFilters((d) => d.dataFilters);
 
@@ -71,13 +76,15 @@ export const useQueryFilters = ({
       chartConfig.chartType,
       chartConfig.filters,
       chartConfig.interactiveFiltersConfig,
-      dataFilters
+      dataFilters,
+      allowNoneValues
     );
   }, [
     chartConfig.chartType,
     chartConfig.filters,
     chartConfig.interactiveFiltersConfig,
     dataFilters,
+    allowNoneValues,
   ]);
 };
 

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -59,7 +59,6 @@ import {
   isTableConfig,
 } from "@/config-types";
 import { mapValueIrisToColor } from "@/configurator/components/ui-helpers";
-import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import { toggleInteractiveFilterDataDimension } from "@/configurator/interactive-filters/interactive-filters-config-state";
 import {
   DimensionValue,
@@ -1387,14 +1386,10 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       if (draft.state === "CONFIGURING_CHART") {
         const { dimensionIri, value } = action.value;
 
-        if (value === FIELD_VALUE_NONE) {
-          delete draft.chartConfig.filters[dimensionIri];
-        } else {
-          draft.chartConfig.filters[dimensionIri] = {
-            type: "single",
-            value,
-          };
-        }
+        draft.chartConfig.filters[dimensionIri] = {
+          type: "single",
+          value,
+        };
       }
       return draft;
 

--- a/app/rdf/query-dimension-values.ts
+++ b/app/rdf/query-dimension-values.ts
@@ -8,6 +8,7 @@ import { Literal, NamedNode, Term } from "rdf-js";
 import { ParsingClient } from "sparql-http-client/ParsingClient";
 import { LRUCache } from "typescript-lru-cache";
 
+import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import { parseObservationValue } from "@/domain/data";
 import { pragmas } from "@/rdf/create-source";
 
@@ -166,6 +167,10 @@ export async function loadDimensionValues(
               (d) => d.path?.value === iri
             );
             if (!filterDimension || dimensionIri?.value === iri) {
+              return "";
+            }
+
+            if (value.type === "single" && value.value === FIELD_VALUE_NONE) {
               return "";
             }
 


### PR DESCRIPTION
This PR:
- changes the way we treat setting "No filter" values in filters. Previously we would remove the filter, but this behavior is not desired in interactive filters. We keep the filter in this case now, as we have a way to remove the filters in the editing mode anyway (by clicking a trash bin icon),
- fixes frozen interactive filters, by comparing new possible filters with interactive filters, and not chart filters.

cc @sosiology