### PR TITLE
fix: Flickering username

### DIFF
--- a/app/login/utils.ts
+++ b/app/login/utils.ts
@@ -1,7 +1,6 @@
 import { Theme } from "@mui/material";
 import { makeStyles } from "@mui/styles";
-import { getProviders, useSession } from "next-auth/react";
-import React from "react";
+import { useSession } from "next-auth/react";
 
 import { HEADER_HEIGHT } from "@/components/header";
 
@@ -24,39 +23,10 @@ export const useRootStyles = makeStyles<Theme>((theme) => ({
 
 export const useUser = () => {
   const { data: session, status: sessionStatus } = useSession();
-  const { data: providers, status: providersStatus } = useProviders();
 
-  if (sessionStatus === "loading" || providersStatus === "loading") {
-    return null;
-  }
-
-  if (!providers || !Object.keys(providers).length) {
-    return null;
-  }
-
-  if (!session) {
+  if (sessionStatus === "loading" || !session) {
     return null;
   }
 
   return session.user;
-};
-
-type Providers = Awaited<ReturnType<typeof getProviders>>;
-
-const useProviders = () => {
-  const [state, setState] = React.useState({
-    status: "loading",
-    data: undefined as Providers | undefined,
-  });
-
-  React.useEffect(() => {
-    const run = async () => {
-      const providers = await getProviders();
-      setState({ status: "loaded", data: providers });
-    };
-
-    run();
-  }, []);
-
-  return state;
 };


### PR DESCRIPTION
This PR removes providers presence checking each time we want to get current user, as there doesn't seem a reason to do so at this point, and this causes the username to switch back between currently logged in username and "Sign in" string when navigating through the pages.