### PR TITLE
refactor: Move dataSet from configurator state to chart state

### DIFF
--- a/app/browser/dataset-preview.tsx
+++ b/app/browser/dataset-preview.tsx
@@ -8,7 +8,6 @@ import * as React from "react";
 import { DataSetPreviewTable } from "@/browse/datatable";
 import { useFootnotesStyles } from "@/components/chart-footnotes";
 import { DataDownloadMenu, RunSparqlQuery } from "@/components/data-download";
-import DebugPanel from "@/components/debug-panel";
 import Flex from "@/components/flex";
 import { HintRed, Loading, LoadingDataError } from "@/components/hint";
 import { DataSource } from "@/config-types";
@@ -194,7 +193,6 @@ export const DataSetPreview = ({
               </Trans>
             </Typography>
           </Flex>
-          <DebugPanel configurator />
         </Paper>
       </Flex>
     );

--- a/app/charts/index.spec.ts
+++ b/app/charts/index.spec.ts
@@ -15,6 +15,7 @@ describe("initial config", () => {
   it("should create an initial table config with column order based on dimension order", () => {
     const config = getInitialConfig({
       chartType: "table",
+      dataSet: "https://environment.ld.admin.ch/foen/nfi",
       dimensions: forestAreaData.data.dataCubeByIri.dimensions as NonNullable<
         ComponentsQuery["dataCubeByIri"]
       >["dimensions"],
@@ -81,6 +82,7 @@ describe("chart type switch", () => {
       key: "column",
       version: "1.4.0",
       chartType: "column",
+      dataSet: "https://environment.ld.admin.ch/foen/ubd0104",
       filters: {},
       meta: {
         title: {

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -327,6 +327,7 @@ const META: Meta = {
 
 type GetInitialConfigOptions = {
   key?: string;
+  dataSet: string;
   chartType: ChartType;
   dimensions: DataCubeMetadataWithHierarchies["dimensions"];
   measures: DataCubeMetadataWithHierarchies["measures"];
@@ -335,16 +336,18 @@ type GetInitialConfigOptions = {
 export const getInitialConfig = (
   options: GetInitialConfigOptions
 ): ChartConfig => {
-  const { key, chartType, dimensions, measures } = options;
+  const { key, dataSet, chartType, dimensions, measures } = options;
   const genericConfigProps: {
     key: string;
     version: string;
     meta: Meta;
+    dataSet: string;
     activeField: string | undefined;
   } = {
     key: key ?? createChartId(),
     version: CHART_CONFIG_VERSION,
     meta: META,
+    dataSet,
     activeField: undefined,
   };
   const numericalMeasures = measures.filter(isNumericalMeasure);
@@ -667,6 +670,7 @@ export const getChartConfigAdjustedToChartType = ({
   const initialConfig = getInitialConfig({
     key: chartConfig.key,
     chartType: newChartType,
+    dataSet: chartConfig.dataSet,
     dimensions,
     measures,
   });

--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -171,9 +171,9 @@ const useLegendGroups = ({
   const segmentValues =
     segmentFilters?.type === "multi" ? segmentFilters.values : emptyObj;
 
-  const { dataSet: dataset, dataSource } = configState;
+  const { dataSource } = configState;
   const segmentDimension = useDimension({
-    dataset,
+    dataset: chartConfig.dataSet,
     dataSource,
     locale,
     dimensionIri: segmentField?.componentIri,
@@ -181,7 +181,7 @@ const useLegendGroups = ({
 
   const [hierarchyResp] = useDimensionValuesQuery({
     variables: {
-      dataCubeIri: dataset,
+      dataCubeIri: chartConfig.dataSet,
       dimensionIri: segmentDimension?.iri!,
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,

--- a/app/charts/shared/use-sync-interactive-filters.spec.tsx
+++ b/app/charts/shared/use-sync-interactive-filters.spec.tsx
@@ -45,6 +45,7 @@ const chartConfig = migrateChartConfig(
   {
     migrationProps: {
       meta: {},
+      dataSet: "foo",
     },
   }
 ) as ChartConfig;

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -51,13 +51,12 @@ type ChartPublishedProps = {
 export const ChartPublished = (props: ChartPublishedProps) => {
   const { configKey } = props;
   const [state] = useConfiguratorState(isPublished);
-  const { dataSet, dataSource } = state;
+  const { dataSource } = state;
   const chartConfig = getChartConfig(state);
 
   return (
     <ChartTablePreviewProvider>
       <ChartPublishedInner
-        dataSet={dataSet}
         dataSource={dataSource}
         state={state}
         chartConfig={chartConfig}
@@ -83,7 +82,6 @@ const useStyles = makeStyles<Theme, { shrink: boolean }>((theme) => ({
 }));
 
 type ChartPublishInnerProps = {
-  dataSet: string;
   dataSource: DataSource | undefined;
   state: ConfiguratorStatePublished;
   chartConfig: ChartConfig;
@@ -92,7 +90,6 @@ type ChartPublishInnerProps = {
 
 const ChartPublishedInner = (props: ChartPublishInnerProps) => {
   const {
-    dataSet,
     dataSource = DEFAULT_DATA_SOURCE,
     state,
     chartConfig,
@@ -136,7 +133,7 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
   const locale = useLocale();
   const isTrustedDataSource = useIsTrustedDataSource(dataSource);
   const commonQueryVariables = {
-    iri: dataSet,
+    iri: chartConfig.dataSet,
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
@@ -225,7 +222,7 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
             </Typography>
 
             <MetadataPanel
-              datasetIri={dataSet}
+              datasetIri={chartConfig.dataSet}
               dataSource={dataSource}
               dimensions={allComponents}
               container={rootRef.current}
@@ -247,13 +244,13 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
               {isTablePreview ? (
                 <DataSetTable
                   sx={{ maxHeight: "100%" }}
-                  dataSetIri={dataSet}
+                  dataSetIri={chartConfig.dataSet}
                   dataSource={dataSource}
                   chartConfig={chartConfig}
                 />
               ) : (
                 <ChartWithFilters
-                  dataSet={dataSet}
+                  dataSet={chartConfig.dataSet}
                   dataSource={dataSource}
                   componentIris={componentIris}
                   chartConfig={chartConfig}
@@ -261,7 +258,7 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
               )}
             </Flex>
             <ChartFootnotes
-              dataSetIri={dataSet}
+              dataSetIri={chartConfig.dataSet}
               dataSource={dataSource}
               chartConfig={chartConfig}
               configKey={configKey}

--- a/app/components/chart-selection-tabs.tsx
+++ b/app/components/chart-selection-tabs.tsx
@@ -255,21 +255,15 @@ const TabsFixed = (props: TabsFixedProps) => {
 const PublishChartButton = () => {
   const locale = useLocale();
   const [state, dispatch] = useConfiguratorState(hasChartConfigs);
-  const { dataSet } = state;
+  const chartConfig = getChartConfig(state);
   const variables = {
-    iri: dataSet ?? "",
+    iri: chartConfig.dataSet,
     sourceType: state.dataSource.type,
     sourceUrl: state.dataSource.url,
     locale,
   };
-  const [{ data: metadata }] = useDataCubeMetadataQuery({
-    variables,
-    pause: !dataSet,
-  });
-  const [{ data: components }] = useComponentsQuery({
-    variables,
-    pause: !dataSet,
-  });
+  const [{ data: metadata }] = useDataCubeMetadataQuery({ variables });
+  const [{ data: components }] = useComponentsQuery({ variables });
   const goNext = useEvent(() => {
     if (metadata?.dataCubeByIri && components?.dataCubeByIri) {
       dispatch({

--- a/app/components/debug-panel/DebugPanel.tsx
+++ b/app/components/debug-panel/DebugPanel.tsx
@@ -12,7 +12,11 @@ import {
 import { useState } from "react";
 import { Inspector } from "react-inspector";
 
-import { DataSource, useConfiguratorState } from "@/configurator";
+import {
+  DataSource,
+  getChartConfig,
+  useConfiguratorState,
+} from "@/configurator";
 import { dataSourceToSparqlEditorUrl } from "@/domain/datasource";
 import { useComponentsWithHierarchiesQuery } from "@/graphql/query-hooks";
 import { Icon } from "@/icons";
@@ -86,6 +90,7 @@ const CubeMetadata = ({
 
 const DebugConfigurator = () => {
   const [configuratorState] = useConfiguratorState();
+  const chartConfig = getChartConfig(configuratorState);
   const sparqlEditorUrl = dataSourceToSparqlEditorUrl(
     configuratorState.dataSource
   );
@@ -96,51 +101,43 @@ const DebugConfigurator = () => {
         Cube Tools
       </Typography>
       <Stack spacing={2} sx={{ pl: 5, py: 3 }}>
-        {configuratorState.dataSet ? (
-          <Button
-            component="a"
-            color="primary"
-            variant="text"
-            size="small"
-            href={`https://cube-viewer.zazuko.com/?endpointUrl=${encodeURIComponent(
-              configuratorState.dataSource.url
-            )}&user=&password=&sourceGraph=&cube=${encodeURIComponent(
-              configuratorState.dataSet ?? ""
-            )}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            startIcon={<Icon name="linkExternal" size={16} />}
-          >
-            <Typography variant="body2">Open in Cube Viewer</Typography>
-          </Button>
-        ) : (
-          <Typography variant="body1">Please select a dataset first</Typography>
-        )}
-        {
-          <Button
-            component="a"
-            color="primary"
-            variant="text"
-            size="small"
-            href={`${sparqlEditorUrl}#query=${encodeURIComponent(
-              `#pragma describe.strategy cbd
+        <Button
+          component="a"
+          color="primary"
+          variant="text"
+          size="small"
+          href={`https://cube-viewer.zazuko.com/?endpointUrl=${encodeURIComponent(
+            configuratorState.dataSource.url
+          )}&user=&password=&sourceGraph=&cube=${encodeURIComponent(
+            chartConfig.dataSet
+          )}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          startIcon={<Icon name="linkExternal" size={16} />}
+        >
+          <Typography variant="body2">Open in Cube Viewer</Typography>
+        </Button>
+        <Button
+          component="a"
+          color="primary"
+          variant="text"
+          size="small"
+          href={`${sparqlEditorUrl}#query=${encodeURIComponent(
+            `#pragma describe.strategy cbd
               #pragma join.hash off
               
-DESCRIBE <${configuratorState.dataSet ?? ""}>`
-            )}&requestMethod=POST`}
-            target="_blank"
-            rel="noopener noreferrer"
-            startIcon={<Icon name="linkExternal" size={16} />}
-          >
-            <Typography variant="body2">Cube Metadata Query</Typography>
-          </Button>
-        }
-        {configuratorState.dataSet ? (
-          <CubeMetadata
-            datasetIri={configuratorState.dataSet}
-            dataSource={configuratorState.dataSource}
-          />
-        ) : null}
+DESCRIBE <${chartConfig.dataSet}>`
+          )}&requestMethod=POST`}
+          target="_blank"
+          rel="noopener noreferrer"
+          startIcon={<Icon name="linkExternal" size={16} />}
+        >
+          <Typography variant="body2">Cube Metadata Query</Typography>
+        </Button>
+        <CubeMetadata
+          datasetIri={chartConfig.dataSet}
+          dataSource={configuratorState.dataSource}
+        />
       </Stack>
       <Typography
         component="h3"

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -226,6 +226,7 @@ const GenericChartConfig = t.type({
   key: t.string,
   version: t.string,
   meta: Meta,
+  dataSet: t.string,
   filters: Filters,
   activeField: t.union([t.string, t.undefined]),
 });
@@ -1076,7 +1077,6 @@ export type DataSource = t.TypeOf<typeof DataSource>;
 const Config = t.type(
   {
     version: t.string,
-    dataSet: t.string,
     dataSource: DataSource,
     meta: Meta,
     chartConfigs: t.array(ChartConfig),
@@ -1097,7 +1097,6 @@ export const decodeConfig = (config: unknown) => {
 const ConfiguratorStateInitial = t.type({
   version: t.string,
   state: t.literal("INITIAL"),
-  dataSet: t.undefined,
   dataSource: DataSource,
 });
 export type ConfiguratorStateInitial = t.TypeOf<
@@ -1107,7 +1106,6 @@ export type ConfiguratorStateInitial = t.TypeOf<
 const ConfiguratorStateSelectingDataSet = t.type({
   version: t.string,
   state: t.literal("SELECTING_DATASET"),
-  dataSet: t.union([t.string, t.undefined]),
   dataSource: DataSource,
   meta: Meta,
   chartConfigs: t.undefined,

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -190,7 +190,7 @@ const useEnsurePossibleFilters = ({
         .query<PossibleFiltersQuery, PossibleFiltersQueryVariables>(
           PossibleFiltersDocument,
           {
-            iri: state.dataSet,
+            iri: chartConfig.dataSet,
             sourceType: state.dataSource.type,
             sourceUrl: state.dataSource.url,
             filters: unmappedFilters,
@@ -234,7 +234,7 @@ const useEnsurePossibleFilters = ({
     client,
     dispatch,
     chartConfig,
-    state.dataSet,
+    chartConfig.dataSet,
     state.dataSource.type,
     state.dataSource.url,
   ]);
@@ -263,7 +263,7 @@ const useFilterReorder = ({
   const variables = useMemo(() => {
     const hasUnmappedFilters = Object.keys(unmappedFilters).length > 0;
     const vars = {
-      iri: state.dataSet,
+      iri: chartConfig.dataSet,
       sourceType: state.dataSource.type,
       sourceUrl: state.dataSource.url,
       locale,
@@ -279,7 +279,7 @@ const useFilterReorder = ({
 
     return omitBy(vars, (x) => x === undefined) as typeof vars;
   }, [
-    state.dataSet,
+    chartConfig.dataSet,
     state.dataSource.type,
     state.dataSource.url,
     locale,

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -93,31 +93,24 @@ export const ChartOptionsSelector = ({
   state: ConfiguratorStateConfiguringChart;
 }) => {
   const chartConfig = getChartConfig(state);
-  const { dataSet, dataSource } = state;
+  const { dataSource } = state;
   const { activeField } = chartConfig;
   const locale = useLocale();
+  const commonVariables = {
+    iri: chartConfig.dataSet,
+    sourceType: dataSource.type,
+    sourceUrl: dataSource.url,
+    locale,
+  };
   const [{ data: metadataData }] = useDataCubeMetadataQuery({
-    variables: {
-      iri: dataSet,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-    },
+    variables: commonVariables,
   });
   const [{ data: componentsData }] = useComponentsWithHierarchiesQuery({
-    variables: {
-      iri: dataSet,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-    },
+    variables: commonVariables,
   });
   const [{ data: observationsData }] = useDataCubeObservationsQuery({
     variables: {
-      iri: dataSet,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
+      ...commonVariables,
       filters: chartConfig.filters,
     },
   });
@@ -146,7 +139,6 @@ export const ChartOptionsSelector = ({
           <TableColumnOptions state={state} metaData={metadata} />
         ) : (
           <ActiveFieldSwitch
-            state={state}
             chartConfig={chartConfig}
             metadata={metadata}
             observations={observations}
@@ -163,14 +155,13 @@ export const ChartOptionsSelector = ({
 };
 
 type ActiveFieldSwitchProps = {
-  state: ConfiguratorStateConfiguringChart;
   chartConfig: ChartConfig;
   metadata: DataCubeMetadataWithHierarchies;
   observations: Observation[];
 };
 
 const ActiveFieldSwitch = (props: ActiveFieldSwitchProps) => {
-  const { state, metadata, chartConfig, observations } = props;
+  const { metadata, chartConfig, observations } = props;
   const { dimensions, measures } = metadata;
   const activeField = chartConfig.activeField as EncodingFieldType | undefined;
 
@@ -204,7 +195,6 @@ const ActiveFieldSwitch = (props: ActiveFieldSwitchProps) => {
   return (
     <EncodingOptionsPanel
       encoding={encoding}
-      state={state}
       chartConfig={chartConfig}
       field={activeField}
       component={component}
@@ -217,7 +207,6 @@ const ActiveFieldSwitch = (props: ActiveFieldSwitchProps) => {
 
 type EncodingOptionsPanelProps = {
   encoding: EncodingSpec;
-  state: ConfiguratorStateConfiguringChart;
   chartConfig: ChartConfig;
   field: EncodingFieldType;
   component: DimensionMetadataFragment | undefined;
@@ -229,7 +218,6 @@ type EncodingOptionsPanelProps = {
 const EncodingOptionsPanel = (props: EncodingOptionsPanelProps) => {
   const {
     encoding,
-    state,
     field,
     chartConfig,
     component,
@@ -409,7 +397,6 @@ const EncodingOptionsPanel = (props: EncodingOptionsPanelProps) => {
 
       {encoding.options?.colorComponent && component && (
         <ChartFieldColorComponent
-          state={state}
           chartConfig={chartConfig}
           encoding={encoding}
           component={component}
@@ -442,7 +429,6 @@ const EncodingOptionsPanel = (props: EncodingOptionsPanelProps) => {
       )}
 
       <ChartFieldMultiFilter
-        state={state}
         chartConfig={chartConfig}
         component={component}
         encoding={encoding}
@@ -1195,7 +1181,6 @@ const ChartFieldAnimation = ({ field }: { field: AnimationField }) => {
 };
 
 const ChartFieldMultiFilter = ({
-  state,
   chartConfig,
   component,
   encoding,
@@ -1203,7 +1188,6 @@ const ChartFieldMultiFilter = ({
   dimensions,
   measures,
 }: {
-  state: ConfiguratorStateConfiguringChart;
   chartConfig: ChartConfig;
   component: DimensionMetadataFragment | undefined;
   encoding: EncodingSpec;
@@ -1246,7 +1230,7 @@ const ChartFieldMultiFilter = ({
             <DimensionValuesMultiFilter
               key={component.iri}
               dimensionIri={component.iri}
-              dataSetIri={state.dataSet}
+              dataSetIri={chartConfig.dataSet}
               field={field}
               colorComponent={colorComponent || component}
               // If colorType is defined, we are dealing with color field and
@@ -1542,7 +1526,6 @@ const ChartFieldSize = ({
 };
 
 type ChartFieldColorComponentProps = {
-  state: ConfiguratorStateConfiguringChart;
   chartConfig: ChartConfig;
   encoding: EncodingSpec;
   component: DimensionMetadataFragment;
@@ -1555,7 +1538,6 @@ type ChartFieldColorComponentProps = {
 
 const ChartFieldColorComponent = (props: ChartFieldColorComponentProps) => {
   const {
-    state,
     chartConfig,
     encoding,
     component,
@@ -1660,7 +1642,7 @@ const ChartFieldColorComponent = (props: ChartFieldColorComponentProps) => {
           colorComponentIri && component.iri !== colorComponentIri ? (
             <DimensionValuesMultiFilter
               key={component.iri}
-              dataSetIri={state.dataSet}
+              dataSetIri={chartConfig.dataSet}
               dimensionIri={colorComponentIri}
               field={field}
               colorConfigPath="color"

--- a/app/configurator/components/chart-type-selector.tsx
+++ b/app/configurator/components/chart-type-selector.tsx
@@ -23,6 +23,7 @@ import {
   ChartType,
   ConfiguratorStateConfiguringChart,
   ConfiguratorStatePublishing,
+  getChartConfig,
 } from "@/config-types";
 import { ControlSectionSkeleton } from "@/configurator/components/chart-controls/section";
 import { getFieldLabel } from "@/configurator/components/field-i18n";
@@ -121,9 +122,10 @@ export const ChartTypeSelector = ({
   chartKey: string;
 } & BoxProps) => {
   const locale = useLocale();
+  const chartConfig = getChartConfig(state);
   const [{ data }] = useComponentsWithHierarchiesQuery({
     variables: {
-      iri: state.dataSet,
+      iri: chartConfig.dataSet,
       sourceType: state.dataSource.type,
       sourceUrl: state.dataSource.url,
       locale,

--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -70,6 +70,7 @@ const isAnnotationField = (field: string | undefined) => {
 
 const ConfigureChartStep = () => {
   const [state, dispatch] = useConfiguratorState();
+  const chartConfig = getChartConfig(state);
   const { dataSource, setDataSource } = useDataSourceStore();
 
   const handleClosePanel = useEvent(() => {
@@ -85,11 +86,12 @@ const ConfigureChartStep = () => {
     if (state.state !== "CONFIGURING_CHART") {
       return;
     }
+
     router.push(
       {
         pathname: `/browse`,
         query: {
-          dataset: state.dataSet,
+          dataset: chartConfig.dataSet,
         },
       },
       undefined,
@@ -109,8 +111,6 @@ const ConfigureChartStep = () => {
   if (state.state !== "CONFIGURING_CHART") {
     return null;
   }
-
-  const chartConfig = getChartConfig(state);
 
   return (
     <InteractiveFiltersProvider>
@@ -136,7 +136,7 @@ const ConfigureChartStep = () => {
       <PanelMiddleWrapper>
         <ChartPanel>
           <ChartPreview
-            dataSetIri={state.dataSet}
+            dataSetIri={chartConfig.dataSet}
             dataSource={state.dataSource}
           />
         </ChartPanel>
@@ -173,6 +173,7 @@ const ConfigureChartStep = () => {
 
 const PublishStep = () => {
   const [state] = useConfiguratorState();
+  const chartConfig = getChartConfig(state);
 
   if (state.state !== "PUBLISHING") {
     return null;
@@ -183,7 +184,7 @@ const PublishStep = () => {
       <ChartPanel>
         <InteractiveFiltersProvider>
           <ChartPreview
-            dataSetIri={state.dataSet}
+            dataSetIri={chartConfig.dataSet}
             dataSource={state.dataSource}
           />
         </InteractiveFiltersProvider>

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -432,7 +432,10 @@ export const useChartType = (
         value: {
           chartConfig: getInitialConfig({
             chartType,
-            dataSet: chartConfig.dataSet,
+            dataSet:
+              state.state === "CONFIGURING_CHART"
+                ? getChartConfig(state, state.activeChartKey).dataSet
+                : chartConfig.dataSet,
             dimensions,
             measures,
           }),

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -95,6 +95,7 @@ export const useChartFieldField = ({
   const unmountedRef = useRef(false);
   const [fetching, setFetching] = useState(false);
   const [state, dispatch] = useConfiguratorState();
+  const chartConfig = getChartConfig(state);
   const client = useClient();
   const locale = useLocale();
 
@@ -105,10 +106,6 @@ export const useChartFieldField = ({
   }, []);
 
   const handleChange = useEvent(async (e: SelectChangeEvent<unknown>) => {
-    if (!state.dataSet) {
-      return;
-    }
-
     if (e.target.value !== FIELD_VALUE_NONE) {
       setFetching(true);
       const dimensionIri = e.target.value as string;
@@ -117,7 +114,7 @@ export const useChartFieldField = ({
           DimensionHierarchyDocument,
           {
             locale,
-            cubeIri: state.dataSet,
+            cubeIri: chartConfig.dataSet,
             dimensionIri,
             sourceUrl: state.dataSource.url,
             sourceType: state.dataSource.type,
@@ -435,6 +432,7 @@ export const useChartType = (
         value: {
           chartConfig: getInitialConfig({
             chartType,
+            dataSet: chartConfig.dataSet,
             dimensions,
             measures,
           }),

--- a/app/configurator/interactive-filters/interactive-filters-configurator.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-configurator.tsx
@@ -31,13 +31,13 @@ export const InteractiveFiltersConfigurator = ({
 }: {
   state: ConfiguratorStateConfiguringChart;
 }) => {
-  const { dataSet, dataSource } = state;
+  const { dataSource } = state;
   const chartConfig = getChartConfig(state);
   const { fields } = chartConfig;
   const locale = useLocale();
   const [{ data }] = useComponentsQuery({
     variables: {
-      iri: dataSet,
+      iri: chartConfig.dataSet,
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,

--- a/app/configurator/table/table-chart-configurator.tsx
+++ b/app/configurator/table/table-chart-configurator.tsx
@@ -63,21 +63,17 @@ export const ChartConfiguratorTable = ({
   state: ConfiguratorStateConfiguringChart;
 }) => {
   const locale = useLocale();
-  const [{ data: metadata }] = useDataCubeMetadataQuery({
-    variables: {
-      iri: state.dataSet,
-      sourceType: state.dataSource.type,
-      sourceUrl: state.dataSource.url,
-      locale,
-    },
-  });
+  const [, dispatch] = useConfiguratorState(isConfiguring);
+  const chartConfig = getChartConfig(state);
+  const variables = {
+    iri: chartConfig.dataSet,
+    sourceType: state.dataSource.type,
+    sourceUrl: state.dataSource.url,
+    locale,
+  };
+  const [{ data: metadata }] = useDataCubeMetadataQuery({ variables });
   const [{ data: components }] = useComponentsWithHierarchiesQuery({
-    variables: {
-      iri: state.dataSet,
-      sourceType: state.dataSource.type,
-      sourceUrl: state.dataSource.url,
-      locale,
-    },
+    variables,
   });
 
   const metaData = useMemo(() => {
@@ -88,9 +84,6 @@ export const ChartConfiguratorTable = ({
         }
       : null;
   }, [metadata?.dataCubeByIri, components?.dataCubeByIri]);
-
-  const [, dispatch] = useConfiguratorState(isConfiguring);
-  const chartConfig = getChartConfig(state);
 
   const [currentDraggableId, setCurrentDraggableId] = useState<string | null>(
     null

--- a/app/db/config.ts
+++ b/app/db/config.ts
@@ -120,8 +120,9 @@ const parseDbConfig = (
     ...d,
     data: {
       ...migratedData,
-      dataSet: migrateDataSet(migratedData.dataSet),
-      chartConfigs: migratedData.chartConfigs.map(ensureFiltersOrder),
+      chartConfigs: migratedData.chartConfigs
+        .map(ensureFiltersOrder)
+        .map((d: any) => ({ ...d, dataSet: migrateDataSet(d.dataSet) })),
     },
   };
 };

--- a/app/docs/annotations.docs.tsx
+++ b/app/docs/annotations.docs.tsx
@@ -57,6 +57,7 @@ ${(
               it: "",
             },
           },
+          dataSet: "",
           chartType: "column",
           fields,
           interactiveFiltersConfig: {
@@ -221,6 +222,7 @@ ${(
               it: "",
             },
           },
+          dataSet: "",
           chartType: "column",
           fields,
           interactiveFiltersConfig: {
@@ -284,6 +286,7 @@ ${(
               it: "",
             },
           },
+          dataSet: "",
           chartType: "column",
           fields,
           interactiveFiltersConfig: {

--- a/app/docs/columns.docs.tsx
+++ b/app/docs/columns.docs.tsx
@@ -32,7 +32,6 @@ ${(
           description: { en: "", de: "", fr: "", it: "" },
         },
         dataSource: { type: "sparql", url: "" },
-        dataSet: "",
         chartConfigs: [chartConfig],
         activeChartKey: "scatterplot",
       }}
@@ -94,6 +93,7 @@ const chartConfig: ColumnConfig = {
       it: "",
     },
   },
+  dataSet: "",
   filters: {},
   fields: columnFields,
   interactiveFiltersConfig: {

--- a/app/docs/fixtures.ts
+++ b/app/docs/fixtures.ts
@@ -8,7 +8,6 @@ export const states: ConfiguratorState[] = [
   {
     state: "SELECTING_DATASET",
     version: CONFIGURATOR_STATE_VERSION,
-    dataSet: undefined,
     dataSource: DEFAULT_DATA_SOURCE,
     chartConfigs: undefined,
     meta: {
@@ -30,7 +29,6 @@ export const states: ConfiguratorState[] = [
   {
     state: "CONFIGURING_CHART",
     version: CONFIGURATOR_STATE_VERSION,
-    dataSet: "foo",
     dataSource: DEFAULT_DATA_SOURCE,
     chartConfigs: [
       {
@@ -50,6 +48,7 @@ export const states: ConfiguratorState[] = [
             it: "",
           },
         },
+        dataSet: "",
         chartType: "column",
         fields: {
           x: {
@@ -827,6 +826,7 @@ export const tableConfig: TableConfig = {
       it: "",
     },
   },
+  dataSet: "",
   chartType: "table",
   filters: {},
   interactiveFiltersConfig: undefined,

--- a/app/docs/lines.docs.tsx
+++ b/app/docs/lines.docs.tsx
@@ -34,7 +34,6 @@ ${(
           description: { en: "", de: "", fr: "", it: "" },
         },
         dataSource: { type: "sparql", url: "" },
-        dataSet: "",
         chartConfigs: [chartConfig],
         activeChartKey: "line",
       }}
@@ -144,6 +143,7 @@ const chartConfig: LineConfig = {
       it: "",
     },
   },
+  dataSet: "",
   chartType: "line",
   interactiveFiltersConfig,
   fields,

--- a/app/docs/scatterplot.docs.tsx
+++ b/app/docs/scatterplot.docs.tsx
@@ -37,7 +37,6 @@ ${(
           description: { en: "", de: "", fr: "", it: "" },
         },
         dataSource: { type: "sparql", url: "" },
-        dataSet: "",
         chartConfigs: [chartConfig],
         activeChartKey: "scatterplot",
       }}
@@ -145,6 +144,7 @@ const chartConfig: ScatterPlotConfig = {
       it: "",
     },
   },
+  dataSet: "",
   chartType: "scatterplot",
   filters: {},
   interactiveFiltersConfig,

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -166,16 +166,26 @@ type ProfileVisualizationsRowProps = {
 
 const ProfileVisualizationsRow = (props: ProfileVisualizationsRowProps) => {
   const { userId, config, onRemoveSuccess } = props;
-  const { dataSet, dataSource } = config.data;
+  const { dataSource } = config.data;
+  const dataSets = Array.from(
+    new Set(config.data.chartConfigs.map((d) => d.dataSet))
+  );
+  const dataSet = dataSets.length === 1 ? dataSets[0] : null;
   const locale = useLocale();
-  const [{ data, fetching }] = useDataCubeMetadataQuery({
-    variables: {
-      iri: dataSet,
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-    },
-  });
+  const [{ data, fetching }] = useDataCubeMetadataQuery(
+    dataSet
+      ? {
+          variables: {
+            iri: dataSet,
+            sourceType: dataSource.type,
+            sourceUrl: dataSource.url,
+            locale,
+          },
+        }
+      : {
+          pause: true,
+        }
+  );
   const actions = React.useMemo(() => {
     const actions: ActionProps[] = [
       {
@@ -260,11 +270,11 @@ const ProfileVisualizationsRow = (props: ProfileVisualizationsRowProps) => {
       <TableCell width="auto" sx={{ maxWidth: 320 }}>
         {fetching ? (
           <Skeleton width="50%" height={32} />
-        ) : (
+        ) : dataSet ? (
           <NextLink
-            href={`/browse?dataset=${
-              config.data.dataSet
-            }&dataSource=${sourceToLabel(config.data.dataSource)}`}
+            href={`/browse?dataset=${dataSet}&dataSource=${sourceToLabel(
+              dataSource
+            )}`}
             passHref
             legacyBehavior
           >
@@ -274,6 +284,13 @@ const ProfileVisualizationsRow = (props: ProfileVisualizationsRowProps) => {
               </Typography>
             </Link>
           </NextLink>
+        ) : (
+          <Typography variant="body2" noWrap>
+            {t({
+              id: "login.profile.my-visualizations.multiple-datasets",
+              message: "Multiple datasets",
+            })}
+          </Typography>
         )}
       </TableCell>
       <TableCell width={120}>

--- a/app/utils/chart-config/api.ts
+++ b/app/utils/chart-config/api.ts
@@ -19,7 +19,6 @@ export const createConfig = async (state: ConfiguratorStatePublishing) => {
           // used by a chart that has been published.
           key: createChartId(),
           version: state.version,
-          dataSet: state.dataSet,
           dataSource: state.dataSource,
           meta: state.meta,
           chartConfigs: state.chartConfigs,
@@ -51,7 +50,6 @@ export const updateConfig = async (
         data: {
           key,
           version: state.version,
-          dataSet: state.dataSet,
           dataSource: state.dataSource,
           meta: state.meta,
           chartConfigs: state.chartConfigs,

--- a/app/utils/chart-config/versioning.spec.ts
+++ b/app/utils/chart-config/versioning.spec.ts
@@ -22,6 +22,7 @@ const CONFIGURATOR_STATE = {
       en: "",
     },
   },
+  dataSet: "foo",
 } as unknown as ConfiguratorStateConfiguringChart;
 
 describe("config migrations", () => {

--- a/app/utils/chart-config/versioning.ts
+++ b/app/utils/chart-config/versioning.ts
@@ -12,7 +12,7 @@ type Migration = {
   down: (config: any, migrationProps?: any) => any;
 };
 
-export const CHART_CONFIG_VERSION = "2.2.0";
+export const CHART_CONFIG_VERSION = "2.3.0";
 
 const chartConfigMigrations: Migration[] = [
   {
@@ -750,20 +750,42 @@ const chartConfigMigrations: Migration[] = [
       });
     },
   },
+  {
+    description: `ALL {
+      + dataSet
+    }`,
+    from: "2.2.0",
+    to: "2.3.0",
+    up: (config, configuratorState) => {
+      const newConfig = { ...config, version: "2.3.0" };
+      const { dataSet } = configuratorState;
+
+      return produce(newConfig, (draft: any) => {
+        draft.dataSet = dataSet;
+      });
+    },
+    down: (config) => {
+      const newConfig = { ...config, version: "2.2.0" };
+
+      return produce(newConfig, (draft: any) => {
+        delete draft.dataSet;
+      });
+    },
+  },
 ];
 
 export const migrateChartConfig = makeMigrate(chartConfigMigrations, {
   defaultToVersion: CHART_CONFIG_VERSION,
 });
 
-export const CONFIGURATOR_STATE_VERSION = "2.0.0";
+export const CONFIGURATOR_STATE_VERSION = "3.0.0";
 
 const configuratorStateMigrations: Migration[] = [
   {
-    description: `ALL`,
+    description: "ALL",
     from: "1.0.0",
     to: "2.0.0",
-    up: (config: any) => {
+    up: (config) => {
       const newConfig = { ...config, version: "2.0.0" };
 
       return produce(newConfig, (draft: any) => {
@@ -790,6 +812,58 @@ const configuratorStateMigrations: Migration[] = [
           toVersion: "1.4.2",
         });
         draft.chartConfig = migratedChartConfig;
+      });
+    },
+  },
+  {
+    description: "ALL",
+    from: "2.0.0",
+    to: "3.0.0",
+    up: (config) => {
+      const newConfig = { ...config, version: "3.0.0" };
+
+      return produce(newConfig, (draft: any) => {
+        const chartConfigs: any[] = [];
+
+        for (const chartConfig of draft.chartConfigs) {
+          const migratedChartConfig = migrateChartConfig(chartConfig, {
+            migrationProps: draft,
+            toVersion: "2.3.0",
+          });
+          chartConfigs.push(migratedChartConfig);
+        }
+
+        delete draft.dataSet;
+        draft.chartConfigs = chartConfigs;
+      });
+    },
+    down: (config) => {
+      const newConfig = { ...config, version: "2.0.0" };
+
+      return produce(newConfig, (draft: any) => {
+        let dataSet: string | undefined;
+        const chartConfigs: any[] = [];
+
+        for (const chartConfig of draft.chartConfigs) {
+          if (!dataSet) {
+            dataSet = chartConfig.dataSet;
+          }
+
+          // Only migrate chartConfigs with the same dataSet as configuratorState.
+          if (chartConfig.dataSet === dataSet) {
+            const migratedChartConfig = migrateChartConfig(chartConfig, {
+              migrationProps: draft,
+              toVersion: "2.3.0",
+            });
+            chartConfigs.push(migratedChartConfig);
+          } else {
+            console.warn(
+              "Cannot migrate chartConfig dataSet to configuratorState dataSet because they are not the same."
+            );
+          }
+        }
+
+        draft.dataSet = dataSet;
       });
     },
   },

--- a/app/utils/chart-config/versioning.ts
+++ b/app/utils/chart-config/versioning.ts
@@ -287,12 +287,15 @@ const chartConfigMigrations: Migration[] = [
                 ...(colorScaleType === "discrete"
                   ? {
                       scaleType: colorScaleType,
-                      interpolationType: colorScaleInterpolationType,
+                      interpolationType:
+                        colorScaleInterpolationType === "linear"
+                          ? "quantize"
+                          : colorScaleInterpolationType,
                       nbClass,
                     }
                   : {
                       scaleType: colorScaleType,
-                      interpolationType: colorScaleInterpolationType,
+                      interpolationType: "linear",
                     }),
               },
             };

--- a/app/utils/chart-config/versioning.ts
+++ b/app/utils/chart-config/versioning.ts
@@ -853,7 +853,7 @@ const configuratorStateMigrations: Migration[] = [
           if (chartConfig.dataSet === dataSet) {
             const migratedChartConfig = migrateChartConfig(chartConfig, {
               migrationProps: draft,
-              toVersion: "2.3.0",
+              toVersion: "2.2.0",
             });
             chartConfigs.push(migratedChartConfig);
           } else {


### PR DESCRIPTION
This PR provides the technical foundation for the dashboards to allow charts based on different datasets within the same configurator state.

Essentially, it moves the `dataSet` property from the configurator state down to the charts themselves.

### How to test
1. Go to the deployment preview.
2. Add the following object to the local storage (use `vizualize-configurator-state:EpXqRKzyJxIy` key):
```
{"version":"3.0.0","state":"CONFIGURING_CHART","dataSource":{"type":"sparql","url":"https://lindas.admin.ch/query"},"meta":{"title":{"de":"","fr":"","it":"","en":""},"description":{"de":"","fr":"","it":"","en":""}},"chartConfigs":[{"key":"tPfhn1Lsv4u1","version":"2.3.0","meta":{"title":{"en":"","de":"","fr":"","it":""},"description":{"en":"","de":"","fr":"","it":""}},"dataSet":"https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9","chartType":"column","filters":{"https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Kanton":{"type":"single","value":"https://ld.admin.ch/canton/1"}},"interactiveFiltersConfig":{"legend":{"active":false,"componentIri":""},"timeRange":{"active":false,"componentIri":"https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr","presets":{"type":"range","from":"","to":""}},"dataFilters":{"active":false,"componentIris":[]},"calculation":{"active":false,"type":"identity"}},"fields":{"x":{"componentIri":"https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr","sorting":{"sortingType":"byAuto","sortingOrder":"asc"}},"y":{"componentIri":"https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/AnzahlAnlagen"}}},{"key":"tWem-qDvBFyn","version":"2.3.0","meta":{"title":{"en":"","de":"","fr":"","it":""},"description":{"en":"","de":"","fr":"","it":""}},"dataSet":"https://environment.ld.admin.ch/foen/ubd0104/6","chartType":"line","filters":{"https://environment.ld.admin.ch/foen/ubd0104/parametertype":{"type":"single","value":"E.coli"},"https://environment.ld.admin.ch/foen/ubd0104/station":{"type":"single","value":"https://environment.ld.admin.ch/foen/ubd0104/Station/CH10001"}},"interactiveFiltersConfig":{"legend":{"active":false,"componentIri":""},"timeRange":{"active":false,"componentIri":"https://environment.ld.admin.ch/foen/ubd0104/dateofprobing","presets":{"type":"range","from":"","to":""}},"dataFilters":{"active":false,"componentIris":[]},"calculation":{"active":false,"type":"identity"}},"fields":{"x":{"componentIri":"https://environment.ld.admin.ch/foen/ubd0104/dateofprobing"},"y":{"componentIri":"https://environment.ld.admin.ch/foen/ubd0104/value"}}}],"activeChartKey":"tPfhn1Lsv4u1"}
```
3. Go to `/en/create/EpXqRKzyJxIy?dataSource=Prod`.
4. See that the first chart is based on Photovoltaikanlagen dataset, while the second one is based on Bathing water quality dataset.