### PR TITLE
fix: Reverse the condition to detect literal dimensions

### DIFF
--- a/app/docs/rdf-to-visualize.mdx
+++ b/app/docs/rdf-to-visualize.mdx
@@ -118,11 +118,9 @@ property.
 
 | RDF                                        | Visualize              |
 | :----------------------------------------- | :--------------------- |
-| `?dimension shacl:nodeKind ?shacl:Literal` | `dim.isLiteral = true` |
+| `?dimension shacl:nodeKind !== ?shacl:IRI` | `dim.isLiteral = true` |
 
-`True` when the dimension has `shacl:nodeKind` of `shacl:Literal`. Non literal
-dimensions (`shacl:IRI`) are also called _Shared dimensions_, and their values
-will be fetched outside of the cube.
+`True` when the dimension has `shacl:nodeKind` different than `shacl:IRI`.
 
 #### Data kind
 

--- a/app/rdf/parse.ts
+++ b/app/rdf/parse.ts
@@ -137,8 +137,7 @@ const getDataKind = (term: Term | undefined) => {
 };
 
 export const parseDimensionDatatype = (dim: CubeDimension) => {
-  const isLiteral =
-    dim.out(ns.sh.nodeKind).term?.equals(ns.sh.Literal) ?? false;
+  const isNamedNode = dim.out(ns.sh.nodeKind).term?.equals(ns.sh.IRI) ?? false;
   let dataType = dim.datatype;
   let hasUndefinedValues = false;
 
@@ -166,7 +165,7 @@ export const parseDimensionDatatype = (dim: CubeDimension) => {
     }
   }
 
-  return { isLiteral, dataType, hasUndefinedValues };
+  return { isLiteral: !isNamedNode, dataType, hasUndefinedValues };
 };
 
 type RelationType = "StandardError";


### PR DESCRIPTION
Fixes #1180.

Hi @Rdataflow, thank you for your suggestions, the problem was indeed related to the recent change to detecting literal dimensions. This PR fixes the issue by reversing the condition from

```ts
const isLiteral = dim.out(ns.sh.nodeKind).term?.equals(ns.sh.Literal);
```

to

```ts
const isNamedNode =  dim.out(ns.sh.nodeKind).term?.equals(ns.sh.IRI);
const isLiteral = !isNamedNode
```

This change makes it irrelevant if dimension specifies `ns.sh.Literal`, so I am not 100% sure if that's how the things should be. But with this, we could potentially avoid similar problems as with NFI cubes.

Let me know if the change proposed in this PR should be merged 👍 