### PR TITLE
fix: Locale overwriting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 
 - Fixes
   - Table docs now work correctly again
+  - Changing the locale when previewing a larger cube no longer triggers multiple locale switches
 
 # [3.22.5] - 2023-09-12
 

--- a/app/browse/datatable.tsx
+++ b/app/browse/datatable.tsx
@@ -216,7 +216,7 @@ export const DataSetPreviewTable = ({
   title: string;
   dimensions: DimensionMetadataFragment[];
   measures: DimensionMetadataFragment[];
-  observations: Observation[];
+  observations: Observation[] | undefined;
 }) => {
   const headers = useMemo(() => {
     return getSortedColumns([...dimensions, ...measures]);

--- a/app/browser/dataset-preview.tsx
+++ b/app/browser/dataset-preview.tsx
@@ -108,7 +108,13 @@ export const DataSetPreview = ({
     window.scrollTo({ top: 0 });
   }, []);
 
-  if (metadata?.dataCubeByIri) {
+  if (fetching) {
+    return (
+      <Flex className={classes.loadingWrapper}>
+        <Loading />
+      </Flex>
+    );
+  } else if (metadata?.dataCubeByIri) {
     const { dataCubeByIri } = metadata;
 
     return (
@@ -186,12 +192,6 @@ export const DataSetPreview = ({
           </Flex>
           <DebugPanel configurator />
         </Paper>
-      </Flex>
-    );
-  } else if (fetching) {
-    return (
-      <Flex className={classes.loadingWrapper}>
-        <Loading />
       </Flex>
     );
   } else {

--- a/app/components/use-redirect-to-versioned-cube.spec.tsx
+++ b/app/components/use-redirect-to-versioned-cube.spec.tsx
@@ -87,7 +87,7 @@ describe("use redirect to versioned cube", () => {
       versionedCube: { iri: "https://versioned-cube" },
     });
     expect(router.replace).toHaveBeenCalledWith({
-      pathname: "/de/browse",
+      pathname: "/browse",
       query: {
         dataset: "https://versioned-cube",
       },
@@ -100,7 +100,7 @@ describe("use redirect to versioned cube", () => {
       versionedCube: { iri: "https://versioned-cube2" },
     });
     expect(router.replace).toHaveBeenCalledWith({
-      pathname: "/de/browse",
+      pathname: "/browse",
       query: {
         dataset: "https://versioned-cube2",
       },

--- a/app/components/use-redirect-to-versioned-cube.tsx
+++ b/app/components/use-redirect-to-versioned-cube.tsx
@@ -48,7 +48,7 @@ export const useRedirectToVersionedCube = ({
 
       if (resp) {
         router.replace({
-          pathname: `/browse`,
+          pathname: "/browse",
           query: {
             ...router.query,
             ...(router.query.iri ? { iri: resp.iri } : { dataset: resp.iri }),

--- a/app/components/use-redirect-to-versioned-cube.tsx
+++ b/app/components/use-redirect-to-versioned-cube.tsx
@@ -48,7 +48,7 @@ export const useRedirectToVersionedCube = ({
 
       if (resp) {
         router.replace({
-          pathname: `/${locale}/browse`,
+          pathname: `/browse`,
           query: {
             ...router.query,
             ...(router.query.iri ? { iri: resp.iri } : { dataset: resp.iri }),

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -26,10 +26,9 @@ export default function App({
   pageProps: { session, ...pageProps },
 }: AppProps) {
   const { events: routerEvents, asPath, locale: routerLocale } = useRouter();
+  const locale = parseLocaleString(routerLocale ?? "");
 
   useNProgress();
-
-  const locale = parseLocaleString(routerLocale ?? "");
 
   // Immediately activate locale to avoid re-render
   if (i18n.locale !== locale) {


### PR DESCRIPTION
Fixes #1174.

This PR fixes overwriting of locale when redirecting to a versioned cube by removing locale from `pathname`. There is no need to pass the locale here, and using it led to making the router switch to old locale, while it previously had already updated the locale via `routeChangeComplete` event.

This behavior was only visible when previewing larger cubes, probably due to a fact that it took longer to update the content and a small lag was introduced that made the broken behavior visible.