### PR TITLE
fix: Dates sorting in data download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 
 ## Unreleased
 
-Nothing yet.
+- Fixes
+  - Fixed sorting of dates in XLSX download
 
 # [3.22.1] - 2023-09-05
 

--- a/app/components/data-download.tsx
+++ b/app/components/data-download.tsx
@@ -106,7 +106,37 @@ const prepareData = ({
 }) => {
   const sortedComponents = getSortedColumns(components);
   const columns = keyBy(sortedComponents, (d) => d.iri);
-  const data = observations.map((obs) => {
+  // Sort the data from left to right, keeping the order of the columns.
+  const sorting: SortingField["sorting"] = {
+    sortingType: "byAuto",
+    sortingOrder: "asc",
+  };
+  const sorters = sortedComponents.map<
+    [string, ReturnType<typeof makeDimensionValueSorters>]
+  >((d) => {
+    return [d.iri, makeDimensionValueSorters(d, { sorting })];
+  });
+  // We need to sort before parsing, to access raw observation values, where
+  // dates are formatted in the format of YYYY-MM-DD, etc.
+  const sortedData = [...observations];
+  sortedData.sort((a, b) => {
+    for (const [iri, dimSorters] of sorters) {
+      for (const sorter of dimSorters) {
+        const sortResult = ascending(
+          sorter(a[iri] as string),
+          sorter(b[iri] as string)
+        );
+
+        if (sortResult !== 0) {
+          return sortResult;
+        }
+      }
+    }
+
+    return 0;
+  });
+
+  const parsedData = sortedData.map((obs) => {
     return Object.keys(obs).reduce<Observation>((acc, key) => {
       const col = columns[key];
       const parser = dimensionParsers[key];
@@ -121,37 +151,8 @@ const prepareData = ({
   });
   const columnKeys = Object.values(columns).map(makeColumnLabel);
 
-  // Sort the data from left to right, keeping the order of the columns.
-  const sorting: SortingField["sorting"] = {
-    sortingType: "byAuto",
-    sortingOrder: "asc",
-  };
-  const sorters = sortedComponents.map<
-    [string, ReturnType<typeof makeDimensionValueSorters>]
-  >((d) => {
-    return [d.iri, makeDimensionValueSorters(d, { sorting })];
-  });
-  data.sort((a, b) => {
-    for (const [iri, dimSorters] of sorters) {
-      const colLabel = makeColumnLabel(columns[iri]);
-
-      for (const sorter of dimSorters) {
-        const sortResult = ascending(
-          sorter(a[colLabel] as string),
-          sorter(b[colLabel] as string)
-        );
-
-        if (sortResult !== 0) {
-          return sortResult;
-        }
-      }
-    }
-
-    return 0;
-  });
-
   return {
-    data,
+    data: parsedData,
     columnKeys,
   };
 };


### PR DESCRIPTION
This PR fixes sorting of dates in XLSX download by sorting upfront, before parsing, to access raw observation values, where dates are formatted in YYYY-MM-DD manner.

It should be safe to do so, as dates in Cube Creator are formatted according to ISO standards (https://www.w3.org/TR/owl-time/#time:GeneralDateTimeDescription).