### PR TITLE
fix: Downloads of big datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
   - Added a new group of charts – Combo charts – that includes multi-measure line, dual-axis line and column-line charts
   - Added a way to edit and remove charts for logged in users
   - Improved user profile page
+- Fixes
+  - Big datasets should now be possible to download (disabled API route size limit)
 
 # [3.22.9] - 2023-10-06
 

--- a/app/pages/api/download.ts
+++ b/app/pages/api/download.ts
@@ -54,7 +54,7 @@ export default async function Download(
 export const config = {
   api: {
     bodyParser: {
-      sizeLimit: "40mb",
+      sizeLimit: false,
     },
   },
 };


### PR DESCRIPTION
This PR disables body size limit of download API route to allow downloading bigger datasets.