### PR TITLE
fix: Only enable multiline chart when makes sense

### DIFF
--- a/app/charts/index.spec.ts
+++ b/app/charts/index.spec.ts
@@ -74,6 +74,18 @@ describe("possible chart types", () => {
 
     expect(possibleChartTypes).toEqual(["column", "map", "pie", "table"]);
   });
+
+  it("should not allow multiline chart if there are no several measures of the same unit", () => {
+    const possibleChartTypes = getPossibleChartTypes({
+      dimensions: [],
+      measures: [
+        { __typename: "NumericalMeasure", unit: "m" },
+        { __typename: "NumericalMeasure", unit: "cm" },
+      ] as any,
+    });
+
+    expect(possibleChartTypes).not.toContain("comboLineSingle");
+  });
 });
 
 describe("chart type switch", () => {

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -1,4 +1,4 @@
-import { ascending, descending, group, rollups } from "d3";
+import { ascending, descending, group, rollup, rollups } from "d3";
 import produce from "immer";
 import get from "lodash/get";
 import sortBy from "lodash/sortBy";
@@ -109,10 +109,16 @@ export const regularChartTypes: RegularChartType[] = [
   "map",
 ];
 
-export const comboChartTypes: ComboChartType[] = [
-  "comboLineSingle",
+export const comboDifferentUnitChartTypes: ComboChartType[] = [
   "comboLineDual",
   "comboLineColumn",
+];
+
+export const comboSameUnitChartTypes: ComboChartType[] = ["comboLineSingle"];
+
+export const comboChartTypes: ComboChartType[] = [
+  ...comboSameUnitChartTypes,
+  ...comboDifferentUnitChartTypes,
 ];
 
 export const chartTypesOrder: { [k in ChartType]: number } = {
@@ -1914,14 +1920,23 @@ export const getPossibleChartTypes = ({
       possibles.push(...multipleNumericalMeasuresEnabled);
 
       if (temporalDimensions.length > 0) {
+        const measuresWithUnit = numericalMeasures.filter((d) => d.unit);
         const uniqueUnits = Array.from(
-          new Set(numericalMeasures.filter((d) => d.unit).map((d) => d.unit))
+          new Set(measuresWithUnit.map((d) => d.unit))
         );
 
         if (uniqueUnits.length > 1) {
-          possibles.push(...comboChartTypes);
-        } else if (uniqueUnits.length > 0) {
-          possibles.push("comboLineSingle");
+          possibles.push(...comboDifferentUnitChartTypes);
+        }
+
+        const unitCounts = rollup(
+          measuresWithUnit,
+          (v) => v.length,
+          (d) => d.unit
+        );
+
+        if (Array.from(unitCounts.values()).some((d) => d > 1)) {
+          possibles.push(...comboSameUnitChartTypes);
         }
       }
     }


### PR DESCRIPTION
This PR introduces a change to only enable multiline combo chart when there are at least two numerical measures of the same unit.