### PR TITLE
fix: Changing chart type when copying non-hierarchical charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 
 - Fixes
   - Cube checker now correctly checks if dimensions are present
+  - It's now possible to change the chart type for copied, non-hierarchical charts without having to open an options panel first
 
 # [3.22.6] - 2023-09-19
 


### PR DESCRIPTION
Fixes #1188.

As only some charts support hierarchies, we need to try to retrieve both ComponentsWithHierarchies – and when they're not available, fall back to Components.