### PR TITLE
style: Combo charts UI alignments

### DIFF
--- a/app/charts/combo/chart-combo-line-single.tsx
+++ b/app/charts/combo/chart-combo-line-single.tsx
@@ -83,6 +83,13 @@ export const ChartComboLineSingle = React.memo(
     const { chartConfig, measures } = props;
     const { interactiveFiltersConfig } = chartConfig;
 
+    const getLegendItemDimension = React.useCallback(
+      (label) => {
+        return measures.find((measure) => measure.label === label);
+      },
+      [measures]
+    );
+
     return (
       <ComboLineSingleChart aspectRatio={0.4} {...props}>
         <ChartContainer>
@@ -100,9 +107,7 @@ export const ChartComboLineSingle = React.memo(
           <LegendColor
             chartConfig={chartConfig}
             symbol="line"
-            getLegendItemDimension={(label) => {
-              return measures.find((measure) => measure.label === label);
-            }}
+            getLegendItemDimension={getLegendItemDimension}
           />
         </ChartControlsContainer>
       </ComboLineSingleChart>

--- a/app/charts/combo/chart-combo-line-single.tsx
+++ b/app/charts/combo/chart-combo-line-single.tsx
@@ -80,7 +80,7 @@ export const ChartComboLineSingleVisualization = (
 
 export const ChartComboLineSingle = React.memo(
   (props: ChartProps<ComboLineSingleConfig>) => {
-    const { chartConfig } = props;
+    const { chartConfig, measures } = props;
     const { interactiveFiltersConfig } = chartConfig;
 
     return (
@@ -97,7 +97,13 @@ export const ChartComboLineSingle = React.memo(
           <Tooltip type="multiple" />
         </ChartContainer>
         <ChartControlsContainer>
-          <LegendColor chartConfig={chartConfig} symbol="line" />
+          <LegendColor
+            chartConfig={chartConfig}
+            symbol="line"
+            getLegendItemDimension={(label) => {
+              return measures.find((measure) => measure.label === label);
+            }}
+          />
         </ChartControlsContainer>
       </ComboLineSingleChart>
     );

--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -463,7 +463,9 @@ const DisabledMessageIcon = (props: DisabledMessageIconProps) => {
         </Typography>
       }
       placement="top"
-      componentsProps={{ tooltip: { sx: { width: 140, px: 2, py: 1 } } }}
+      componentsProps={{
+        tooltip: { sx: { width: 140, px: 2, py: 1, lineHeight: 1.2 } },
+      }}
       sx={{ opacity: 1, pointerEvents: "auto", ml: 1 }}
     >
       <Typography color="warning.main">

--- a/app/configurator/components/chart-controls/color-palette.tsx
+++ b/app/configurator/components/chart-controls/color-palette.tsx
@@ -147,7 +147,7 @@ export const ColorPalette = ({
         ))}
       </Select>
       {component && state.state === "CONFIGURING_CHART" && (
-        <ColorPaletteReset
+        <ColorPaletteControls
           field={field}
           component={component}
           state={state}
@@ -197,7 +197,7 @@ const ColorSquare = ({
   );
 };
 
-const ColorPaletteReset = ({
+const ColorPaletteControls = ({
   field,
   colorConfigPath,
   component,
@@ -252,14 +252,37 @@ const ColorPaletteReset = ({
       palette === "dimension";
 
     return (
-      <Button
-        disabled={same}
-        onClick={resetColorPalette}
-        variant="inline"
-        sx={{ mt: 1, px: 1 }}
-      >
-        <Trans id="controls.color.palette.reset">Reset color palette</Trans>
-      </Button>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1, mt: 1 }}>
+        <Button
+          disabled={same}
+          onClick={resetColorPalette}
+          variant="inline"
+          sx={{ px: 1 }}
+        >
+          <Trans id="controls.color.palette.reset">Reset color palette</Trans>
+        </Button>
+        <Typography color="secondary">•</Typography>
+        <Button
+          onClick={() => {
+            return dispatch({
+              type: "CHART_CONFIG_UPDATE_COLOR_MAPPING",
+              value: {
+                field,
+                colorConfigPath,
+                dimensionIri: component.iri,
+                values: component.values,
+                random: true,
+              },
+            });
+          }}
+          variant="inline"
+          sx={{ px: 1 }}
+        >
+          <Trans id="controls.filters.select.refresh-colors">
+            Shuffle colors
+          </Trans>
+        </Button>
+      </Box>
     );
   } else {
     return <Box mt={2} />;

--- a/app/configurator/components/chart-controls/color-picker.tsx
+++ b/app/configurator/components/chart-controls/color-picker.tsx
@@ -1,16 +1,8 @@
 import { Trans } from "@lingui/macro";
-import {
-  Box,
-  Button,
-  Input,
-  Popover,
-  styled,
-  Theme,
-  Typography,
-} from "@mui/material";
+import { Box, Button, Popover, styled, Theme, Typography } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import { color as d3Color } from "d3";
-import React, { MouseEventHandler, useCallback, useRef, useState } from "react";
+import { MouseEventHandler, useCallback, useRef } from "react";
 
 import useDisclosure from "@/components/use-disclosure";
 import VisuallyHidden from "@/components/visually-hidden";
@@ -75,21 +67,12 @@ const useColorPickerStyles = makeStyles((theme: Theme) => ({
     gap: 2,
     marginBottom: 2,
   },
-  input: {
-    color: theme.palette.grey[700],
-    borderColor: theme.palette.divider,
-    backgroundColor: theme.palette.grey[100],
-    fontSize: "0.875rem",
-    "&:focus": { outline: "none", borderColor: theme.palette.primary.main },
-  },
 }));
 
 export const ColorPicker = ({ selectedColor, colors, onChange }: Props) => {
-  const [inputColorValue, setInputColorValue] = useState(selectedColor);
-
+  const classes = useColorPickerStyles();
   const selectColor = useCallback(
     (_color) => {
-      setInputColorValue(_color);
       // Make sure onChange is only called with valid colors
       const c = d3Color(_color);
 
@@ -97,22 +80,8 @@ export const ColorPicker = ({ selectedColor, colors, onChange }: Props) => {
         onChange?.(_color);
       }
     },
-    [onChange, setInputColorValue]
+    [onChange]
   );
-
-  const formatInputColor = useCallback(
-    (_color) => {
-      // Make sure onChange is only called with valid colors
-      const c = d3Color(_color);
-
-      if (c) {
-        setInputColorValue(_color);
-      }
-    },
-    [setInputColorValue]
-  );
-
-  const classes = useColorPickerStyles();
 
   return (
     <Box className={classes.root}>
@@ -127,18 +96,6 @@ export const ColorPicker = ({ selectedColor, colors, onChange }: Props) => {
             }}
           />
         ))}
-      </Box>
-      <Box sx={{ position: "relative" }}>
-        <Input
-          className={classes.input}
-          value={inputColorValue}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-            selectColor(e.currentTarget.value);
-          }}
-          onBlur={(e) => {
-            formatInputColor(e.currentTarget.value);
-          }}
-        />
       </Box>
     </Box>
   );

--- a/app/configurator/components/chart-controls/color-picker.tsx
+++ b/app/configurator/components/chart-controls/color-picker.tsx
@@ -2,7 +2,7 @@ import { Trans } from "@lingui/macro";
 import { Box, Button, Popover, styled, Theme, Typography } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import { color as d3Color } from "d3";
-import { MouseEventHandler, useCallback, useRef } from "react";
+import { MouseEventHandler, useRef } from "react";
 
 import useDisclosure from "@/components/use-disclosure";
 import VisuallyHidden from "@/components/visually-hidden";
@@ -71,17 +71,6 @@ const useColorPickerStyles = makeStyles((theme: Theme) => ({
 
 export const ColorPicker = ({ selectedColor, colors, onChange }: Props) => {
   const classes = useColorPickerStyles();
-  const selectColor = useCallback(
-    (_color) => {
-      // Make sure onChange is only called with valid colors
-      const c = d3Color(_color);
-
-      if (c) {
-        onChange?.(_color);
-      }
-    },
-    [onChange]
-  );
 
   return (
     <Box className={classes.root}>
@@ -91,9 +80,7 @@ export const ColorPicker = ({ selectedColor, colors, onChange }: Props) => {
             key={color}
             color={color}
             selected={color === selectedColor}
-            onClick={() => {
-              selectColor(color);
-            }}
+            onClick={() => onChange?.(color)}
           />
         ))}
       </Box>

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -924,7 +924,7 @@ const ChartComboLineColumnYField = (
             sortOptions={false}
             label={t({
               id: "controls.chart.combo.y.column-measure",
-              message: "Column measure",
+              message: "Left axis (column)",
             })}
             value={y.columnComponentIri}
             onChange={(e) => {
@@ -949,7 +949,7 @@ const ChartComboLineColumnYField = (
             sortOptions={false}
             label={t({
               id: "controls.chart.combo.y.line-measure",
-              message: "Line measure",
+              message: "Right axis (line)",
             })}
             value={y.lineComponentIri}
             onChange={(e) => {

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -939,31 +939,8 @@ const ChartComboLineColumnYField = (
                 },
               });
             }}
+            sx={{ mb: 2 }}
           />
-
-          <Box component="fieldset" mt={2} mb={4}>
-            <FieldSetLegend
-              legendTitle={
-                <Trans id="controls.chart.combo.y.axis-orientation">
-                  Axis orientation
-                </Trans>
-              }
-            />
-            <Flex sx={{ justifyContent: "flex-start" }}>
-              {[
-                { value: "right", label: t({ id: "left", message: "Left" }) },
-                { value: "left", label: t({ id: "right", message: "Right" }) },
-              ].map((d) => (
-                <ChartOptionRadioField
-                  key={d.value}
-                  label={d.label}
-                  field="y"
-                  path="lineAxisOrientation"
-                  value={d.value}
-                />
-              ))}
-            </Flex>
-          </Box>
 
           <Select
             id={`mesure-${y.lineComponentIri}`}

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -25,7 +25,6 @@ import get from "lodash/get";
 import groupBy from "lodash/groupBy";
 import keyBy from "lodash/keyBy";
 import orderBy from "lodash/orderBy";
-import sortBy from "lodash/sortBy";
 import uniqBy from "lodash/uniqBy";
 import React, {
   forwardRef,
@@ -83,7 +82,6 @@ import { Icon } from "@/icons";
 import SvgIcCheck from "@/icons/components/IcCheck";
 import SvgIcChevronRight from "@/icons/components/IcChevronRight";
 import SvgIcClose from "@/icons/components/IcClose";
-import SvgIcFormatting from "@/icons/components/IcFormatting";
 import SvgIcRefresh from "@/icons/components/IcRefresh";
 import { getTimeInterval } from "@/intervals";
 import { useLocale } from "@/locales/use-locale";
@@ -303,44 +301,19 @@ const MultiFilterContent = ({
     anchorEl?.focus();
   });
 
-  const handleUpdateColorMapping = useEvent(
-    ({
-      type,
-    }: {
-      type: /** Goes back to original color mapping. */
-      | "reset"
-        /** Shuffles colors to create new, randomized color mapping. */
-        | "shuffle";
-    }) => {
-      const values = colorComponent?.values || [];
-
-      switch (type) {
-        case "reset":
-          return dispatch({
-            type: "CHART_CONFIG_UPDATE_COLOR_MAPPING",
-            value: {
-              field,
-              colorConfigPath,
-              dimensionIri,
-              values,
-              random: false,
-            },
-          });
-        case "shuffle":
-          const usedValues = new Set(values.map((v) => v.value));
-          return dispatch({
-            type: "CHART_CONFIG_UPDATE_COLOR_MAPPING",
-            value: {
-              field,
-              colorConfigPath,
-              dimensionIri,
-              values: sortBy(values, (d) => (usedValues.has(d.value) ? 0 : 1)),
-              random: true,
-            },
-          });
-      }
-    }
-  );
+  const handleResetColorMapping = useEvent(() => {
+    const values = colorComponent?.values ?? [];
+    dispatch({
+      type: "CHART_CONFIG_UPDATE_COLOR_MAPPING",
+      value: {
+        field,
+        colorConfigPath,
+        dimensionIri,
+        values,
+        random: false,
+      },
+    });
+  });
 
   const colorConfig = useMemo(() => {
     return getColorConfig(chartConfig, colorConfigPath);
@@ -400,43 +373,23 @@ const MultiFilterContent = ({
             <Trans id="controls.filters.select.selected-filters">
               Selected filters
             </Trans>
-            {hasColorMapping ? (
-              colorConfig?.palette === "dimension" ? (
-                <Tooltip
-                  title={
-                    <Trans id="controls.filters.select.reset-colors">
-                      Reset colors
-                    </Trans>
-                  }
+            {hasColorMapping && colorConfig?.palette === "dimension" && (
+              <Tooltip
+                title={
+                  <Trans id="controls.filters.select.reset-colors">
+                    Reset colors
+                  </Trans>
+                }
+              >
+                <IconButton
+                  size="small"
+                  onClick={handleResetColorMapping}
+                  sx={{ ml: 1, my: -2 }}
                 >
-                  <IconButton
-                    sx={{ ml: 1, my: -2 }}
-                    size="small"
-                    onClick={() => handleUpdateColorMapping({ type: "reset" })}
-                  >
-                    <SvgIcRefresh fontSize="inherit" />
-                  </IconButton>
-                </Tooltip>
-              ) : (
-                <Tooltip
-                  title={
-                    <Trans id="controls.filters.select.refresh-colors">
-                      Refresh colors
-                    </Trans>
-                  }
-                >
-                  <IconButton
-                    sx={{ ml: 1, my: -2 }}
-                    size="small"
-                    onClick={() =>
-                      handleUpdateColorMapping({ type: "shuffle" })
-                    }
-                  >
-                    <SvgIcFormatting fontSize="inherit" />
-                  </IconButton>
-                </Tooltip>
-              )
-            ) : null}
+                  <SvgIcRefresh fontSize="inherit" />
+                </IconButton>
+              </Tooltip>
+            )}
           </Typography>
           <Typography variant="body2" component="span">
             <Trans id="controls.filter.nb-elements">

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -591,7 +591,6 @@ const TreeAccordion = ({
           className={classes.optionCheck}
           style={{
             visibility: state === "NOT_SELECTED" ? "hidden" : "visible",
-            marginTop: 8,
           }}
         />
       </TreeAccordionSummary>

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -460,7 +460,7 @@ msgstr "Von"
 
 #: app/configurator/components/filters.tsx
 msgid "controls.filters.select.refresh-colors"
-msgstr "Farben auffrischen"
+msgstr "Farben mischen"
 
 #: app/configurator/components/filters.tsx
 msgid "controls.filters.select.reset-colors"

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -250,7 +250,7 @@ msgstr "Achsenausrichtung"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.chart.combo.y.column-measure"
-msgstr "Säule Messung"
+msgstr "Linke Achse (Säule)"
 
 #: app/configurator/components/chart-options-selector.tsx
 #: app/configurator/components/chart-options-selector.tsx
@@ -271,7 +271,7 @@ msgstr "Messung der linken Achse"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.chart.combo.y.line-measure"
-msgstr "Linie Messung"
+msgstr "Rechte Achse (Linie)"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.chart.combo.y.no-compatible-measures"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -250,7 +250,7 @@ msgstr "Axis orientation"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.chart.combo.y.column-measure"
-msgstr "Column measure"
+msgstr "Left axis (column)"
 
 #: app/configurator/components/chart-options-selector.tsx
 #: app/configurator/components/chart-options-selector.tsx
@@ -271,7 +271,7 @@ msgstr "Left axis measure"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.chart.combo.y.line-measure"
-msgstr "Line measure"
+msgstr "Right axis (line)"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.chart.combo.y.no-compatible-measures"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -460,7 +460,7 @@ msgstr "From"
 
 #: app/configurator/components/filters.tsx
 msgid "controls.filters.select.refresh-colors"
-msgstr "Refresh colors"
+msgstr "Shuffle colors"
 
 #: app/configurator/components/filters.tsx
 msgid "controls.filters.select.reset-colors"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -250,7 +250,7 @@ msgstr "Orientation de l'axe"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.chart.combo.y.column-measure"
-msgstr "Mesure de la colonne"
+msgstr "Axe gauche (colonne)"
 
 #: app/configurator/components/chart-options-selector.tsx
 #: app/configurator/components/chart-options-selector.tsx
@@ -271,7 +271,7 @@ msgstr "Mesure de l'axe gauche"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.chart.combo.y.line-measure"
-msgstr "Mesure de la ligne"
+msgstr "Axe droit (ligne)"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.chart.combo.y.no-compatible-measures"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -460,7 +460,7 @@ msgstr "Du"
 
 #: app/configurator/components/filters.tsx
 msgid "controls.filters.select.refresh-colors"
-msgstr "Renouveller les couleurs"
+msgstr "Mélanger les couleurs"
 
 #: app/configurator/components/filters.tsx
 msgid "controls.filters.select.reset-colors"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -250,7 +250,7 @@ msgstr "Orientamento dell'asse"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.chart.combo.y.column-measure"
-msgstr "Misura della colonna"
+msgstr "Asse sinistro (colonna)"
 
 #: app/configurator/components/chart-options-selector.tsx
 #: app/configurator/components/chart-options-selector.tsx
@@ -271,7 +271,7 @@ msgstr "Misura dell'asse sinistro"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.chart.combo.y.line-measure"
-msgstr "Misura della linea"
+msgstr "Asse destro (linea)"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.chart.combo.y.no-compatible-measures"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -460,7 +460,7 @@ msgstr "Della"
 
 #: app/configurator/components/filters.tsx
 msgid "controls.filters.select.refresh-colors"
-msgstr "Aggiorna i colori"
+msgstr "Mescolare i colori"
 
 #: app/configurator/components/filters.tsx
 msgid "controls.filters.select.reset-colors"


### PR DESCRIPTION
This PR updates the Combo charts-related styles along with several other styling adjustments.

- Removed text input from `ColorPicker`
- Removed axis orientation radio buttons from `ComboColumnLine` chart
- Added `OpenMetadataPanelWrapper` to legend items in `ComboLineSingle` chart
- Updated UI strings for left / right axes (`ComboColumnLine` chart)