### PR TITLE
feat: Add a way to retrieve observations from multiple cubes

### DIFF
--- a/app/browse/datatable.tsx
+++ b/app/browse/datatable.tsx
@@ -256,16 +256,24 @@ export const DataSetTable = ({
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
-    filters: [{ iri: dataSetIri, componentIris, filters }],
   };
   const [{ data: metadataData }] = useDataCubesMetadataQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri }],
+    },
   });
   const [{ data: componentsData }] = useDataCubesComponentsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri, componentIris }],
+    },
   });
   const [{ data: observationsData }] = useDataCubesObservationsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri, componentIris, filters }],
+    },
   });
 
   const headers = useMemo(() => {

--- a/app/browse/datatable.tsx
+++ b/app/browse/datatable.tsx
@@ -30,9 +30,9 @@ import {
 } from "@/domain/data";
 import { useDimensionFormatters } from "@/formatters";
 import {
-  useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
+  useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import SvgIcChevronDown from "@/icons/components/IcChevronDown";
 import { useLocale } from "@/locales/use-locale";
@@ -256,26 +256,16 @@ export const DataSetTable = ({
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
+    filters: [{ iri: dataSetIri, componentIris, filters }],
   };
   const [{ data: metadataData }] = useDataCubesMetadataQuery({
-    variables: {
-      ...commonQueryVariables,
-      filters: [{ iri: dataSetIri }],
-    },
+    variables: commonQueryVariables,
   });
   const [{ data: componentsData }] = useDataCubesComponentsQuery({
-    variables: {
-      ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris, filters }],
-    },
+    variables: commonQueryVariables,
   });
-  const [{ data: observationsData }] = useDataCubeObservationsQuery({
-    variables: {
-      ...commonQueryVariables,
-      iri: dataSetIri,
-      componentIris,
-      filters,
-    },
+  const [{ data: observationsData }] = useDataCubesObservationsQuery({
+    variables: commonQueryVariables,
   });
 
   const headers = useMemo(() => {
@@ -291,14 +281,14 @@ export const DataSetTable = ({
 
   return metadataData?.dataCubesMetadata &&
     componentsData?.dataCubesComponents &&
-    observationsData?.dataCubeByIri ? (
+    observationsData?.dataCubesObservations ? (
     <Box sx={{ maxHeight: "600px", overflow: "auto", ...sx }}>
       <PreviewTable
         // FIXME: adapt to design
         title={metadataData.dataCubesMetadata.map((d) => d.title).join(", ")}
         headers={headers}
-        observations={observationsData.dataCubeByIri.observations.data}
-        linkToMetadataPanel={true}
+        observations={observationsData.dataCubesObservations.data}
+        linkToMetadataPanel
       />
     </Box>
   ) : (

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -43,16 +43,24 @@ export const ChartAreasVisualization = ({
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
-    filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
   };
   const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri }],
+    },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri, componentIris }],
+    },
   });
   const [observationsQuery] = useDataCubesObservationsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
+    },
   });
 
   return (

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -17,9 +17,9 @@ import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import { AreaConfig, DataSource, QueryFilters } from "@/config-types";
 import {
-  useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
+  useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
@@ -43,26 +43,16 @@ export const ChartAreasVisualization = ({
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
+    filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
   };
   const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: {
-      ...commonQueryVariables,
-      filters: [{ iri: dataSetIri }],
-    },
+    variables: commonQueryVariables,
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: {
-      ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris }],
-    },
+    variables: commonQueryVariables,
   });
-  const [observationsQuery] = useDataCubeObservationsQuery({
-    variables: {
-      ...commonQueryVariables,
-      iri: dataSetIri,
-      componentIris,
-      filters: queryFilters,
-    },
+  const [observationsQuery] = useDataCubesObservationsQuery({
+    variables: commonQueryVariables,
   });
 
   return (

--- a/app/charts/chart-loading-wrapper.tsx
+++ b/app/charts/chart-loading-wrapper.tsx
@@ -15,9 +15,9 @@ import {
 } from "@/components/hint";
 import { ChartConfig } from "@/configurator";
 import {
-  DataCubeObservationsQuery,
   DataCubesComponentsQuery,
   DataCubesMetadataQuery,
+  DataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 
 type ElementProps<RE> = RE extends React.ElementType<infer P> ? P : never;
@@ -43,7 +43,7 @@ export const ChartLoadingWrapper = <
     "data" | "fetching" | "error"
   >;
   observationsQuery: Pick<
-    UseQueryResponse<DataCubeObservationsQuery>[0],
+    UseQueryResponse<DataCubesObservationsQuery>[0],
     "data" | "fetching" | "error"
   >;
   chartConfig: TChartConfig;
@@ -71,7 +71,7 @@ export const ChartLoadingWrapper = <
   } = observationsQuery;
 
   const metadata = metadataData?.dataCubesMetadata;
-  const observations = observationsData?.dataCubeByIri?.observations.data;
+  const observations = observationsData?.dataCubesObservations?.data;
   const dimensions = componentsData?.dataCubesComponents.dimensions;
   const measures = componentsData?.dataCubesComponents.measures;
 

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -27,9 +27,9 @@ import { LegendColor } from "@/charts/shared/legend-color";
 import { ColumnConfig, DataSource, QueryFilters } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import {
-  useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
+  useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
@@ -53,26 +53,16 @@ export const ChartColumnsVisualization = ({
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
+    filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
   };
   const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: {
-      ...commonQueryVariables,
-      filters: [{ iri: dataSetIri }],
-    },
+    variables: commonQueryVariables,
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: {
-      ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris }],
-    },
+    variables: commonQueryVariables,
   });
-  const [observationsQuery] = useDataCubeObservationsQuery({
-    variables: {
-      ...commonQueryVariables,
-      iri: dataSetIri,
-      componentIris,
-      filters: queryFilters,
-    },
+  const [observationsQuery] = useDataCubesObservationsQuery({
+    variables: commonQueryVariables,
   });
 
   return (

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -53,16 +53,24 @@ export const ChartColumnsVisualization = ({
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
-    filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
   };
   const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri }],
+    },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri, componentIris }],
+    },
   });
   const [observationsQuery] = useDataCubesObservationsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
+    },
   });
 
   return (

--- a/app/charts/combo/chart-combo-line-column.tsx
+++ b/app/charts/combo/chart-combo-line-column.tsx
@@ -43,16 +43,24 @@ export const ChartComboLineColumnVisualization = (
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
-    filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
   };
   const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri }],
+    },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri, componentIris }],
+    },
   });
   const [observationsQuery] = useDataCubesObservationsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
+    },
   });
 
   return (

--- a/app/charts/combo/chart-combo-line-column.tsx
+++ b/app/charts/combo/chart-combo-line-column.tsx
@@ -17,9 +17,9 @@ import {
   QueryFilters,
 } from "@/config-types";
 import {
-  useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
+  useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
@@ -43,26 +43,16 @@ export const ChartComboLineColumnVisualization = (
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
+    filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
   };
   const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: {
-      ...commonQueryVariables,
-      filters: [{ iri: dataSetIri }],
-    },
+    variables: commonQueryVariables,
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: {
-      ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris }],
-    },
+    variables: commonQueryVariables,
   });
-  const [observationsQuery] = useDataCubeObservationsQuery({
-    variables: {
-      ...commonQueryVariables,
-      componentIris,
-      iri: dataSetIri,
-      filters: queryFilters,
-    },
+  const [observationsQuery] = useDataCubesObservationsQuery({
+    variables: commonQueryVariables,
   });
 
   return (

--- a/app/charts/combo/chart-combo-line-dual.tsx
+++ b/app/charts/combo/chart-combo-line-dual.tsx
@@ -13,9 +13,9 @@ import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import { ComboLineDualConfig, DataSource, QueryFilters } from "@/config-types";
 import {
-  useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
+  useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
@@ -39,26 +39,16 @@ export const ChartComboLineDualVisualization = (
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
+    filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
   };
   const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: {
-      ...commonQueryVariables,
-      filters: [{ iri: dataSetIri }],
-    },
+    variables: commonQueryVariables,
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: {
-      ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris }],
-    },
+    variables: commonQueryVariables,
   });
-  const [observationsQuery] = useDataCubeObservationsQuery({
-    variables: {
-      ...commonQueryVariables,
-      iri: dataSetIri,
-      componentIris,
-      filters: queryFilters,
-    },
+  const [observationsQuery] = useDataCubesObservationsQuery({
+    variables: commonQueryVariables,
   });
 
   return (

--- a/app/charts/combo/chart-combo-line-dual.tsx
+++ b/app/charts/combo/chart-combo-line-dual.tsx
@@ -39,16 +39,24 @@ export const ChartComboLineDualVisualization = (
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
-    filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
   };
   const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri }],
+    },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri, componentIris }],
+    },
   });
   const [observationsQuery] = useDataCubesObservationsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
+    },
   });
 
   return (

--- a/app/charts/combo/chart-combo-line-single.tsx
+++ b/app/charts/combo/chart-combo-line-single.tsx
@@ -48,16 +48,24 @@ export const ChartComboLineSingleVisualization = (
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
-    filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
   };
   const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri }],
+    },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri, componentIris }],
+    },
   });
   const [observationsQuery] = useDataCubesObservationsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
+    },
   });
 
   return (

--- a/app/charts/combo/chart-combo-line-single.tsx
+++ b/app/charts/combo/chart-combo-line-single.tsx
@@ -22,9 +22,9 @@ import {
   QueryFilters,
 } from "@/config-types";
 import {
-  useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
+  useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
@@ -48,26 +48,16 @@ export const ChartComboLineSingleVisualization = (
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
+    filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
   };
   const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: {
-      ...commonQueryVariables,
-      filters: [{ iri: dataSetIri }],
-    },
+    variables: commonQueryVariables,
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: {
-      ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris }],
-    },
+    variables: commonQueryVariables,
   });
