### PR TITLE
fix: Hierarchical cascading filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 
 - Fixes
   - Table docs now work correctly again
+  - Cascading mode now works correctly for hierarchical dimensions used as interactive filters
 
 # [3.22.5] - 2023-09-12
 

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -380,7 +380,10 @@ const DataFilterHierarchyDimension = (
   const options = React.useMemo(() => {
     let opts = [] as { label: string; value: string; isNoneValue?: boolean }[];
     if (hierarchy) {
-      opts = hierarchyToOptions(hierarchy);
+      opts = hierarchyToOptions(
+        hierarchy,
+        dimensionValues.map((d) => d.value)
+      );
     } else {
       // @ts-ignore
       opts = dimensionValues;

--- a/app/utils/hierarchy.ts
+++ b/app/utils/hierarchy.ts
@@ -1,7 +1,7 @@
 import { ascending } from "d3";
 
 import { SelectTreeProps } from "@/components/select-tree";
-import { OptionGroup, Option } from "@/configurator";
+import { Option, OptionGroup } from "@/configurator";
 import { HierarchyParents } from "@/configurator/components/use-hierarchy-parents";
 import { DimensionValue } from "@/domain/data";
 import { truthy } from "@/domain/types";
@@ -36,7 +36,7 @@ export const makeOptionGroups = (
 
 export const hierarchyToOptions = (
   hierarchy: HierarchyValue[],
-  possibleValues?: DimensionValue["value"][]
+  possibleValues: DimensionValue["value"][]
 ) => {
   const possibleValuesSet = possibleValues
     ? new Set(possibleValues)


### PR DESCRIPTION
Fixes #1176.

It turns out we didn't filter hierarchy when passing it to a filter. This PR fixes that, as well as makes it necessary to pass `possibleValues` to `hierarchyToOptions` function, so this error shouldn't appear again.

To test, replicate a chart from #1176 using the preview deployment.