### PR TITLE
perf: Optimize dataset previews performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
   - Hierarchy names are now correctly retrieved
 - Performance
   - We no longer fetch shape when initalizing the cube, as we might need to re-fetch it again if a newer cube is required
+  - Vastly improved performance of dataset preview by using a new version of `cube-view-query` library (`View.preview`)
 
 # [3.24.0] - 2023-11-08
 

--- a/app/typings/rdf.d.ts
+++ b/app/typings/rdf.d.ts
@@ -101,12 +101,17 @@ declare module "rdf-cube-view-query" {
     dimension(options: { cubeDimension: NamedNode | string }): Dimension | null;
     observationsQuery({ disableDistinct }: { disableDistinct?: boolean }): {
       query: $FixMe;
+      previewQuery: $FixMe;
       dimensionMap: Map;
     };
     async observations({
       disableDistinct,
     }: {
       disableDistinct?: boolean;
+    }): Promise<Record<string, Literal | NamedNode>[]>;
+    async preview(options: {
+      limit?: number;
+      offset?: number;
     }): Promise<Record<string, Literal | NamedNode>[]>;
     addDimension(dimension: Dimension): View;
     createDimension(options: $FixMe): Dimension;


### PR DESCRIPTION
This PR improves performance of fetching dataset previews by using a[ new version](https://github.com/zazuko/rdf-cube-view-query/commit/a83ec4c789dada1d8300bec4fefc28576f0184c2) of cube-view-query library.

### How to test
Open any dataset in deployment preview and TEST to see the difference :)