### PR TITLE
perf: Disable loading of dimension values for preview query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 
 - Fixes
   - Cube checker now correctly checks if dimensions are present
+- Performance
+  - Dataset preview should now load quicker as we no longer fetch dimension values along with it
 
 # [3.22.6] - 2023-09-19
 

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -7,7 +7,12 @@ fragment dimensionMetadata on Dimension {
   dataType
   scaleType
   order
-  values(sourceType: $sourceType, sourceUrl: $sourceUrl, filters: $filters)
+  values(
+    sourceType: $sourceType
+    sourceUrl: $sourceUrl
+    filters: $filters
+    disableLoad: $disableValuesLoad
+  )
   unit
   related {
     iri
@@ -120,6 +125,7 @@ query DataCubePreview(
   $locale: String!
   $latest: Boolean
   $filters: Filters
+  $disableValuesLoad: Boolean = true
 ) {
   dataCubeByIri(
     iri: $iri
@@ -127,15 +133,24 @@ query DataCubePreview(
     sourceUrl: $sourceUrl
     locale: $locale
     latest: $latest
+    disableValuesLoad: $disableValuesLoad
   ) {
     iri
     title
     description
     publicationStatus
-    dimensions(sourceType: $sourceType, sourceUrl: $sourceUrl) {
+    dimensions(
+      sourceType: $sourceType
+      sourceUrl: $sourceUrl
+      disableValuesLoad: $disableValuesLoad
+    ) {
       ...dimensionMetadata
     }
-    measures(sourceType: $sourceType, sourceUrl: $sourceUrl) {
+    measures(
+      sourceType: $sourceType
+      sourceUrl: $sourceUrl
+      disableValuesLoad: $disableValuesLoad
+    ) {
       ...dimensionMetadata
     }
     observations(sourceType: $sourceType, sourceUrl: $sourceUrl, limit: 10) {
@@ -193,6 +208,7 @@ query Components(
   $latest: Boolean
   $filters: Filters
   $componentIris: [String!]
+  $disableValuesLoad: Boolean = false
 ) {
   dataCubeByIri(
     iri: $iri
@@ -200,11 +216,13 @@ query Components(
     sourceUrl: $sourceUrl
     locale: $locale
     latest: $latest
+    disableValuesLoad: $disableValuesLoad
   ) {
     dimensions(
       sourceType: $sourceType
       sourceUrl: $sourceUrl
       componentIris: $componentIris
+      disableValuesLoad: $disableValuesLoad
     ) {
       ...dimensionMetadata
     }
@@ -212,6 +230,7 @@ query Components(
       sourceType: $sourceType
       sourceUrl: $sourceUrl
       componentIris: $componentIris
+      disableValuesLoad: $disableValuesLoad
     ) {
       ...dimensionMetadata
     }

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -64,6 +64,7 @@ export type DataCubeDimensionsArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   componentIris?: Maybe<Array<Scalars['String']>>;
+  disableValuesLoad?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -78,6 +79,7 @@ export type DataCubeMeasuresArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   componentIris?: Maybe<Array<Scalars['String']>>;
+  disableValuesLoad?: Maybe<Scalars['Boolean']>;
 };
 
 export type DataCubeOrganization = {
@@ -142,6 +144,7 @@ export type DimensionValuesArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   filters?: Maybe<Scalars['Filters']>;
+  disableLoad?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -183,6 +186,7 @@ export type GeoCoordinatesDimensionValuesArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   filters?: Maybe<Scalars['Filters']>;
+  disableLoad?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -214,6 +218,7 @@ export type GeoShapesDimensionValuesArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   filters?: Maybe<Scalars['Filters']>;
+  disableLoad?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -258,6 +263,7 @@ export type NominalDimensionValuesArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   filters?: Maybe<Scalars['Filters']>;
+  disableLoad?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -291,6 +297,7 @@ export type NumericalMeasureValuesArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   filters?: Maybe<Scalars['Filters']>;
+  disableLoad?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -340,6 +347,7 @@ export type OrdinalDimensionValuesArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   filters?: Maybe<Scalars['Filters']>;
+  disableLoad?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -369,6 +377,7 @@ export type OrdinalMeasureValuesArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   filters?: Maybe<Scalars['Filters']>;
+  disableLoad?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -397,6 +406,7 @@ export type QueryDataCubeByIriArgs = {
   latest?: Maybe<Scalars['Boolean']>;
   filters?: Maybe<Scalars['Filters']>;
   componentIris?: Maybe<Array<Scalars['String']>>;
+  disableValuesLoad?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -485,6 +495,7 @@ export type StandardErrorDimensionValuesArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   filters?: Maybe<Scalars['Filters']>;
+  disableLoad?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -516,6 +527,7 @@ export type TemporalDimensionValuesArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   filters?: Maybe<Scalars['Filters']>;
+  disableLoad?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -545,6 +557,7 @@ export type TemporalOrdinalDimensionValuesArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   filters?: Maybe<Scalars['Filters']>;
+  disableLoad?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -834,6 +847,7 @@ export type DataCubePreviewQueryVariables = Exact<{
   locale: Scalars['String'];
   latest?: Maybe<Scalars['Boolean']>;
   filters?: Maybe<Scalars['Filters']>;
+  disableValuesLoad?: Maybe<Scalars['Boolean']>;
 }>;
 
 
@@ -891,6 +905,7 @@ export type ComponentsQueryVariables = Exact<{
   latest?: Maybe<Scalars['Boolean']>;
   filters?: Maybe<Scalars['Filters']>;
   componentIris?: Maybe<Array<Scalars['String']> | Scalars['String']>;
+  disableValuesLoad?: Maybe<Scalars['Boolean']>;
 }>;
 
 
@@ -1153,7 +1168,12 @@ export const DimensionMetadataFragmentDoc = gql`
   dataType
   scaleType
   order
-  values(sourceType: $sourceType, sourceUrl: $sourceUrl, filters: $filters)
+  values(
+    sourceType: $sourceType
+    sourceUrl: $sourceUrl
+    filters: $filters
+    disableLoad: $disableValuesLoad
+  )
   unit
   related {
     iri
@@ -1271,22 +1291,31 @@ export function useDataCubesQuery(options: Omit<Urql.UseQueryArgs<DataCubesQuery
   return Urql.useQuery<DataCubesQuery>({ query: DataCubesDocument, ...options });
 };
 export const DataCubePreviewDocument = gql`
-    query DataCubePreview($iri: String!, $sourceType: String!, $sourceUrl: String!, $locale: String!, $latest: Boolean, $filters: Filters) {
+    query DataCubePreview($iri: String!, $sourceType: String!, $sourceUrl: String!, $locale: String!, $latest: Boolean, $filters: Filters, $disableValuesLoad: Boolean = true) {
   dataCubeByIri(
     iri: $iri
     sourceType: $sourceType
     sourceUrl: $sourceUrl
     locale: $locale
     latest: $latest
+    disableValuesLoad: $disableValuesLoad
   ) {
     iri
     title
     description
     publicationStatus
-    dimensions(sourceType: $sourceType, sourceUrl: $sourceUrl) {
+    dimensions(
+      sourceType: $sourceType
+      sourceUrl: $sourceUrl
+      disableValuesLoad: $disableValuesLoad
+    ) {
       ...dimensionMetadata
     }
-    measures(sourceType: $sourceType, sourceUrl: $sourceUrl) {
+    measures(
+      sourceType: $sourceType
+      sourceUrl: $sourceUrl
+      disableValuesLoad: $disableValuesLoad
+    ) {
       ...dimensionMetadata
     }
     observations(sourceType: $sourceType, sourceUrl: $sourceUrl, limit: 10) {
@@ -1340,18 +1369,20 @@ export function useDataCubeMetadataQuery(options: Omit<Urql.UseQueryArgs<DataCub
   return Urql.useQuery<DataCubeMetadataQuery>({ query: DataCubeMetadataDocument, ...options });
 };
 export const ComponentsDocument = gql`
-    query Components($iri: String!, $sourceType: String!, $sourceUrl: String!, $locale: String!, $latest: Boolean, $filters: Filters, $componentIris: [String!]) {
+    query Components($iri: String!, $sourceType: String!, $sourceUrl: String!, $locale: String!, $latest: Boolean, $filters: Filters, $componentIris: [String!], $disableValuesLoad: Boolean = false) {
   dataCubeByIri(
     iri: $iri
     sourceType: $sourceType
     sourceUrl: $sourceUrl
     locale: $locale
     latest: $latest
+    disableValuesLoad: $disableValuesLoad
   ) {
     dimensions(
       sourceType: $sourceType
       sourceUrl: $sourceUrl
       componentIris: $componentIris
+      disableValuesLoad: $disableValuesLoad
     ) {
       ...dimensionMetadata
     }
@@ -1359,6 +1390,7 @@ export const ComponentsDocument = gql`
       sourceType: $sourceType
       sourceUrl: $sourceUrl
       componentIris: $componentIris
+      disableValuesLoad: $disableValuesLoad
     ) {
       ...dimensionMetadata
     }

--- a/app/graphql/resolver-types.ts
+++ b/app/graphql/resolver-types.ts
@@ -66,6 +66,7 @@ export type DataCubeDimensionsArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   componentIris?: Maybe<Array<Scalars['String']>>;
+  disableValuesLoad?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -80,6 +81,7 @@ export type DataCubeMeasuresArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   componentIris?: Maybe<Array<Scalars['String']>>;
+  disableValuesLoad?: Maybe<Scalars['Boolean']>;
 };
 
 export type DataCubeOrganization = {
@@ -144,6 +146,7 @@ export type DimensionValuesArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   filters?: Maybe<Scalars['Filters']>;
+  disableLoad?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -185,6 +188,7 @@ export type GeoCoordinatesDimensionValuesArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   filters?: Maybe<Scalars['Filters']>;
+  disableLoad?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -216,6 +220,7 @@ export type GeoShapesDimensionValuesArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   filters?: Maybe<Scalars['Filters']>;
+  disableLoad?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -260,6 +265,7 @@ export type NominalDimensionValuesArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   filters?: Maybe<Scalars['Filters']>;
+  disableLoad?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -293,6 +299,7 @@ export type NumericalMeasureValuesArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   filters?: Maybe<Scalars['Filters']>;
+  disableLoad?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -342,6 +349,7 @@ export type OrdinalDimensionValuesArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   filters?: Maybe<Scalars['Filters']>;
+  disableLoad?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -371,6 +379,7 @@ export type OrdinalMeasureValuesArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   filters?: Maybe<Scalars['Filters']>;
+  disableLoad?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -399,6 +408,7 @@ export type QueryDataCubeByIriArgs = {
   latest?: Maybe<Scalars['Boolean']>;
   filters?: Maybe<Scalars['Filters']>;
   componentIris?: Maybe<Array<Scalars['String']>>;
+  disableValuesLoad?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -487,6 +497,7 @@ export type StandardErrorDimensionValuesArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   filters?: Maybe<Scalars['Filters']>;
+  disableLoad?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -518,6 +529,7 @@ export type TemporalDimensionValuesArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   filters?: Maybe<Scalars['Filters']>;
+  disableLoad?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -547,6 +559,7 @@ export type TemporalOrdinalDimensionValuesArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   filters?: Maybe<Scalars['Filters']>;
+  disableLoad?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -636,6 +649,7 @@ export type ResolversTypes = ResolversObject<{
   DataCube: ResolverTypeWrapper<ResolvedDataCube>;
   String: ResolverTypeWrapper<Scalars['String']>;
   Int: ResolverTypeWrapper<Scalars['Int']>;
+  Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
   DataCubeOrganization: ResolverTypeWrapper<DataCubeOrganization>;
   DataCubePublicationStatus: DataCubePublicationStatus;
   DataCubeResult: ResolverTypeWrapper<Omit<DataCubeResult, 'dataCube'> & { dataCube: ResolversTypes['DataCube'] }>;
@@ -645,7 +659,6 @@ export type ResolversTypes = ResolversObject<{
   DataCubeTheme: ResolverTypeWrapper<DataCubeTheme>;
   DatasetCount: ResolverTypeWrapper<DatasetCount>;
   Dimension: ResolverTypeWrapper<ResolvedDimension>;
-  Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
   DimensionValue: ResolverTypeWrapper<Scalars['DimensionValue']>;
   FilterValue: ResolverTypeWrapper<Scalars['FilterValue']>;
   Filters: ResolverTypeWrapper<Scalars['Filters']>;
@@ -679,6 +692,7 @@ export type ResolversParentTypes = ResolversObject<{
   DataCube: ResolvedDataCube;
   String: Scalars['String'];
   Int: Scalars['Int'];
+  Boolean: Scalars['Boolean'];
   DataCubeOrganization: DataCubeOrganization;
   DataCubeResult: Omit<DataCubeResult, 'dataCube'> & { dataCube: ResolversParentTypes['DataCube'] };
   Float: Scalars['Float'];
@@ -686,7 +700,6 @@ export type ResolversParentTypes = ResolversObject<{
   DataCubeTheme: DataCubeTheme;
   DatasetCount: DatasetCount;
   Dimension: ResolvedDimension;
-  Boolean: Scalars['Boolean'];
   DimensionValue: Scalars['DimensionValue'];
   FilterValue: Scalars['FilterValue'];
   Filters: Scalars['Filters'];

--- a/app/graphql/resolvers/rdf.ts
+++ b/app/graphql/resolvers/rdf.ts
@@ -333,7 +333,11 @@ export const hierarchy: NonNullable<DimensionResolvers["hierarchy"]> = async (
 
 export const dimensionValues: NonNullable<
   NonNullable<Resolvers["Dimension"]>["values"]
-> = async (parent, { filters }, { setup }, info) => {
+> = async (parent, { filters, disableLoad }, { setup }, info) => {
+  if (disableLoad) {
+    return [];
+  }
+
   const { loaders, sparqlClient, cache } = await setup(info);
   // Different loader if we have filters or not
   const loader = getDimensionValuesLoader(

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -57,6 +57,7 @@ type DataCube {
     sourceType: String!
     sourceUrl: String!
     componentIris: [String!]
+    disableValuesLoad: Boolean
   ): [Dimension!]!
   dimensionByIri(
     iri: String!
@@ -67,6 +68,7 @@ type DataCube {
     sourceType: String!
     sourceUrl: String!
     componentIris: [String!]
+    disableValuesLoad: Boolean
   ): [Measure!]!
   themes: [DataCubeTheme!]!
 }
@@ -102,6 +104,7 @@ interface Dimension {
     sourceType: String!
     sourceUrl: String!
     filters: Filters
+    disableLoad: Boolean
   ): [DimensionValue!]!
   related: [RelatedDimension!]
   hierarchy(sourceType: String!, sourceUrl: String!): [HierarchyValue!]
@@ -128,6 +131,7 @@ type GeoCoordinatesDimension implements Dimension {
     sourceType: String!
     sourceUrl: String!
     filters: Filters
+    disableLoad: Boolean
   ): [DimensionValue!]!
   geoCoordinates: [GeoCoordinates!]
   related: [RelatedDimension!]
@@ -154,6 +158,7 @@ type GeoShapesDimension implements Dimension {
     sourceType: String!
     sourceUrl: String!
     filters: Filters
+    disableLoad: Boolean
   ): [DimensionValue!]!
   geoShapes: GeoShapes
   related: [RelatedDimension!]
@@ -174,6 +179,7 @@ type NominalDimension implements Dimension {
     sourceType: String!
     sourceUrl: String!
     filters: Filters
+    disableLoad: Boolean
   ): [DimensionValue!]!
   related: [RelatedDimension!]
   hierarchy(sourceType: String!, sourceUrl: String!): [HierarchyValue!]
@@ -193,6 +199,7 @@ type OrdinalDimension implements Dimension {
     sourceType: String!
     sourceUrl: String!
     filters: Filters
+    disableLoad: Boolean
   ): [DimensionValue!]!
   related: [RelatedDimension!]
   hierarchy(sourceType: String!, sourceUrl: String!): [HierarchyValue!]
@@ -212,6 +219,7 @@ type StandardErrorDimension implements Dimension {
     sourceType: String!
     sourceUrl: String!
     filters: Filters
+    disableLoad: Boolean
   ): [DimensionValue!]!
   related: [RelatedDimension!]
   hierarchy(sourceType: String!, sourceUrl: String!): [HierarchyValue!]
@@ -243,6 +251,7 @@ type TemporalDimension implements Dimension {
     sourceType: String!
     sourceUrl: String!
     filters: Filters
+    disableLoad: Boolean
   ): [DimensionValue!]!
   related: [RelatedDimension!]
   hierarchy(sourceType: String!, sourceUrl: String!): [HierarchyValue!]
@@ -262,6 +271,7 @@ type TemporalOrdinalDimension implements Dimension {
     sourceType: String!
     sourceUrl: String!
     filters: Filters
+    disableLoad: Boolean
   ): [DimensionValue!]!
   related: [RelatedDimension!]
   hierarchy(sourceType: String!, sourceUrl: String!): [HierarchyValue!]
@@ -287,6 +297,7 @@ type NumericalMeasure implements Dimension {
     sourceType: String!
     sourceUrl: String!
     filters: Filters
+    disableLoad: Boolean
   ): [DimensionValue!]!
   related: [RelatedDimension!]
   hierarchy(sourceType: String!, sourceUrl: String!): [HierarchyValue!]
@@ -306,6 +317,7 @@ type OrdinalMeasure implements Dimension {
     sourceType: String!
     sourceUrl: String!
     filters: Filters
+    disableLoad: Boolean
   ): [DimensionValue!]!
   related: [RelatedDimension!]
   hierarchy(sourceType: String!, sourceUrl: String!): [HierarchyValue!]
@@ -355,6 +367,7 @@ type Query {
     latest: Boolean = true
     filters: Filters
     componentIris: [String!]
+    disableValuesLoad: Boolean
   ): DataCube
   possibleFilters(
     iri: String!

--- a/e2e/abbreviations.spec.ts
+++ b/e2e/abbreviations.spec.ts
@@ -47,7 +47,7 @@ test("it should be possible to enable abbreviations for colors & x field (column
 
   await actions.drawer.close();
 
-  await actions.editor.selectActiveField("Color");
+  await actions.editor.selectActiveField("Segmentation");
 
   await (await selectors.panels.drawer().within().findByText("None")).click();
 
@@ -80,7 +80,7 @@ test("hierarchies: it should be possible to enable abbreviations for colors", as
   );
 
   await selectors.edition.drawerLoaded();
-  await actions.editor.selectActiveField("Color");
+  await actions.editor.selectActiveField("Segmentation");
 
   await (await selectors.panels.drawer().within().findByText("None")).click();
 

--- a/e2e/color-mapping-maps.spec.ts
+++ b/e2e/color-mapping-maps.spec.ts
@@ -26,7 +26,9 @@ test("should be possible to de-select options from color component in maps", asy
 
   await selectors.chart.loaded();
 
-  const colorControlSection = within(selectors.edition.controlSection("Color"));
+  const colorControlSection = within(
+    selectors.edition.controlSection("Segmentation")
+  );
 
   const filtersButton = await colorControlSection.findByText(
     "Edit filters",

--- a/e2e/filter-position.spec.ts
+++ b/e2e/filter-position.spec.ts
@@ -10,7 +10,7 @@ test("Filters should be sorted by position", async ({ selectors, actions }) => {
 
   await selectors.edition.drawerLoaded();
 
-  await actions.editor.selectActiveField("Color");
+  await actions.editor.selectActiveField("Segmentation");
 
   const selectorLocator = await selectors.panels
     .drawer()

--- a/e2e/ordinal-measures.spec.ts
+++ b/e2e/ordinal-measures.spec.ts
@@ -69,7 +69,7 @@ describe("viewing a dataset with only ordinal measures", () => {
     // Chart needs to re-load when symbol layer is selected
     await selectors.chart.loaded();
 
-    await within(selectors.edition.controlSection("Color"))
+    await within(selectors.edition.controlSection("Segmentation"))
       .getByText("None")
       .click();
 

--- a/e2e/sorting.spec.ts
+++ b/e2e/sorting.spec.ts
@@ -32,11 +32,11 @@ test("Segment sorting", async ({
   for (const chartType of ["Columns", "Lines", "Areas", "Pie"] as const) {
     await selectors.edition.drawerLoaded();
     await actions.editor.changeChartType(chartType);
-    await actions.editor.selectActiveField("Color");
+    await actions.editor.selectActiveField("Segmentation");
 
     // Switch color on the first chart
     if (chartType === "Columns") {
-      await within(selectors.edition.controlSection("Color"))
+      await within(selectors.edition.controlSection("Segmentation"))
         .getByText("None")
         .click();
 
@@ -92,11 +92,11 @@ test("Segment sorting with hierarchy", async ({
   );
 
   await selectors.edition.drawerLoaded();
-  await actions.editor.selectActiveField("Color");
+  await actions.editor.selectActiveField("Segmentation");
 
   await sleep(3_000);
 
-  const colorSection = selectors.edition.controlSection("Color");
+  const colorSection = selectors.edition.controlSection("Segmentation");
   await within(colorSection).getByText("None").click();
 
   await actions.mui.selectOption("Region");

--- a/e2e/symbol-layer-colors.spec.ts
+++ b/e2e/symbol-layer-colors.spec.ts
@@ -18,7 +18,7 @@ test("Selecting SymbolLayer colors> should be possible to select geo dimension a
 
   await selectors.chart.loaded();
 
-  await within(selectors.edition.controlSection("Color"))
+  await within(selectors.edition.controlSection("Segmentation"))
     .getByText("None")
     .click();
 


### PR DESCRIPTION
Closes #1192.

To improve performance of fetching the dataset preview, this PR disables loading of dimension values along with it.

It means that we lose the feature to sort the preview by value positions, but for 10-observations preview that might not be necessary anyway.

At first I tried to add a new GQL fragment, `DimensionMetadataWithoutValuesFragment`, but ultimately I decided to introduce a new property to `dataCubeByIri` query – `disableValuesLoad` – to keep the same types, as we use `DimensionMetadataFragment` across the whole application, and the preview query is scoped to one components (dataset preview table).