### PR TITLE
docs: Describe chart preview via API + expose DebugPanel via flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
   - Cascading filters are not stuck anymore in the loading mode in some cases
 - Maintenance
   - GQL debug panel now includes queries fired through SPARQLClientStream (e.g. hierarchies) and CONSTRUCT queries
+  - Configurator and interactive filters debug panel is now displayed if `flag__debug` is set to true
+- Docs
+  - Added chart preview via API section to the documentation
 
 # [3.22.8] - 2023-09-29
 

--- a/app/components/debug-panel/DebugPanel.tsx
+++ b/app/components/debug-panel/DebugPanel.tsx
@@ -165,13 +165,14 @@ DESCRIBE <${configuratorState.dataSet ?? ""}>`
   );
 };
 
-const DebugPanel = ({
-  configurator = false,
-  interactiveFilters = false,
-}: {
+export type DebugPanelProps = {
   configurator?: Boolean;
   interactiveFilters?: Boolean;
-}) => {
+};
+
+const DebugPanel = (props: DebugPanelProps) => {
+  const { configurator = false, interactiveFilters = false } = props;
+
   return (
     <Box
       sx={{
@@ -198,9 +199,4 @@ const DebugPanel = ({
   );
 };
 
-const DebugPanelNull = () => null;
-
-const ExportedDebugPanel =
-  process.env.NODE_ENV === "development" ? DebugPanel : DebugPanelNull;
-
-export default ExportedDebugPanel;
+export default DebugPanel;

--- a/app/components/debug-panel/index.tsx
+++ b/app/components/debug-panel/index.tsx
@@ -2,12 +2,24 @@ import { CircularProgress } from "@mui/material";
 import dynamic from "next/dynamic";
 import { Suspense } from "react";
 
-const LazyDebugPanel = dynamic(() => import("./DebugPanel"));
+import { flag } from "@/flags";
 
-export default process.env.NODE_ENV === "development"
-  ? (props: React.ComponentProps<typeof LazyDebugPanel>) => (
-      <Suspense fallback={<CircularProgress />}>
-        <LazyDebugPanel {...props} />
-      </Suspense>
-    )
-  : () => null;
+import { DebugPanelProps } from "./DebugPanel";
+
+const LazyDebugPanel = dynamic(() => import("./DebugPanel"), { ssr: false });
+
+const DebugPanel = (props: DebugPanelProps) => {
+  const shouldShow = flag("debug") || process.env.NODE_ENV === "development";
+
+  if (!shouldShow) {
+    return null;
+  }
+
+  return (
+    <Suspense fallback={<CircularProgress />}>
+      <LazyDebugPanel {...props} />
+    </Suspense>
+  );
+};
+
+export default DebugPanel;

--- a/app/docs/chart-preview-via-api.mdx
+++ b/app/docs/chart-preview-via-api.mdx
@@ -1,0 +1,160 @@
+<style>{`
+  table:not([class]) {
+     margin-top: 1rem;
+     font-size: 0.875rem;
+     cell-spacing: none;
+     border-spacing: 0;
+     border-collapse: collapse;
+  }
+
+  table:not([class]) tr:nth-child(2n) {
+    background: #eee;
+  }
+
+  table:not([class]) td, table:not([class]) th {
+    border-bottom: #ccc 1px solid;
+    margin-top: 0;
+    padding: 0.25rem 0.5rem;
+  }
+
+  table:not([class]) tr {
+    margin-bottom: 0;
+  }
+
+  li > code {
+    font-size: 0.875rem;
+  }
+`}</style>
+
+While usually you'll want to publish your chart, sometimes you might want to simply preview it, without going through the publishing process.
+This could be especially helpful to programatically generate charts based on many different configuration options.
+Visualize offers a way to preview charts without publishing them, by using a custom API.
+
+## iframe
+
+**Demo**: Visit <a href="/_preview" target="_blank">`/_preview`</a> to see a page with an iframe containing a chart preview.
+
+This method works by pointing an iframe to the `/preview` page, and posting a message with the chart state to the iframe window on load.
+
+<CodeSpecimen
+  lang="js"
+  raw
+  rawBody={`const iframe = document.getElementById("chart");
+iframe.onload = () => {
+  const iframeWindow = iframe?.contentWindow;
+  if (iframeWindow) {
+    iframeWindow.postMessage(chartState, "*");
+  }
+};
+`}
+/>
+
+## POST request
+
+**Demo**: Visit <a href="/_preview_post" target="_blank">`/_preview_post`</a> to see a page with two buttons that open a new page with a chart preview after clicking.
+
+This method works by sending a POST request to `/preview_post` page with chart state when clicking on a form button.
+The `/preview_post` page retrieves the content of a request in `getServerSideProps` and renders a preview of a chart.
+
+It's important to only use one input inside a form (as we split the string by `=`).
+
+<CodeSpecimen
+  lang="css"
+  raw
+  rawBody={`<form method="post" action="/preview_post" target="_blank">
+  <input
+    type="hidden"
+    name="chartState"
+    value={JSON.stringify(photovoltaikanlagenState)}
+  />
+  <input type="submit" value="☀️ Preview a Photovoltaikanlagen chart" />
+</form>`}
+/>
+
+### Chart config schema
+
+As the application constantly evolves, the chart config schema might change.
+You can find the latest version of the schema in the [config-types.ts](https://github.com/visualize-admin/visualization-tool/blob/main/app/config-types.ts) file.
+
+An example chart config is shown below.
+
+<CodeSpecimen
+  lang="json"
+  raw
+  rawBody={`{
+  state: "CONFIGURING_CHART",
+  dataSet:
+    "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/7",
+  dataSource: {
+    type: "sparql",
+    url: "https://lindas.admin.ch/query",
+  },
+  meta: {
+    title: {
+      de: "",
+      fr: "",
+      it: "",
+      en: "",
+    },
+    description: {
+      de: "",
+      fr: "",
+      it: "",
+      en: "",
+    },
+  },
+  chartConfig: {
+    version: "1.4.2",
+    chartType: "column",
+    filters: {
+      "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Kanton":
+        {
+          type: "single",
+          value: "https://ld.admin.ch/canton/1",
+        },
+    },
+    interactiveFiltersConfig: {
+      legend: {
+        active: false,
+        componentIri: "",
+      },
+      timeRange: {
+        active: false,
+        componentIri:
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr",
+        presets: {
+          type: "range",
+          from: "",
+          to: "",
+        },
+      },
+      dataFilters: {
+        active: false,
+        componentIris: [],
+      },
+      calculation: {
+        active: false,
+        type: "identity",
+      },
+    },
+    fields: {
+      x: {
+        componentIri:
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr",
+        sorting: {
+          sortingType: "byAuto",
+          sortingOrder: "asc",
+        },
+      },
+      y: {
+        componentIri:
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/AnzahlAnlagen",
+      },
+    },
+  },
+}`}
+/>
+
+Note that it's encouraged to visit the Visualize application with &flag\_\_debug==true added to the URL to enable
+the debug mode, which will show the chart config directly below the chart that is being edited. It also enables
+the "Dump to console" button, which will log the chart config to the browser console, for easier re-use.

--- a/app/pages/docs/index.tsx
+++ b/app/pages/docs/index.tsx
@@ -92,6 +92,11 @@ const pages: ConfigPageOrGroup[] = [
         content: require("@/docs/rdf-to-visualize.mdx"),
       },
       {
+        path: "/charts/preview-via-api",
+        title: "Preview via API",
+        content: require("@/docs/chart-preview-via-api.mdx"),
+      },
+      {
         path: "/charts/annotations",
         title: "Annotations",
         content: require("@/docs/annotations.docs"),


### PR DESCRIPTION
Closes #1200.

As the types can differ a lot between different chart types, and there are some hidden dependencies to some properties (e.g. multi filter connected to temporal X field, some sorting options only available for column charts, segmentation not available for maps, etc, etc), I decided to point to the file with types in the docs and **expose the configurator & interactive filters debug panel via flag**.

By doing this, editors will be able to edit a chart, tailor it to their needs, and dump the state to the console to copy and modify it slightly to fit their needs. With this we don't need to prepare a complete list of all combination possibilities between the types, which would be really difficult, but rather encourage to pre-create a chart and edit it afterwards, making sure that all necessary side effects have been applied.