### PR TITLE
feat: Add a way to retrieve metadata from multiple cubes

### DIFF
--- a/app/browse/datatable.tsx
+++ b/app/browse/datatable.tsx
@@ -30,9 +30,9 @@ import {
 } from "@/domain/data";
 import { useDimensionFormatters } from "@/formatters";
 import {
-  useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
 } from "@/graphql/query-hooks";
 import SvgIcChevronDown from "@/icons/components/IcChevronDown";
 import { useLocale } from "@/locales/use-locale";
@@ -257,10 +257,10 @@ export const DataSetTable = ({
     sourceUrl: dataSource.url,
     locale,
   };
-  const [{ data: metadataData }] = useDataCubeMetadataQuery({
+  const [{ data: metadataData }] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      iri: dataSetIri,
+      filters: [{ iri: dataSetIri }],
     },
   });
   const [{ data: componentsData }] = useDataCubesComponentsQuery({
@@ -289,12 +289,13 @@ export const DataSetTable = ({
     ]);
   }, [componentsData?.dataCubesComponents]);
 
-  return metadataData?.dataCubeByIri &&
+  return metadataData?.dataCubesMetadata &&
     componentsData?.dataCubesComponents &&
     observationsData?.dataCubeByIri ? (
     <Box sx={{ maxHeight: "600px", overflow: "auto", ...sx }}>
       <PreviewTable
-        title={metadataData.dataCubeByIri.title}
+        // FIXME: adapt to design
+        title={metadataData.dataCubesMetadata.map((d) => d.title).join(", ")}
         headers={headers}
         observations={observationsData.dataCubeByIri.observations.data}
         linkToMetadataPanel={true}

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -17,9 +17,9 @@ import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import { AreaConfig, DataSource, QueryFilters } from "@/config-types";
 import {
-  useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
@@ -44,10 +44,10 @@ export const ChartAreasVisualization = ({
     sourceUrl: dataSource.url,
     locale,
   };
-  const [metadataQuery] = useDataCubeMetadataQuery({
+  const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      iri: dataSetIri,
+      filters: [{ iri: dataSetIri }],
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({

--- a/app/charts/chart-loading-wrapper.tsx
+++ b/app/charts/chart-loading-wrapper.tsx
@@ -15,9 +15,9 @@ import {
 } from "@/components/hint";
 import { ChartConfig } from "@/configurator";
 import {
-  DataCubeMetadataQuery,
   DataCubeObservationsQuery,
   DataCubesComponentsQuery,
+  DataCubesMetadataQuery,
 } from "@/graphql/query-hooks";
 
 type ElementProps<RE> = RE extends React.ElementType<infer P> ? P : never;
@@ -35,7 +35,7 @@ export const ChartLoadingWrapper = <
   ComponentProps,
 }: {
   metadataQuery: Pick<
-    UseQueryResponse<DataCubeMetadataQuery>[0],
+    UseQueryResponse<DataCubesMetadataQuery>[0],
     "data" | "fetching" | "error"
   >;
   componentsQuery: Pick<
@@ -70,7 +70,7 @@ export const ChartLoadingWrapper = <
     error: observationsError,
   } = observationsQuery;
 
-  const metadata = metadataData?.dataCubeByIri;
+  const metadata = metadataData?.dataCubesMetadata;
   const observations = observationsData?.dataCubeByIri?.observations.data;
   const dimensions = componentsData?.dataCubesComponents.dimensions;
   const measures = componentsData?.dataCubesComponents.measures;
@@ -90,7 +90,8 @@ export const ChartLoadingWrapper = <
   }, [dimensions, measures]);
 
   if (metadata && dimensions && measures && observations) {
-    const { title } = metadata;
+    // FIXME: adapt to design
+    const title = metadata.map((d) => d.title).join(", ");
 
     return (
       <Box

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -27,9 +27,9 @@ import { LegendColor } from "@/charts/shared/legend-color";
 import { ColumnConfig, DataSource, QueryFilters } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import {
-  useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
@@ -54,10 +54,10 @@ export const ChartColumnsVisualization = ({
     sourceUrl: dataSource.url,
     locale,
   };
-  const [metadataQuery] = useDataCubeMetadataQuery({
+  const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      iri: dataSetIri,
+      filters: [{ iri: dataSetIri }],
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({

--- a/app/charts/combo/chart-combo-line-column.tsx
+++ b/app/charts/combo/chart-combo-line-column.tsx
@@ -17,9 +17,9 @@ import {
   QueryFilters,
 } from "@/config-types";
 import {
-  useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
@@ -44,10 +44,10 @@ export const ChartComboLineColumnVisualization = (
     sourceUrl: dataSource.url,
     locale,
   };
-  const [metadataQuery] = useDataCubeMetadataQuery({
+  const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      iri: dataSetIri,
+      filters: [{ iri: dataSetIri }],
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({

--- a/app/charts/combo/chart-combo-line-dual.tsx
+++ b/app/charts/combo/chart-combo-line-dual.tsx
@@ -13,9 +13,9 @@ import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import { ComboLineDualConfig, DataSource, QueryFilters } from "@/config-types";
 import {
-  useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
@@ -40,10 +40,10 @@ export const ChartComboLineDualVisualization = (
     sourceUrl: dataSource.url,
     locale,
   };
-  const [metadataQuery] = useDataCubeMetadataQuery({
+  const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      iri: dataSetIri,
+      filters: [{ iri: dataSetIri }],
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({

--- a/app/charts/combo/chart-combo-line-single.tsx
+++ b/app/charts/combo/chart-combo-line-single.tsx
@@ -22,9 +22,9 @@ import {
   QueryFilters,
 } from "@/config-types";
 import {
-  useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
@@ -49,10 +49,10 @@ export const ChartComboLineSingleVisualization = (
     sourceUrl: dataSource.url,
     locale,
   };
-  const [metadataQuery] = useDataCubeMetadataQuery({
+  const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      iri: dataSetIri,
+      filters: [{ iri: dataSetIri }],
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -18,9 +18,9 @@ import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import { DataSource, LineConfig, QueryFilters } from "@/config-types";
 import {
-  useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
@@ -45,10 +45,10 @@ export const ChartLinesVisualization = ({
     sourceUrl: dataSource.url,
     locale,
   };
-  const [metadataQuery] = useDataCubeMetadataQuery({
+  const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      iri: dataSetIri,
+      filters: [{ iri: dataSetIri }],
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -15,9 +15,9 @@ import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import { GeoShapes } from "@/domain/data";
 import {
   GeoCoordinates,
-  useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
   useGeoCoordinatesByDimensionIriQuery,
   useGeoShapesByDimensionIriQuery,
 } from "@/graphql/query-hooks";
@@ -46,10 +46,10 @@ export const ChartMapVisualization = ({
     sourceUrl: dataSource.url,
     locale,
   };
-  const [metadataQuery] = useDataCubeMetadataQuery({
+  const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      iri: dataSetIri,
+      filters: [{ iri: dataSetIri }],
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -14,9 +14,9 @@ import { OnlyNegativeDataHint } from "@/components/hint";
 import { DataSource, PieConfig, QueryFilters } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import {
-  useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
@@ -41,10 +41,10 @@ export const ChartPieVisualization = ({
     sourceUrl: dataSource.url,
     locale,
   };
-  const [metadataQuery] = useDataCubeMetadataQuery({
+  const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      iri: dataSetIri,
+      filters: [{ iri: dataSetIri }],
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -22,9 +22,9 @@ import { InteractionVoronoi } from "@/charts/shared/overlay-voronoi";
 import { DataSource, QueryFilters, ScatterPlotConfig } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import {
-  useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
@@ -49,10 +49,10 @@ export const ChartScatterplotVisualization = ({
     sourceUrl: dataSource.url,
     locale,
   };
-  const [metadataQuery] = useDataCubeMetadataQuery({
+  const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      iri: dataSetIri,
+      filters: [{ iri: dataSetIri }],
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({

--- a/app/charts/table/chart-table.tsx
+++ b/app/charts/table/chart-table.tsx
@@ -5,9 +5,9 @@ import { Table } from "@/charts/table/table";
 import { TableChart } from "@/charts/table/table-state";
 import { DataSource, TableConfig } from "@/configurator";
 import {
-  useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
@@ -30,10 +30,10 @@ export const ChartTableVisualization = ({
     sourceUrl: dataSource.url,
     locale,
   };
-  const [metadataQuery] = useDataCubeMetadataQuery({
+  const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      iri: dataSetIri,
+      filters: [{ iri: dataSetIri }],
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -35,8 +35,8 @@ import {
   useIsTrustedDataSource,
 } from "@/domain/datasource";
 import {
-  useDataCubeMetadataQuery,
   useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
 } from "@/graphql/query-hooks";
 import { DataCubePublicationStatus } from "@/graphql/resolver-types";
 import { useLocale } from "@/locales/use-locale";
@@ -137,10 +137,12 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
     sourceUrl: dataSource.url,
     locale,
   };
-  const [{ data: metadata }] = useDataCubeMetadataQuery({
+  const [{ data: metadata }] = useDataCubesMetadataQuery({
     variables: {
-      ...commonQueryVariables,
-      iri: chartConfig.dataSet,
+      sourceType: dataSource.type,
+      sourceUrl: dataSource.url,
+      locale,
+      filters: [{ iri: chartConfig.dataSet }],
     },
   });
   const componentIris = extractChartConfigsComponentIris(state.chartConfigs);
@@ -169,8 +171,9 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
     <MetadataPanelStoreContext.Provider value={metadataPanelStore}>
       <Box className={classes.root} ref={rootRef}>
         <ChartErrorBoundary resetKeys={[chartConfig]}>
-          {metadata?.dataCubeByIri?.publicationStatus ===
-            DataCubePublicationStatus.Draft && (
+          {metadata?.dataCubesMetadata.some(
+            (d) => d.publicationStatus === DataCubePublicationStatus.Draft
+          ) && (
             <Box sx={{ mb: 4 }}>
               <HintRed iconName="datasetError" iconSize={64}>
                 <Trans id="dataset.publicationStatus.draft.warning">
@@ -181,7 +184,7 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
               </HintRed>
             </Box>
           )}
-          {metadata?.dataCubeByIri?.expires && (
+          {metadata?.dataCubesMetadata.some((d) => d.expires) && (
             <Box sx={{ mb: 4 }}>
               <HintRed iconName="datasetError" iconSize={64}>
                 <Trans id="dataset.publicationStatus.expires.warning">

--- a/app/components/chart-selection-tabs.tsx
+++ b/app/components/chart-selection-tabs.tsx
@@ -19,10 +19,7 @@ import {
 } from "@/configurator";
 import { ChartTypeSelector } from "@/configurator/components/chart-type-selector";
 import { getIconName } from "@/configurator/components/ui-helpers";
-import {
-  useDataCubeMetadataQuery,
-  useDataCubesComponentsQuery,
-} from "@/graphql/query-hooks";
+import { useDataCubesComponentsQuery } from "@/graphql/query-hooks";
 import { Icon, IconName } from "@/icons";
 import { useLocale } from "@/src";
 import { fetchChartConfig } from "@/utils/chart-config/api";
@@ -260,21 +257,13 @@ const PublishChartButton = () => {
     sourceType: state.dataSource.type,
     sourceUrl: state.dataSource.url,
     locale,
+    filters: [{ iri: chartConfig.dataSet }],
   };
-  const [{ data: metadata }] = useDataCubeMetadataQuery({
-    variables: {
-      ...commonQueryVariables,
-      iri: chartConfig.dataSet,
-    },
-  });
   const [{ data: components }] = useDataCubesComponentsQuery({
-    variables: {
-      ...commonQueryVariables,
-      filters: [{ iri: chartConfig.dataSet }],
-    },
+    variables: commonQueryVariables,
   });
   const goNext = useEvent(() => {
-    if (metadata?.dataCubeByIri && components?.dataCubesComponents) {
+    if (components?.dataCubesComponents) {
       dispatch({
         type: "STEP_NEXT",
         dataCubesComponents: components.dataCubesComponents,
@@ -301,7 +290,7 @@ const PublishChartButton = () => {
     <Button
       color="primary"
       variant="contained"
-      onClick={metadata && components ? goNext : undefined}
+      onClick={components ? goNext : undefined}
       sx={{ minWidth: "fit-content" }}
     >
       {editingPublishedChart ? (

--- a/app/components/dataset-metadata.tsx
+++ b/app/components/dataset-metadata.tsx
@@ -37,6 +37,7 @@ export const DataSetMetadata = ({
       filters: [{ iri: dataSetIri }],
     },
   });
+  // FIXME: adapt to design
   const cube = data?.dataCubesMetadata[0];
   const openDataLink = cube ? makeOpenDataLink(locale, cube) : null;
   if (fetching || error || !cube) {

--- a/app/components/dataset-metadata.tsx
+++ b/app/components/dataset-metadata.tsx
@@ -13,12 +13,10 @@ import React, { ReactNode } from "react";
 
 import Tag from "@/components/tag";
 import { DataSource } from "@/config-types";
+import { DataCubeMetadata } from "@/domain/data";
 import { truthy } from "@/domain/types";
 import { useFormatDate } from "@/formatters";
-import {
-  DataCubeMetadataQuery,
-  useDataCubeMetadataQuery,
-} from "@/graphql/query-hooks";
+import { useDataCubesMetadataQuery } from "@/graphql/query-hooks";
 import { Icon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
 import { makeOpenDataLink } from "@/utils/opendata";
@@ -32,16 +30,16 @@ export const DataSetMetadata = ({
 }) => {
   const locale = useLocale();
   const formatDate = useFormatDate();
-  const [{ data, fetching, error }] = useDataCubeMetadataQuery({
+  const [{ data, fetching, error }] = useDataCubesMetadataQuery({
     variables: {
-      iri: dataSetIri,
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
+      filters: [{ iri: dataSetIri }],
     },
   });
-  const cube = data?.dataCubeByIri;
-  const openDataLink = makeOpenDataLink(locale, cube);
+  const cube = data?.dataCubesMetadata[0];
+  const openDataLink = cube ? makeOpenDataLink(locale, cube) : null;
   if (fetching || error || !cube) {
     // The error and loading are managed by the component
     // displayed in the middle panel
@@ -83,10 +81,10 @@ export const DataSetMetadata = ({
         <Trans id="dataset.metadata.email">Contact points</Trans>
       </DatasetMetadataTitle>
       <DatasetMetadataBody>
-        {cube.contactEmail ? (
+        {cube.contactPoint?.email && cube.contactPoint.name ? (
           <DatasetMetadataLink
-            href={`mailto:${cube.contactEmail}`}
-            label={cube.contactName ?? cube.contactEmail}
+            href={`mailto:${cube.contactPoint.email}`}
+            label={cube.contactPoint.name ?? cube.contactPoint.email}
           />
         ) : (
           "–"
@@ -171,18 +169,14 @@ const DatasetMetadataLink = ({
   </Link>
 );
 
-const DatasetTags = ({
-  cube,
-}: {
-  cube: NonNullable<DataCubeMetadataQuery["dataCubeByIri"]>;
-}) => {
+const DatasetTags = ({ cube }: { cube: DataCubeMetadata }) => {
   return (
     <>
       <DatasetMetadataTitle>
         <Trans id="dataset-preview.keywords">Keywords</Trans>
       </DatasetMetadataTitle>
       <Stack spacing={1} direction="column" sx={{ mt: 3 }}>
-        {[cube.creator, ...cube.themes].filter(truthy).map((t) => {
+        {[cube.creator, ...(cube.themes ?? [])].filter(truthy).map((t) => {
           const type =
             t.__typename === "DataCubeTheme" ? "theme" : "organization";
 

--- a/app/components/dataset-metadata.tsx
+++ b/app/components/dataset-metadata.tsx
@@ -14,7 +14,6 @@ import React, { ReactNode } from "react";
 import Tag from "@/components/tag";
 import { DataSource } from "@/config-types";
 import { DataCubeMetadata } from "@/domain/data";
-import { truthy } from "@/domain/types";
 import { useFormatDate } from "@/formatters";
 import { useDataCubesMetadataQuery } from "@/graphql/query-hooks";
 import { Icon } from "@/icons";
@@ -176,37 +175,58 @@ const DatasetTags = ({ cube }: { cube: DataCubeMetadata }) => {
         <Trans id="dataset-preview.keywords">Keywords</Trans>
       </DatasetMetadataTitle>
       <Stack spacing={1} direction="column" sx={{ mt: 3 }}>
-        {[cube.creator, ...(cube.themes ?? [])].filter(truthy).map((t) => {
-          const type =
-            t.__typename === "DataCubeTheme" ? "theme" : "organization";
-
-          return t.label ? (
-            <NextLink
-              key={t.iri}
-              href={`/browse/${type}/${encodeURIComponent(t.iri)}`}
-              passHref
-              legacyBehavior
-            >
-              <Tag
-                component={MUILink}
-                // @ts-ignore
-                underline="none"
-                type={type}
-                title={t.label || undefined}
-                sx={{
-                  maxWidth: "100%",
-                  display: "flex",
-                  whiteSpace: "nowrap",
-                  textOverflow: "ellipsis",
-                  overflow: "hidden",
-                }}
-              >
-                {t.label}
-              </Tag>
-            </NextLink>
-          ) : null;
-        })}
+        {cube.creator?.iri && (
+          <DatasetMetadataTag
+            type="organization"
+            iri={cube.creator.iri}
+            label={cube.creator.label}
+          />
+        )}
+        {cube.themes?.map((t) => (
+          <DatasetMetadataTag
+            key={t.iri}
+            type="theme"
+            iri={t.iri}
+            label={t.label}
+          />
+        ))}
       </Stack>
     </>
+  );
+};
+
+type DatasetMetadataTagProps = {
+  type: "organization" | "theme";
+  iri: string;
+  label?: string | null;
+};
+
+const DatasetMetadataTag = (props: DatasetMetadataTagProps) => {
+  const { type, iri, label } = props;
+
+  return (
+    <NextLink
+      key={iri}
+      href={`/browse/${type}/${encodeURIComponent(iri)}`}
+      passHref
+      legacyBehavior
+    >
+      <Tag
+        component={MUILink}
+        // @ts-ignore
+        underline="none"
+        type={type}
+        title={label ?? undefined}
+        sx={{
+          maxWidth: "100%",
+          display: "flex",
+          whiteSpace: "nowrap",
+          textOverflow: "ellipsis",
+          overflow: "hidden",
+        }}
+      >
+        {label}
+      </Tag>
+    </NextLink>
   );
 };

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -311,7 +311,6 @@ const useFilterReorder = ({
     chartConfig.dataSet,
   ]);
 
-  // const metadata = metadataData?.dataCubesMetadata;
   const dimensions = componentsData?.dataCubesComponents?.dimensions;
   const measures = componentsData?.dataCubesComponents?.measures;
 

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -73,11 +73,9 @@ import {
   Measure,
 } from "@/domain/data";
 import {
-  DataCubeMetadataQuery,
   PossibleFiltersDocument,
   PossibleFiltersQuery,
   PossibleFiltersQueryVariables,
-  useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
 } from "@/graphql/query-hooks";
@@ -280,12 +278,6 @@ const useFilterReorder = ({
   ]);
 
   const [
-    { data: metadataData, fetching: metadataFetching },
-    executeMetadataQuery,
-  ] = useDataCubeMetadataQuery({
-    variables,
-  });
-  const [
     { data: componentsData, fetching: componentsFetching },
     exectueComponentsQuery,
   ] = useDataCubesComponentsQuery({
@@ -300,7 +292,6 @@ const useFilterReorder = ({
   });
 
   useEffect(() => {
-    executeMetadataQuery({ variables });
     exectueComponentsQuery({
       variables: {
         sourceType: state.dataSource.type,
@@ -313,7 +304,6 @@ const useFilterReorder = ({
     });
   }, [
     variables,
-    executeMetadataQuery,
     exectueComponentsQuery,
     state.dataSource.type,
     state.dataSource.url,
@@ -321,13 +311,13 @@ const useFilterReorder = ({
     chartConfig.dataSet,
   ]);
 
-  const metadata = metadataData?.dataCubeByIri;
+  // const metadata = metadataData?.dataCubesMetadata;
   const dimensions = componentsData?.dataCubesComponents?.dimensions;
   const measures = componentsData?.dataCubesComponents?.measures;
 
   // Handlers
   const handleMove = useEvent((dimensionIri: string, delta: number) => {
-    if (!metadata || !dimensions || !measures) {
+    if (!dimensions || !measures) {
       return;
     }
 
@@ -342,7 +332,6 @@ const useFilterReorder = ({
       type: "CHART_CONFIG_REPLACED",
       value: {
         chartConfig: newChartConfig,
-        dataCubeMetadata: metadata,
         dataCubesComponents: {
           dimensions,
           measures,
@@ -389,8 +378,7 @@ const useFilterReorder = ({
   const { fetching: possibleFiltersFetching } = useEnsurePossibleFilters({
     state,
   });
-  const fetching =
-    possibleFiltersFetching || metadataFetching || componentsFetching;
+  const fetching = possibleFiltersFetching || componentsFetching;
 
   const { filterDimensions, addableDimensions } = useMemo(() => {
     const keysOrder = Object.fromEntries(
@@ -422,7 +410,6 @@ const useFilterReorder = ({
     handleMove,
     handleDragEnd,
     fetching,
-    metadata,
     dimensions,
     measures,
     filterDimensions,
@@ -556,7 +543,6 @@ export const ChartConfigurator = ({
     handleAddDimensionFilter,
     handleRemoveDimensionFilter,
     handleDragEnd,
-    metadata,
     dimensions,
     measures,
     filterDimensions,
@@ -575,7 +561,7 @@ export const ChartConfigurator = ({
 
   const classes = useStyles({ fetching });
 
-  if (!metadata || !dimensions || !measures) {
+  if (!dimensions || !measures) {
     return (
       <>
         <ControlSectionSkeleton />
@@ -612,7 +598,6 @@ export const ChartConfigurator = ({
           <ChartFields
             dataSource={state.dataSource}
             chartConfig={chartConfig}
-            metadata={metadata}
             dimensions={dimensions}
             measures={measures}
           />
@@ -762,13 +747,12 @@ export const ChartConfigurator = ({
 type ChartFieldsProps = {
   dataSource: DataSource;
   chartConfig: ChartConfig;
-  metadata: NonNullable<DataCubeMetadataQuery["dataCubeByIri"]>;
   dimensions: Dimension[];
   measures: Measure[];
 };
 
 const ChartFields = (props: ChartFieldsProps) => {
-  const { dataSource, chartConfig, metadata, dimensions, measures } = props;
+  const { dataSource, chartConfig, dimensions, measures } = props;
   const components = [...dimensions, ...measures];
   const queryFilters = useQueryFilters({ chartConfig });
   const locale = useLocale();
@@ -776,7 +760,7 @@ const ChartFields = (props: ChartFieldsProps) => {
   const [{ data: observationsData }] = useDataCubeObservationsQuery({
     variables: {
       locale,
-      iri: metadata.iri,
+      iri: chartConfig.dataSet,
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       componentIris: components.map((d) => d.iri),

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -80,7 +80,6 @@ import {
   Observation,
 } from "@/domain/data";
 import {
-  useDataCubeMetadataQuery,
   useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
 } from "@/graphql/query-hooks";
@@ -103,9 +102,6 @@ export const ChartOptionsSelector = ({
     sourceUrl: dataSource.url,
     locale,
   };
-  const [{ data: metadataData }] = useDataCubeMetadataQuery({
-    variables: commonVariables,
-  });
   const [{ data: componentsData }] = useDataCubesComponentsQuery({
     variables: {
       sourceType: dataSource.type,
@@ -121,12 +117,11 @@ export const ChartOptionsSelector = ({
     },
   });
 
-  const metadata = metadataData?.dataCubeByIri;
   const dimensions = componentsData?.dataCubesComponents.dimensions;
   const measures = componentsData?.dataCubesComponents.measures;
   const observations = observationsData?.dataCubeByIri?.observations.data;
 
-  return metadata && dimensions && measures && observations ? (
+  return dimensions && measures && observations ? (
     <Box
       sx={{
         // we need these overflow parameters to allow iOS scrolling
@@ -138,7 +133,6 @@ export const ChartOptionsSelector = ({
         isTableConfig(chartConfig) ? (
           <TableColumnOptions
             state={state}
-            metadata={metadata}
             dimensions={dimensions}
             measures={measures}
           />

--- a/app/configurator/table/table-chart-configurator.hook.tsx
+++ b/app/configurator/table/table-chart-configurator.hook.tsx
@@ -11,10 +11,7 @@ import {
   useConfiguratorState,
 } from "@/configurator/configurator-state";
 import { moveFields } from "@/configurator/table/table-config-state";
-import {
-  useDataCubeMetadataQuery,
-  useDataCubesComponentsQuery,
-} from "@/graphql/query-hooks";
+import { useDataCubesComponentsQuery } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
 export const useTableChartController = (
@@ -23,14 +20,6 @@ export const useTableChartController = (
   const locale = useLocale();
   const [, dispatch] = useConfiguratorState(isConfiguring);
   const chartConfig = getChartConfig(state);
-  const [{ data: metadata }] = useDataCubeMetadataQuery({
-    variables: {
-      iri: chartConfig.dataSet,
-      sourceType: state.dataSource.type,
-      sourceUrl: state.dataSource.url,
-      locale,
-    },
-  });
   const [{ data: components }] = useDataCubesComponentsQuery({
     variables: {
       sourceType: state.dataSource.type,
@@ -57,7 +46,7 @@ export const useTableChartController = (
       if (
         !destination ||
         chartConfig.chartType !== "table" ||
-        !(metadata?.dataCubeByIri && components?.dataCubesComponents)
+        !components?.dataCubesComponents
       ) {
         return;
       }
@@ -71,17 +60,11 @@ export const useTableChartController = (
         type: "CHART_CONFIG_REPLACED",
         value: {
           chartConfig: newChartConfig,
-          dataCubeMetadata: metadata.dataCubeByIri,
           dataCubesComponents: components.dataCubesComponents,
         },
       });
     },
-    [
-      chartConfig,
-      components?.dataCubesComponents,
-      dispatch,
-      metadata?.dataCubeByIri,
-    ]
+    [chartConfig, components?.dataCubesComponents, dispatch]
   );
 
   const handleDragStart = useCallback<OnDragStartResponder>(
@@ -107,7 +90,6 @@ export const useTableChartController = (
   );
 
   return {
-    metadata,
     dimensions: components?.dataCubesComponents.dimensions,
     measures: components?.dataCubesComponents.measures,
     currentDraggableId,

--- a/app/configurator/table/table-chart-options.tsx
+++ b/app/configurator/table/table-chart-options.tsx
@@ -51,7 +51,6 @@ import {
   isTemporalDimension,
   Measure,
 } from "@/domain/data";
-import { DataCubeMetadataQuery } from "@/graphql/query-hooks";
 import {
   getDefaultCategoricalPalette,
   getDefaultCategoricalPaletteName,
@@ -61,13 +60,11 @@ import {
 const useTableColumnGroupHiddenField = ({
   path,
   field,
-  metadata,
   dimensions,
   measures,
 }: {
   path: "isGroup" | "isHidden";
   field: string;
-  metadata: DataCubeMetadataQuery["dataCubeByIri"];
   dimensions: Dimension[];
   measures: Measure[];
 }): FieldProps => {
@@ -75,7 +72,7 @@ const useTableColumnGroupHiddenField = ({
   const chartConfig = getChartConfig(state);
   const onChange = useCallback<(e: ChangeEvent<HTMLInputElement>) => void>(
     (e) => {
-      if (!isTableConfig(chartConfig) || !metadata) {
+      if (!isTableConfig(chartConfig)) {
         return;
       }
 
@@ -89,7 +86,6 @@ const useTableColumnGroupHiddenField = ({
         type: "CHART_CONFIG_REPLACED",
         value: {
           chartConfig: newChartConfig,
-          dataCubeMetadata: metadata,
           dataCubesComponents: {
             dimensions,
             measures,
@@ -97,7 +93,7 @@ const useTableColumnGroupHiddenField = ({
         },
       });
     },
-    [chartConfig, path, field, dispatch, metadata, dimensions, measures]
+    [chartConfig, path, field, dispatch, dimensions, measures]
   );
   const stateValue = get(chartConfig, `fields["${field}"].${path}`, "");
   const checked = stateValue ? stateValue : false;
@@ -115,7 +111,6 @@ const ChartOptionGroupHiddenField = ({
   path,
   defaultChecked,
   disabled = false,
-  metadata,
   dimensions,
   measures,
 }: {
@@ -124,14 +119,12 @@ const ChartOptionGroupHiddenField = ({
   path: "isGroup" | "isHidden";
   defaultChecked?: boolean;
   disabled?: boolean;
-  metadata: DataCubeMetadataQuery["dataCubeByIri"];
   dimensions: Dimension[];
   measures: Measure[];
 }) => {
   const fieldProps = useTableColumnGroupHiddenField({
     field,
     path,
-    metadata,
     dimensions,
     measures,
   });
@@ -148,12 +141,10 @@ const ChartOptionGroupHiddenField = ({
 
 export const TableColumnOptions = ({
   state,
-  metadata,
   dimensions,
   measures,
 }: {
   state: ConfiguratorStateConfiguringChart;
-  metadata: NonNullable<DataCubeMetadataQuery["dataCubeByIri"]>;
   dimensions: Dimension[];
   measures: Measure[];
 }) => {
@@ -177,7 +168,6 @@ export const TableColumnOptions = ({
     return (
       <TableSortingOptions
         state={state}
-        metadata={metadata}
         dimensions={dimensions}
         measures={measures}
       />
@@ -257,7 +247,6 @@ export const TableColumnOptions = ({
               })}
               field={activeField}
               path="isGroup"
-              metadata={metadata}
               dimensions={dimensions}
               measures={measures}
             />
@@ -269,7 +258,6 @@ export const TableColumnOptions = ({
             })}
             field={activeField}
             path="isHidden"
-            metadata={metadata}
             dimensions={dimensions}
             measures={measures}
           />
@@ -359,7 +347,7 @@ export const TableColumnOptions = ({
                 key={component.iri}
                 field={component.iri}
                 dimension={component}
-                dataSetIri={metadata.iri}
+                dataSetIri={chartConfig.dataSet}
                 colorComponent={component}
                 colorConfigPath="columnStyle"
               />

--- a/app/configurator/table/table-chart-sorting-options.tsx
+++ b/app/configurator/table/table-chart-sorting-options.tsx
@@ -40,7 +40,6 @@ import {
   removeSortingOption,
 } from "@/configurator/table/table-config-state";
 import { Dimension, isNumericalMeasure, Measure } from "@/domain/data";
-import { DataCubeMetadataQuery } from "@/graphql/query-hooks";
 import { Icon } from "@/icons";
 import useEvent from "@/utils/use-event";
 
@@ -97,7 +96,6 @@ const useStyles = makeStyles<Theme>((theme) => ({
 }));
 
 const TableSortingOptionItem = ({
-  metadata,
   dimensions,
   measures,
   componentIri,
@@ -105,7 +103,6 @@ const TableSortingOptionItem = ({
   chartConfig,
   sortingOrder,
 }: {
-  metadata: DataCubeMetadataQuery["dataCubeByIri"];
   dimensions: Dimension[];
   measures: Measure[];
   index: number;
@@ -118,17 +115,12 @@ const TableSortingOptionItem = ({
   );
 
   const onRemove = useEvent(() => {
-    if (!metadata) {
-      return;
-    }
-
     dispatch({
       type: "CHART_CONFIG_REPLACED",
       value: {
         chartConfig: removeSortingOption(chartConfig, {
           index,
         }),
-        dataCubeMetadata: metadata,
         dataCubesComponents: {
           dimensions,
           measures,
@@ -138,10 +130,6 @@ const TableSortingOptionItem = ({
   });
 
   const onChangeSortingOrder = useEvent((e: ChangeEvent<HTMLInputElement>) => {
-    if (!metadata) {
-      return;
-    }
-
     dispatch({
       type: "CHART_CONFIG_REPLACED",
       value: {
@@ -149,7 +137,6 @@ const TableSortingOptionItem = ({
           index,
           sortingOrder: e.currentTarget.value as "asc" | "desc",
         }),
-        dataCubeMetadata: metadata,
         dataCubesComponents: {
           dimensions,
           measures,
@@ -167,7 +154,6 @@ const TableSortingOptionItem = ({
       <Typography variant="body1" className={classes.selectWrapper}>
         <ChangeTableSortingOption
           index={index}
-          metadata={metadata}
           dimensions={dimensions}
           measures={measures}
           chartConfig={chartConfig}
@@ -208,12 +194,10 @@ const TableSortingOptionItem = ({
 };
 
 const AddTableSortingOption = ({
-  metadata,
   dimensions,
   measures,
   chartConfig,
 }: {
-  metadata: DataCubeMetadataQuery["dataCubeByIri"];
   dimensions: Dimension[];
   measures: Measure[];
   chartConfig: TableConfig;
@@ -222,10 +206,6 @@ const AddTableSortingOption = ({
 
   const onChange = useCallback(
     (e: SelectChangeEvent<unknown>) => {
-      if (!metadata) {
-        return;
-      }
-
       const { value } = e.target;
       const component = [...dimensions, ...measures].find(
         ({ iri }) => iri === value
@@ -240,7 +220,6 @@ const AddTableSortingOption = ({
               componentType: component.__typename,
               sortingOrder: "asc",
             }),
-            dataCubeMetadata: metadata,
             dataCubesComponents: {
               dimensions,
               measures,
@@ -249,7 +228,7 @@ const AddTableSortingOption = ({
         });
       }
     },
-    [chartConfig, dimensions, dispatch, measures, metadata]
+    [chartConfig, dimensions, dispatch, measures]
   );
 
   const columns = useOrderedTableColumns(chartConfig.fields);
@@ -305,13 +284,11 @@ const AddTableSortingOption = ({
 };
 
 const ChangeTableSortingOption = ({
-  metadata,
   dimensions,
   measures,
   chartConfig,
   index,
 }: {
-  metadata: DataCubeMetadataQuery["dataCubeByIri"];
   dimensions: Dimension[];
   measures: Measure[];
   chartConfig: TableConfig;
@@ -321,10 +298,6 @@ const ChangeTableSortingOption = ({
 
   const onChange = useCallback(
     (e: SelectChangeEvent<unknown>) => {
-      if (!metadata) {
-        return;
-      }
-
       const { value } = e.target;
       const component = [...dimensions, ...measures].find(
         ({ iri }) => iri === value
@@ -342,7 +315,6 @@ const ChangeTableSortingOption = ({
                 sortingOrder: "asc",
               },
             }),
-            dataCubeMetadata: metadata,
             dataCubesComponents: {
               dimensions,
               measures,
@@ -351,7 +323,7 @@ const ChangeTableSortingOption = ({
         });
       }
     },
-    [chartConfig, dimensions, dispatch, index, measures, metadata]
+    [chartConfig, dimensions, dispatch, index, measures]
   );
 
   const columns = useOrderedTableColumns(chartConfig.fields);
@@ -383,12 +355,10 @@ const ChangeTableSortingOption = ({
 
 export const TableSortingOptions = ({
   state,
-  metadata,
   dimensions,
   measures,
 }: {
   state: ConfiguratorStateConfiguringChart;
-  metadata: DataCubeMetadataQuery["dataCubeByIri"];
   dimensions: Dimension[];
   measures: Measure[];
 }) => {
@@ -399,7 +369,7 @@ export const TableSortingOptions = ({
 
   const onDragEnd = useCallback<OnDragEndResponder>(
     ({ source, destination }) => {
-      if (!destination || chartConfig.chartType !== "table" || !metadata) {
+      if (!destination || chartConfig.chartType !== "table") {
         return;
       }
 
@@ -410,7 +380,6 @@ export const TableSortingOptions = ({
             source,
             destination,
           }),
-          dataCubeMetadata: metadata,
           dataCubesComponents: {
             dimensions,
             measures,
@@ -418,7 +387,7 @@ export const TableSortingOptions = ({
         },
       });
     },
-    [chartConfig, dimensions, dispatch, measures, metadata]
+    [chartConfig, dimensions, dispatch, measures]
   );
 
   if (!activeField || chartConfig.chartType !== "table") {
@@ -465,7 +434,6 @@ export const TableSortingOptions = ({
                               <TableSortingOptionItem
                                 {...option}
                                 index={i}
-                                metadata={metadata}
                                 dimensions={dimensions}
                                 measures={measures}
                                 chartConfig={chartConfig}
@@ -502,7 +470,6 @@ export const TableSortingOptions = ({
                   }}
                 >
                   <AddTableSortingOption
-                    metadata={metadata}
                     dimensions={dimensions}
                     measures={measures}
                     chartConfig={chartConfig}

--- a/app/domain/data.ts
+++ b/app/domain/data.ts
@@ -2,7 +2,9 @@ import { Literal, NamedNode, Term } from "rdf-js";
 
 import { ComponentType } from "@/config-types";
 import {
+  DataCubeOrganization,
   DataCubePublicationStatus,
+  DataCubeTheme,
   RelatedDimension,
   ScaleType,
   TimeUnit,
@@ -43,6 +45,29 @@ export type Observation = Record<string, ObservationValue>;
 export type DataCubesComponents = {
   dimensions: Dimension[];
   measures: Measure[];
+};
+
+export type DataCubeMetadata = {
+  iri: string;
+  identifier: string;
+  title: string;
+  description: string;
+  version?: string;
+  datePublished?: string;
+  dateModified?: string;
+  publicationStatus: DataCubePublicationStatus;
+  themes?: DataCubeTheme[];
+  creator?: DataCubeOrganization;
+  versionHistory?: string;
+  contactPoint?: {
+    name?: string;
+    email?: string;
+  };
+  publisher?: string;
+  landingPage?: string;
+  expires?: string;
+  keywords?: string[];
+  workExamples?: string[];
 };
 
 export type Component = Dimension | Measure;

--- a/app/domain/data.ts
+++ b/app/domain/data.ts
@@ -49,7 +49,7 @@ export type DataCubesComponents = {
 
 export type DataCubeMetadata = {
   iri: string;
-  identifier: string;
+  identifier?: string;
   title: string;
   description: string;
   version?: string;
@@ -66,7 +66,6 @@ export type DataCubeMetadata = {
   publisher?: string;
   landingPage?: string;
   expires?: string;
-  keywords?: string[];
   workExamples?: string[];
 };
 

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -89,6 +89,20 @@ query DataCubeMetadata(
   }
 }
 
+query DataCubesMetadata(
+  $sourceType: String!
+  $sourceUrl: String!
+  $locale: String!
+  $filters: [DataCubeFilter!]!
+) {
+  dataCubesMetadata(
+    sourceType: $sourceType
+    sourceUrl: $sourceUrl
+    locale: $locale
+    filters: $filters
+  )
+}
+
 query DataCubesComponents(
   $sourceType: String!
   $sourceUrl: String!

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -50,45 +50,6 @@ query DataCubePreview(
   }
 }
 
-query DataCubeMetadata(
-  $iri: String!
-  $sourceType: String!
-  $sourceUrl: String!
-  $locale: String!
-  $latest: Boolean
-) {
-  dataCubeByIri(
-    iri: $iri
-    sourceType: $sourceType
-    sourceUrl: $sourceUrl
-    locale: $locale
-    latest: $latest
-  ) {
-    iri
-    identifier
-    title
-    description
-    publisher
-    version
-    workExamples
-    contactName
-    contactEmail
-    landingPage
-    expires
-    datePublished
-    dateModified
-    publicationStatus
-    themes {
-      iri
-      label
-    }
-    creator {
-      iri
-      label
-    }
-  }
-}
-
 query DataCubesMetadata(
   $sourceType: String!
   $sourceUrl: String!

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -586,17 +586,6 @@ export type DataCubePreviewQueryVariables = Exact<{
 
 export type DataCubePreviewQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', iri: string, title: string, description?: Maybe<string>, publicationStatus: DataCubePublicationStatus, observations: { __typename: 'ObservationsQuery', data: Array<Observation>, sparql: string, sparqlEditorUrl?: Maybe<string> } }> };
 
-export type DataCubeMetadataQueryVariables = Exact<{
-  iri: Scalars['String'];
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  locale: Scalars['String'];
-  latest?: Maybe<Scalars['Boolean']>;
-}>;
-
-
-export type DataCubeMetadataQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', iri: string, identifier?: Maybe<string>, title: string, description?: Maybe<string>, publisher?: Maybe<string>, version?: Maybe<string>, workExamples?: Maybe<Array<Maybe<string>>>, contactName?: Maybe<string>, contactEmail?: Maybe<string>, landingPage?: Maybe<string>, expires?: Maybe<string>, datePublished?: Maybe<string>, dateModified?: Maybe<string>, publicationStatus: DataCubePublicationStatus, themes: Array<{ __typename: 'DataCubeTheme', iri: string, label?: Maybe<string> }>, creator?: Maybe<{ __typename: 'DataCubeOrganization', iri: string, label?: Maybe<string> }> }> };
-
 export type DataCubesMetadataQueryVariables = Exact<{
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
@@ -712,44 +701,6 @@ export const DataCubePreviewDocument = gql`
 
 export function useDataCubePreviewQuery(options: Omit<Urql.UseQueryArgs<DataCubePreviewQueryVariables>, 'query'> = {}) {
   return Urql.useQuery<DataCubePreviewQuery>({ query: DataCubePreviewDocument, ...options });
-};
-export const DataCubeMetadataDocument = gql`
-    query DataCubeMetadata($iri: String!, $sourceType: String!, $sourceUrl: String!, $locale: String!, $latest: Boolean) {
-  dataCubeByIri(
-    iri: $iri
-    sourceType: $sourceType
-    sourceUrl: $sourceUrl
-    locale: $locale
-    latest: $latest
-  ) {
-    iri
-    identifier
-    title
-    description
-    publisher
-    version
-    workExamples
-    contactName
-    contactEmail
-    landingPage
-    expires
-    datePublished
-    dateModified
-    publicationStatus
-    themes {
-      iri
-      label
-    }
-    creator {
-      iri
-      label
-    }
-  }
-}
-    `;
-
-export function useDataCubeMetadataQuery(options: Omit<Urql.UseQueryArgs<DataCubeMetadataQueryVariables>, 'query'> = {}) {
-  return Urql.useQuery<DataCubeMetadataQuery>({ query: DataCubeMetadataDocument, ...options });
 };
 export const DataCubesMetadataDocument = gql`
     query DataCubesMetadata($sourceType: String!, $sourceUrl: String!, $locale: String!, $filters: [DataCubeFilter!]!) {

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -1,3 +1,4 @@
+import { DataCubeMetadata } from '../domain/data';
 import { DataCubesComponents } from '../domain/data';
 import { DimensionValue } from '../domain/data';
 import { QueryFilters } from '../configurator';
@@ -19,6 +20,7 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
+  DataCubeMetadata: DataCubeMetadata;
   DataCubesComponents: DataCubesComponents;
   DimensionValue: DimensionValue;
   FilterValue: any;
@@ -94,6 +96,7 @@ export type DataCubeFilter = {
   filters?: Maybe<Scalars['Filters']>;
   latest?: Maybe<Scalars['Boolean']>;
 };
+
 
 export type DataCubeOrganization = {
   __typename: 'DataCubeOrganization';
@@ -366,6 +369,7 @@ export type OrdinalMeasureHierarchyArgs = {
 export type Query = {
   __typename: 'Query';
   dataCubesComponents: Scalars['DataCubesComponents'];
+  dataCubesMetadata: Array<Scalars['DataCubeMetadata']>;
   dataCubeByIri?: Maybe<DataCube>;
   possibleFilters: Array<ObservationFilter>;
   searchCubes: Array<SearchCubeResult>;
@@ -373,6 +377,14 @@ export type Query = {
 
 
 export type QueryDataCubesComponentsArgs = {
+  sourceType: Scalars['String'];
+  sourceUrl: Scalars['String'];
+  locale: Scalars['String'];
+  filters: Array<DataCubeFilter>;
+};
+
+
+export type QueryDataCubesMetadataArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
@@ -585,6 +597,16 @@ export type DataCubeMetadataQueryVariables = Exact<{
 
 export type DataCubeMetadataQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', iri: string, identifier?: Maybe<string>, title: string, description?: Maybe<string>, publisher?: Maybe<string>, version?: Maybe<string>, workExamples?: Maybe<Array<Maybe<string>>>, contactName?: Maybe<string>, contactEmail?: Maybe<string>, landingPage?: Maybe<string>, expires?: Maybe<string>, datePublished?: Maybe<string>, dateModified?: Maybe<string>, publicationStatus: DataCubePublicationStatus, themes: Array<{ __typename: 'DataCubeTheme', iri: string, label?: Maybe<string> }>, creator?: Maybe<{ __typename: 'DataCubeOrganization', iri: string, label?: Maybe<string> }> }> };
 
+export type DataCubesMetadataQueryVariables = Exact<{
+  sourceType: Scalars['String'];
+  sourceUrl: Scalars['String'];
+  locale: Scalars['String'];
+  filters: Array<DataCubeFilter> | DataCubeFilter;
+}>;
+
+
+export type DataCubesMetadataQuery = { __typename: 'Query', dataCubesMetadata: Array<DataCubeMetadata> };
+
 export type DataCubesComponentsQueryVariables = Exact<{
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
@@ -728,6 +750,20 @@ export const DataCubeMetadataDocument = gql`
 
 export function useDataCubeMetadataQuery(options: Omit<Urql.UseQueryArgs<DataCubeMetadataQueryVariables>, 'query'> = {}) {
   return Urql.useQuery<DataCubeMetadataQuery>({ query: DataCubeMetadataDocument, ...options });
+};
+export const DataCubesMetadataDocument = gql`
+    query DataCubesMetadata($sourceType: String!, $sourceUrl: String!, $locale: String!, $filters: [DataCubeFilter!]!) {
+  dataCubesMetadata(
+    sourceType: $sourceType
+    sourceUrl: $sourceUrl
+    locale: $locale
+    filters: $filters
+  )
+}
+    `;
+
+export function useDataCubesMetadataQuery(options: Omit<Urql.UseQueryArgs<DataCubesMetadataQueryVariables>, 'query'> = {}) {
+  return Urql.useQuery<DataCubesMetadataQuery>({ query: DataCubesMetadataDocument, ...options });
 };
 export const DataCubesComponentsDocument = gql`
     query DataCubesComponents($sourceType: String!, $sourceUrl: String!, $locale: String!, $filters: [DataCubeFilter!]!) {

--- a/app/graphql/resolver-types.ts
+++ b/app/graphql/resolver-types.ts
@@ -1,3 +1,4 @@
+import { DataCubeMetadata } from '../domain/data';
 import { DataCubesComponents } from '../domain/data';
 import { DimensionValue } from '../domain/data';
 import { Filters } from '../configurator';
@@ -20,6 +21,7 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
+  DataCubeMetadata: DataCubeMetadata;
   DataCubesComponents: DataCubesComponents;
   DimensionValue: DimensionValue;
   FilterValue: any;
@@ -95,6 +97,7 @@ export type DataCubeFilter = {
   filters?: Maybe<Scalars['Filters']>;
   latest?: Maybe<Scalars['Boolean']>;
 };
+
 
 export type DataCubeOrganization = {
   __typename?: 'DataCubeOrganization';
@@ -367,6 +370,7 @@ export type OrdinalMeasureHierarchyArgs = {
 export type Query = {
   __typename?: 'Query';
   dataCubesComponents: Scalars['DataCubesComponents'];
+  dataCubesMetadata: Array<Scalars['DataCubeMetadata']>;
   dataCubeByIri?: Maybe<DataCube>;
   possibleFilters: Array<ObservationFilter>;
   searchCubes: Array<SearchCubeResult>;
@@ -374,6 +378,14 @@ export type Query = {
 
 
 export type QueryDataCubesComponentsArgs = {
+  sourceType: Scalars['String'];
+  sourceUrl: Scalars['String'];
+  locale: Scalars['String'];
+  filters: Array<DataCubeFilter>;
+};
+
+
+export type QueryDataCubesMetadataArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
@@ -621,6 +633,7 @@ export type ResolversTypes = ResolversObject<{
   Int: ResolverTypeWrapper<Scalars['Int']>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
   DataCubeFilter: DataCubeFilter;
+  DataCubeMetadata: ResolverTypeWrapper<Scalars['DataCubeMetadata']>;
   DataCubeOrganization: ResolverTypeWrapper<DataCubeOrganization>;
   DataCubePublicationStatus: DataCubePublicationStatus;
   DataCubeTheme: ResolverTypeWrapper<DataCubeTheme>;
@@ -666,6 +679,7 @@ export type ResolversParentTypes = ResolversObject<{
   Int: Scalars['Int'];
   Boolean: Scalars['Boolean'];
   DataCubeFilter: DataCubeFilter;
+  DataCubeMetadata: Scalars['DataCubeMetadata'];
   DataCubeOrganization: DataCubeOrganization;
   DataCubeTheme: DataCubeTheme;
   DataCubesComponents: Scalars['DataCubesComponents'];
@@ -723,6 +737,10 @@ export type DataCubeResolvers<ContextType = VisualizeGraphQLContext, ParentType 
   themes?: Resolver<Array<ResolversTypes['DataCubeTheme']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
+
+export interface DataCubeMetadataScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DataCubeMetadata'], any> {
+  name: 'DataCubeMetadata';
+}
 
 export type DataCubeOrganizationResolvers<ContextType = VisualizeGraphQLContext, ParentType extends ResolversParentTypes['DataCubeOrganization'] = ResolversParentTypes['DataCubeOrganization']> = ResolversObject<{
   iri?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -911,6 +929,7 @@ export type OrdinalMeasureResolvers<ContextType = VisualizeGraphQLContext, Paren
 
 export type QueryResolvers<ContextType = VisualizeGraphQLContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
   dataCubesComponents?: Resolver<ResolversTypes['DataCubesComponents'], ParentType, ContextType, RequireFields<QueryDataCubesComponentsArgs, 'sourceType' | 'sourceUrl' | 'locale' | 'filters'>>;
+  dataCubesMetadata?: Resolver<Array<ResolversTypes['DataCubeMetadata']>, ParentType, ContextType, RequireFields<QueryDataCubesMetadataArgs, 'sourceType' | 'sourceUrl' | 'locale' | 'filters'>>;
   dataCubeByIri?: Resolver<Maybe<ResolversTypes['DataCube']>, ParentType, ContextType, RequireFields<QueryDataCubeByIriArgs, 'sourceType' | 'sourceUrl' | 'iri' | 'latest'>>;
   possibleFilters?: Resolver<Array<ResolversTypes['ObservationFilter']>, ParentType, ContextType, RequireFields<QueryPossibleFiltersArgs, 'iri' | 'sourceType' | 'sourceUrl' | 'filters'>>;
   searchCubes?: Resolver<Array<ResolversTypes['SearchCubeResult']>, ParentType, ContextType, RequireFields<QuerySearchCubesArgs, 'sourceType' | 'sourceUrl'>>;
@@ -998,6 +1017,7 @@ export interface ValuePositionScalarConfig extends GraphQLScalarTypeConfig<Resol
 
 export type Resolvers<ContextType = VisualizeGraphQLContext> = ResolversObject<{
   DataCube?: DataCubeResolvers<ContextType>;
+  DataCubeMetadata?: GraphQLScalarType;
   DataCubeOrganization?: DataCubeOrganizationResolvers<ContextType>;
   DataCubeTheme?: DataCubeThemeResolvers<ContextType>;
   DataCubesComponents?: GraphQLScalarType;

--- a/app/graphql/resolvers/index.ts
+++ b/app/graphql/resolvers/index.ts
@@ -29,6 +29,10 @@ export const Query: QueryResolvers = {
     const source = getSource(args.sourceType);
     return await source.dataCubesComponents(parent, args, context, info);
   },
+  dataCubesMetadata: async (parent, args, context, info) => {
+    const source = getSource(args.sourceType);
+    return await source.dataCubesMetadata(parent, args, context, info);
+  },
   dataCubeByIri: async (parent, args, context, info) => {
     const source = getSource(args.sourceType);
     return await source.dataCubeByIri(parent, args, context, info);

--- a/app/graphql/resolvers/sql.ts
+++ b/app/graphql/resolvers/sql.ts
@@ -129,6 +129,12 @@ export const dataCubesComponents: NonNullable<
   return { dimensions: [], measures: [] };
 };
 
+export const dataCubesMetadata: NonNullable<
+  QueryResolvers["dataCubesMetadata"]
+> = async () => {
+  return [];
+};
+
 export const dataCubeByIri: NonNullable<QueryResolvers["dataCubeByIri"]> =
   async (_, { iri }) => {
     const result = await fetchSQL({ path: `cubes/${iri}` });

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -351,6 +351,7 @@ input DataCubeFilter {
 }
 
 scalar DataCubesComponents
+scalar DataCubeMetadata
 
 # The "Query" type is special: it lists all of the available queries that
 # clients can execute, along with the return type for each.
@@ -361,6 +362,12 @@ type Query {
     locale: String!
     filters: [DataCubeFilter!]!
   ): DataCubesComponents!
+  dataCubesMetadata(
+    sourceType: String!
+    sourceUrl: String!
+    locale: String!
+    filters: [DataCubeFilter!]!
+  ): [DataCubeMetadata!]!
   dataCubeByIri(
     sourceType: String!
     sourceUrl: String!

--- a/app/graphql/shared-types.ts
+++ b/app/graphql/shared-types.ts
@@ -3,44 +3,17 @@ import { Literal, NamedNode } from "rdf-js";
 
 import { ExtendedCube } from "@/rdf/extended-cube";
 
-import { Observation } from "../domain/data";
+import { DataCubeMetadata, Observation } from "../domain/data";
 
 import { RelatedDimension } from "./query-hooks";
-import {
-  DataCubeOrganization,
-  DataCubePublicationStatus,
-  DataCubeTheme,
-  ScaleType,
-  TimeUnit,
-} from "./resolver-types";
+import { ScaleType, TimeUnit } from "./resolver-types";
 
 /** Types shared by graphql-codegen and resolver code */
 
 export type ResolvedDataCube = {
   cube: ExtendedCube;
   locale: string;
-  data: {
-    iri: string;
-    identifier: string;
-    title: string;
-    description: string;
-    version?: string;
-    datePublished?: string;
-    dateModified?: string;
-    publicationStatus: DataCubePublicationStatus;
-    themes?: DataCubeTheme[];
-    creator?: DataCubeOrganization;
-    versionHistory?: string;
-    contactPoint?: {
-      name?: string;
-      email?: string;
-    };
-    publisher?: string;
-    landingPage?: string;
-    expires?: string;
-    keywords?: string[];
-    workExamples?: string[];
-  };
+  data: DataCubeMetadata;
 };
 
 export type ResolvedDimension = {

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -27,7 +27,7 @@ import useDisclosure from "@/components/use-disclosure";
 import { ParsedConfig } from "@/db/config";
 import { sourceToLabel } from "@/domain/datasource";
 import { truthy } from "@/domain/types";
-import { useDataCubeMetadataQuery } from "@/graphql/query-hooks";
+import { useDataCubesMetadataQuery } from "@/graphql/query-hooks";
 import { Icon, IconName } from "@/icons";
 import { useRootStyles } from "@/login/utils";
 import { useLocale } from "@/src";
@@ -172,14 +172,14 @@ const ProfileVisualizationsRow = (props: ProfileVisualizationsRowProps) => {
   );
   const dataSet = dataSets.length === 1 ? dataSets[0] : null;
   const locale = useLocale();
-  const [{ data, fetching }] = useDataCubeMetadataQuery(
+  const [{ data, fetching }] = useDataCubesMetadataQuery(
     dataSet
       ? {
           variables: {
-            iri: dataSet,
             sourceType: dataSource.type,
             sourceUrl: dataSource.url,
             locale,
+            filters: [{ iri: dataSet }],
           },
         }
       : {
@@ -280,7 +280,7 @@ const ProfileVisualizationsRow = (props: ProfileVisualizationsRowProps) => {
           >
             <Link target="_blank" color="primary">
               <Typography variant="body2" noWrap>
-                {data?.dataCubeByIri?.title ?? ""}
+                {data?.dataCubesMetadata[0]?.title ?? ""}
               </Typography>
             </Link>
           </NextLink>

--- a/app/rdf/parse.ts
+++ b/app/rdf/parse.ts
@@ -90,7 +90,6 @@ export const parseCube = ({
       publisher: cube.out(ns.dcterms.publisher)?.value,
       landingPage: cube.out(ns.dcat.landingPage)?.value,
       expires: cube.out(ns.schema.expires)?.value,
-      keywords: cube.out(ns.dcat.keyword)?.values,
       workExamples: cube.out(ns.schema.workExample)?.values,
     },
   };

--- a/app/rdf/query-cube-metadata.ts
+++ b/app/rdf/query-cube-metadata.ts
@@ -1,9 +1,9 @@
 import RDF from "@rdfjs/data-model";
-import { SELECT, sparql } from "@tpluscode/sparql-builder";
+import { SELECT } from "@tpluscode/sparql-builder";
 import keyBy from "lodash/keyBy";
 import { ParsingClient } from "sparql-http-client/ParsingClient";
 
-import { schema, dcat, dcterms, cube } from "../../app/rdf/namespace";
+import { cube, schema } from "../../app/rdf/namespace";
 import { DataCubeOrganization, DataCubeTheme } from "../graphql/query-hooks";
 
 import { pragmas } from "./create-source";
@@ -54,8 +54,7 @@ export const createThemeLoader =
       });
     }
 
-    const parsed = results.map(parseSparqlTheme);
-    return parsed;
+    return results.map(parseSparqlTheme);
   };
 
 export const createOrganizationLoader =
@@ -80,118 +79,8 @@ export const createOrganizationLoader =
       });
     }
 
-    const parsed = results.map(parseSparqlOrganization);
-    return parsed;
+    return results.map(parseSparqlOrganization);
   };
-
-export const loadThemes = ({
-  locale,
-  sparqlClient,
-}: {
-  locale: string;
-  sparqlClient: ParsingClient;
-}) => {
-  return createThemeLoader({ locale, sparqlClient })();
-};
-
-export const loadOrganizations = ({
-  locale,
-  sparqlClient,
-}: {
-  locale: string;
-  sparqlClient: ParsingClient;
-}) => {
-  return createOrganizationLoader({ locale, sparqlClient })();
-};
-
-export const queryDatasetCountByOrganization = async ({
-  sparqlClient,
-  theme,
-  includeDrafts,
-}: {
-  sparqlClient: ParsingClient;
-  theme?: string;
-  includeDrafts?: boolean;
-}) => {
-  const query = SELECT`(count(?iri) as ?count) ?creator`.WHERE`
-    ?iri ${dcterms.creator} ?creator.
-    ${theme ? sparql`?iri ${dcat.theme} <${theme}>.` : ``}
-    ${makeVisualizeDatasetFilter({ includeDrafts })}
-  `.GROUP().BY`?creator`.build();
-  const results = await sparqlClient.query.select(query, {
-    operation: "postUrlencoded",
-  });
-  return results
-    .map((r) => {
-      return {
-        count: parseInt(r.count.value, 10),
-        iri: r.creator?.value,
-      };
-    })
-    .filter((r) => r.iri);
-};
-
-export const queryDatasetCountByTheme = async ({
-  sparqlClient,
-  organization,
-  includeDrafts,
-}: {
-  sparqlClient: ParsingClient;
-  organization?: string;
-  includeDrafts?: boolean;
-}) => {
-  const query = SELECT`(count(?iri) as ?count) ?theme`.WHERE`
-    ?iri ${dcat.theme} ?theme.
-    ${organization ? sparql`?iri ${dcterms.creator} <${organization}>.` : ``}
-    ?theme ${
-      schema.inDefinedTermSet
-    } <https://register.ld.admin.ch/opendataswiss/category>.
-    ${makeVisualizeDatasetFilter({ includeDrafts })}
-  `.GROUP().BY`?theme`.build();
-  const results = await sparqlClient.query.select(query, {
-    operation: "postUrlencoded",
-  });
-  return results
-    .map((r) => {
-      return {
-        count: parseInt(r.count.value, 10),
-        iri: r.theme?.value,
-      };
-    })
-    .filter((r) => r.iri);
-};
-
-export const queryDatasetCountBySubTheme = async ({
-  sparqlClient,
-  organization,
-  theme,
-  includeDrafts,
-}: {
-  sparqlClient: ParsingClient;
-  organization?: string;
-  theme?: string;
-  includeDrafts?: boolean;
-}) => {
-  const baseQuery = SELECT`(count(?iri) as ?count) ?subtheme`.WHERE`
-    ?iri ${schema.about} ?subtheme.
-    ${organization ? sparql`?iri ${dcterms.creator} <${organization}>.` : ``}
-    ${theme ? sparql`?iri ${dcat.theme} <${theme}>.` : ``}
-    ?iri ${schema.about} ?subtheme. 
-    ${makeVisualizeDatasetFilter({ includeDrafts })}
-  `.build();
-  const query = `${baseQuery} GROUP BY ?subtheme`;
-  const results = await sparqlClient.query.select(query, {
-    operation: "postUrlencoded",
-  });
-  return results
-    .map((r) => {
-      return {
-        count: parseInt(r.count.value, 10),
-        iri: r.subtheme?.value,
-      };
-    })
-    .filter((r) => r.iri);
-};
 
 export const queryLatestPublishedCubeFromUnversionedIri = async (
   sparqlClient: ParsingClient,
@@ -227,28 +116,4 @@ export const queryLatestPublishedCubeFromUnversionedIri = async (
   return {
     iri: results[0].iri.value,
   };
-};
-
-export const loadSubthemes = async ({
-  sparqlClient,
-  parentIri,
-  locale,
-}: {
-  sparqlClient: ParsingClient;
-  parentIri: string;
-  locale: string;
-}) => {
-  const query = SELECT`?iri ?label`.WHERE`
-    ?iri ${schema.inDefinedTermSet} <${parentIri}>;
-    ${makeLocalesFilter("?iri", schema.name, "?label", locale)}
-  `.build();
-  const results = await sparqlClient.query.select(query, {
-    operation: "postUrlencoded",
-  });
-  return results.map((r) => {
-    return {
-      iri: r.iri.value,
-      label: r.label.value,
-    };
-  });
 };

--- a/app/rdf/query-cube-metadata.ts
+++ b/app/rdf/query-cube-metadata.ts
@@ -1,14 +1,171 @@
 import RDF from "@rdfjs/data-model";
 import { SELECT } from "@tpluscode/sparql-builder";
 import keyBy from "lodash/keyBy";
+import { Literal, NamedNode } from "rdf-js";
 import { ParsingClient } from "sparql-http-client/ParsingClient";
 
+import { DataCubeMetadata } from "@/domain/data";
+import * as ns from "@/rdf/namespace";
+
 import { cube, schema } from "../../app/rdf/namespace";
-import { DataCubeOrganization, DataCubeTheme } from "../graphql/query-hooks";
+import {
+  DataCubeOrganization,
+  DataCubePublicationStatus,
+  DataCubeTheme,
+} from "../graphql/query-hooks";
 
 import { pragmas } from "./create-source";
 import { makeLocalesFilter } from "./query-labels";
-import { makeVisualizeDatasetFilter } from "./query-utils";
+import {
+  GROUP_SEPARATOR,
+  buildLocalizedSubQuery,
+  makeVisualizeDatasetFilter,
+} from "./query-utils";
+
+type RawDataCubeMetadata = {
+  iri: NamedNode;
+  identifier: NamedNode;
+  title: Literal;
+  description: Literal;
+  version: Literal;
+  datePublished: Literal;
+  dateModified: Literal;
+  status: NamedNode;
+  themeIris: NamedNode;
+  themeLabels: Literal;
+  creatorIri: NamedNode;
+  creatorLabel: Literal;
+  versionHistory: NamedNode;
+  contactPointEmail: Literal;
+  contactPointName: Literal;
+  publisher: NamedNode;
+  landingPage: NamedNode;
+  expires: Literal;
+  workExamples: NamedNode;
+};
+
+const parseRawMetadata = (cube: RawDataCubeMetadata): DataCubeMetadata => {
+  const themeIris = cube.themeIris.value.split(GROUP_SEPARATOR);
+  const themeLabels = cube.themeLabels.value.split(GROUP_SEPARATOR);
+
+  return {
+    iri: cube.iri.value,
+    identifier: cube.identifier?.value,
+    title: cube.title.value,
+    description: cube.description?.value,
+    version: cube.version?.value,
+    datePublished: cube.datePublished?.value,
+    dateModified: cube.dateModified?.value,
+    publicationStatus:
+      cube.status.value ===
+      ns.adminVocabulary("CreativeWorkStatus/Published").value
+        ? DataCubePublicationStatus.Published
+        : DataCubePublicationStatus.Draft,
+    themes:
+      themeIris.length === themeLabels.length
+        ? themeIris.map((iri, i) => ({
+            iri,
+            label: themeLabels[i],
+          }))
+        : [],
+    creator:
+      cube.creatorIri && cube.creatorLabel
+        ? { iri: cube.creatorIri.value, label: cube.creatorLabel.value }
+        : undefined,
+    versionHistory: cube.versionHistory?.value,
+    contactPoint: {
+      email: cube.contactPointEmail?.value,
+      name: cube.contactPointName?.value,
+    },
+    publisher: cube.publisher?.value,
+    landingPage: cube.landingPage?.value,
+    expires: cube.expires?.value,
+    workExamples: cube.workExamples?.value.split(GROUP_SEPARATOR),
+  };
+};
+
+export const getCubeMetadata = async (
+  iri: string,
+  { locale, sparqlClient }: { locale: string; sparqlClient: ParsingClient }
+): Promise<DataCubeMetadata> => {
+  const query = SELECT`
+    ?iri ?identifier ?title ?description ?version ?datePublished ?dateModified ?status ?creatorIri ?creatorLabel ?versionHistory ?contactPointName ?contactPointEmail ?publisher ?landingPage ?expires
+    (GROUP_CONCAT(DISTINCT ?themeIri; SEPARATOR="${GROUP_SEPARATOR}") AS ?themeIris) (GROUP_CONCAT(DISTINCT ?themeLabel; SEPARATOR="${GROUP_SEPARATOR}") AS ?themeLabels)
+    (GROUP_CONCAT(DISTINCT ?subthemeIri; SEPARATOR="${GROUP_SEPARATOR}") AS ?subthemeIris) (GROUP_CONCAT(DISTINCT ?subthemeLabel; SEPARATOR="${GROUP_SEPARATOR}") AS ?subthemeLabels)
+    (GROUP_CONCAT(DISTINCT ?workExample; SEPARATOR="${GROUP_SEPARATOR}") AS ?workExamples)
+    `.WHERE`
+    VALUES ?iri { <${iri}> }
+    OPTIONAL { ?iri ${ns.dcterms.identifier} ?identifier . }
+    ${buildLocalizedSubQuery("iri", "schema:name", "title", {
+      locale,
+    })}
+    ${buildLocalizedSubQuery("iri", "schema:description", "description", {
+      locale,
+    })}
+    OPTIONAL { ?iri ${ns.schema.version} ?version . }
+    OPTIONAL { ?iri ${ns.schema.datePublished} ?datePublished . }
+    OPTIONAL { ?iri ${ns.schema.dateModified} ?dateModified . }
+    ?iri ${ns.schema.creativeWorkStatus} ?status .
+    OPTIONAL {
+      ?iri ${ns.dcterms.creator} ?creatorIri .
+      GRAPH <https://lindas.admin.ch/sfa/opendataswiss> {
+        ?creatorIri a ${ns.schema.Organization} ;
+          ${
+            ns.schema.inDefinedTermSet
+          } <https://register.ld.admin.ch/opendataswiss/org> .
+          ${buildLocalizedSubQuery(
+            "creatorIri",
+            "schema:name",
+            "creatorLabel",
+            { locale }
+          )}
+      }
+    }
+    OPTIONAL {
+      ?iri ${ns.dcat.theme} ?themeIri .
+      GRAPH <https://lindas.admin.ch/sfa/opendataswiss> {
+        ?themeIri a ${ns.schema.DefinedTerm} ;
+        ${
+          ns.schema.inDefinedTermSet
+        } <https://register.ld.admin.ch/opendataswiss/category> .
+        ${buildLocalizedSubQuery("themeIri", "schema:name", "themeLabel", {
+          locale,
+        })}
+      }
+    }
+    OPTIONAL { ?versionHistory ${ns.schema.hasPart} ?iri . }
+    OPTIONAL {
+      ?iri ${ns.dcat.contactPoint} ?contactPoint .
+      ?contactPoint ${ns.vcard.fn} ?contactPointName .
+      ?contactPoint ${ns.vcard.hasEmail} ?contactPointEmail .
+    }
+    OPTIONAL { ?iri ${ns.dcterms.publisher} ?publisher . }
+    OPTIONAL { ?iri ${ns.dcat.landingPage} ?landingPage . }
+    OPTIONAL { ?iri ${ns.schema.expires} ?expires . }
+    OPTIONAL { ?iri ${ns.schema.workExample} ?workExample . }
+  `.GROUP().BY`?iri`.THEN.BY`?identifier`.THEN.BY`?title`.THEN.BY`?description`
+    .THEN.BY`?version`.THEN.BY`?datePublished`.THEN.BY`?dateModified`.THEN
+    .BY`?status`.THEN.BY`?creatorIri`.THEN.BY`?creatorLabel`.THEN
+    .BY`?versionHistory`.THEN.BY`?contactPointName`.THEN.BY`?contactPointEmail`
+    .THEN.BY`?publisher`.THEN.BY`?landingPage`.THEN.BY`?expires`
+    .prologue`${pragmas}`;
+
+  const results = (await query.execute(sparqlClient.query, {
+    operation: "postUrlencoded",
+  })) as RawDataCubeMetadata[];
+
+  if (results.length === 0) {
+    throw new Error(`No cube found for ${iri}!`);
+  }
+
+  if (results.length > 1) {
+    throw new Error(`Multiple cubes found for ${iri}!`);
+  }
+
+  const result = results[0];
+
+  return parseRawMetadata(result);
+};
 
 type RawDataCubeTheme = Omit<DataCubeTheme, "__typename">;
 type RawDataCubeOrganization = Omit<DataCubeOrganization, "__typename">;

--- a/app/rdf/query-utils.ts
+++ b/app/rdf/query-utils.ts
@@ -1,6 +1,38 @@
 import { sparql } from "@tpluscode/sparql-builder";
 
+import { locales } from "@/locales/locales";
+
 import { cube, schema } from "../../app/rdf/namespace";
+
+export const GROUP_SEPARATOR = "|||";
+
+export const buildLocalizedSubQuery = (
+  s: string,
+  p: string,
+  o: string,
+  { locale }: { locale: string }
+) => {
+  // Include the empty locale as well.
+  const locales = getOrderedLocales(locale).concat("");
+
+  return `${locales
+    .map(
+      (locale) => `OPTIONAL {
+          ?${s} ${p} ?${o}_${locale} .
+          FILTER(LANG(?${o}_${locale}) = "${locale}")
+        }`
+    )
+    .join("\n")}
+      BIND(COALESCE(${locales
+        .map((locale) => `?${o}_${locale}`)
+        .join(", ")}) AS ?${o})
+  `;
+};
+
+const getOrderedLocales = (locale: string) => {
+  const rest = locales.filter((d) => d !== locale);
+  return [locale, ...rest];
+};
 
 export const makeVisualizeDatasetFilter = (options?: {
   includeDrafts?: boolean;

--- a/app/scripts/cube.ts
+++ b/app/scripts/cube.ts
@@ -9,15 +9,15 @@ import { DataSource } from "@/configurator";
 
 import { GRAPHQL_ENDPOINT } from "../domain/env";
 import {
-  DataCubeMetadataDocument,
-  DataCubeMetadataQuery,
-  DataCubeMetadataQueryVariables,
   DataCubePreviewDocument,
   DataCubePreviewQuery,
   DataCubePreviewQueryVariables,
   DataCubesComponentsDocument,
   DataCubesComponentsQuery,
   DataCubesComponentsQueryVariables,
+  DataCubesMetadataDocument,
+  DataCubesMetadataQuery,
+  DataCubesMetadataQueryVariables,
 } from "../graphql/query-hooks";
 
 config();
@@ -44,14 +44,13 @@ const showCubeInfo = async ({
   report,
 }: Args<CubeQueryOptions>) => {
   const res = await client
-    .query<DataCubeMetadataQuery, DataCubeMetadataQueryVariables>(
-      DataCubeMetadataDocument,
+    .query<DataCubesMetadataQuery, DataCubesMetadataQueryVariables>(
+      DataCubesMetadataDocument,
       {
-        iri,
         sourceType,
         sourceUrl,
         locale,
-        latest,
+        filters: [{ iri, latest }],
       }
     )
     .toPromise();
@@ -60,7 +59,7 @@ const showCubeInfo = async ({
     throw new Error(res.error.message);
   }
 
-  const cube = res.data?.dataCubeByIri;
+  const cube = res.data?.dataCubesMetadata[0];
 
   if (cube?.iri !== iri) {
     console.warn(
@@ -108,14 +107,13 @@ const previewCube = async ({
   report,
 }: Args<CubeQueryOptions>) => {
   const { data: info, error } = await client
-    .query<DataCubeMetadataQuery, DataCubeMetadataQueryVariables>(
-      DataCubeMetadataDocument,
+    .query<DataCubesMetadataQuery, DataCubesMetadataQueryVariables>(
+      DataCubesMetadataDocument,
       {
-        iri,
         sourceType,
         sourceUrl,
         locale,
-        latest,
+        filters: [{ iri, latest }],
       }
     )
     .toPromise();
@@ -124,7 +122,7 @@ const previewCube = async ({
     throw new Error(error.message);
   }
 
-  if (!info || !info["dataCubeByIri"]) {
+  if (!info || !info.dataCubesMetadata[0]) {
     throw new Error(`Could not find datacube ${iri}`);
   }
 

--- a/app/utils/opendata.ts
+++ b/app/utils/opendata.ts
@@ -1,9 +1,6 @@
-import { DataCubeMetadataQuery } from "@/graphql/query-hooks";
+import { DataCubeMetadata } from "@/domain/data";
 
-const makeOpenDataLink = (
-  lang: string,
-  cube: DataCubeMetadataQuery["dataCubeByIri"]
-) => {
+const makeOpenDataLink = (lang: string, cube: DataCubeMetadata) => {
   const identifier = cube?.identifier;
   const creatorIri = cube?.creator?.iri;
   const isPublished = cube?.workExamples?.includes(

--- a/codegen.yml
+++ b/codegen.yml
@@ -23,6 +23,7 @@ generates:
         GeoShape: "../domain/data#GeoShape"
         SearchCube: "../domain/data#SearchCube"
         DataCubesComponents: "../domain/data#DataCubesComponents"
+        DataCubeMetadata: "../domain/data#DataCubeMetadata"
   app/graphql/resolver-types.ts:
     plugins:
       - "typescript"
@@ -41,6 +42,7 @@ generates:
         GeoShape: "../domain/data#GeoShape"
         SearchCube: "../domain/data#SearchCube"
         DataCubesComponents: "../domain/data#DataCubesComponents"
+        DataCubeMetadata: "../domain/data#DataCubeMetadata"
       mappers:
         DataCube: "./shared-types#ResolvedDataCube"
         ObservationsQuery: "./shared-types#ResolvedObservationsQuery"


### PR DESCRIPTION
This PR adapts the application logic to support retrieving metadata from multiple cubes at once. As we don't yet a design for this feature, there are some `FIXME: adapt to design` comments in places that would need to be revisited once ready.

### GQL / SPARQL
- Removed `DataCubeMetadata` query (replaced by `DataCubesMetadata`)
- Changed the way we fetch cube metadata from `DESCRIBE`ing cube shape to only fetching what we actually need via a dedicated, more performant query. To further improve performance and limit resolver chains, I've extracted the dimension types from GQL to TypeScript. It also means that we now explicitly parse them inside the resolver and don't need to fire additional queries to get theme and creator labels
- Cleaned up the repository from fetching cube metadata in places that didn't require it

---
## Context
This PR is a second part of preparations for merging the cubes. For the technical concept, see [this Notion document](https://www.notion.so/interactivethings/Combine-two-cubes-in-the-same-chart-d5711b414a7747e79edfc3cfe17d2c9b).

- [x] `DataCubesComponents`
- [x] `DataCubesMetadata`
- [ ] `DataCubesObservations`

## How to test
1. Click around in the application and make sure nothing is broken 💥 
2. Open [GQL playground](https://visualization-tool-git-feat-multiple-cubes-metadata-ixt1.vercel.app/api/graphql) and send e.g. the following query to see that metadata from both cubes was fetched.

**Query**
```graphql
query DataCubesMetadata(
  $sourceType: String!
  $sourceUrl: String!
  $locale: String!
  $filters: [DataCubeFilter!]!
) {
  dataCubesMetadata(
    sourceType: $sourceType
    sourceUrl: $sourceUrl
    locale: $locale
    filters: $filters
  )
}
```

**Variables**
```js
{
  "sourceType": "sparql",
  "sourceUrl": "https://lindas.admin.ch/query",
  "locale": "en",
  "filters": [{ "iri": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9", "latest": true }, { "iri": "https://environment.ld.admin.ch/foen/ubd0104/6", "latest": true }]
}
```