-  const [observationsQuery] = useDataCubeObservationsQuery({
-    variables: {
-      ...commonQueryVariables,
-      iri: dataSetIri,
-      componentIris,
-      filters: queryFilters,
-    },
+  const [observationsQuery] = useDataCubesObservationsQuery({
+    variables: commonQueryVariables,
   });
 
   return (

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -18,9 +18,9 @@ import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import { DataSource, LineConfig, QueryFilters } from "@/config-types";
 import {
-  useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
+  useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
@@ -44,26 +44,16 @@ export const ChartLinesVisualization = ({
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
+    filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
   };
   const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: {
-      ...commonQueryVariables,
-      filters: [{ iri: dataSetIri }],
-    },
+    variables: commonQueryVariables,
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: {
-      ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris }],
-    },
+    variables: commonQueryVariables,
   });
-  const [observationsQuery] = useDataCubeObservationsQuery({
-    variables: {
-      ...commonQueryVariables,
-      iri: dataSetIri,
-      componentIris,
-      filters: queryFilters,
-    },
+  const [observationsQuery] = useDataCubesObservationsQuery({
+    variables: commonQueryVariables,
   });
 
   return (

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -44,16 +44,24 @@ export const ChartLinesVisualization = ({
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
-    filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
   };
   const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri }],
+    },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri, componentIris }],
+    },
   });
   const [observationsQuery] = useDataCubesObservationsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
+    },
   });
 
   return (

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -15,9 +15,9 @@ import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import { GeoShapes } from "@/domain/data";
 import {
   GeoCoordinates,
-  useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
+  useDataCubesObservationsQuery,
   useGeoCoordinatesByDimensionIriQuery,
   useGeoShapesByDimensionIriQuery,
 } from "@/graphql/query-hooks";
@@ -45,33 +45,23 @@ export const ChartMapVisualization = ({
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
+    filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
   };
   const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: {
-      ...commonQueryVariables,
-      filters: [{ iri: dataSetIri }],
-    },
+    variables: commonQueryVariables,
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: {
-      ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris }],
-    },
+    variables: commonQueryVariables,
   });
-  const [observationsQuery] = useDataCubeObservationsQuery({
-    variables: {
-      ...commonQueryVariables,
-      iri: dataSetIri,
-      componentIris,
-      filters: queryFilters,
-    },
+  const [observationsQuery] = useDataCubesObservationsQuery({
+    variables: commonQueryVariables,
   });
   const { data: componentsData } = componentsQuery;
   const { data: observationsData } = observationsQuery;
 
   const dimensions = componentsData?.dataCubesComponents?.dimensions;
   const measures = componentsData?.dataCubesComponents?.measures;
-  const observations = observationsData?.dataCubeByIri?.observations.data;
+  const observations = observationsData?.dataCubesObservations?.data;
 
   const [{ data: fetchedGeoCoordinates, error: geoCoordinatesError }] =
     useGeoCoordinatesByDimensionIriQuery({

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -45,16 +45,24 @@ export const ChartMapVisualization = ({
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
-    filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
   };
   const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri }],
+    },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri, componentIris }],
+    },
   });
   const [observationsQuery] = useDataCubesObservationsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
+    },
   });
   const { data: componentsData } = componentsQuery;
   const { data: observationsData } = observationsQuery;

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -14,9 +14,9 @@ import { OnlyNegativeDataHint } from "@/components/hint";
 import { DataSource, PieConfig, QueryFilters } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import {
-  useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
+  useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
@@ -40,26 +40,16 @@ export const ChartPieVisualization = ({
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
+    filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
   };
   const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: {
-      ...commonQueryVariables,
-      filters: [{ iri: dataSetIri }],
-    },
+    variables: commonQueryVariables,
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: {
-      ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris }],
-    },
+    variables: commonQueryVariables,
   });
-  const [observationsQuery] = useDataCubeObservationsQuery({
-    variables: {
-      ...commonQueryVariables,
-      iri: dataSetIri,
-      componentIris,
-      filters: queryFilters,
-    },
+  const [observationsQuery] = useDataCubesObservationsQuery({
+    variables: commonQueryVariables,
   });
 
   return (

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -40,16 +40,24 @@ export const ChartPieVisualization = ({
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
-    filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
   };
   const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri }],
+    },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri, componentIris }],
+    },
   });
   const [observationsQuery] = useDataCubesObservationsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
+    },
   });
 
   return (

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -22,9 +22,9 @@ import { InteractionVoronoi } from "@/charts/shared/overlay-voronoi";
 import { DataSource, QueryFilters, ScatterPlotConfig } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import {
-  useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
+  useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
@@ -48,26 +48,16 @@ export const ChartScatterplotVisualization = ({
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
+    filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
   };
   const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: {
-      ...commonQueryVariables,
-      filters: [{ iri: dataSetIri }],
-    },
+    variables: commonQueryVariables,
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: {
-      ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris }],
-    },
+    variables: commonQueryVariables,
   });
-  const [observationsQuery] = useDataCubeObservationsQuery({
-    variables: {
-      ...commonQueryVariables,
-      iri: dataSetIri,
-      componentIris,
-      filters: queryFilters,
-    },
+  const [observationsQuery] = useDataCubesObservationsQuery({
+    variables: commonQueryVariables,
   });
 
   return (

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -48,16 +48,24 @@ export const ChartScatterplotVisualization = ({
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
-    filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
   };
   const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri }],
+    },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri, componentIris }],
+    },
   });
   const [observationsQuery] = useDataCubesObservationsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
+    },
   });
 
   return (

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -185,7 +185,8 @@ export const extractChartConfigComponentIris = (chartConfig: ChartConfig) => {
     [...fieldIris, ...additionalFieldIris, ...filterIris, ...IFIris].filter(
       Boolean
     )
-  );
+    // Important so the order is consistent when querying.
+  ).sort();
 };
 
 /** Use to remove missing values from chart data. */

--- a/app/charts/table/chart-table.tsx
+++ b/app/charts/table/chart-table.tsx
@@ -5,9 +5,9 @@ import { Table } from "@/charts/table/table";
 import { TableChart } from "@/charts/table/table-state";
 import { DataSource, TableConfig } from "@/configurator";
 import {
-  useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
+  useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
@@ -29,26 +29,16 @@ export const ChartTableVisualization = ({
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
+    filters: [{ iri: dataSetIri, componentIris }],
   };
   const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: {
-      ...commonQueryVariables,
-      filters: [{ iri: dataSetIri }],
-    },
+    variables: commonQueryVariables,
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: {
-      ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris }],
-    },
+    variables: commonQueryVariables,
   });
-  const [observationsQuery] = useDataCubeObservationsQuery({
-    variables: {
-      ...commonQueryVariables,
-      iri: dataSetIri,
-      componentIris,
-      filters: chartConfig.filters,
-    },
+  const [observationsQuery] = useDataCubesObservationsQuery({
+    variables: commonQueryVariables,
   });
 
   return (

--- a/app/charts/table/chart-table.tsx
+++ b/app/charts/table/chart-table.tsx
@@ -29,16 +29,24 @@ export const ChartTableVisualization = ({
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
-    filters: [{ iri: dataSetIri, componentIris }],
   };
   const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri }],
+    },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri, componentIris }],
+    },
   });
   const [observationsQuery] = useDataCubesObservationsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri, componentIris }],
+    },
   });
 
   return (

--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -75,14 +75,19 @@ export const ChartFootnotes = ({
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
-    filters: [{ iri: dataSetIri, componentIris, filters }],
   };
   const [{ data }] = useDataCubesMetadataQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri }],
+    },
   });
   // Data for data download
   const [{ data: visibleData }] = useDataCubesObservationsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri, componentIris, filters }],
+    },
   });
   const sparqlEditorUrls = visibleData?.dataCubesObservations?.sparqlEditorUrls;
   const formatLocale = useTimeFormatLocale();

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -5,6 +5,7 @@ import Head from "next/head";
 import { useMemo } from "react";
 
 import { DataSetTable } from "@/browse/datatable";
+import { extractChartConfigComponentIris } from "@/charts/shared/chart-helpers";
 import { ChartErrorBoundary } from "@/components/chart-error-boundary";
 import { ChartFootnotes } from "@/components/chart-footnotes";
 import {
@@ -71,13 +72,20 @@ export const ChartPreviewInner = (props: ChartPreviewProps) => {
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
-    filters: [{ iri: dataSetIri }],
   };
   const [{ data: metadata }] = useDataCubesMetadataQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      filters: [{ iri: dataSetIri }],
+    },
   });
+  const componentIris = extractChartConfigComponentIris(chartConfig);
   const [{ data: components }] = useDataCubesComponentsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      ...commonQueryVariables,
+      // FIXME: make a distinction per cube
+      filters: [{ iri: dataSetIri, componentIris }],
+    },
   });
   const {
     state: isTablePreview,
@@ -213,7 +221,7 @@ export const ChartPreviewInner = (props: ChartPreviewProps) => {
                 <ChartWithFilters
                   dataSet={dataSetIri}
                   dataSource={dataSource}
-                  componentIris={undefined}
+                  componentIris={componentIris}
                   chartConfig={chartConfig}
                 />
               )}

--- a/app/components/chart-selection-tabs.tsx
+++ b/app/components/chart-selection-tabs.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/router";
 import React from "react";
 import { DragDropContext, Draggable, Droppable } from "react-beautiful-dnd";
 
