### PR TITLE
fix(interaction): :bug: create conditional Xplacement based on container width

### DIFF
--- a/app/charts/shared/interaction/tooltip-box.tsx
+++ b/app/charts/shared/interaction/tooltip-box.tsx
@@ -69,6 +69,30 @@ const usePosition = () => {
   return [box, handleRef] as const;
 };
 
+/**
+ * Responsible for folding the container size into a single value based on breakpoints.
+ * After accepting the container width, it accepts functions each breakpoint to return the generic value.
+ */
+const foldContainerSize =
+  <T,>(containerWidth: number) =>
+  ({
+    xs,
+    md,
+    lg,
+  }: {
+    xs: (width: number) => T;
+    md?: (width: number) => T;
+    lg?: (width: number) => T;
+  }) => {
+    if (lg && containerWidth >= 900) {
+      return lg(containerWidth);
+    }
+    if (md && containerWidth >= 600) {
+      return md(containerWidth);
+    }
+    return xs(containerWidth);
+  };
+
 export const getCenteredTooltipPlacement = (props: {
   chartWidth: number;
   xAnchor: number;
@@ -82,7 +106,10 @@ export const getCenteredTooltipPlacement = (props: {
         y: "top",
       }
     : {
-        x: xAnchor < chartWidth * 0.25 ? "right" : "left",
+        x: foldContainerSize<Xplacement>(chartWidth)({
+          xs: (w) => (xAnchor < w * 0.5 ? "right" : "left"),
+          md: (w) => (xAnchor < w * 0.25 ? "right" : "left"),
+        }),
         y: "middle",
       };
 };


### PR DESCRIPTION
>The Mouse Over Box should appear on the right Side so as not to be cut off. The Problem appears only by embedding in AEM or iFrame. The URL to share is ok : https://visualize.admin.ch/en/v/uCDwLYAzMW5c
>
>![image](https://github.com/visualize-admin/visualization-tool/assets/59728961/69fbd344-9d43-4a60-a6bc-14def589ae48)
>
>#1266

## Goals/Scope
After investigating it seems the bug is cased on small containers where the tooltip size is larger then the allotted space.  Since larger screens still work, I looked to create a solution that could conditionally place the tooltip based on the charts size rather then measuring the window.

## Description
Created a fold function that accepts the `chartWidth` and returns a function that can be used to define the behaviour of the xPlacement depending on that size.  Here we can define the `xs` (smallest) and `md` (@breakpoint 600) to define the mobile-first behaviours.  

## Comments
I'm not sure how to test the embedded links without deploying this to INT, any suggestions are welcome in the comments 👇