### PR TITLE
performance: Use CONSTRUCT query for dimension values metadata

### DIFF
--- a/app/next.config.js
+++ b/app/next.config.js
@@ -99,6 +99,11 @@ module.exports = withPreconstruct(
           new IgnorePlugin({ resourceRegExp: /^(pg-native|vue)$/ })
         );
 
+        config.resolve.fallback = {
+          ...config.resolve.fallback,
+          fs: false,
+        };
+
         return config;
       },
     })

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -29,21 +29,18 @@ import {
 import { ResolvedDataCube, ResolvedDimension } from "../graphql/shared-types";
 
 import * as ns from "./namespace";
-import { schema } from "./namespace";
 import {
   getQueryLocales,
-  getScaleType,
   isCubePublished,
   parseCube,
   parseCubeDimension,
   parseRelatedDimensions,
 } from "./parse";
+import { executeWithCache } from "./query-cache";
 import {
   loadDimensionValues,
   loadMinMaxDimensionValues,
 } from "./query-dimension-values";
-import { loadResourceLabels } from "./query-labels";
-import { loadResourceLiterals } from "./query-literals";
 import { loadUnversionedResources } from "./query-sameas";
 import { loadUnits } from "./query-unit-labels";
 
@@ -433,7 +430,6 @@ export const getCubeDimensionValuesWithMetadata = async ({
         } as DimensionValue);
       }
     });
-
   } else if (literals.length > 0) {
     literals.forEach(({ value }) =>
       result.push({

--- a/app/rdf/query-cache.ts
+++ b/app/rdf/query-cache.ts
@@ -2,8 +2,8 @@ import {
   SparqlQuery,
   SparqlQueryExecutable,
 } from "@tpluscode/sparql-builder/lib";
-import StreamClient from "sparql-http-client";
 import { ParsingClient } from "sparql-http-client/ParsingClient";
+import { StreamClient } from "sparql-http-client/StreamClient";
 import { LRUCache } from "typescript-lru-cache";
 
 type SparqlClient = StreamClient | ParsingClient;
@@ -16,16 +16,19 @@ export const executeWithCache = async <T>(
 ) => {
   const key = `${sparqlClient.query.endpoint.endpointUrl} - ${query.build()}`;
   const cached = cache?.get(key);
+
   if (cached) {
     return cached as T;
-  } else {
-    const result = await query.execute(sparqlClient.query, {
-      operation: "postUrlencoded",
-    });
-    const parsed = parse(result) as T;
-    if (cache) {
-      cache.set(key, parsed);
-    }
-    return parsed;
   }
+
+  const result = await query.execute(sparqlClient.query, {
+    operation: "postUrlencoded",
+  });
+  const parsed = parse(result) as T;
+
+  if (cache) {
+    cache.set(key, parsed);
+  }
+
+  return parsed;
 };

--- a/app/utils/getSaveJson.ts
+++ b/app/utils/getSaveJson.ts
@@ -1,0 +1,40 @@
+import fs from "fs";
+
+/**
+ * Use this function to get a JSON file from the filesystem.
+ * If the file doesn't exist, the function will return the `initialState`.
+ */
+export const getJSON = <T extends object>(
+  filename: string,
+  initialState: T
+): T => {
+  try {
+    const file = fs.readFileSync(`${filename}.json`, "utf-8");
+
+    if (file) {
+      return JSON.parse(file) as T;
+    }
+  } catch (e) {
+    console.log(`No file found for ${filename}.json. Creating new one!`);
+  }
+
+  return initialState;
+};
+
+/**
+ * Use this function to save a JSON file to the filesystem.
+ * 
+ * @example
+ * const data = getJSON("timeResults", {
+    constructTime: 0,
+    selectTime: 0,
+    queryCount: 0,
+  });
+  data.constructTime += constructTime;
+  data.selectTime += selectTime;
+  data.queryCount++;
+  saveJSON("timeResults", data);
+ */
+export const saveJSON = <T extends object>(filename: string, data: T) => {
+  fs.writeFileSync(`${filename}.json`, JSON.stringify(data, null, 2), "utf-8");
+};


### PR DESCRIPTION
This PR aims at improving the performance of dimension values fetching by replacing several SELECT queries with one CONSTRUCT query.

### Observations
I compared the performance of the old and new way of fetching and included the results below. I based these measurements on four datasets:
- Einmalvergütung für Photovoltaikanlagen,
- Gebäudeprogramm - CO2-Wirkungen je Massnahmenbereich,
- State accounts - Function,
- NFI: Topics by stage of stand development,

opening each one in the editing mode and triggering fetching of dimension metadata values the same number of times for each dataset.

---

| Key   | Value |
|---------------------|-----|
| Number of queries   | 510 |
| Avg. time SELECT    | 242ms |
| Avg. time CONSTRUCT | 249ms (+3%) |

I've also removed the conditions to limit inclusion of some properties based on scale type, as I am not 100% sure if they are needed anymore (e.g. if dimension values description can really only be present when scale type is either ordinal or nominal). Also, when they were added to the data, I think it makes sense to include them even when scale type is mapped wrongly. When they were removed, the performance of CONSTRUCT queries based on 406 new queries was better than SELECT queries by 0.04%.

cc @adintegra @RDataFlow