### PR TITLE
feat: Disable no-unit measures in multi line combo charts

### DIFF
--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -616,10 +616,12 @@ const ChartComboLineSingleYField = (
       } = {}
     ) => {
       const options = getComboOptionGroups(numericalMeasures, (m) => {
-        return enableAll
+        return !m.unit
+          ? true
+          : enableAll
           ? false
           : m.unit !== unit ||
-              (y.componentIris.includes(m.iri) && m.iri !== iri);
+            (y.componentIris.includes(m.iri) && m.iri !== iri);
       });
 
       if (allowNone) {


### PR DESCRIPTION
This PR disables selecting measures without units in multi-line combo chart.