### PR TITLE
fix: Navigation issue with metadata not showing up

### DIFF
--- a/app/browser/context.tsx
+++ b/app/browser/context.tsx
@@ -14,7 +14,7 @@ import useEvent from "@/utils/use-event";
 import { getFiltersFromParams } from "./filters";
 
 export const getBrowseParamsFromQuery = (query: Router["query"]) => {
-  const values = mapValues(
+  const rawValues = mapValues(
     pick(query, [
       "type",
       "iri",
@@ -25,16 +25,24 @@ export const getBrowseParamsFromQuery = (query: Router["query"]) => {
       "order",
       "search",
       "dataset",
+      "previous",
     ]),
     (v) => (Array.isArray(v) ? v[0] : v)
   );
 
+  const { type, iri, subtype, subiri, topic, includeDrafts, ...values } =
+    rawValues;
+  const previous = values.previous ? JSON.parse(values.previous) : undefined;
+
   return pickBy(
     {
       ...values,
-      includeDrafts: values.includeDrafts
-        ? JSON.parse(values.includeDrafts)
-        : false,
+      type: type ?? previous?.type,
+      iri: iri ?? previous?.iri,
+      subtype: subtype ?? previous?.subtype,
+      subiri: subiri ?? previous?.subiri,
+      topic: topic ?? previous?.topic,
+      includeDrafts: includeDrafts ? JSON.parse(includeDrafts) : undefined,
     },
     (x) => x !== undefined
   );

--- a/app/browser/dataset-browse.tsx
+++ b/app/browser/dataset-browse.tsx
@@ -10,7 +10,7 @@ import {
   Typography,
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
-import { Reorder } from "framer-motion";
+import { AnimatePresence, Reorder } from "framer-motion";
 import orderBy from "lodash/orderBy";
 import pickBy from "lodash/pickBy";
 import sortBy from "lodash/sortBy";
@@ -662,6 +662,7 @@ export const SearchFilters = ({
   const themeNav =
     displayedThemes && displayedThemes.length > 0 ? (
       <NavSection
+        key="themes"
         items={displayedThemes}
         theme={{
           backgroundColor: "category.light",
@@ -690,6 +691,7 @@ export const SearchFilters = ({
   const orgNav =
     displayedOrgs && displayedOrgs.length > 0 ? (
       <NavSection
+        key="orgs"
         items={displayedOrgs}
         theme={{
           backgroundColor: "organization.light",
@@ -713,29 +715,28 @@ export const SearchFilters = ({
       />
     ) : null;
 
-  let navs = [themeNav, orgNav];
-
-  if (filters[0]?.__typename === "DataCubeTheme") {
-    navs = [themeNav, orgNav];
-  } else if (filters[0]?.__typename === "DataCubeOrganization") {
-    navs = [orgNav, themeNav];
-  }
-
   return (
     <Flex
-      sx={{
-        flexDirection: "column",
-        height: "100%",
-      }}
-      px={4}
-      pt="0.75rem"
-      role="search"
       key={filters.length}
+      role="search"
+      sx={{ height: "100%", px: 4, pt: "0.75rem" }}
     >
-      <Stack spacing={5}>
-        {navs[0]}
-        {navs[1]}
-      </Stack>
+      {/* Need to "catch" the Reorder items here, as otherwise there is an exiting
+          bug as they get picked by parent AnimatePresence. Probably related to
+          https://github.com/framer/motion/issues/1619. */}
+      <AnimatePresence>
+        {filters[0]?.__typename === "DataCubeOrganization" ? (
+          <Flex sx={{ flexDirection: "column", gap: 5, width: "100%" }}>
+            {orgNav}
+            {themeNav}
+          </Flex>
+        ) : (
+          <Flex sx={{ flexDirection: "column", gap: 5, width: "100%" }}>
+            {themeNav}
+            {orgNav}
+          </Flex>
+        )}
+      </AnimatePresence>
     </Flex>
   );
 };

--- a/app/browser/select-dataset-step.tsx
+++ b/app/browser/select-dataset-step.tsx
@@ -282,9 +282,8 @@ const SelectDatasetStepContent = () => {
           <AnimatePresence mode="wait">
             {dataset ? (
               <MotionBox
-                key="dataset-metadata"
-                px={4}
-                mx={4}
+                key="metadata"
+                sx={{ mx: 4, px: 4 }}
                 {...navPresenceProps}
               >
                 <NextLink href={backLink} passHref legacyBehavior>
@@ -312,77 +311,78 @@ const SelectDatasetStepContent = () => {
             )}
           </AnimatePresence>
         </PanelLeftWrapper>
-        <PanelMiddleWrapper className={classes.panelMiddle}>
-          <Box sx={{ maxWidth: 1040 }}>
-            <AnimatePresence mode="wait">
-              {dataset ? (
-                <MotionBox {...navPresenceProps} key="preview">
-                  <DataSetPreview
-                    dataSetIri={dataset}
-                    dataSource={configState.dataSource}
-                  />
-                </MotionBox>
-              ) : (
-                <MotionBox key="filters" {...navPresenceProps}>
-                  <AnimatePresence>
-                    {queryFilters.length > 0 && (
-                      <MotionBox
-                        {...{
-                          initial: {
-                            transform: "translateY(-16px)",
-                            height: 0,
-                            marginBottom: 0,
-                            opacity: 0,
-                          },
-                          animate: {
-                            transform: "translateY(0px)",
-                            height: "auto",
-                            marginBottom: 16,
-                            opacity: 1,
-                          },
-                          exit: {
-                            transform: "translateY(-16px)",
-                            height: 0,
-                            marginBottom: 0,
-                            opacity: 0,
-                          },
-                          transition: {
-                            duration: DURATION,
-                          },
-                        }}
+        <PanelMiddleWrapper
+          className={classes.panelMiddle}
+          sx={{ maxWidth: 1040 }}
+        >
+          <AnimatePresence mode="wait">
+            {dataset ? (
+              <MotionBox key="preview" {...navPresenceProps}>
+                <DataSetPreview
+                  dataSetIri={dataset}
+                  dataSource={configState.dataSource}
+                />
+              </MotionBox>
+            ) : (
+              <MotionBox key="filters" {...navPresenceProps}>
+                <AnimatePresence>
+                  {queryFilters.length > 0 && (
+                    <MotionBox
+                      {...{
+                        initial: {
+                          transform: "translateY(-16px)",
+                          height: 0,
+                          marginBottom: 0,
+                          opacity: 0,
+                        },
+                        animate: {
+                          transform: "translateY(0px)",
+                          height: "auto",
+                          marginBottom: 16,
+                          opacity: 1,
+                        },
+                        exit: {
+                          transform: "translateY(-16px)",
+                          height: 0,
+                          marginBottom: 0,
+                          opacity: 0,
+                        },
+                        transition: {
+                          duration: DURATION,
+                        },
+                      }}
+                    >
+                      <Typography
+                        key="filters"
+                        className={classes.filters}
+                        variant="h1"
                       >
-                        <Typography
-                          key="filters"
-                          className={classes.filters}
-                          variant="h1"
-                        >
-                          {queryFilters
-                            .map((d) => {
-                              const searchList =
-                                d.type === "DataCubeTheme" ? themes : orgs;
-                              const item = (
-                                searchList as { iri: string; label?: string }[]
-                              ).find(({ iri }) => iri === d.value);
-                              return (item ?? d).label;
-                            })
-                            .join(", ")}
-                        </Typography>
-                      </MotionBox>
-                    )}
-                  </AnimatePresence>
-                  <SearchDatasetControls
-                    browseState={browseState}
-                    cubes={cubes}
-                  />
-                  <DatasetResults
-                    fetching={fetching}
-                    error={error}
-                    cubes={cubes}
-                  />
-                </MotionBox>
-              )}
-            </AnimatePresence>
-          </Box>
+                        {queryFilters
+                          .map((d) => {
+                            const searchList =
+                              d.type === "DataCubeTheme" ? themes : orgs;
+                            const item = (
+                              searchList as { iri: string; label?: string }[]
+                            ).find(({ iri }) => iri === d.value);
+                            return (item ?? d).label;
+                          })
+                          .join(", ")}
+                      </Typography>
+                    </MotionBox>
+                  )}
+                </AnimatePresence>
+                <SearchDatasetControls
+                  browseState={browseState}
+                  cubes={cubes}
+                />
+                <DatasetResults
+                  fetching={fetching}
+                  error={error}
+                  cubes={cubes}
+                />
+              </MotionBox>
+            )}
+          </AnimatePresence>
         </PanelMiddleWrapper>
       </PanelLayout>
       <Box

--- a/app/components/presence.tsx
+++ b/app/components/presence.tsx
@@ -25,23 +25,9 @@ export const accordionPresenceProps = {
 };
 
 export const navPresenceProps = {
-  variants: {
-    enter: () => ({
-      opacity: 0,
-      x: 20,
-      transition: {
-        when: "beforeChildren",
-        staggerChildren: DURATION,
-      },
-    }),
-    center: () => ({ opacity: 1, x: 0 }),
-    exit: () => ({
-      opacity: 0,
-    }),
-  },
-  initial: "enter",
-  animate: "center",
-  exit: "exit",
+  initial: { opacity: 0, x: 20 },
+  animate: { opacity: 1, x: 0 },
+  exit: { opacity: 0, x: 20 },
   transition: {
     duration: DURATION,
   },


### PR DESCRIPTION
This PR fixes the issue of metadata panel not showing in dataset preview when some filters were applied prior to navigating there.

The problem was that the `AnimationPresence's` `onExitAnimation` was not triggered, probably related to nesting of `AnimatePresences` with layout animations, some bugs with exit layout animations have been reported e.g. [here](https://github.com/framer/motion/issues/1619). Wrapping the `SearchFilters`' children with `AnimatePresence` fixed the error.

To reproduce go to https://test.visualize.admin.ch/en/browse/theme/https%3A%2F%2Fregister.ld.admin.ch%2Fopendataswiss%2Fcategory%2Fadministration?dataSource=Prod and select the first dataset.

I also fixed a smaller issue with search filters being cleared when going to dataset preview, this bug looked like in the video below; now the filters shouldn't be cleared anymore.

https://github.com/visualize-admin/visualization-tool/assets/52032047/cfcb9469-d515-4a51-9413-0f4590a7282e


