### PR TITLE
perf: Retrieve (min|max)Inclusive values stored behind sh:or

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 
 ## Unreleased
 
+- Performance
+  - (min & max)Inclusive values stored in `sh:or` are now also retrieved
 - Style
   - Map now outlines shapes on hover, instead of changing their colors
 

--- a/app/domain/data.ts
+++ b/app/domain/data.ts
@@ -78,7 +78,6 @@ export const parseRDFLiteral = <T = ObservationValue>(value: Literal): T => {
     case "string":
     case "boolean":
       return v as T;
-    // return v === "true" ? true : false;
     case "float":
     case "integer":
     case "long":
@@ -96,13 +95,6 @@ export const parseRDFLiteral = <T = ObservationValue>(value: Literal): T => {
     case "unsignedShort":
     case "unsignedByte":
       return +v as T;
-    // TODO: Figure out how to preserve granularity of date (maybe include interval?)
-    // case "date":
-    // case "time":
-    // case "dateTime":
-    // case "gYear":
-    // case "gYearMonth":
-    //   return new Date(v);
     default:
       return v as T;
   }

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -232,16 +232,18 @@ export const getCubeDimensionValues = async ({
       ];
     }
 
-    const firstPointer = dimension.out(ns.sh.or).out(ns.rdf.first);
-    const firstMin = firstPointer.out(ns.sh.minInclusive);
-    const firstMax = firstPointer.out(ns.sh.maxInclusive);
+    const listPointer = dimension
+      .out(ns.sh.or)
+      .out([ns.rdf.first, ns.rdf.rest]);
+    const listMin = listPointer.out(ns.sh.minInclusive);
+    const listMax = listPointer.out(ns.sh.maxInclusive);
 
     if (
-      typeof firstMin.value !== "undefined" &&
-      typeof firstMax.value !== "undefined"
+      typeof listMin.value !== "undefined" &&
+      typeof listMax.value !== "undefined"
     ) {
-      const min = +firstMin.value;
-      const max = +firstMax.value;
+      const min = +listMin.value;
+      const max = +listMax.value;
 
       return [
         { value: min, label: `${min}` },

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -218,19 +218,36 @@ export const getCubeDimensionValues = async ({
 }): Promise<DimensionValue[]> => {
   const { dimension, cube, locale, data } = rdimension;
 
-  if (
-    typeof dimension.minInclusive !== "undefined" &&
-    typeof dimension.maxInclusive !== "undefined" &&
-    data.dataKind !== "Time" &&
-    data.scaleType !== "Ordinal"
-  ) {
-    const min = parseObservationValue({ value: dimension.minInclusive }) ?? 0;
-    const max = parseObservationValue({ value: dimension.maxInclusive }) ?? 0;
+  if (data.dataKind !== "Time" && data.scaleType !== "Ordinal") {
+    if (
+      typeof dimension.minInclusive !== "undefined" &&
+      typeof dimension.maxInclusive !== "undefined"
+    ) {
+      const min = parseObservationValue({ value: dimension.minInclusive }) ?? 0;
+      const max = parseObservationValue({ value: dimension.maxInclusive }) ?? 0;
 
-    return [
-      { value: min, label: `${min}` },
-      { value: max, label: `${max}` },
-    ];
+      return [
+        { value: min, label: `${min}` },
+        { value: max, label: `${max}` },
+      ];
+    }
+
+    const firstPointer = dimension.out(ns.sh.or).out(ns.rdf.first);
+    const firstMin = firstPointer.out(ns.sh.minInclusive);
+    const firstMax = firstPointer.out(ns.sh.maxInclusive);
+
+    if (
+      typeof firstMin.value !== "undefined" &&
+      typeof firstMax.value !== "undefined"
+    ) {
+      const min = +firstMin.value;
+      const max = +firstMax.value;
+
+      return [
+        { value: min, label: `${min}` },
+        { value: max, label: `${max}` },
+      ];
+    }
   }
 
   if (shouldLoadMinMaxValues(rdimension)) {


### PR DESCRIPTION
Closes #1219.

This PR includes retrieval or min and max values stored behind `sh:or`.