+import { extractChartConfigComponentIris } from "@/charts/shared/chart-helpers";
 import Flex from "@/components/flex";
 import {
   ChartConfig,
@@ -253,14 +254,14 @@ const PublishChartButton = () => {
   const locale = useLocale();
   const [state, dispatch] = useConfiguratorState(hasChartConfigs);
   const chartConfig = getChartConfig(state);
-  const commonQueryVariables = {
-    sourceType: state.dataSource.type,
-    sourceUrl: state.dataSource.url,
-    locale,
-    filters: [{ iri: chartConfig.dataSet }],
-  };
+  const componentIris = extractChartConfigComponentIris(chartConfig);
   const [{ data: components }] = useDataCubesComponentsQuery({
-    variables: commonQueryVariables,
+    variables: {
+      sourceType: state.dataSource.type,
+      sourceUrl: state.dataSource.url,
+      locale,
+      filters: [{ iri: chartConfig.dataSet, componentIris }],
+    },
   });
   const goNext = useEvent(() => {
     if (components?.dataCubesComponents) {

--- a/app/components/data-download.tsx
+++ b/app/components/data-download.tsx
@@ -38,12 +38,12 @@ import {
   getFormattersForLocale,
 } from "@/formatters";
 import {
-  DataCubeObservationsDocument,
-  DataCubeObservationsQuery,
-  DataCubeObservationsQueryVariables,
   DataCubesComponentsDocument,
   DataCubesComponentsQuery,
   DataCubesComponentsQueryVariables,
+  DataCubesObservationsDocument,
+  DataCubesObservationsQuery,
+  DataCubesObservationsQueryVariables,
 } from "@/graphql/query-hooks";
 import { Icon } from "@/icons";
 import { Locale } from "@/locales/locales";
@@ -327,11 +327,12 @@ const DownloadMenuItem = ({
   const download = useCallback(
     async (
       componentsData: DataCubesComponentsQuery,
-      observationsData: DataCubeObservationsQuery
+      observationsData: DataCubesObservationsQuery
     ) => {
       if (
         !(
-          componentsData?.dataCubesComponents && observationsData?.dataCubeByIri
+          componentsData?.dataCubesComponents &&
+          observationsData?.dataCubesObservations
         )
       ) {
         return;
@@ -340,7 +341,7 @@ const DownloadMenuItem = ({
       const { dimensions, measures } = componentsData.dataCubesComponents;
       const components = [...dimensions, ...measures];
       const dimensionParsers = getDimensionParsers(components, { locale });
-      const observations = observationsData.dataCubeByIri.observations.data;
+      const observations = observationsData.dataCubesObservations.data;
       const { columnKeys, data } = prepareData({
         components,
         observations,
@@ -392,20 +393,18 @@ const DownloadMenuItem = ({
                 sourceType: dataSource.type,
                 sourceUrl: dataSource.url,
                 locale,
-                filters: [{ iri: dataSetIri }],
+                filters: [{ iri: dataSetIri, filters }],
               })
               .toPromise(),
             urqlClient
               .query<
-                DataCubeObservationsQuery,
-                DataCubeObservationsQueryVariables
-              >(DataCubeObservationsDocument, {
-                iri: dataSetIri,
+                DataCubesObservationsQuery,
+                DataCubesObservationsQueryVariables
+              >(DataCubesObservationsDocument, {
                 sourceType: dataSource.type,
                 sourceUrl: dataSource.url,
                 locale,
-                componentIris: undefined,
-                filters,
+                filters: [{ iri: dataSetIri, filters }],
               })
               .toPromise(),
           ]);

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -30,7 +30,10 @@ import {
 import { useClient } from "urql";
 
 import { getChartSpec } from "@/charts/chart-config-ui-options";
-import { useQueryFilters } from "@/charts/shared/chart-helpers";
+import {
+  extractChartConfigComponentIris,
+  useQueryFilters,
+} from "@/charts/shared/chart-helpers";
 import { OpenMetadataPanelWrapper } from "@/components/metadata-panel";
 import MoveDragButtons from "@/components/move-drag-buttons";
 import useDisclosure from "@/components/use-disclosure";
@@ -754,6 +757,7 @@ const ChartFields = (props: ChartFieldsProps) => {
   const { dataSource, chartConfig, dimensions, measures } = props;
   const components = [...dimensions, ...measures];
   const queryFilters = useQueryFilters({ chartConfig });
+  const componentIris = extractChartConfigComponentIris(chartConfig);
   const locale = useLocale();
   const [{ data: observationsData }] = useDataCubesObservationsQuery({
     variables: {
@@ -761,11 +765,7 @@ const ChartFields = (props: ChartFieldsProps) => {
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       filters: [
-        {
-          iri: chartConfig.dataSet,
-          componentIris: components.map((d) => d.iri),
-          filters: queryFilters,
-        },
+        { iri: chartConfig.dataSet, componentIris, filters: queryFilters },
       ],
     },
   });

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -76,8 +76,8 @@ import {
   PossibleFiltersDocument,
   PossibleFiltersQuery,
   PossibleFiltersQueryVariables,
-  useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
+  useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { Icon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
@@ -755,18 +755,21 @@ const ChartFields = (props: ChartFieldsProps) => {
   const components = [...dimensions, ...measures];
   const queryFilters = useQueryFilters({ chartConfig });
   const locale = useLocale();
-
-  const [{ data: observationsData }] = useDataCubeObservationsQuery({
+  const [{ data: observationsData }] = useDataCubesObservationsQuery({
     variables: {
       locale,
-      iri: chartConfig.dataSet,
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
-      componentIris: components.map((d) => d.iri),
-      filters: queryFilters,
+      filters: [
+        {
+          iri: chartConfig.dataSet,
+          componentIris: components.map((d) => d.iri),
+          filters: queryFilters,
+        },
+      ],
     },
   });
-  const observations = observationsData?.dataCubeByIri?.observations.data ?? [];
+  const observations = observationsData?.dataCubesObservations?.data ?? [];
 
   return (
     <>

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -80,8 +80,8 @@ import {
   Observation,
 } from "@/domain/data";
 import {
-  useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
+  useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { NumericalMeasure } from "@/graphql/resolver-types";
 import SvgIcExclamation from "@/icons/components/IcExclamation";
@@ -97,29 +97,20 @@ export const ChartOptionsSelector = ({
   const { activeField } = chartConfig;
   const locale = useLocale();
   const commonVariables = {
-    iri: chartConfig.dataSet,
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
     locale,
+    filters: [{ iri: chartConfig.dataSet, filters: chartConfig.filters }],
   };
   const [{ data: componentsData }] = useDataCubesComponentsQuery({
-    variables: {
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-      filters: [{ iri: chartConfig.dataSet }],
-    },
+    variables: commonVariables,
   });
-  const [{ data: observationsData }] = useDataCubeObservationsQuery({
-    variables: {
-      ...commonVariables,
-      filters: chartConfig.filters,
-    },
+  const [{ data: observationsData }] = useDataCubesObservationsQuery({
+    variables: commonVariables,
   });
-
   const dimensions = componentsData?.dataCubesComponents.dimensions;
   const measures = componentsData?.dataCubesComponents.measures;
-  const observations = observationsData?.dataCubeByIri?.observations.data;
+  const observations = observationsData?.dataCubesObservations?.data;
 
   return dimensions && measures && observations ? (
     <Box

--- a/app/domain/data.ts
+++ b/app/domain/data.ts
@@ -42,6 +42,14 @@ export type HierarchyValue = {
 
 export type Observation = Record<string, ObservationValue>;
 
+export type DataCubesObservations = {
+  data: Observation[];
+  sparqlEditorUrls: {
+    cubeIri: string;
+    url: string;
+  }[];
+};
+
 export type DataCubesComponents = {
   dimensions: Dimension[];
   measures: Measure[];

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -44,7 +44,6 @@ query DataCubePreview(
     publicationStatus
     observations(sourceType: $sourceType, sourceUrl: $sourceUrl, limit: 10) {
       data
-      sparql
       sparqlEditorUrl
     }
   }

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -16,7 +16,7 @@ query DataCubesMetadata(
   $sourceType: String!
   $sourceUrl: String!
   $locale: String!
-  $filters: [DataCubeFilter!]!
+  $filters: [DataCubeMetadataFilter!]!
 ) {
   dataCubesMetadata(
     sourceType: $sourceType

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -2,7 +2,7 @@ query DataCubesComponents(
   $sourceType: String!
   $sourceUrl: String!
   $locale: String!
-  $filters: [DataCubeFilter!]!
+  $filters: [DataCubeComponentFilter!]!
 ) {
   dataCubesComponents(
     sourceType: $sourceType
@@ -30,7 +30,7 @@ query DataCubesObservations(
   $sourceType: String!
   $sourceUrl: String!
   $locale: String!
-  $filters: [DataCubeFilter!]!
+  $filters: [DataCubeObservationFilter!]!
 ) {
   dataCubesObservations(
     sourceType: $sourceType

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -1,3 +1,45 @@
+query DataCubesComponents(
+  $sourceType: String!
+  $sourceUrl: String!
+  $locale: String!
+  $filters: [DataCubeFilter!]!
+) {
+  dataCubesComponents(
+    sourceType: $sourceType
+    sourceUrl: $sourceUrl
+    locale: $locale
+    filters: $filters
+  )
+}
+
+query DataCubesMetadata(
+  $sourceType: String!
+  $sourceUrl: String!
+  $locale: String!
+  $filters: [DataCubeFilter!]!
+) {
+  dataCubesMetadata(
+    sourceType: $sourceType
+    sourceUrl: $sourceUrl
+    locale: $locale
+    filters: $filters
+  )
+}
+
+query DataCubesObservations(
+  $sourceType: String!
+  $sourceUrl: String!
+  $locale: String!
+  $filters: [DataCubeFilter!]!
+) {
+  dataCubesObservations(
+    sourceType: $sourceType
+    sourceUrl: $sourceUrl
+    locale: $locale
+    filters: $filters
+  )
+}
+
 query SearchCubes(
   $sourceType: String!
   $sourceUrl: String!
@@ -47,34 +89,6 @@ query DataCubePreview(
       sparqlEditorUrl
     }
   }
-}
-
-query DataCubesMetadata(
-  $sourceType: String!
-  $sourceUrl: String!
-  $locale: String!
-  $filters: [DataCubeFilter!]!
-) {
-  dataCubesMetadata(
-    sourceType: $sourceType
-    sourceUrl: $sourceUrl
-    locale: $locale
-    filters: $filters
-  )
-}
-
-query DataCubesComponents(
-  $sourceType: String!
-  $sourceUrl: String!
-  $locale: String!
-  $filters: [DataCubeFilter!]!
-) {
-  dataCubesComponents(
-    sourceType: $sourceType
-    sourceUrl: $sourceUrl
-    locale: $locale
-    filters: $filters
-  )
 }
 
 query GeoCoordinatesByDimensionIri(
@@ -132,36 +146,6 @@ query GeoShapesByDimensionIri(
       ... on GeoShapesDimension {
         geoShapes
       }
-    }
-  }
-}
-
-query DataCubeObservations(
-  $iri: String!
-  $sourceType: String!
-  $sourceUrl: String!
-  $locale: String!
-  $componentIris: [String!]
-  $filters: Filters
-  $latest: Boolean
-  $limit: Int
-) {
-  dataCubeByIri(
-    iri: $iri
-    sourceType: $sourceType
-    sourceUrl: $sourceUrl
-    locale: $locale
-    latest: $latest
-  ) {
-    observations(
-      sourceType: $sourceType
-      sourceUrl: $sourceUrl
-      componentIris: $componentIris
-      filters: $filters
-      limit: $limit
-    ) {
-      data
-      sparqlEditorUrl
     }
   }
 }

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -92,7 +92,7 @@ export type DataCubeMeasuresArgs = {
   disableValuesLoad?: Maybe<Scalars['Boolean']>;
 };
 
-export type DataCubeFilter = {
+export type DataCubeComponentFilter = {
   iri: Scalars['String'];
   latest?: Maybe<Scalars['Boolean']>;
   filters?: Maybe<Scalars['Filters']>;
@@ -103,6 +103,14 @@ export type DataCubeFilter = {
 export type DataCubeMetadataFilter = {
   iri: Scalars['String'];
   latest?: Maybe<Scalars['Boolean']>;
+};
+
+export type DataCubeObservationFilter = {
+  iri: Scalars['String'];
+  latest?: Maybe<Scalars['Boolean']>;
+  filters?: Maybe<Scalars['Filters']>;
+  componentIris?: Maybe<Array<Scalars['String']>>;
+  joinBy?: Maybe<Scalars['String']>;
 };
 
 export type DataCubeOrganization = {
@@ -383,7 +391,7 @@ export type QueryDataCubesComponentsArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
-  filters: Array<DataCubeFilter>;
+  filters: Array<DataCubeComponentFilter>;
 };
 
 
@@ -399,7 +407,7 @@ export type QueryDataCubesObservationsArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
-  filters: Array<DataCubeFilter>;
+  filters: Array<DataCubeObservationFilter>;
 };
 
 
@@ -576,7 +584,7 @@ export type DataCubesComponentsQueryVariables = Exact<{
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
-  filters: Array<DataCubeFilter> | DataCubeFilter;
+  filters: Array<DataCubeComponentFilter> | DataCubeComponentFilter;
 }>;
 
 
@@ -596,7 +604,7 @@ export type DataCubesObservationsQueryVariables = Exact<{
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
-  filters: Array<DataCubeFilter> | DataCubeFilter;
+  filters: Array<DataCubeObservationFilter> | DataCubeObservationFilter;
 }>;
 
 
@@ -663,7 +671,7 @@ export type PossibleFiltersQuery = { __typename: 'Query', possibleFilters: Array
 
 
 export const DataCubesComponentsDocument = gql`
-    query DataCubesComponents($sourceType: String!, $sourceUrl: String!, $locale: String!, $filters: [DataCubeFilter!]!) {
+    query DataCubesComponents($sourceType: String!, $sourceUrl: String!, $locale: String!, $filters: [DataCubeComponentFilter!]!) {
   dataCubesComponents(
     sourceType: $sourceType
     sourceUrl: $sourceUrl
@@ -691,7 +699,7 @@ export function useDataCubesMetadataQuery(options: Omit<Urql.UseQueryArgs<DataCu
   return Urql.useQuery<DataCubesMetadataQuery>({ query: DataCubesMetadataDocument, ...options });
 };
 export const DataCubesObservationsDocument = gql`
-    query DataCubesObservations($sourceType: String!, $sourceUrl: String!, $locale: String!, $filters: [DataCubeFilter!]!) {
+    query DataCubesObservations($sourceType: String!, $sourceUrl: String!, $locale: String!, $filters: [DataCubeObservationFilter!]!) {
   dataCubesObservations(
     sourceType: $sourceType
     sourceUrl: $sourceUrl

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -94,11 +94,16 @@ export type DataCubeMeasuresArgs = {
 
 export type DataCubeFilter = {
   iri: Scalars['String'];
-  componentIris?: Maybe<Array<Scalars['String']>>;
-  filters?: Maybe<Scalars['Filters']>;
   latest?: Maybe<Scalars['Boolean']>;
+  filters?: Maybe<Scalars['Filters']>;
+  componentIris?: Maybe<Array<Scalars['String']>>;
 };
 
+
+export type DataCubeMetadataFilter = {
+  iri: Scalars['String'];
+  latest?: Maybe<Scalars['Boolean']>;
+};
 
 export type DataCubeOrganization = {
   __typename: 'DataCubeOrganization';
@@ -386,7 +391,7 @@ export type QueryDataCubesMetadataArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
-  filters: Array<DataCubeFilter>;
+  filters: Array<DataCubeMetadataFilter>;
 };
 
 
@@ -581,7 +586,7 @@ export type DataCubesMetadataQueryVariables = Exact<{
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
-  filters: Array<DataCubeFilter> | DataCubeFilter;
+  filters: Array<DataCubeMetadataFilter> | DataCubeMetadataFilter;
 }>;
 
 
@@ -672,7 +677,7 @@ export function useDataCubesComponentsQuery(options: Omit<Urql.UseQueryArgs<Data
   return Urql.useQuery<DataCubesComponentsQuery>({ query: DataCubesComponentsDocument, ...options });
 };
 export const DataCubesMetadataDocument = gql`
-    query DataCubesMetadata($sourceType: String!, $sourceUrl: String!, $locale: String!, $filters: [DataCubeFilter!]!) {
+    query DataCubesMetadata($sourceType: String!, $sourceUrl: String!, $locale: String!, $filters: [DataCubeMetadataFilter!]!) {
   dataCubesMetadata(
     sourceType: $sourceType
     sourceUrl: $sourceUrl

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -1,5 +1,6 @@
 import { DataCubeMetadata } from '../domain/data';
 import { DataCubesComponents } from '../domain/data';
+import { DataCubesObservations } from '../domain/data';
 import { DimensionValue } from '../domain/data';
 import { QueryFilters } from '../configurator';
 import { HierarchyValue } from '../domain/data';
@@ -22,6 +23,7 @@ export type Scalars = {
   Float: number;
   DataCubeMetadata: DataCubeMetadata;
   DataCubesComponents: DataCubesComponents;
+  DataCubesObservations: DataCubesObservations;
   DimensionValue: DimensionValue;
   FilterValue: any;
   Filters: QueryFilters;
@@ -114,6 +116,7 @@ export type DataCubeTheme = {
   iri: Scalars['String'];
   label?: Maybe<Scalars['String']>;
 };
+
 
 
 export type Dimension = {
@@ -364,6 +367,7 @@ export type Query = {
   __typename: 'Query';
   dataCubesComponents: Scalars['DataCubesComponents'];
   dataCubesMetadata: Array<Scalars['DataCubeMetadata']>;
+  dataCubesObservations: Scalars['DataCubesObservations'];
   dataCubeByIri?: Maybe<DataCube>;
   possibleFilters: Array<ObservationFilter>;
   searchCubes: Array<SearchCubeResult>;
@@ -379,6 +383,14 @@ export type QueryDataCubesComponentsArgs = {
 
 
 export type QueryDataCubesMetadataArgs = {
+  sourceType: Scalars['String'];
+  sourceUrl: Scalars['String'];
+  locale: Scalars['String'];
+  filters: Array<DataCubeFilter>;
+};
+
+
+export type QueryDataCubesObservationsArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
@@ -555,6 +567,36 @@ export enum TimeUnit {
 
 
 
+export type DataCubesComponentsQueryVariables = Exact<{
+  sourceType: Scalars['String'];
+  sourceUrl: Scalars['String'];
+  locale: Scalars['String'];
+  filters: Array<DataCubeFilter> | DataCubeFilter;
+}>;
+
+
+export type DataCubesComponentsQuery = { __typename: 'Query', dataCubesComponents: DataCubesComponents };
+
+export type DataCubesMetadataQueryVariables = Exact<{
+  sourceType: Scalars['String'];
+  sourceUrl: Scalars['String'];
+  locale: Scalars['String'];
+  filters: Array<DataCubeFilter> | DataCubeFilter;
+}>;
+
+
+export type DataCubesMetadataQuery = { __typename: 'Query', dataCubesMetadata: Array<DataCubeMetadata> };
+
+export type DataCubesObservationsQueryVariables = Exact<{
+  sourceType: Scalars['String'];
+  sourceUrl: Scalars['String'];
+  locale: Scalars['String'];
+  filters: Array<DataCubeFilter> | DataCubeFilter;
+}>;
+
+
+export type DataCubesObservationsQuery = { __typename: 'Query', dataCubesObservations: DataCubesObservations };
+
 export type SearchCubesQueryVariables = Exact<{
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
@@ -580,26 +622,6 @@ export type DataCubePreviewQueryVariables = Exact<{
 
 export type DataCubePreviewQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', iri: string, title: string, description?: Maybe<string>, publicationStatus: DataCubePublicationStatus, observations: { __typename: 'ObservationsQuery', data: Array<Observation>, sparqlEditorUrl?: Maybe<string> } }> };
 
-export type DataCubesMetadataQueryVariables = Exact<{
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  locale: Scalars['String'];
-  filters: Array<DataCubeFilter> | DataCubeFilter;
-}>;
-
-
-export type DataCubesMetadataQuery = { __typename: 'Query', dataCubesMetadata: Array<DataCubeMetadata> };
-
-export type DataCubesComponentsQueryVariables = Exact<{
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  locale: Scalars['String'];
-  filters: Array<DataCubeFilter> | DataCubeFilter;
-}>;
-
-
-export type DataCubesComponentsQuery = { __typename: 'Query', dataCubesComponents: DataCubesComponents };
-
 export type GeoCoordinatesByDimensionIriQueryVariables = Exact<{
   dataCubeIri: Scalars['String'];
   dimensionIri: Scalars['String'];
@@ -624,20 +646,6 @@ export type GeoShapesByDimensionIriQueryVariables = Exact<{
 
 export type GeoShapesByDimensionIriQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', dimensionByIri?: Maybe<{ __typename: 'GeoCoordinatesDimension' } | { __typename: 'GeoShapesDimension', geoShapes?: Maybe<any> } | { __typename: 'NominalDimension' } | { __typename: 'NumericalMeasure' } | { __typename: 'OrdinalDimension' } | { __typename: 'OrdinalMeasure' } | { __typename: 'StandardErrorDimension' } | { __typename: 'TemporalDimension' } | { __typename: 'TemporalOrdinalDimension' }> }> };
 
-export type DataCubeObservationsQueryVariables = Exact<{
-  iri: Scalars['String'];
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  locale: Scalars['String'];
-  componentIris?: Maybe<Array<Scalars['String']> | Scalars['String']>;
-  filters?: Maybe<Scalars['Filters']>;
-  latest?: Maybe<Scalars['Boolean']>;
-  limit?: Maybe<Scalars['Int']>;
-}>;
-
-
-export type DataCubeObservationsQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', observations: { __typename: 'ObservationsQuery', data: Array<Observation>, sparqlEditorUrl?: Maybe<string> } }> };
-
 export type PossibleFiltersQueryVariables = Exact<{
   iri: Scalars['String'];
   sourceType: Scalars['String'];
@@ -649,6 +657,48 @@ export type PossibleFiltersQueryVariables = Exact<{
 export type PossibleFiltersQuery = { __typename: 'Query', possibleFilters: Array<{ __typename: 'ObservationFilter', iri: string, type: string, value?: Maybe<any> }> };
 
 
+export const DataCubesComponentsDocument = gql`
+    query DataCubesComponents($sourceType: String!, $sourceUrl: String!, $locale: String!, $filters: [DataCubeFilter!]!) {
+  dataCubesComponents(
+    sourceType: $sourceType
+    sourceUrl: $sourceUrl
+    locale: $locale
+    filters: $filters
+  )
+}
+    `;
+
+export function useDataCubesComponentsQuery(options: Omit<Urql.UseQueryArgs<DataCubesComponentsQueryVariables>, 'query'> = {}) {
+  return Urql.useQuery<DataCubesComponentsQuery>({ query: DataCubesComponentsDocument, ...options });
+};
+export const DataCubesMetadataDocument = gql`
+    query DataCubesMetadata($sourceType: String!, $sourceUrl: String!, $locale: String!, $filters: [DataCubeFilter!]!) {
+  dataCubesMetadata(
+    sourceType: $sourceType
+    sourceUrl: $sourceUrl
+    locale: $locale
+    filters: $filters
+  )
+}
+    `;
+
+export function useDataCubesMetadataQuery(options: Omit<Urql.UseQueryArgs<DataCubesMetadataQueryVariables>, 'query'> = {}) {
+  return Urql.useQuery<DataCubesMetadataQuery>({ query: DataCubesMetadataDocument, ...options });
+};
+export const DataCubesObservationsDocument = gql`
+    query DataCubesObservations($sourceType: String!, $sourceUrl: String!, $locale: String!, $filters: [DataCubeFilter!]!) {
+  dataCubesObservations(
+    sourceType: $sourceType
+    sourceUrl: $sourceUrl
+    locale: $locale
+    filters: $filters
+  )
+}
+    `;
+
+export function useDataCubesObservationsQuery(options: Omit<Urql.UseQueryArgs<DataCubesObservationsQueryVariables>, 'query'> = {}) {
+  return Urql.useQuery<DataCubesObservationsQuery>({ query: DataCubesObservationsDocument, ...options });
+};
 export const SearchCubesDocument = gql`
     query SearchCubes($sourceType: String!, $sourceUrl: String!, $locale: String!, $query: String, $order: SearchCubeResultOrder, $includeDrafts: Boolean, $filters: [SearchCubeFilter!]) {
   searchCubes(
@@ -694,34 +744,6 @@ export const DataCubePreviewDocument = gql`
 
 export function useDataCubePreviewQuery(options: Omit<Urql.UseQueryArgs<DataCubePreviewQueryVariables>, 'query'> = {}) {
   return Urql.useQuery<DataCubePreviewQuery>({ query: DataCubePreviewDocument, ...options });
-};
-export const DataCubesMetadataDocument = gql`
-    query DataCubesMetadata($sourceType: String!, $sourceUrl: String!, $locale: String!, $filters: [DataCubeFilter!]!) {
-  dataCubesMetadata(
-    sourceType: $sourceType
-    sourceUrl: $sourceUrl
-    locale: $locale
-    filters: $filters
-  )
-}
-    `;
-
-export function useDataCubesMetadataQuery(options: Omit<Urql.UseQueryArgs<DataCubesMetadataQueryVariables>, 'query'> = {}) {
-  return Urql.useQuery<DataCubesMetadataQuery>({ query: DataCubesMetadataDocument, ...options });
-};
-export const DataCubesComponentsDocument = gql`
-    query DataCubesComponents($sourceType: String!, $sourceUrl: String!, $locale: String!, $filters: [DataCubeFilter!]!) {
-  dataCubesComponents(
-    sourceType: $sourceType
-    sourceUrl: $sourceUrl
-    locale: $locale
-    filters: $filters
-  )
-}
-    `;
-
-export function useDataCubesComponentsQuery(options: Omit<Urql.UseQueryArgs<DataCubesComponentsQueryVariables>, 'query'> = {}) {
-  return Urql.useQuery<DataCubesComponentsQuery>({ query: DataCubesComponentsDocument, ...options });
 };
 export const GeoCoordinatesByDimensionIriDocument = gql`
     query GeoCoordinatesByDimensionIri($dataCubeIri: String!, $dimensionIri: String!, $sourceType: String!, $sourceUrl: String!, $locale: String!, $latest: Boolean) {
@@ -777,32 +799,6 @@ export const GeoShapesByDimensionIriDocument = gql`
 
 export function useGeoShapesByDimensionIriQuery(options: Omit<Urql.UseQueryArgs<GeoShapesByDimensionIriQueryVariables>, 'query'> = {}) {
   return Urql.useQuery<GeoShapesByDimensionIriQuery>({ query: GeoShapesByDimensionIriDocument, ...options });
-};
-export const DataCubeObservationsDocument = gql`
-    query DataCubeObservations($iri: String!, $sourceType: String!, $sourceUrl: String!, $locale: String!, $componentIris: [String!], $filters: Filters, $latest: Boolean, $limit: Int) {
-  dataCubeByIri(
-    iri: $iri
-    sourceType: $sourceType
-    sourceUrl: $sourceUrl
-    locale: $locale
-    latest: $latest
-  ) {
-    observations(
-      sourceType: $sourceType
-      sourceUrl: $sourceUrl
-      componentIris: $componentIris
-      filters: $filters
-      limit: $limit
-    ) {
-      data
-      sparqlEditorUrl
-    }
-  }
-}
-    `;
-
-export function useDataCubeObservationsQuery(options: Omit<Urql.UseQueryArgs<DataCubeObservationsQueryVariables>, 'query'> = {}) {
-  return Urql.useQuery<DataCubeObservationsQuery>({ query: DataCubeObservationsDocument, ...options });
 };
 export const PossibleFiltersDocument = gql`
     query PossibleFilters($iri: String!, $sourceType: String!, $sourceUrl: String!, $filters: Filters!) {

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -296,13 +296,7 @@ export type ObservationFilter = {
 
 export type ObservationsQuery = {
   __typename: 'ObservationsQuery';
-  /** Observations with their values parsed to native JS types */
   data: Array<Scalars['Observation']>;
-  /** Observations with their original RDF-y type */
-  rawData: Array<Scalars['RawObservation']>;
-  /** The generated SPARQL query string of the current query (doesn't fetch any data) */
-  sparql: Scalars['String'];
-  /** The generated SPARQL query URL of the current query to run a query on the endpoint's editor directly */
   sparqlEditorUrl?: Maybe<Scalars['String']>;
 };
 
@@ -584,7 +578,7 @@ export type DataCubePreviewQueryVariables = Exact<{
 }>;
 
 
-export type DataCubePreviewQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', iri: string, title: string, description?: Maybe<string>, publicationStatus: DataCubePublicationStatus, observations: { __typename: 'ObservationsQuery', data: Array<Observation>, sparql: string, sparqlEditorUrl?: Maybe<string> } }> };
+export type DataCubePreviewQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', iri: string, title: string, description?: Maybe<string>, publicationStatus: DataCubePublicationStatus, observations: { __typename: 'ObservationsQuery', data: Array<Observation>, sparqlEditorUrl?: Maybe<string> } }> };
 
 export type DataCubesMetadataQueryVariables = Exact<{
   sourceType: Scalars['String'];
@@ -692,7 +686,6 @@ export const DataCubePreviewDocument = gql`
     publicationStatus
     observations(sourceType: $sourceType, sourceUrl: $sourceUrl, limit: 10) {
       data
-      sparql
       sparqlEditorUrl
     }
   }

--- a/app/graphql/resolver-types.ts
+++ b/app/graphql/resolver-types.ts
@@ -93,7 +93,7 @@ export type DataCubeMeasuresArgs = {
   disableValuesLoad?: Maybe<Scalars['Boolean']>;
 };
 
-export type DataCubeFilter = {
+export type DataCubeComponentFilter = {
   iri: Scalars['String'];
   latest?: Maybe<Scalars['Boolean']>;
   filters?: Maybe<Scalars['Filters']>;
@@ -104,6 +104,14 @@ export type DataCubeFilter = {
 export type DataCubeMetadataFilter = {
   iri: Scalars['String'];
   latest?: Maybe<Scalars['Boolean']>;
+};
+
+export type DataCubeObservationFilter = {
+  iri: Scalars['String'];
+  latest?: Maybe<Scalars['Boolean']>;
+  filters?: Maybe<Scalars['Filters']>;
+  componentIris?: Maybe<Array<Scalars['String']>>;
+  joinBy?: Maybe<Scalars['String']>;
 };
 
 export type DataCubeOrganization = {
@@ -384,7 +392,7 @@ export type QueryDataCubesComponentsArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
-  filters: Array<DataCubeFilter>;
+  filters: Array<DataCubeComponentFilter>;
 };
 
 
@@ -400,7 +408,7 @@ export type QueryDataCubesObservationsArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
-  filters: Array<DataCubeFilter>;
+  filters: Array<DataCubeObservationFilter>;
 };
 
 
@@ -643,9 +651,10 @@ export type ResolversTypes = ResolversObject<{
   String: ResolverTypeWrapper<Scalars['String']>;
   Int: ResolverTypeWrapper<Scalars['Int']>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
-  DataCubeFilter: DataCubeFilter;
+  DataCubeComponentFilter: DataCubeComponentFilter;
   DataCubeMetadata: ResolverTypeWrapper<Scalars['DataCubeMetadata']>;
   DataCubeMetadataFilter: DataCubeMetadataFilter;
+  DataCubeObservationFilter: DataCubeObservationFilter;
   DataCubeOrganization: ResolverTypeWrapper<DataCubeOrganization>;
   DataCubePublicationStatus: DataCubePublicationStatus;
   DataCubeTheme: ResolverTypeWrapper<DataCubeTheme>;
@@ -691,9 +700,10 @@ export type ResolversParentTypes = ResolversObject<{
   String: Scalars['String'];
   Int: Scalars['Int'];
   Boolean: Scalars['Boolean'];
-  DataCubeFilter: DataCubeFilter;
+  DataCubeComponentFilter: DataCubeComponentFilter;
   DataCubeMetadata: Scalars['DataCubeMetadata'];
   DataCubeMetadataFilter: DataCubeMetadataFilter;
+  DataCubeObservationFilter: DataCubeObservationFilter;
   DataCubeOrganization: DataCubeOrganization;
   DataCubeTheme: DataCubeTheme;
   DataCubesComponents: Scalars['DataCubesComponents'];

--- a/app/graphql/resolver-types.ts
+++ b/app/graphql/resolver-types.ts
@@ -95,11 +95,16 @@ export type DataCubeMeasuresArgs = {
 
 export type DataCubeFilter = {
   iri: Scalars['String'];
-  componentIris?: Maybe<Array<Scalars['String']>>;
-  filters?: Maybe<Scalars['Filters']>;
   latest?: Maybe<Scalars['Boolean']>;
+  filters?: Maybe<Scalars['Filters']>;
+  componentIris?: Maybe<Array<Scalars['String']>>;
 };
 
+
+export type DataCubeMetadataFilter = {
+  iri: Scalars['String'];
+  latest?: Maybe<Scalars['Boolean']>;
+};
 
 export type DataCubeOrganization = {
   __typename?: 'DataCubeOrganization';
@@ -387,7 +392,7 @@ export type QueryDataCubesMetadataArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
-  filters: Array<DataCubeFilter>;
+  filters: Array<DataCubeMetadataFilter>;
 };
 
 
@@ -640,6 +645,7 @@ export type ResolversTypes = ResolversObject<{
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
   DataCubeFilter: DataCubeFilter;
   DataCubeMetadata: ResolverTypeWrapper<Scalars['DataCubeMetadata']>;
+  DataCubeMetadataFilter: DataCubeMetadataFilter;
   DataCubeOrganization: ResolverTypeWrapper<DataCubeOrganization>;
   DataCubePublicationStatus: DataCubePublicationStatus;
   DataCubeTheme: ResolverTypeWrapper<DataCubeTheme>;
@@ -687,6 +693,7 @@ export type ResolversParentTypes = ResolversObject<{
   Boolean: Scalars['Boolean'];
   DataCubeFilter: DataCubeFilter;
   DataCubeMetadata: Scalars['DataCubeMetadata'];
+  DataCubeMetadataFilter: DataCubeMetadataFilter;
   DataCubeOrganization: DataCubeOrganization;
   DataCubeTheme: DataCubeTheme;
   DataCubesComponents: Scalars['DataCubesComponents'];

--- a/app/graphql/resolver-types.ts
+++ b/app/graphql/resolver-types.ts
@@ -297,13 +297,7 @@ export type ObservationFilter = {
 
 export type ObservationsQuery = {
   __typename?: 'ObservationsQuery';
-  /** Observations with their values parsed to native JS types */
   data: Array<Scalars['Observation']>;
-  /** Observations with their original RDF-y type */
-  rawData: Array<Scalars['RawObservation']>;
-  /** The generated SPARQL query string of the current query (doesn't fetch any data) */
-  sparql: Scalars['String'];
-  /** The generated SPARQL query URL of the current query to run a query on the endpoint's editor directly */
   sparqlEditorUrl?: Maybe<Scalars['String']>;
 };
 
@@ -889,8 +883,6 @@ export type ObservationFilterResolvers<ContextType = VisualizeGraphQLContext, Pa
 
 export type ObservationsQueryResolvers<ContextType = VisualizeGraphQLContext, ParentType extends ResolversParentTypes['ObservationsQuery'] = ResolversParentTypes['ObservationsQuery']> = ResolversObject<{
   data?: Resolver<Array<ResolversTypes['Observation']>, ParentType, ContextType>;
-  rawData?: Resolver<Array<ResolversTypes['RawObservation']>, ParentType, ContextType>;
-  sparql?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   sparqlEditorUrl?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;

--- a/app/graphql/resolver-types.ts
+++ b/app/graphql/resolver-types.ts
@@ -1,5 +1,6 @@
 import { DataCubeMetadata } from '../domain/data';
 import { DataCubesComponents } from '../domain/data';
+import { DataCubesObservations } from '../domain/data';
 import { DimensionValue } from '../domain/data';
 import { Filters } from '../configurator';
 import { HierarchyValue } from '../domain/data';
@@ -23,6 +24,7 @@ export type Scalars = {
   Float: number;
   DataCubeMetadata: DataCubeMetadata;
   DataCubesComponents: DataCubesComponents;
+  DataCubesObservations: DataCubesObservations;
   DimensionValue: DimensionValue;
   FilterValue: any;
   Filters: Filters;
@@ -115,6 +117,7 @@ export type DataCubeTheme = {
   iri: Scalars['String'];
   label?: Maybe<Scalars['String']>;
 };
+
 
 
 export type Dimension = {
@@ -365,6 +368,7 @@ export type Query = {
   __typename?: 'Query';
   dataCubesComponents: Scalars['DataCubesComponents'];
   dataCubesMetadata: Array<Scalars['DataCubeMetadata']>;
+  dataCubesObservations: Scalars['DataCubesObservations'];
   dataCubeByIri?: Maybe<DataCube>;
   possibleFilters: Array<ObservationFilter>;
   searchCubes: Array<SearchCubeResult>;
@@ -380,6 +384,14 @@ export type QueryDataCubesComponentsArgs = {
 
 
 export type QueryDataCubesMetadataArgs = {
+  sourceType: Scalars['String'];
+  sourceUrl: Scalars['String'];
+  locale: Scalars['String'];
+  filters: Array<DataCubeFilter>;
+};
+
+
+export type QueryDataCubesObservationsArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
@@ -632,6 +644,7 @@ export type ResolversTypes = ResolversObject<{
   DataCubePublicationStatus: DataCubePublicationStatus;
   DataCubeTheme: ResolverTypeWrapper<DataCubeTheme>;
   DataCubesComponents: ResolverTypeWrapper<Scalars['DataCubesComponents']>;
+  DataCubesObservations: ResolverTypeWrapper<Scalars['DataCubesObservations']>;
   Dimension: ResolverTypeWrapper<ResolvedDimension>;
   DimensionValue: ResolverTypeWrapper<Scalars['DimensionValue']>;
   FilterValue: ResolverTypeWrapper<Scalars['FilterValue']>;
@@ -677,6 +690,7 @@ export type ResolversParentTypes = ResolversObject<{
   DataCubeOrganization: DataCubeOrganization;
   DataCubeTheme: DataCubeTheme;
   DataCubesComponents: Scalars['DataCubesComponents'];
+  DataCubesObservations: Scalars['DataCubesObservations'];
   Dimension: ResolvedDimension;
   DimensionValue: Scalars['DimensionValue'];
   FilterValue: Scalars['FilterValue'];
@@ -750,6 +764,10 @@ export type DataCubeThemeResolvers<ContextType = VisualizeGraphQLContext, Parent
 
 export interface DataCubesComponentsScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DataCubesComponents'], any> {
   name: 'DataCubesComponents';
+}
+
+export interface DataCubesObservationsScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DataCubesObservations'], any> {
+  name: 'DataCubesObservations';
 }
 
 export type DimensionResolvers<ContextType = VisualizeGraphQLContext, ParentType extends ResolversParentTypes['Dimension'] = ResolversParentTypes['Dimension']> = ResolversObject<{
@@ -922,6 +940,7 @@ export type OrdinalMeasureResolvers<ContextType = VisualizeGraphQLContext, Paren
 export type QueryResolvers<ContextType = VisualizeGraphQLContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
   dataCubesComponents?: Resolver<ResolversTypes['DataCubesComponents'], ParentType, ContextType, RequireFields<QueryDataCubesComponentsArgs, 'sourceType' | 'sourceUrl' | 'locale' | 'filters'>>;
   dataCubesMetadata?: Resolver<Array<ResolversTypes['DataCubeMetadata']>, ParentType, ContextType, RequireFields<QueryDataCubesMetadataArgs, 'sourceType' | 'sourceUrl' | 'locale' | 'filters'>>;
+  dataCubesObservations?: Resolver<ResolversTypes['DataCubesObservations'], ParentType, ContextType, RequireFields<QueryDataCubesObservationsArgs, 'sourceType' | 'sourceUrl' | 'locale' | 'filters'>>;
   dataCubeByIri?: Resolver<Maybe<ResolversTypes['DataCube']>, ParentType, ContextType, RequireFields<QueryDataCubeByIriArgs, 'sourceType' | 'sourceUrl' | 'iri' | 'latest'>>;
   possibleFilters?: Resolver<Array<ResolversTypes['ObservationFilter']>, ParentType, ContextType, RequireFields<QueryPossibleFiltersArgs, 'iri' | 'sourceType' | 'sourceUrl' | 'filters'>>;
   searchCubes?: Resolver<Array<ResolversTypes['SearchCubeResult']>, ParentType, ContextType, RequireFields<QuerySearchCubesArgs, 'sourceType' | 'sourceUrl'>>;
@@ -1013,6 +1032,7 @@ export type Resolvers<ContextType = VisualizeGraphQLContext> = ResolversObject<{
   DataCubeOrganization?: DataCubeOrganizationResolvers<ContextType>;
   DataCubeTheme?: DataCubeThemeResolvers<ContextType>;
   DataCubesComponents?: GraphQLScalarType;
+  DataCubesObservations?: GraphQLScalarType;
   Dimension?: DimensionResolvers<ContextType>;
   DimensionValue?: GraphQLScalarType;
   FilterValue?: GraphQLScalarType;

--- a/app/graphql/resolvers.spec.ts
+++ b/app/graphql/resolvers.spec.ts
@@ -62,13 +62,11 @@ describe("possible filters", () => {
     getCubeObservations.mockImplementation(async ({ filters }) => {
       if (Object.keys(filters).length == 2) {
         return {
-          observations: [],
-          observationsRaw: {},
           query: "",
+          observations: [],
         };
       } else {
         return {
-          observationsRaw: {},
           query: "",
           observations: [
             {

--- a/app/graphql/resolvers/index.ts
+++ b/app/graphql/resolvers/index.ts
@@ -181,9 +181,6 @@ export const resolvers: Resolvers = {
   },
   ObservationsQuery: {
     data: async ({ data: { observations } }) => observations,
-    rawData: async ({ data: { observationsRaw } }) => observationsRaw,
-    sparql: async ({ data: { query } }) =>
-      query.replace(/\n+/g, " ").replace(/"/g, "'"),
     sparqlEditorUrl: async (
       { data: { query } },
       {},

--- a/app/graphql/resolvers/index.ts
+++ b/app/graphql/resolvers/index.ts
@@ -33,6 +33,10 @@ export const Query: QueryResolvers = {
     const source = getSource(args.sourceType);
     return await source.dataCubesMetadata(parent, args, context, info);
   },
+  dataCubesObservations: async (parent, args, context, info) => {
+    const source = getSource(args.sourceType);
+    return await source.dataCubesObservations(parent, args, context, info);
+  },
   dataCubeByIri: async (parent, args, context, info) => {
     const source = getSource(args.sourceType);
     return await source.dataCubeByIri(parent, args, context, info);

--- a/app/graphql/resolvers/rdf.ts
+++ b/app/graphql/resolvers/rdf.ts
@@ -16,6 +16,7 @@ import { truthy } from "@/domain/types";
 import { Loaders } from "@/graphql/context";
 import {
   DataCubeComponentFilter,
+  DataCubeObservationFilter,
   DataCubeResolvers,
   DimensionResolvers,
   QueryResolvers,
@@ -328,6 +329,8 @@ export const dataCubesObservations: NonNullable<
   }
 
   const { loaders, sparqlClient, cache } = await setup(info);
+  // If the cube was updated, we need to also update the filter with the correct iri.
+  const filtersWithCorrectIri: DataCubeObservationFilter[] = [];
 
   const data: Observation[] = [];
   const sparqlEditorUrls: DataCubesObservations["sparqlEditorUrls"] = [];
@@ -344,6 +347,11 @@ export const dataCubesObservations: NonNullable<
       const cube = latest ? await getLatestCube(rawCube) : rawCube;
       // TODO: optimize to avoid fetching the shape at all
       await cube.fetchShape();
+      filtersWithCorrectIri.push({
+        ...filter,
+        iri: cube.term?.value!,
+      });
+
       const { query, observations } = await getCubeObservations({
         cube,
         locale,

--- a/app/graphql/resolvers/rdf.ts
+++ b/app/graphql/resolvers/rdf.ts
@@ -253,7 +253,10 @@ export const dataCubesComponents: NonNullable<
               locale,
               sparqlClient,
               sparqlClientStream,
-              cache
+              cache,
+              // Only pass values if there are no filters, as we need to fetch
+              // the full, not filtered hierarchy.
+              cubeFilters?.filters ? undefined : values
             )
           : null;
         const baseDimension = {

--- a/app/graphql/resolvers/rdf.ts
+++ b/app/graphql/resolvers/rdf.ts
@@ -323,6 +323,10 @@ export const dataCubesMetadata: NonNullable<
 export const dataCubesObservations: NonNullable<
   QueryResolvers["dataCubesObservations"]
 > = async (_, { locale, filters }, { setup }, info) => {
+  if (filters.length > 1 && filters.some((f) => f.joinBy === undefined)) {
+    throw new Error("Can't query multiple cubes observations without joinBy!");
+  }
+
   const { loaders, sparqlClient, cache } = await setup(info);
 
   const data: Observation[] = [];

--- a/app/graphql/resolvers/rdf.ts
+++ b/app/graphql/resolvers/rdf.ts
@@ -15,7 +15,7 @@ import {
 import { truthy } from "@/domain/types";
 import { Loaders } from "@/graphql/context";
 import {
-  DataCubeFilter,
+  DataCubeComponentFilter,
   DataCubeResolvers,
   DimensionResolvers,
   QueryResolvers,
@@ -156,7 +156,7 @@ export const dataCubesComponents: NonNullable<
     info
   );
   // If the cube was updated, we need to also update the filter with the correct iri.
-  const filtersWithCorrectIri: DataCubeFilter[] = [];
+  const filtersWithCorrectIri: DataCubeComponentFilter[] = [];
 
   const cubes = (
     await Promise.all(

--- a/app/graphql/resolvers/rdf.ts
+++ b/app/graphql/resolvers/rdf.ts
@@ -374,7 +374,7 @@ export const dataCubeObservations: NonNullable<
   info
 ) => {
   const { sparqlClient, cache } = await setup(info);
-  const { query, observations, observationsRaw } = await getCubeObservations({
+  const { query, observations } = await getCubeObservations({
     cube,
     locale,
     sparqlClient,
@@ -390,7 +390,6 @@ export const dataCubeObservations: NonNullable<
     data: {
       query,
       observations,
-      observationsRaw,
       selectedFields: [],
     },
   };

--- a/app/graphql/resolvers/sql.ts
+++ b/app/graphql/resolvers/sql.ts
@@ -313,7 +313,6 @@ export const dataCubeObservations: NonNullable<
     data: {
       query: "",
       observations,
-      observationsRaw: [],
       selectedFields: [],
     },
   };

--- a/app/graphql/resolvers/sql.ts
+++ b/app/graphql/resolvers/sql.ts
@@ -317,3 +317,12 @@ export const dataCubeObservations: NonNullable<
     },
   };
 };
+
+export const dataCubesObservations: NonNullable<
+  QueryResolvers["dataCubesObservations"]
+> = async () => {
+  return {
+    data: [],
+    sparqlEditorUrls: [],
+  };
+};

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -337,7 +337,7 @@ enum SearchCubeResultOrder {
   CREATED_DESC
 }
 
-input DataCubeFilter {
+input DataCubeComponentFilter {
   iri: String!
   latest: Boolean
   filters: Filters
@@ -347,6 +347,14 @@ input DataCubeFilter {
 input DataCubeMetadataFilter {
   iri: String!
   latest: Boolean
+}
+
+input DataCubeObservationFilter {
+  iri: String!
+  latest: Boolean
+  filters: Filters
+  componentIris: [String!]
+  joinBy: String
 }
 
 scalar DataCubesComponents
@@ -360,7 +368,7 @@ type Query {
     sourceType: String!
     sourceUrl: String!
     locale: String!
-    filters: [DataCubeFilter!]!
+    filters: [DataCubeComponentFilter!]!
   ): DataCubesComponents!
   dataCubesMetadata(
     sourceType: String!
@@ -372,7 +380,7 @@ type Query {
     sourceType: String!
     sourceUrl: String!
     locale: String!
-    filters: [DataCubeFilter!]!
+    filters: [DataCubeObservationFilter!]!
   ): DataCubesObservations!
   dataCubeByIri(
     sourceType: String!

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -346,6 +346,7 @@ input DataCubeFilter {
 
 scalar DataCubesComponents
 scalar DataCubeMetadata
+scalar DataCubesObservations
 
 # The "Query" type is special: it lists all of the available queries that
 # clients can execute, along with the return type for each.
@@ -362,6 +363,12 @@ type Query {
     locale: String!
     filters: [DataCubeFilter!]!
   ): [DataCubeMetadata!]!
+  dataCubesObservations(
+    sourceType: String!
+    sourceUrl: String!
+    locale: String!
+    filters: [DataCubeFilter!]!
+  ): DataCubesObservations!
   dataCubeByIri(
     sourceType: String!
     sourceUrl: String!

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -339,8 +339,13 @@ enum SearchCubeResultOrder {
 
 input DataCubeFilter {
   iri: String!
-  componentIris: [String!]
+  latest: Boolean
   filters: Filters
+  componentIris: [String!]
+}
+
+input DataCubeMetadataFilter {
+  iri: String!
   latest: Boolean
 }
 
@@ -361,7 +366,7 @@ type Query {
     sourceType: String!
     sourceUrl: String!
     locale: String!
-    filters: [DataCubeFilter!]!
+    filters: [DataCubeMetadataFilter!]!
   ): [DataCubeMetadata!]!
   dataCubesObservations(
     sourceType: String!

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -9,13 +9,7 @@ scalar ValuePosition
 scalar HierarchyValue
 
 type ObservationsQuery {
-  "Observations with their values parsed to native JS types"
   data: [Observation!]!
-  "Observations with their original RDF-y type"
-  rawData: [RawObservation!]!
-  "The generated SPARQL query string of the current query (doesn't fetch any data)"
-  sparql: String!
-  "The generated SPARQL query URL of the current query to run a query on the endpoint's editor directly"
   sparqlEditorUrl: String
 }
 

--- a/app/graphql/shared-types.ts
+++ b/app/graphql/shared-types.ts
@@ -1,5 +1,4 @@
 import { CubeDimension } from "rdf-cube-view-query";
-import { Literal, NamedNode } from "rdf-js";
 
 import { ExtendedCube } from "@/rdf/extended-cube";
 
@@ -54,6 +53,5 @@ export type ResolvedObservationsQuery = {
   data: {
     query: string;
     observations: Observation[];
-    observationsRaw: Record<string, Literal | NamedNode>[];
   };
 };

--- a/app/pages/_pivot.tsx
+++ b/app/pages/_pivot.tsx
@@ -20,8 +20,8 @@ import { Loading } from "@/components/hint";
 import { Dimension, HierarchyValue } from "@/domain/data";
 import {
   Measure,
-  useDataCubeObservationsQuery,
   useDataCubesComponentsQuery,
+  useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { visitHierarchy } from "@/rdf/tree-utils";
 import useEvent from "@/utils/use-event";
@@ -175,12 +175,12 @@ const PivotTable = ({ dataset }: { dataset: typeof datasets[string] }) => {
       },
     });
   const [{ data: observationsData, fetching: fetchingObservations }] =
-    useDataCubeObservationsQuery({
+    useDataCubesObservationsQuery({
       variables: {
-        iri: dataset.iri,
         sourceUrl: "https://int.lindas.admin.ch/query",
         sourceType: "sparql",
         locale: "en",
+        filters: [{ iri: dataset.iri }],
       },
     });
 
@@ -192,8 +192,8 @@ const PivotTable = ({ dataset }: { dataset: typeof datasets[string] }) => {
   }, [allDimensions, ignoredDimensions]);
   const measures = componentsData?.dataCubesComponents?.measures;
   const observations = useMemo(() => {
-    return observationsData?.dataCubeByIri?.observations.data || [];
-  }, [observationsData?.dataCubeByIri?.observations.data]);
+    return observationsData?.dataCubesObservations?.data ?? [];
+  }, [observationsData?.dataCubesObservations?.data]);
 
   const handleChangePivot = (ev: ChangeEvent<HTMLSelectElement>) => {
     const name = ev.currentTarget.value;

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -536,9 +536,9 @@ export const getCubeObservations = async ({
   locale: string;
   sparqlClient: ParsingClient;
   /** Observations filters that should be considered */
-  filters?: Filters;
+  filters?: Filters | null;
   /** Limit on the number of observations returned */
-  limit?: number;
+  limit?: number | null;
   /** Returns IRIs instead of labels for NamedNodes  */
   raw?: boolean;
   componentIris?: Maybe<string[]>;
@@ -876,7 +876,7 @@ async function fetchViewObservations({
   observationsView,
   disableDistinct,
 }: {
-  limit: number | undefined;
+  limit?: number | null;
   observationsView: View;
   disableDistinct: boolean;
 }) {

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -21,7 +21,10 @@ import {
   parseRDFLiteral,
   shouldLoadMinMaxValues,
 } from "../domain/data";
-import { ResolvedDimension } from "../graphql/shared-types";
+import {
+  ResolvedDimension,
+  ResolvedObservationsQuery,
+} from "../graphql/shared-types";
 
 import * as ns from "./namespace";
 import { schema } from "./namespace";
@@ -540,11 +543,7 @@ export const getCubeObservations = async ({
   raw?: boolean;
   componentIris?: Maybe<string[]>;
   cache: LRUCache | undefined;
-}): Promise<{
-  query: string;
-  observations: Observation[];
-  observationsRaw: Record<string, Literal | NamedNode>[];
-}> => {
+}): Promise<ResolvedObservationsQuery["data"]> => {
   const cubeView = View.fromCube(cube, false);
 
   const allResolvedDimensions = await getCubeDimensions({
@@ -609,7 +608,7 @@ export const getCubeObservations = async ({
   const { query, observationsRaw } = await fetchViewObservations({
     limit,
     observationsView,
-    disableDistinct: !!(!filters || Object.keys(filters).length === 0),
+    disableDistinct: !filters || Object.keys(filters).length === 0,
   });
 
   const serverFilter =
@@ -659,11 +658,7 @@ export const getCubeObservations = async ({
     }
   }
 
-  return {
-    query,
-    observationsRaw: serverFilter ? filteredObservationsRaw : observationsRaw,
-    observations,
-  };
+  return { query, observations };
 };
 
 const makeServerFilter = (filters: Record<string, FilterValueMulti>) => {

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -8,7 +8,7 @@ import { ParsingClient } from "sparql-http-client/ParsingClient";
 import { LRUCache } from "typescript-lru-cache";
 
 import { PromiseValue, truthy } from "@/domain/types";
-import { DataCubeFilter } from "@/graphql/resolver-types";
+import { DataCubeComponentFilter } from "@/graphql/resolver-types";
 import { pragmas } from "@/rdf/create-source";
 import { ExtendedCube } from "@/rdf/extended-cube";
 
@@ -122,7 +122,7 @@ const getDimensionUnits = (d: CubeDimension) => {
 export const getCubesDimensions = async (
   cubes: ExtendedCube[],
   options: {
-    filters: DataCubeFilter[];
+    filters: DataCubeComponentFilter[];
     locale: string;
     sparqlClient: ParsingClient;
     cache: LRUCache | undefined;

--- a/codegen.yml
+++ b/codegen.yml
@@ -24,6 +24,7 @@ generates:
         SearchCube: "../domain/data#SearchCube"
         DataCubesComponents: "../domain/data#DataCubesComponents"
         DataCubeMetadata: "../domain/data#DataCubeMetadata"
+        DataCubesObservations: "../domain/data#DataCubesObservations"
   app/graphql/resolver-types.ts:
     plugins:
       - "typescript"
@@ -43,6 +44,7 @@ generates:
         SearchCube: "../domain/data#SearchCube"
         DataCubesComponents: "../domain/data#DataCubesComponents"
         DataCubeMetadata: "../domain/data#DataCubeMetadata"
+        DataCubesObservations: "../domain/data#DataCubesObservations"
       mappers:
         DataCube: "./shared-types#ResolvedDataCube"
         ObservationsQuery: "./shared-types#ResolvedObservationsQuery"


### PR DESCRIPTION
This PR adapts the application logic to support retrieving observations from multiple cubes at once (merging them along the way).

### GQL / SPARQL
- Removed `DataCubeObservations` query (replaced by `DataCubesObservations`)
- Observations queried from multiple cubes are now merged on the server-side by joinBy dimensions (assumed to be temporal dimensions of the same unit in the first iteration). This would need to be guaranteed by the front-end
- Removed unused variables (`rawObservations`, `sparql`) from observations query
- Introduced separate filter types per query (components, metadata, observations)
- Optimized hierarchy query to not re-fetch dimension values in case no filters were applied

---
## Context
This PR is a third part of preparations for merging the cubes. For the technical concept, see [this Notion document](https://www.notion.so/interactivethings/Combine-two-cubes-in-the-same-chart-d5711b414a7747e79edfc3cfe17d2c9b).

- [x] `DataCubesComponents`
- [x] `DataCubesMetadata`
- [x] `DataCubesObservations`

## How to test
1. Click around in the application and make sure nothing is broken 💥 
2. Open [GQL playground](https://visualization-tool-git-feat-multiple-cubes-observations-ixt1.vercel.app/api/graphql) and send e.g. the following query to see that observations from both cubes was fetched (and merged when encountering the same value from joinBy dimensions).

**Query**
```graphql
query DataCubesObservations(
  $sourceType: String!
  $sourceUrl: String!
  $locale: String!
  $filters: [DataCubeObservationFilter!]!
) {
  dataCubesObservations(
    sourceType: $sourceType
    sourceUrl: $sourceUrl
    locale: $locale
    filters: $filters
  )
}
```

**Variables**
```js
{
  "sourceType": "sparql",
  "sourceUrl": "https://lindas.admin.ch/query",
  "locale": "en",
  "filters": [
    {
      "iri": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9",
      "latest": true,
      "filters": {
        "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Kanton": {
          "type": "single",
          "value": "https://ld.admin.ch/canton/1"
        }
      },
      "joinBy":"https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr"
    }
,
    {
      "iri": "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_co2wirkung/4",
      "filters": {
        "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_co2wirkung/region": {
          "type": "single",
          "value": "https://ld.admin.ch/country/CHE"
        },
        "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_co2wirkung/massnahmenbereich": {
          "type": "single",
          "value": "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_co2wirkung/ogd18_catalog/Haustechnik"
        }
      },
      "joinBy":"https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_co2wirkung/Jahr"
    } 
  ]
}
```