### PR TITLE
fix(column): :recycle: remove ErrorWhisker and Tooltip when error is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 
 ## Unreleased
 
-Nothing yet.
+- Fixes
+  - remove ErrorWhisker and Tooltip when error is null in Column charts
 
 # [3.24.0] - 2023-11-08
 

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -388,7 +388,7 @@ const useColumnsGroupedState = (
     });
 
     const getError = (d: Observation) => {
-      if (!showYStandardError || !getYError) {
+      if (!showYStandardError || !getYError || getYError(d) == null) {
         return;
       }
 

--- a/app/charts/column/columns-grouped.tsx
+++ b/app/charts/column/columns-grouped.tsx
@@ -4,6 +4,7 @@ import { GroupedColumnsState } from "@/charts/column/columns-grouped-state";
 import {
   RenderColumnDatum,
   RenderWhiskerDatum,
+  filterWithoutErrors,
   renderColumns,
   renderWhiskers,
 } from "@/charts/column/rendering-utils";
@@ -17,6 +18,7 @@ export const ErrorWhiskers = () => {
     xScale,
     xScaleIn,
     getYErrorRange,
+    getYError,
     yScale,
     getSegment,
     grouped,
@@ -31,25 +33,28 @@ export const ErrorWhiskers = () => {
       return [];
     }
 
-    return grouped.flatMap(([segment, observations]) =>
-      observations.map((d) => {
-        const x0 = xScaleIn(getSegment(d)) as number;
-        const bandwidth = xScaleIn.bandwidth();
-        const barwidth = Math.min(bandwidth, 15);
-        const [y1, y2] = getYErrorRange(d);
+    return grouped
+      .filter((d) => d[1].some(filterWithoutErrors(getYError)))
+      .flatMap(([segment, observations]) =>
+        observations.map((d) => {
+          const x0 = xScaleIn(getSegment(d)) as number;
+          const bandwidth = xScaleIn.bandwidth();
+          const barwidth = Math.min(bandwidth, 15);
+          const [y1, y2] = getYErrorRange(d);
 
-        return {
-          key: `${segment}-${getSegment(d)}`,
-          x: (xScale(segment) as number) + x0 + bandwidth / 2 - barwidth / 2,
-          y1: yScale(y1),
-          y2: yScale(y2),
-          width: barwidth,
-        };
-      })
-    );
+          return {
+            key: `${segment}-${getSegment(d)}`,
+            x: (xScale(segment) as number) + x0 + bandwidth / 2 - barwidth / 2,
+            y1: yScale(y1),
+            y2: yScale(y2),
+            width: barwidth,
+          };
+        })
+      );
   }, [
     getSegment,
     getYErrorRange,
+    getYError,
     grouped,
     showYStandardError,
     xScale,

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -226,7 +226,7 @@ const useColumnsState = (
       );
 
     const getError = (d: Observation) => {
-      if (!showYStandardError || !getYError) {
+      if (!showYStandardError || !getYError || getYError(d) === null) {
         return;
       }
 

--- a/app/charts/column/columns.tsx
+++ b/app/charts/column/columns.tsx
@@ -3,6 +3,7 @@ import React from "react";
 
 import { ColumnsState } from "@/charts/column/columns-state";
 import {
+  filterWithoutErrors,
   RenderColumnDatum,
   renderColumns,
   RenderWhiskerDatum,
@@ -33,22 +34,20 @@ export const ErrorWhiskers = () => {
       return [];
     }
 
-    return chartData
-      .filter((d) => !!getYError?.(d))
-      .map((d, i) => {
-        const x0 = xScale(getX(d)) as number;
-        const bandwidth = xScale.bandwidth();
-        const barwidth = Math.min(bandwidth, 15);
-        const [y1, y2] = getYErrorRange(d);
+    return chartData.filter(filterWithoutErrors(getYError)).map((d, i) => {
+      const x0 = xScale(getX(d)) as number;
+      const bandwidth = xScale.bandwidth();
+      const barwidth = Math.min(bandwidth, 15);
+      const [y1, y2] = getYErrorRange(d);
 
-        return {
-          key: `${i}`,
-          x: x0 + bandwidth / 2 - barwidth / 2,
-          y1: yScale(y1),
-          y2: yScale(y2),
-          width: barwidth,
-        };
-      });
+      return {
+        key: `${i}`,
+        x: x0 + bandwidth / 2 - barwidth / 2,
+        y1: yScale(y1),
+        y2: yScale(y2),
+        width: barwidth,
+      };
+    });
   }, [
     chartData,
     getX,
@@ -59,7 +58,7 @@ export const ErrorWhiskers = () => {
     yScale,
   ]);
 
-    React.useEffect(() => {
+  React.useEffect(() => {
     if (ref.current) {
       renderContainer(ref.current, {
         id: "columns-error-whiskers",

--- a/app/charts/column/columns.tsx
+++ b/app/charts/column/columns.tsx
@@ -16,6 +16,7 @@ import { useTheme } from "@/themes";
 export const ErrorWhiskers = () => {
   const {
     getX,
+    getYError,
     getYErrorRange,
     chartData,
     yScale,
@@ -32,23 +33,33 @@ export const ErrorWhiskers = () => {
       return [];
     }
 
-    return chartData.map((d, i) => {
-      const x0 = xScale(getX(d)) as number;
-      const bandwidth = xScale.bandwidth();
-      const barwidth = Math.min(bandwidth, 15);
-      const [y1, y2] = getYErrorRange(d);
+    return chartData
+      .filter((d) => !!getYError?.(d))
+      .map((d, i) => {
+        const x0 = xScale(getX(d)) as number;
+        const bandwidth = xScale.bandwidth();
+        const barwidth = Math.min(bandwidth, 15);
+        const [y1, y2] = getYErrorRange(d);
 
-      return {
-        key: `${i}`,
-        x: x0 + bandwidth / 2 - barwidth / 2,
-        y1: yScale(y1),
-        y2: yScale(y2),
-        width: barwidth,
-      };
-    });
-  }, [chartData, getX, getYErrorRange, showYStandardError, xScale, yScale]);
+        return {
+          key: `${i}`,
+          x: x0 + bandwidth / 2 - barwidth / 2,
+          y1: yScale(y1),
+          y2: yScale(y2),
+          width: barwidth,
+        };
+      });
+  }, [
+    chartData,
+    getX,
+    getYError,
+    getYErrorRange,
+    showYStandardError,
+    xScale,
+    yScale,
+  ]);
 
-  React.useEffect(() => {
+    React.useEffect(() => {
     if (ref.current) {
       renderContainer(ref.current, {
         id: "columns-error-whiskers",

--- a/app/charts/column/rendering-utils.ts
+++ b/app/charts/column/rendering-utils.ts
@@ -4,6 +4,7 @@ import {
   RenderOptions,
   maybeTransition,
 } from "@/charts/shared/rendering-utils";
+import { Observation, ObservationValue } from "@/domain/data";
 
 export type RenderColumnDatum = {
   key: string;
@@ -158,3 +159,8 @@ export const renderWhiskers = (
         })
     );
 };
+
+export const filterWithoutErrors =
+  (getError: ((d: Observation) => ObservationValue) | null) =>
+  (d: Observation): boolean =>
+    !!getError?.(d);


### PR DESCRIPTION
It was requested to remove the Standard Errors from the column visualization (#589) so that the ErrorWhiskers component does not show for these columns.

While I was able to filter the chartDatum for any values where the getYError was null, I was also able to remove the getError from the getAnnotationinfo when null
### Before
![Screenshot 2023-11-06 at 14 36 00](https://github.com/visualize-admin/visualization-tool/assets/59728961/e17467c1-4901-4941-95e9-cfa3110e51d6)
### After
![Screenshot 2023-11-06 at 14 36 10](https://github.com/visualize-admin/visualization-tool/assets/59728961/3f6a0171-9e97-4721-8880-11905a3c474e)
