### PR TITLE
fix: Cut Y axis labels

### DIFF
--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -91,7 +91,14 @@ const useAreasState = (
     getSegmentAbbreviationOrLabel,
   } = variables;
   const getIdentityY = useGetIdentityY(yMeasure.iri);
-  const { chartData, scalesData, segmentData, timeRangeData, allData } = data;
+  const {
+    chartData,
+    scalesData,
+    segmentData,
+    timeRangeData,
+    paddingData,
+    allData,
+  } = data;
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   const width = useWidth();
@@ -281,12 +288,12 @@ const useAreasState = (
     });
   }, [scalesData, normalize, getXAsString, getY]);
 
-  const allYScale = useMemo(() => {
+  const paddingYScale = useMemo(() => {
     //  When the user can toggle between absolute and relative values, we use the
     // absolute values to calculate the yScale domain, so that the yScale doesn't
     // change when the user toggles between absolute and relative values.
     if (interactiveFiltersConfig?.calculation.active) {
-      const scale = getStackedYScale(allData, {
+      const scale = getStackedYScale(paddingData, {
         normalize: false,
         getX: getXAsString,
         getY,
@@ -299,9 +306,13 @@ const useAreasState = (
       return scale;
     }
 
-    return getStackedYScale(allData, { normalize, getX: getXAsString, getY });
+    return getStackedYScale(paddingData, {
+      normalize,
+      getX: getXAsString,
+      getY,
+    });
   }, [
-    allData,
+    paddingData,
     getXAsString,
     getY,
     interactiveFiltersConfig?.calculation.active,
@@ -310,7 +321,7 @@ const useAreasState = (
 
   /** Dimensions */
   const { left, bottom } = useChartPadding({
-    allYScale,
+    yScale: paddingYScale,
     width,
     aspectRatio,
     interactiveFiltersConfig,

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -90,7 +90,14 @@ const useColumnsGroupedState = (
     getSegment,
     getSegmentAbbreviationOrLabel,
   } = variables;
-  const { chartData, scalesData, segmentData, timeRangeData, allData } = data;
+  const {
+    chartData,
+    scalesData,
+    segmentData,
+    timeRangeData,
+    paddingData,
+    allData,
+  } = data;
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   const width = useWidth();
@@ -170,7 +177,7 @@ const useColumnsGroupedState = (
     xTimeRangeDomainLabels,
     colors,
     yScale,
-    allYScale,
+    paddingYScale,
     interactiveXTimeRangeScale,
     xScale,
     xScaleIn,
@@ -247,22 +254,26 @@ const useColumnsGroupedState = (
     );
     const yScale = scaleLinear().domain([minValue, maxValue]).nice();
 
-    const allMinValue = Math.min(
-      min(allData, (d) => (getYErrorRange ? getYErrorRange(d)[0] : getY(d))) ??
-        0,
+    const minPaddingValue = Math.min(
+      min(paddingData, (d) =>
+        getYErrorRange ? getYErrorRange(d)[0] : getY(d)
+      ) ?? 0,
       0
     );
-    const allMaxValue = Math.max(
-      max(allData, (d) => (getYErrorRange ? getYErrorRange(d)[1] : getY(d))) ??
-        0,
+    const maxPaddingValue = Math.max(
+      max(paddingData, (d) =>
+        getYErrorRange ? getYErrorRange(d)[1] : getY(d)
+      ) ?? 0,
       0
     );
-    const allYScale = scaleLinear().domain([allMinValue, allMaxValue]).nice();
+    const paddingYScale = scaleLinear()
+      .domain([minPaddingValue, maxPaddingValue])
+      .nice();
 
     return {
       colors,
       yScale,
-      allYScale,
+      paddingYScale,
       interactiveXTimeRangeScale,
       xScale,
       xScaleIn,
@@ -282,7 +293,7 @@ const useColumnsGroupedState = (
     getXLabel,
     segments,
     timeRangeData,
-    allData,
+    paddingData,
     allSegments,
     segmentsByAbbreviationOrLabel,
     segmentsByValue,
@@ -320,7 +331,7 @@ const useColumnsGroupedState = (
   }, [getSegment, getX, chartData, segmentSortingOrder, segments, xScale]);
 
   const { left, bottom } = useChartPadding({
-    allYScale,
+    yScale: paddingYScale,
     width,
     aspectRatio,
     interactiveFiltersConfig,

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -99,7 +99,14 @@ const useColumnsStackedState = (
     getSegmentAbbreviationOrLabel,
   } = variables;
   const getIdentityY = useGetIdentityY(yMeasure.iri);
-  const { chartData, scalesData, segmentData, timeRangeData, allData } = data;
+  const {
+    chartData,
+    scalesData,
+    segmentData,
+    timeRangeData,
+    paddingData,
+    allData,
+  } = data;
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   const width = useWidth();
@@ -312,12 +319,12 @@ const useColumnsStackedState = (
     });
   }, [scalesData, normalize, getX, getY, getAnimation]);
 
-  const allYScale = useMemo(() => {
+  const paddingYScale = useMemo(() => {
     //  When the user can toggle between absolute and relative values, we use the
     // absolute values to calculate the yScale domain, so that the yScale doesn't
     // change when the user toggles between absolute and relative values.
     if (interactiveFiltersConfig?.calculation.active) {
-      const scale = getStackedYScale(allData, {
+      const scale = getStackedYScale(paddingData, {
         normalize: false,
         getX,
         getY,
@@ -331,7 +338,7 @@ const useColumnsStackedState = (
       return scale;
     }
 
-    return getStackedYScale(allData, {
+    return getStackedYScale(paddingData, {
       normalize,
       getX,
       getY,
@@ -339,7 +346,7 @@ const useColumnsStackedState = (
     });
   }, [
     interactiveFiltersConfig?.calculation.active,
-    allData,
+    paddingData,
     normalize,
     getX,
     getY,
@@ -373,7 +380,7 @@ const useColumnsStackedState = (
 
   /** Chart dimensions */
   const { left, bottom } = useChartPadding({
-    allYScale,
+    yScale: paddingYScale,
     width,
     aspectRatio,
     interactiveFiltersConfig,

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -78,7 +78,7 @@ const useColumnsState = (
     getYError,
     getYErrorRange,
   } = variables;
-  const { chartData, scalesData, timeRangeData, allData } = data;
+  const { chartData, scalesData, timeRangeData, paddingData, allData } = data;
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   const width = useWidth();
@@ -99,7 +99,7 @@ const useColumnsState = (
   const {
     xScale,
     yScale,
-    allYScale,
+    paddingYScale,
     interactiveXTimeRangeScale,
     xScaleInteraction,
     xTimeRangeDomainLabels,
@@ -151,22 +151,26 @@ const useColumnsState = (
     );
     const yScale = scaleLinear().domain([minValue, maxValue]).nice();
 
-    const allMinValue = Math.min(
-      min(allData, (d) => (getYErrorRange ? getYErrorRange(d)[0] : getY(d))) ??
-        0,
+    const paddingMinValue = Math.min(
+      min(paddingData, (d) =>
+        getYErrorRange ? getYErrorRange(d)[0] : getY(d)
+      ) ?? 0,
       0
     );
-    const allMaxValue = Math.max(
-      max(allData, (d) => (getYErrorRange ? getYErrorRange(d)[1] : getY(d))) ??
-        0,
+    const paddingMaxValue = Math.max(
+      max(paddingData, (d) =>
+        getYErrorRange ? getYErrorRange(d)[1] : getY(d)
+      ) ?? 0,
       0
     );
-    const allYScale = scaleLinear().domain([allMinValue, allMaxValue]).nice();
+    const paddingYScale = scaleLinear()
+      .domain([paddingMinValue, paddingMaxValue])
+      .nice();
 
     return {
       xScale,
       yScale,
-      allYScale,
+      paddingYScale,
       interactiveXTimeRangeScale,
       xScaleInteraction,
       xTimeRangeDomainLabels,
@@ -178,7 +182,7 @@ const useColumnsState = (
     getY,
     getYErrorRange,
     scalesData,
-    allData,
+    paddingData,
     timeRangeData,
     fields.x.sorting,
     fields.x.useAbbreviations,
@@ -188,7 +192,7 @@ const useColumnsState = (
   ]);
 
   const { left, bottom } = useChartPadding({
-    allYScale,
+    yScale: paddingYScale,
     width,
     aspectRatio,
     interactiveFiltersConfig,

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -81,7 +81,14 @@ const useLinesState = (
     getSegment,
     getSegmentAbbreviationOrLabel,
   } = variables;
-  const { chartData, scalesData, segmentData, timeRangeData, allData } = data;
+  const {
+    chartData,
+    scalesData,
+    segmentData,
+    timeRangeData,
+    paddingData,
+    allData,
+  } = data;
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   const width = useWidth();
@@ -132,10 +139,11 @@ const useLinesState = (
   const yDomain = [minValue, maxValue];
   const yScale = scaleLinear().domain(yDomain).nice();
 
-  const allMinValue = Math.min(min(allData, getY) ?? 0, 0);
-  const allMaxValue = max(allData, getY) ?? 0;
-  const allYDomain = [allMinValue, allMaxValue];
-  const allYScale = scaleLinear().domain(allYDomain).nice();
+  const paddingMinValue = Math.min(min(paddingData, getY) ?? 0, 0);
+  const paddingMaxValue = max(paddingData, getY) ?? 0;
+  const paddingYScale = scaleLinear()
+    .domain([paddingMinValue, paddingMaxValue])
+    .nice();
 
   // segments
   const segmentFilter = segmentDimension?.iri
@@ -195,7 +203,7 @@ const useLinesState = (
 
   // Dimensions
   const { left, bottom } = useChartPadding({
-    allYScale,
+    yScale: paddingYScale,
     width,
     aspectRatio,
     interactiveFiltersConfig,

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -64,7 +64,7 @@ const useScatterplotState = (
     getSegment,
     getSegmentAbbreviationOrLabel,
   } = variables;
-  const { chartData, scalesData, segmentData, allData } = data;
+  const { chartData, scalesData, segmentData, paddingData, allData } = data;
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   const width = useWidth();
@@ -86,10 +86,11 @@ const useScatterplotState = (
   const yDomain = [yMinValue, yMaxValue];
   const yScale = scaleLinear().domain(yDomain).nice();
 
-  const allYMinValue = Math.min(min(allData, (d) => getY(d)) ?? 0, 0);
-  const allYMaxValue = max(allData, getY) ?? 0;
-  const allYDomain = [allYMinValue, allYMaxValue];
-  const allYScale = scaleLinear().domain(allYDomain).nice();
+  const paddingYMinValue = Math.min(min(paddingData, (d) => getY(d)) ?? 0, 0);
+  const paddingYMaxValue = max(paddingData, getY) ?? 0;
+  const paddingYScale = scaleLinear()
+    .domain([paddingYMinValue, paddingYMaxValue])
+    .nice();
 
   const hasSegment = fields.segment ? true : false;
   const segmentFilter = segmentDimension?.iri
@@ -144,7 +145,7 @@ const useScatterplotState = (
   }
   // Dimensions
   const { left, bottom } = useChartPadding({
-    allYScale,
+    yScale: paddingYScale,
     width,
     aspectRatio,
     interactiveFiltersConfig,

--- a/app/charts/shared/chart-dimensions.tsx
+++ b/app/charts/shared/chart-dimensions.tsx
@@ -10,7 +10,7 @@ import { ChartConfig } from "@/configurator";
 import { getTextWidth } from "@/utils/get-text-width";
 
 type ComputeChartPaddingProps = {
-  allYScale: d3.ScaleLinear<number, number>;
+  yScale: d3.ScaleLinear<number, number>;
   width: number;
   aspectRatio: number;
   interactiveFiltersConfig: ChartConfig["interactiveFiltersConfig"];
@@ -22,7 +22,7 @@ type ComputeChartPaddingProps = {
 
 const computeChartPadding = (props: ComputeChartPaddingProps) => {
   const {
-    allYScale,
+    yScale,
     width,
     aspectRatio,
     interactiveFiltersConfig,
@@ -36,7 +36,7 @@ const computeChartPadding = (props: ComputeChartPaddingProps) => {
   // with decimals have greater text length than the extremes.
   // Width * aspectRatio is taken as an approximation of chartHeight
   // since we do not have access to chartHeight yet.
-  const fakeTicks = allYScale.ticks(getTickNumber(width * aspectRatio));
+  const fakeTicks = yScale.ticks(getTickNumber(width * aspectRatio));
   const minLeftTickWidth =
     !!interactiveFiltersConfig?.calculation.active || normalize
       ? getTextWidth("100%", { fontSize: TICK_FONT_SIZE }) + TICK_PADDING
@@ -66,7 +66,7 @@ const computeChartPadding = (props: ComputeChartPaddingProps) => {
 
 export const useChartPadding = (props: ComputeChartPaddingProps) => {
   const {
-    allYScale,
+    yScale,
     width,
     aspectRatio,
     interactiveFiltersConfig,
@@ -78,7 +78,7 @@ export const useChartPadding = (props: ComputeChartPaddingProps) => {
 
   return useMemo(() => {
     return computeChartPadding({
-      allYScale,
+      yScale,
       width,
       aspectRatio,
       interactiveFiltersConfig,
@@ -88,7 +88,7 @@ export const useChartPadding = (props: ComputeChartPaddingProps) => {
       normalize,
     });
   }, [
-    allYScale,
+    yScale,
     width,
     aspectRatio,
     interactiveFiltersConfig,

--- a/app/charts/shared/chart-dimensions.tsx
+++ b/app/charts/shared/chart-dimensions.tsx
@@ -53,7 +53,7 @@ const computeChartPadding = (props: ComputeChartPaddingProps) => {
   let bottom =
     interactiveFiltersConfig?.timeRange.active || animationPresent
       ? BRUSH_BOTTOM_SPACE
-      : 40;
+      : 48;
 
   if (bandDomain?.length) {
     bottom +=

--- a/app/charts/shared/chart-state.ts
+++ b/app/charts/shared/chart-state.ts
@@ -350,6 +350,8 @@ export type ChartStateData = {
   segmentData: Observation[];
   /** Data to be used for interactive time range slider domain. */
   timeRangeData: Observation[];
+  /** Data used to compute the axes padding. */
+  paddingData: Observation[];
   /** Full dataset, needed to show the timeline when using time slider.
    * We can't use `scalesData` here, due to the fact the the `useChartData` hook gets
    * re-rendered and prevents the timeline from working it such case. */
@@ -505,11 +507,20 @@ export const useChartData = (
     return observations.filter(overEvery(timeRangeFilters));
   }, [observations, timeRangeFilters]);
 
+  const paddingData = React.useMemo(() => {
+    if (dynamicScales) {
+      return chartData;
+    } else {
+      return observations.filter(overEvery(interactiveLegendFilters));
+    }
+  }, [dynamicScales, chartData, observations, interactiveLegendFilters]);
+
   return {
     chartData,
     scalesData,
     segmentData,
     timeRangeData,
+    paddingData,
   };
 };
 


### PR DESCRIPTION
Fixes #1183.

It turns out we need to have one more type of chart data, where we filter it only by interactive color legend filters to properly compute left chart margin.

To test, recreate the chart from #1183 and see that the labels are no longer cut.