### PR TITLE
refactor: Multi-cube ChartConfig

### DIFF
--- a/app/browse/datatable.tsx
+++ b/app/browse/datatable.tsx
@@ -283,6 +283,7 @@ export const DataSetTable = ({
   const queryFilters = useQueryFilters({
     chartConfig,
     dimensions: componentsData?.dataCubesComponents?.dimensions ?? [],
+    measures: componentsData?.dataCubesComponents?.measures ?? [],
   });
   const [{ data: observationsData }] = useDataCubesObservationsQuery({
     variables: {

--- a/app/browse/datatable.tsx
+++ b/app/browse/datatable.tsx
@@ -32,8 +32,8 @@ import { useDimensionFormatters } from "@/formatters";
 import {
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
+  useDataCubesObservationsQuery,
 } from "@/graphql/hooks";
-import { useDataCubesObservationsQuery } from "@/graphql/query-hooks";
 import SvgIcChevronDown from "@/icons/components/IcChevronDown";
 import { useLocale } from "@/locales/use-locale";
 import { uniqueMapBy } from "@/utils/uniqueMapBy";
@@ -288,7 +288,7 @@ export const DataSetTable = ({
   const [{ data: observationsData }] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: queryFilters ?? [],
+      cubeFilters: queryFilters ?? [],
     },
     pause: fetchingComponents || !queryFilters,
   });

--- a/app/browse/datatable.tsx
+++ b/app/browse/datatable.tsx
@@ -29,9 +29,9 @@ import {
   isNumericalMeasure,
 } from "@/domain/data";
 import { useDimensionFormatters } from "@/formatters";
+import { useDataCubesMetadataQuery } from "@/graphql/hooks";
 import {
   useDataCubesComponentsQuery,
-  useDataCubesMetadataQuery,
   useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import SvgIcChevronDown from "@/icons/components/IcChevronDown";
@@ -257,7 +257,7 @@ export const DataSetTable = ({
   const [{ data: metadataData }] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
+      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const [{ data: componentsData, fetching: fetchingComponents }] =

--- a/app/browse/datatable.tsx
+++ b/app/browse/datatable.tsx
@@ -29,11 +29,11 @@ import {
   isNumericalMeasure,
 } from "@/domain/data";
 import { useDimensionFormatters } from "@/formatters";
-import { useDataCubesMetadataQuery } from "@/graphql/hooks";
 import {
   useDataCubesComponentsQuery,
-  useDataCubesObservationsQuery,
-} from "@/graphql/query-hooks";
+  useDataCubesMetadataQuery,
+} from "@/graphql/hooks";
+import { useDataCubesObservationsQuery } from "@/graphql/query-hooks";
 import SvgIcChevronDown from "@/icons/components/IcChevronDown";
 import { useLocale } from "@/locales/use-locale";
 import { uniqueMapBy } from "@/utils/uniqueMapBy";
@@ -264,7 +264,7 @@ export const DataSetTable = ({
     useDataCubesComponentsQuery({
       variables: {
         ...commonQueryVariables,
-        filters: chartConfig.cubes.map((cube) => ({
+        cubeFilters: chartConfig.cubes.map((cube) => ({
           iri: cube.iri,
           componentIris,
         })),

--- a/app/browse/datatable.tsx
+++ b/app/browse/datatable.tsx
@@ -282,15 +282,15 @@ export const DataSetTable = ({
   }, [componentsData?.dataCubesComponents]);
   const queryFilters = useQueryFilters({
     chartConfig,
-    dimensions: componentsData?.dataCubesComponents?.dimensions ?? [],
-    measures: componentsData?.dataCubesComponents?.measures ?? [],
+    dimensions: componentsData?.dataCubesComponents?.dimensions,
+    measures: componentsData?.dataCubesComponents?.measures,
   });
   const [{ data: observationsData }] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: queryFilters,
+      filters: queryFilters ?? [],
     },
-    pause: fetchingComponents,
+    pause: fetchingComponents || !queryFilters,
   });
 
   return metadataData?.dataCubesMetadata &&

--- a/app/browser/dataset-preview.tsx
+++ b/app/browser/dataset-preview.tsx
@@ -11,10 +11,8 @@ import { DataDownloadMenu, RunSparqlQuery } from "@/components/data-download";
 import Flex from "@/components/flex";
 import { HintRed, Loading, LoadingDataError } from "@/components/hint";
 import { DataSource } from "@/config-types";
-import {
-  useDataCubePreviewQuery,
-  useDataCubesComponentsQuery,
-} from "@/graphql/query-hooks";
+import { useDataCubesComponentsQuery } from "@/graphql/hooks";
+import { useDataCubePreviewQuery } from "@/graphql/query-hooks";
 import { DataCubePublicationStatus } from "@/graphql/resolver-types";
 import { useLocale } from "@/locales/use-locale";
 
@@ -116,7 +114,7 @@ export const DataSetPreview = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      filters,
+      cubeFilters: filters,
     },
   });
   const classes = useStyles({

--- a/app/browser/dataset-preview.tsx
+++ b/app/browser/dataset-preview.tsx
@@ -94,6 +94,7 @@ export const DataSetPreview = ({
 }) => {
   const footnotesClasses = useFootnotesStyles({ useMarginTop: false });
   const locale = useLocale();
+  const filters = [{ iri: dataSetIri }];
   const [
     { data: previewData, fetching: fetchingPreview, error: previewError },
   ] = useDataCubePreviewQuery({
@@ -115,7 +116,7 @@ export const DataSetPreview = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      filters: [{ iri: dataSetIri }],
+      filters,
     },
   });
   const classes = useStyles({
@@ -196,9 +197,9 @@ export const DataSetPreview = ({
           <Flex className={classes.footnotesWrapper}>
             <Flex className={footnotesClasses.actions}>
               <DataDownloadMenu
-                dataSetIri={dataSetIri}
                 dataSource={dataSource}
                 title={dataCubeByIri.title}
+                filters={filters}
               />
               {dataCubeByIri.observations.sparqlEditorUrl && (
                 <RunSparqlQuery

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -111,7 +111,7 @@ const useAreasState = (
   const calculationType = useInteractiveFilters((d) => d.calculation.type);
 
   const segmentsByValue = useMemo(() => {
-    const values = segmentDimension?.values || [];
+    const values = segmentDimension?.values ?? [];
 
     return new Map(values.map((d) => [d.value, d]));
   }, [segmentDimension?.values]);
@@ -122,7 +122,8 @@ const useAreasState = (
   const segmentSortingOrder = segmentSorting?.sortingOrder;
 
   const segmentFilter = segmentDimension?.iri
-    ? chartConfig.filters[segmentDimension?.iri]
+    ? chartConfig.cubes.find((d) => d.iri === segmentDimension.cubeIri)
+        ?.filters[segmentDimension.iri]
     : undefined;
 
   const sumsBySegment = useMemo(() => {

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -16,10 +16,12 @@ import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import { AreaConfig, DataSource } from "@/config-types";
-import { useDataCubesMetadataQuery } from "@/graphql/hooks";
+import {
+  useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
+} from "@/graphql/hooks";
 import {
   DataCubeObservationFilter,
-  useDataCubesComponentsQuery,
   useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
@@ -52,7 +54,7 @@ export const ChartAreasVisualization = ({
   const [componentsQuery] = useDataCubesComponentsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({
+      cubeFilters: chartConfig.cubes.map((cube) => ({
         iri: cube.iri,
         componentIris,
       })),

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -15,8 +15,9 @@ import { Ruler } from "@/charts/shared/interaction/ruler";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
-import { AreaConfig, DataSource, QueryFilters } from "@/config-types";
+import { AreaConfig, DataSource } from "@/config-types";
 import {
+  DataCubeObservationFilter,
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
   useDataCubesObservationsQuery,
@@ -26,16 +27,14 @@ import { useLocale } from "@/locales/use-locale";
 import { ChartProps } from "../shared/ChartProps";
 
 export const ChartAreasVisualization = ({
-  dataSetIri,
   dataSource,
   chartConfig,
   queryFilters,
   componentIris,
 }: {
-  dataSetIri: string;
   dataSource: DataSource;
   chartConfig: AreaConfig;
-  queryFilters: QueryFilters;
+  queryFilters: DataCubeObservationFilter[];
   componentIris: string[] | undefined;
 }) => {
   const locale = useLocale();
@@ -47,19 +46,22 @@ export const ChartAreasVisualization = ({
   const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri }],
+      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris }],
+      filters: chartConfig.cubes.map((cube) => ({
+        iri: cube.iri,
+        componentIris,
+      })),
     },
   });
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
+      filters: queryFilters,
     },
   });
 

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -34,7 +34,7 @@ export const ChartAreasVisualization = ({
 }: {
   dataSource: DataSource;
   chartConfig: AreaConfig;
-  queryFilters: DataCubeObservationFilter[];
+  queryFilters?: DataCubeObservationFilter[];
   componentIris: string[] | undefined;
 }) => {
   const locale = useLocale();
@@ -61,8 +61,9 @@ export const ChartAreasVisualization = ({
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: queryFilters,
+      filters: queryFilters ?? [],
     },
+    pause: !queryFilters,
   });
 
   return (

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -19,11 +19,9 @@ import { AreaConfig, DataSource } from "@/config-types";
 import {
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
-} from "@/graphql/hooks";
-import {
-  DataCubeObservationFilter,
   useDataCubesObservationsQuery,
-} from "@/graphql/query-hooks";
+} from "@/graphql/hooks";
+import { DataCubeObservationFilter } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
 import { ChartProps } from "../shared/ChartProps";
@@ -63,7 +61,7 @@ export const ChartAreasVisualization = ({
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: queryFilters ?? [],
+      cubeFilters: queryFilters ?? [],
     },
     pause: !queryFilters,
   });

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -16,10 +16,10 @@ import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import { AreaConfig, DataSource } from "@/config-types";
+import { useDataCubesMetadataQuery } from "@/graphql/hooks";
 import {
   DataCubeObservationFilter,
   useDataCubesComponentsQuery,
-  useDataCubesMetadataQuery,
   useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
@@ -46,7 +46,7 @@ export const ChartAreasVisualization = ({
   const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
+      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({

--- a/app/charts/chart-config-ui-options.ts
+++ b/app/charts/chart-config-ui-options.ts
@@ -198,10 +198,15 @@ const onColorComponentIriChange: OnEncodingOptionChange<string, MapConfig> = (
         interpolationType: "linear",
       };
     }
+
+    // Remove old filter.
+    const cube = chartConfig.cubes.find((d) => d.iri === component.cubeIri);
+
+    if (cube) {
+      unset(cube, `filters["${currentColorComponentIri}"]`);
+    }
   }
 
-  // Remove old filter.
-  unset(chartConfig, `filters["${currentColorComponentIri}"]`);
   setWith(chartConfig, `${basePath}.color`, newField, Object);
 };
 

--- a/app/charts/chart-config-ui-options.ts
+++ b/app/charts/chart-config-ui-options.ts
@@ -502,9 +502,15 @@ export const defaultSegmentOnChange: OnEncodingChange<
     chartConfig.fields.segment.colorMapping = colorMapping;
   }
 
-  if (selectedValues.length) {
-    const multiFilter = makeMultiFilter(selectedValues.map((d) => d.value));
-    chartConfig.filters[iri] = multiFilter;
+  if (!selectedValues.length || !component) {
+    return;
+  }
+
+  const multiFilter = makeMultiFilter(selectedValues.map((d) => d.value));
+  const cube = chartConfig.cubes.find((d) => d.iri === component.cubeIri);
+
+  if (cube) {
+    cube.filters[iri] = multiFilter;
   }
 };
 

--- a/app/charts/chart-loading-wrapper.tsx
+++ b/app/charts/chart-loading-wrapper.tsx
@@ -14,11 +14,11 @@ import {
   NoDataHint,
 } from "@/components/hint";
 import { ChartConfig } from "@/configurator";
-import { useDataCubesMetadataQuery } from "@/graphql/hooks";
 import {
-  DataCubesComponentsQuery,
-  DataCubesObservationsQuery,
-} from "@/graphql/query-hooks";
+  useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
+} from "@/graphql/hooks";
+import { DataCubesObservationsQuery } from "@/graphql/query-hooks";
 
 type ElementProps<RE> = RE extends React.ElementType<infer P> ? P : never;
 
@@ -35,10 +35,7 @@ export const ChartLoadingWrapper = <
   ComponentProps,
 }: {
   metadataQuery: ReturnType<typeof useDataCubesMetadataQuery>[0];
-  componentsQuery: Pick<
-    UseQueryResponse<DataCubesComponentsQuery>[0],
-    "data" | "fetching" | "error"
-  >;
+  componentsQuery: ReturnType<typeof useDataCubesComponentsQuery>[0];
   observationsQuery: Pick<
     UseQueryResponse<DataCubesObservationsQuery>[0],
     "data" | "fetching" | "error"

--- a/app/charts/chart-loading-wrapper.tsx
+++ b/app/charts/chart-loading-wrapper.tsx
@@ -14,9 +14,9 @@ import {
   NoDataHint,
 } from "@/components/hint";
 import { ChartConfig } from "@/configurator";
+import { useDataCubesMetadataQuery } from "@/graphql/hooks";
 import {
   DataCubesComponentsQuery,
-  DataCubesMetadataQuery,
   DataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 
@@ -34,10 +34,7 @@ export const ChartLoadingWrapper = <
   Component,
   ComponentProps,
 }: {
-  metadataQuery: Pick<
-    UseQueryResponse<DataCubesMetadataQuery>[0],
-    "data" | "fetching" | "error"
-  >;
+  metadataQuery: ReturnType<typeof useDataCubesMetadataQuery>[0];
   componentsQuery: Pick<
     UseQueryResponse<DataCubesComponentsQuery>[0],
     "data" | "fetching" | "error"

--- a/app/charts/chart-loading-wrapper.tsx
+++ b/app/charts/chart-loading-wrapper.tsx
@@ -1,7 +1,6 @@
 import { Box } from "@mui/material";
 import keyBy from "lodash/keyBy";
 import React from "react";
-import { UseQueryResponse } from "urql";
 
 import { ChartProps } from "@/charts/shared/ChartProps";
 import { A11yTable } from "@/charts/shared/a11y-table";
@@ -17,8 +16,8 @@ import { ChartConfig } from "@/configurator";
 import {
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
+  useDataCubesObservationsQuery,
 } from "@/graphql/hooks";
-import { DataCubesObservationsQuery } from "@/graphql/query-hooks";
 
 type ElementProps<RE> = RE extends React.ElementType<infer P> ? P : never;
 
@@ -36,10 +35,7 @@ export const ChartLoadingWrapper = <
 }: {
   metadataQuery: ReturnType<typeof useDataCubesMetadataQuery>[0];
   componentsQuery: ReturnType<typeof useDataCubesComponentsQuery>[0];
-  observationsQuery: Pick<
-    UseQueryResponse<DataCubesObservationsQuery>[0],
-    "data" | "fetching" | "error"
-  >;
+  observationsQuery: ReturnType<typeof useDataCubesObservationsQuery>[0];
   chartConfig: TChartConfig;
   Component: TChartComponent;
   ComponentProps?: Omit<

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -30,10 +30,10 @@ import {
   useChartConfigFilters,
 } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
+import { useDataCubesMetadataQuery } from "@/graphql/hooks";
 import {
   DataCubeObservationFilter,
   useDataCubesComponentsQuery,
-  useDataCubesMetadataQuery,
   useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
@@ -60,7 +60,7 @@ export const ChartColumnsVisualization = ({
   const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
+      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -24,9 +24,14 @@ import {
 } from "@/charts/shared/containers";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
-import { ColumnConfig, DataSource, QueryFilters } from "@/config-types";
+import {
+  ColumnConfig,
+  DataSource,
+  useChartConfigFilters,
+} from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import {
+  DataCubeObservationFilter,
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
   useDataCubesObservationsQuery,
@@ -36,17 +41,15 @@ import { useLocale } from "@/locales/use-locale";
 import { ChartProps } from "../shared/ChartProps";
 
 export const ChartColumnsVisualization = ({
-  dataSetIri,
   dataSource,
   componentIris,
   chartConfig,
   queryFilters,
 }: {
-  dataSetIri: string;
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: ColumnConfig;
-  queryFilters: QueryFilters;
+  queryFilters: DataCubeObservationFilter[];
 }) => {
   const locale = useLocale();
   const commonQueryVariables = {
@@ -57,19 +60,22 @@ export const ChartColumnsVisualization = ({
   const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri }],
+      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris }],
+      filters: chartConfig.cubes.map((cube) => ({
+        iri: cube.iri,
+        componentIris,
+      })),
     },
   });
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
+      filters: queryFilters,
     },
   });
 
@@ -86,7 +92,8 @@ export const ChartColumnsVisualization = ({
 
 export const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
   const { chartConfig, dimensions } = props;
-  const { fields, filters, interactiveFiltersConfig } = chartConfig;
+  const { fields, interactiveFiltersConfig } = chartConfig;
+  const filters = useChartConfigFilters(chartConfig);
 
   return (
     <>

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -49,7 +49,7 @@ export const ChartColumnsVisualization = ({
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: ColumnConfig;
-  queryFilters: DataCubeObservationFilter[];
+  queryFilters?: DataCubeObservationFilter[];
 }) => {
   const locale = useLocale();
   const commonQueryVariables = {
@@ -75,8 +75,9 @@ export const ChartColumnsVisualization = ({
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: queryFilters,
+      filters: queryFilters ?? [],
     },
+    pause: !queryFilters,
   });
 
   return (

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -33,11 +33,9 @@ import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import {
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
-} from "@/graphql/hooks";
-import {
-  DataCubeObservationFilter,
   useDataCubesObservationsQuery,
-} from "@/graphql/query-hooks";
+} from "@/graphql/hooks";
+import { DataCubeObservationFilter } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
 import { ChartProps } from "../shared/ChartProps";
@@ -77,7 +75,7 @@ export const ChartColumnsVisualization = ({
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: queryFilters ?? [],
+      cubeFilters: queryFilters ?? [],
     },
     pause: !queryFilters,
   });

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -30,10 +30,12 @@ import {
   useChartConfigFilters,
 } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
-import { useDataCubesMetadataQuery } from "@/graphql/hooks";
+import {
+  useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
+} from "@/graphql/hooks";
 import {
   DataCubeObservationFilter,
-  useDataCubesComponentsQuery,
   useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
@@ -66,7 +68,7 @@ export const ChartColumnsVisualization = ({
   const [componentsQuery] = useDataCubesComponentsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({
+      cubeFilters: chartConfig.cubes.map((cube) => ({
         iri: cube.iri,
         componentIris,
       })),

--- a/app/charts/column/columns-grouped-state-props.ts
+++ b/app/charts/column/columns-grouped-state-props.ts
@@ -19,7 +19,11 @@ import {
   useSegmentVariables,
 } from "@/charts/shared/chart-state";
 import { useRenderingKeyVariable } from "@/charts/shared/rendering-utils";
-import { ColumnConfig, ColumnFields } from "@/configurator";
+import {
+  ColumnConfig,
+  ColumnFields,
+  useChartConfigFilters,
+} from "@/configurator";
 import { Observation } from "@/domain/data";
 import { sortByIndex } from "@/utils/array";
 
@@ -43,8 +47,9 @@ export const useColumnsGroupedStateVariables = (
     measures,
     measuresByIri,
   } = props;
-  const { fields, filters, interactiveFiltersConfig } = chartConfig;
+  const { fields, interactiveFiltersConfig } = chartConfig;
   const { x, y, segment, animation } = fields;
+  const filters = useChartConfigFilters(chartConfig);
 
   const baseVariables = useBaseVariables(chartConfig);
   const bandXVariables = useBandXVariables(x, {

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -127,7 +127,8 @@ const useColumnsGroupedState = (
   }, [segmentData, getY, getSegment]);
 
   const segmentFilter = segmentDimension?.iri
-    ? chartConfig.filters[segmentDimension.iri]
+    ? chartConfig.cubes.find((d) => d.iri === segmentDimension.cubeIri)
+        ?.filters[segmentDimension.iri]
     : undefined;
   const { allSegments, segments } = useMemo(() => {
     const allUniqueSegments = Array.from(
@@ -165,7 +166,8 @@ const useColumnsGroupedState = (
   ]);
 
   /* Scales */
-  const xFilter = chartConfig.filters[fields.x.componentIri];
+  const xFilter = chartConfig.cubes.find((d) => d.iri === xDimension.cubeIri)
+    ?.filters[xDimension.iri];
   const sumsByX = useMemo(() => {
     return Object.fromEntries(
       rollup(

--- a/app/charts/column/columns-stacked-state-props.ts
+++ b/app/charts/column/columns-stacked-state-props.ts
@@ -16,7 +16,11 @@ import {
   useSegmentVariables,
 } from "@/charts/shared/chart-state";
 import { useRenderingKeyVariable } from "@/charts/shared/rendering-utils";
-import { ColumnConfig, ColumnFields } from "@/configurator";
+import {
+  ColumnConfig,
+  ColumnFields,
+  useChartConfigFilters,
+} from "@/configurator";
 import { Observation } from "@/domain/data";
 import { sortByIndex } from "@/utils/array";
 
@@ -38,8 +42,9 @@ export const useColumnsStackedStateVariables = (
     dimensionsByIri,
     measuresByIri,
   } = props;
-  const { fields, filters, interactiveFiltersConfig } = chartConfig;
+  const { fields, interactiveFiltersConfig } = chartConfig;
   const { x, y, segment, animation } = fields;
+  const filters = useChartConfigFilters(chartConfig);
 
   const baseVariables = useBaseVariables(chartConfig);
   const bandXVariables = useBandXVariables(x, {

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -136,7 +136,8 @@ const useColumnsStackedState = (
   }, [getSegment, getY, scalesData]);
 
   const segmentFilter = segmentDimension?.iri
-    ? chartConfig.filters[segmentDimension?.iri]
+    ? chartConfig.cubes.find((d) => d.iri === segmentDimension.cubeIri)
+        ?.filters[segmentDimension.iri]
     : undefined;
   const { allSegments, segments } = useMemo(() => {
     const allUniqueSegments = Array.from(new Set(segmentData.map(getSegment)));
@@ -206,7 +207,8 @@ const useColumnsStackedState = (
     });
   }, [getSegment, getY, chartDataGroupedByX, segments, xKey]);
 
-  const xFilter = chartConfig.filters[xDimension.iri];
+  const xFilter = chartConfig.cubes.find((d) => d.iri === xDimension.cubeIri)
+    ?.filters[xDimension.iri];
   // Map ordered segments labels to colors
   const {
     colors,

--- a/app/charts/column/columns-state-props.ts
+++ b/app/charts/column/columns-state-props.ts
@@ -16,7 +16,11 @@ import {
   useNumericalYVariables,
 } from "@/charts/shared/chart-state";
 import { useRenderingKeyVariable } from "@/charts/shared/rendering-utils";
-import { ColumnConfig, ColumnFields } from "@/configurator";
+import {
+  ColumnConfig,
+  ColumnFields,
+  useChartConfigFilters,
+} from "@/configurator";
 import { Observation } from "@/domain/data";
 
 import { ChartProps } from "../shared/ChartProps";
@@ -38,8 +42,9 @@ export const useColumnsStateVariables = (
     measures,
     measuresByIri,
   } = props;
-  const { fields, filters, interactiveFiltersConfig } = chartConfig;
+  const { fields, interactiveFiltersConfig } = chartConfig;
   const { x, y, animation } = fields;
+  const filters = useChartConfigFilters(chartConfig);
 
   const baseVariables = useBaseVariables(chartConfig);
   const bandXVariables = useBandXVariables(x, {

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -109,7 +109,9 @@ const useColumnsState = (
       measureBySegment: sumsByX,
       useAbbreviations: fields.x.useAbbreviations,
       dimensionFilter: xDimension?.iri
-        ? chartConfig.filters[xDimension.iri]
+        ? chartConfig.cubes.find((d) => d.iri === xDimension.cubeIri)?.filters[
+            xDimension.iri
+          ]
         : undefined,
     });
     const sortingOrders = getSortingOrders(sorters, fields.x.sorting);
@@ -185,7 +187,7 @@ const useColumnsState = (
     fields.x.sorting,
     fields.x.useAbbreviations,
     xDimension,
-    chartConfig.filters,
+    chartConfig.cubes,
     sumsByX,
   ]);
 

--- a/app/charts/combo/chart-combo-line-column.tsx
+++ b/app/charts/combo/chart-combo-line-column.tsx
@@ -12,10 +12,10 @@ import { HoverDotMultiple } from "@/charts/shared/interaction/hover-dots-multipl
 import { Ruler } from "@/charts/shared/interaction/ruler";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { ComboLineColumnConfig, DataSource } from "@/config-types";
+import { useDataCubesMetadataQuery } from "@/graphql/hooks";
 import {
   DataCubeObservationFilter,
   useDataCubesComponentsQuery,
-  useDataCubesMetadataQuery,
   useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
@@ -42,7 +42,7 @@ export const ChartComboLineColumnVisualization = (
   const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
+      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({

--- a/app/charts/combo/chart-combo-line-column.tsx
+++ b/app/charts/combo/chart-combo-line-column.tsx
@@ -26,7 +26,7 @@ type ChartComboLineColumnVisualizationProps = {
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: ComboLineColumnConfig;
-  queryFilters: DataCubeObservationFilter[];
+  queryFilters?: DataCubeObservationFilter[];
 };
 
 export const ChartComboLineColumnVisualization = (
@@ -57,8 +57,9 @@ export const ChartComboLineColumnVisualization = (
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: queryFilters,
+      filters: queryFilters ?? [],
     },
+    pause: !queryFilters,
   });
 
   return (

--- a/app/charts/combo/chart-combo-line-column.tsx
+++ b/app/charts/combo/chart-combo-line-column.tsx
@@ -15,11 +15,9 @@ import { ComboLineColumnConfig, DataSource } from "@/config-types";
 import {
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
-} from "@/graphql/hooks";
-import {
-  DataCubeObservationFilter,
   useDataCubesObservationsQuery,
-} from "@/graphql/query-hooks";
+} from "@/graphql/hooks";
+import { DataCubeObservationFilter } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
 import { ChartProps } from "../shared/ChartProps";
@@ -59,7 +57,7 @@ export const ChartComboLineColumnVisualization = (
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: queryFilters ?? [],
+      cubeFilters: queryFilters ?? [],
     },
     pause: !queryFilters,
   });

--- a/app/charts/combo/chart-combo-line-column.tsx
+++ b/app/charts/combo/chart-combo-line-column.tsx
@@ -12,10 +12,12 @@ import { HoverDotMultiple } from "@/charts/shared/interaction/hover-dots-multipl
 import { Ruler } from "@/charts/shared/interaction/ruler";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { ComboLineColumnConfig, DataSource } from "@/config-types";
-import { useDataCubesMetadataQuery } from "@/graphql/hooks";
+import {
+  useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
+} from "@/graphql/hooks";
 import {
   DataCubeObservationFilter,
-  useDataCubesComponentsQuery,
   useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
@@ -48,7 +50,7 @@ export const ChartComboLineColumnVisualization = (
   const [componentsQuery] = useDataCubesComponentsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({
+      cubeFilters: chartConfig.cubes.map((cube) => ({
         iri: cube.iri,
         componentIris,
       })),

--- a/app/charts/combo/chart-combo-line-column.tsx
+++ b/app/charts/combo/chart-combo-line-column.tsx
@@ -11,12 +11,9 @@ import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { HoverDotMultiple } from "@/charts/shared/interaction/hover-dots-multiple";
 import { Ruler } from "@/charts/shared/interaction/ruler";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
+import { ComboLineColumnConfig, DataSource } from "@/config-types";
 import {
-  ComboLineColumnConfig,
-  DataSource,
-  QueryFilters,
-} from "@/config-types";
-import {
+  DataCubeObservationFilter,
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
   useDataCubesObservationsQuery,
@@ -26,18 +23,16 @@ import { useLocale } from "@/locales/use-locale";
 import { ChartProps } from "../shared/ChartProps";
 
 type ChartComboLineColumnVisualizationProps = {
-  dataSetIri: string;
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: ComboLineColumnConfig;
-  queryFilters: QueryFilters;
+  queryFilters: DataCubeObservationFilter[];
 };
 
 export const ChartComboLineColumnVisualization = (
   props: ChartComboLineColumnVisualizationProps
 ) => {
-  const { dataSetIri, dataSource, componentIris, chartConfig, queryFilters } =
-    props;
+  const { dataSource, componentIris, chartConfig, queryFilters } = props;
   const locale = useLocale();
   const commonQueryVariables = {
     sourceType: dataSource.type,
@@ -47,19 +42,22 @@ export const ChartComboLineColumnVisualization = (
   const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri }],
+      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris }],
+      filters: chartConfig.cubes.map((cube) => ({
+        iri: cube.iri,
+        componentIris,
+      })),
     },
   });
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
+      filters: queryFilters,
     },
   });
 

--- a/app/charts/combo/chart-combo-line-dual.tsx
+++ b/app/charts/combo/chart-combo-line-dual.tsx
@@ -11,8 +11,9 @@ import { HoverDotMultiple } from "@/charts/shared/interaction/hover-dots-multipl
 import { Ruler } from "@/charts/shared/interaction/ruler";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
-import { ComboLineDualConfig, DataSource, QueryFilters } from "@/config-types";
+import { ComboLineDualConfig, DataSource } from "@/config-types";
 import {
+  DataCubeObservationFilter,
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
   useDataCubesObservationsQuery,
@@ -22,18 +23,16 @@ import { useLocale } from "@/locales/use-locale";
 import { ChartProps } from "../shared/ChartProps";
 
 type ChartComboLineDualVisualizationProps = {
-  dataSetIri: string;
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: ComboLineDualConfig;
-  queryFilters: QueryFilters;
+  queryFilters: DataCubeObservationFilter[];
 };
 
 export const ChartComboLineDualVisualization = (
   props: ChartComboLineDualVisualizationProps
 ) => {
-  const { dataSetIri, dataSource, componentIris, chartConfig, queryFilters } =
-    props;
+  const { dataSource, componentIris, chartConfig, queryFilters } = props;
   const locale = useLocale();
   const commonQueryVariables = {
     sourceType: dataSource.type,
@@ -43,19 +42,22 @@ export const ChartComboLineDualVisualization = (
   const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri }],
+      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris }],
+      filters: chartConfig.cubes.map((cube) => ({
+        iri: cube.iri,
+        componentIris,
+      })),
     },
   });
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
+      filters: queryFilters,
     },
   });
 

--- a/app/charts/combo/chart-combo-line-dual.tsx
+++ b/app/charts/combo/chart-combo-line-dual.tsx
@@ -26,7 +26,7 @@ type ChartComboLineDualVisualizationProps = {
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: ComboLineDualConfig;
-  queryFilters: DataCubeObservationFilter[];
+  queryFilters?: DataCubeObservationFilter[];
 };
 
 export const ChartComboLineDualVisualization = (
@@ -57,8 +57,9 @@ export const ChartComboLineDualVisualization = (
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: queryFilters,
+      filters: queryFilters ?? [],
     },
+    pause: !queryFilters,
   });
 
   return (

--- a/app/charts/combo/chart-combo-line-dual.tsx
+++ b/app/charts/combo/chart-combo-line-dual.tsx
@@ -12,10 +12,12 @@ import { Ruler } from "@/charts/shared/interaction/ruler";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import { ComboLineDualConfig, DataSource } from "@/config-types";
-import { useDataCubesMetadataQuery } from "@/graphql/hooks";
+import {
+  useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
+} from "@/graphql/hooks";
 import {
   DataCubeObservationFilter,
-  useDataCubesComponentsQuery,
   useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
@@ -48,7 +50,7 @@ export const ChartComboLineDualVisualization = (
   const [componentsQuery] = useDataCubesComponentsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({
+      cubeFilters: chartConfig.cubes.map((cube) => ({
         iri: cube.iri,
         componentIris,
       })),

--- a/app/charts/combo/chart-combo-line-dual.tsx
+++ b/app/charts/combo/chart-combo-line-dual.tsx
@@ -15,11 +15,9 @@ import { ComboLineDualConfig, DataSource } from "@/config-types";
 import {
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
-} from "@/graphql/hooks";
-import {
-  DataCubeObservationFilter,
   useDataCubesObservationsQuery,
-} from "@/graphql/query-hooks";
+} from "@/graphql/hooks";
+import { DataCubeObservationFilter } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
 import { ChartProps } from "../shared/ChartProps";
@@ -59,7 +57,7 @@ export const ChartComboLineDualVisualization = (
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: queryFilters ?? [],
+      cubeFilters: queryFilters ?? [],
     },
     pause: !queryFilters,
   });

--- a/app/charts/combo/chart-combo-line-dual.tsx
+++ b/app/charts/combo/chart-combo-line-dual.tsx
@@ -12,10 +12,10 @@ import { Ruler } from "@/charts/shared/interaction/ruler";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import { ComboLineDualConfig, DataSource } from "@/config-types";
+import { useDataCubesMetadataQuery } from "@/graphql/hooks";
 import {
   DataCubeObservationFilter,
   useDataCubesComponentsQuery,
-  useDataCubesMetadataQuery,
   useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
@@ -42,7 +42,7 @@ export const ChartComboLineDualVisualization = (
   const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
+      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({

--- a/app/charts/combo/chart-combo-line-single.tsx
+++ b/app/charts/combo/chart-combo-line-single.tsx
@@ -20,11 +20,9 @@ import { ComboLineSingleConfig, DataSource } from "@/config-types";
 import {
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
-} from "@/graphql/hooks";
-import {
-  DataCubeObservationFilter,
   useDataCubesObservationsQuery,
-} from "@/graphql/query-hooks";
+} from "@/graphql/hooks";
+import { DataCubeObservationFilter } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
 import { ChartProps } from "../shared/ChartProps";
@@ -64,7 +62,7 @@ export const ChartComboLineSingleVisualization = (
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: queryFilters ?? [],
+      cubeFilters: queryFilters ?? [],
     },
     pause: !queryFilters,
   });

--- a/app/charts/combo/chart-combo-line-single.tsx
+++ b/app/charts/combo/chart-combo-line-single.tsx
@@ -17,10 +17,10 @@ import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import { ComboLineSingleConfig, DataSource } from "@/config-types";
+import { useDataCubesMetadataQuery } from "@/graphql/hooks";
 import {
   DataCubeObservationFilter,
   useDataCubesComponentsQuery,
-  useDataCubesMetadataQuery,
   useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
@@ -47,7 +47,7 @@ export const ChartComboLineSingleVisualization = (
   const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
+      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({

--- a/app/charts/combo/chart-combo-line-single.tsx
+++ b/app/charts/combo/chart-combo-line-single.tsx
@@ -31,7 +31,7 @@ type ChartComboLineSingleVisualizationProps = {
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: ComboLineSingleConfig;
-  queryFilters: DataCubeObservationFilter[];
+  queryFilters?: DataCubeObservationFilter[];
 };
 
 export const ChartComboLineSingleVisualization = (
@@ -62,8 +62,9 @@ export const ChartComboLineSingleVisualization = (
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: queryFilters,
+      filters: queryFilters ?? [],
     },
+    pause: !queryFilters,
   });
 
   return (

--- a/app/charts/combo/chart-combo-line-single.tsx
+++ b/app/charts/combo/chart-combo-line-single.tsx
@@ -16,12 +16,9 @@ import { Ruler } from "@/charts/shared/interaction/ruler";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
+import { ComboLineSingleConfig, DataSource } from "@/config-types";
 import {
-  ComboLineSingleConfig,
-  DataSource,
-  QueryFilters,
-} from "@/config-types";
-import {
+  DataCubeObservationFilter,
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
   useDataCubesObservationsQuery,
@@ -31,18 +28,16 @@ import { useLocale } from "@/locales/use-locale";
 import { ChartProps } from "../shared/ChartProps";
 
 type ChartComboLineSingleVisualizationProps = {
-  dataSetIri: string;
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: ComboLineSingleConfig;
-  queryFilters: QueryFilters;
+  queryFilters: DataCubeObservationFilter[];
 };
 
 export const ChartComboLineSingleVisualization = (
   props: ChartComboLineSingleVisualizationProps
 ) => {
-  const { dataSetIri, dataSource, componentIris, chartConfig, queryFilters } =
-    props;
+  const { dataSource, componentIris, chartConfig, queryFilters } = props;
   const locale = useLocale();
   const commonQueryVariables = {
     sourceType: dataSource.type,
@@ -52,19 +47,22 @@ export const ChartComboLineSingleVisualization = (
   const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri }],
+      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris }],
+      filters: chartConfig.cubes.map((cube) => ({
+        iri: cube.iri,
+        componentIris,
+      })),
     },
   });
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
+      filters: queryFilters,
     },
   });
 

--- a/app/charts/combo/chart-combo-line-single.tsx
+++ b/app/charts/combo/chart-combo-line-single.tsx
@@ -17,10 +17,12 @@ import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import { ComboLineSingleConfig, DataSource } from "@/config-types";
-import { useDataCubesMetadataQuery } from "@/graphql/hooks";
+import {
+  useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
+} from "@/graphql/hooks";
 import {
   DataCubeObservationFilter,
-  useDataCubesComponentsQuery,
   useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
@@ -53,7 +55,7 @@ export const ChartComboLineSingleVisualization = (
   const [componentsQuery] = useDataCubesComponentsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({
+      cubeFilters: chartConfig.cubes.map((cube) => ({
         iri: cube.iri,
         componentIris,
       })),

--- a/app/charts/combo/combo-line-column-state-props.ts
+++ b/app/charts/combo/combo-line-column-state-props.ts
@@ -15,7 +15,7 @@ import {
   useChartData,
 } from "@/charts/shared/chart-state";
 import { useRenderingKeyVariable } from "@/charts/shared/rendering-utils";
-import { ComboLineColumnConfig } from "@/configurator";
+import { ComboLineColumnConfig, useChartConfigFilters } from "@/configurator";
 
 import { ChartProps } from "../shared/ChartProps";
 
@@ -46,8 +46,9 @@ export const useComboLineColumnStateVariables = (
     measuresByIri,
     observations,
   } = props;
-  const { fields, filters, interactiveFiltersConfig } = chartConfig;
+  const { fields, interactiveFiltersConfig } = chartConfig;
   const { x } = fields;
+  const filters = useChartConfigFilters(chartConfig);
 
   const baseVariables = useBaseVariables(chartConfig);
   const bandXVariables = useBandXVariables(x, {

--- a/app/charts/combo/combo-line-column.tsx
+++ b/app/charts/combo/combo-line-column.tsx
@@ -97,7 +97,10 @@ const Lines = () => {
     .line<Observation>()
     // FIXME: add missing observations basing on the time interval, so we can
     // properly indicate the missing data.
-    .defined((d) => yLine.getY(d) !== null)
+    .defined((d) => {
+      const y = yLine.getY(d);
+      return y !== null && !isNaN(y);
+    })
     .x((d) => (xScale(getX(d)) as number) + xScale.bandwidth() * 0.5)
     .y((d) => yScale(yLine.getY(d) as number));
 

--- a/app/charts/combo/combo-line-dual.tsx
+++ b/app/charts/combo/combo-line-dual.tsx
@@ -14,7 +14,10 @@ export const ComboLineDual = () => {
       {[y.left, y.right].map(({ orientation, iri, label, getY }) => {
         const line = d3
           .line<Observation>()
-          .defined((d) => getY(d) !== null)
+          .defined((d) => {
+            const y = getY(d);
+            return y !== null && !isNaN(y);
+          })
           .x((d) => xScale(getX(d)))
           .y((d) => yOrientationScales[orientation](getY(d) as number));
 

--- a/app/charts/combo/combo-line-single.tsx
+++ b/app/charts/combo/combo-line-single.tsx
@@ -14,7 +14,10 @@ export const ComboLineSingle = () => {
       {y.lines.map(({ iri, label, getY }) => {
         const line = d3
           .line<Observation>()
-          .defined((d) => getY(d) !== null)
+          .defined((d) => {
+            const y = getY(d);
+            return y !== null && !isNaN(y);
+          })
           .x((d) => xScale(getX(d)))
           .y((d) => yScale(getY(d) as number));
 

--- a/app/charts/index.spec.ts
+++ b/app/charts/index.spec.ts
@@ -17,7 +17,7 @@ describe("initial config", () => {
   it("should create an initial table config with column order based on dimension order", () => {
     const config = getInitialConfig({
       chartType: "table",
-      dataSet: "https://environment.ld.admin.ch/foen/nfi",
+      iris: ["https://environment.ld.admin.ch/foen/nfi"],
       dimensions: forestAreaData.data.dataCubeByIri
         .dimensions as any as Dimension[],
       measures: forestAreaData.data.dataCubeByIri.measures as any as Measure[],
@@ -91,8 +91,12 @@ describe("chart type switch", () => {
       key: "column",
       version: "1.4.0",
       chartType: "column",
-      dataSet: "https://environment.ld.admin.ch/foen/ubd0104",
-      filters: {},
+      cubes: [
+        {
+          iri: "https://environment.ld.admin.ch/foen/ubd0104",
+          filters: {},
+        },
+      ],
       meta: {
         title: {
           en: "",

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -20,11 +20,9 @@ import { DataSource, LineConfig } from "@/config-types";
 import {
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
-} from "@/graphql/hooks";
-import {
-  DataCubeObservationFilter,
   useDataCubesObservationsQuery,
-} from "@/graphql/query-hooks";
+} from "@/graphql/hooks";
+import { DataCubeObservationFilter } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
 import { ChartProps } from "../shared/ChartProps";
@@ -64,7 +62,7 @@ export const ChartLinesVisualization = ({
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: queryFilters ?? [],
+      cubeFilters: queryFilters ?? [],
     },
     pause: !queryFilters,
   });

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -17,10 +17,12 @@ import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import { DataSource, LineConfig } from "@/config-types";
-import { useDataCubesMetadataQuery } from "@/graphql/hooks";
+import {
+  useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
+} from "@/graphql/hooks";
 import {
   DataCubeObservationFilter,
-  useDataCubesComponentsQuery,
   useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
@@ -53,7 +55,7 @@ export const ChartLinesVisualization = ({
   const [componentsQuery] = useDataCubesComponentsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({
+      cubeFilters: chartConfig.cubes.map((cube) => ({
         iri: cube.iri,
         componentIris,
       })),

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -17,10 +17,10 @@ import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import { DataSource, LineConfig } from "@/config-types";
+import { useDataCubesMetadataQuery } from "@/graphql/hooks";
 import {
   DataCubeObservationFilter,
   useDataCubesComponentsQuery,
-  useDataCubesMetadataQuery,
   useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
@@ -47,7 +47,7 @@ export const ChartLinesVisualization = ({
   const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
+      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -36,7 +36,7 @@ export const ChartLinesVisualization = ({
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: LineConfig;
-  queryFilters: DataCubeObservationFilter[];
+  queryFilters?: DataCubeObservationFilter[];
 }) => {
   const locale = useLocale();
   const commonQueryVariables = {
@@ -62,8 +62,9 @@ export const ChartLinesVisualization = ({
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: queryFilters,
+      filters: queryFilters ?? [],
     },
+    pause: !queryFilters,
   });
 
   return (

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -16,8 +16,9 @@ import { Ruler } from "@/charts/shared/interaction/ruler";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
-import { DataSource, LineConfig, QueryFilters } from "@/config-types";
+import { DataSource, LineConfig } from "@/config-types";
 import {
+  DataCubeObservationFilter,
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
   useDataCubesObservationsQuery,
@@ -27,17 +28,15 @@ import { useLocale } from "@/locales/use-locale";
 import { ChartProps } from "../shared/ChartProps";
 
 export const ChartLinesVisualization = ({
-  dataSetIri,
   dataSource,
   componentIris,
   chartConfig,
   queryFilters,
 }: {
-  dataSetIri: string;
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: LineConfig;
-  queryFilters: QueryFilters;
+  queryFilters: DataCubeObservationFilter[];
 }) => {
   const locale = useLocale();
   const commonQueryVariables = {
@@ -48,19 +47,22 @@ export const ChartLinesVisualization = ({
   const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri }],
+      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris }],
+      filters: chartConfig.cubes.map((cube) => ({
+        iri: cube.iri,
+        componentIris,
+      })),
     },
   });
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
+      filters: queryFilters,
     },
   });
 

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -148,7 +148,8 @@ const useLinesState = (
 
   // segments
   const segmentFilter = segmentDimension?.iri
-    ? chartConfig.filters[segmentDimension?.iri]
+    ? chartConfig.cubes.find((d) => d.iri === segmentDimension.cubeIri)
+        ?.filters[segmentDimension.iri]
     : undefined;
   const { allSegments, segments } = useMemo(() => {
     const allUniqueSegments = Array.from(new Set(segmentData.map(getSegment)));

--- a/app/charts/line/lines.tsx
+++ b/app/charts/line/lines.tsx
@@ -10,7 +10,10 @@ export const Lines = () => {
     useChartState() as LinesState;
 
   const lineGenerator = line<Observation>()
-    .defined((d) => getY(d) !== null)
+    .defined((d) => {
+      const y = getY(d);
+      return y !== null && !isNaN(y);
+    })
     .x((d) => xScale(getX(d)))
     .y((d) => yScale(getY(d) as number));
 

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -13,11 +13,13 @@ import { NoGeometriesHint } from "@/components/hint";
 import { DataSource, MapConfig, useChartConfigFilters } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import { GeoShapes } from "@/domain/data";
-import { useDataCubesMetadataQuery } from "@/graphql/hooks";
+import {
+  useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
+} from "@/graphql/hooks";
 import {
   DataCubeObservationFilter,
   GeoCoordinates,
-  useDataCubesComponentsQuery,
   useDataCubesObservationsQuery,
   useGeoCoordinatesByDimensionIriQuery,
   useGeoShapesByDimensionIriQuery,
@@ -54,7 +56,7 @@ export const ChartMapVisualization = ({
   const [componentsQuery] = useDataCubesComponentsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({
+      cubeFilters: chartConfig.cubes.map((cube) => ({
         iri: cube.iri,
         componentIris,
       })),

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -35,7 +35,7 @@ export const ChartMapVisualization = ({
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: MapConfig;
-  queryFilters: DataCubeObservationFilter[];
+  queryFilters?: DataCubeObservationFilter[];
 }) => {
   const locale = useLocale();
   const areaDimensionIri = chartConfig.fields.areaLayer?.componentIri || "";
@@ -63,8 +63,9 @@ export const ChartMapVisualization = ({
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: queryFilters,
+      filters: queryFilters ?? [],
     },
+    pause: !queryFilters,
   });
   const { data: componentsData } = componentsQuery;
   const { data: observationsData } = observationsQuery;

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -13,11 +13,11 @@ import { NoGeometriesHint } from "@/components/hint";
 import { DataSource, MapConfig, useChartConfigFilters } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import { GeoShapes } from "@/domain/data";
+import { useDataCubesMetadataQuery } from "@/graphql/hooks";
 import {
   DataCubeObservationFilter,
   GeoCoordinates,
   useDataCubesComponentsQuery,
-  useDataCubesMetadataQuery,
   useDataCubesObservationsQuery,
   useGeoCoordinatesByDimensionIriQuery,
   useGeoShapesByDimensionIriQuery,
@@ -48,7 +48,7 @@ export const ChartMapVisualization = ({
   const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
+      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -16,11 +16,11 @@ import { GeoShapes } from "@/domain/data";
 import {
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
+  useDataCubesObservationsQuery,
 } from "@/graphql/hooks";
 import {
   DataCubeObservationFilter,
   GeoCoordinates,
-  useDataCubesObservationsQuery,
   useGeoCoordinatesByDimensionIriQuery,
   useGeoShapesByDimensionIriQuery,
 } from "@/graphql/query-hooks";
@@ -65,7 +65,7 @@ export const ChartMapVisualization = ({
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: queryFilters ?? [],
+      cubeFilters: queryFilters ?? [],
     },
     pause: !queryFilters,
   });

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -11,9 +11,10 @@ import {
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { OnlyNegativeDataHint } from "@/components/hint";
-import { DataSource, PieConfig, QueryFilters } from "@/config-types";
+import { DataSource, PieConfig, useChartConfigFilters } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import {
+  DataCubeObservationFilter,
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
   useDataCubesObservationsQuery,
@@ -23,17 +24,15 @@ import { useLocale } from "@/locales/use-locale";
 import { ChartProps } from "../shared/ChartProps";
 
 export const ChartPieVisualization = ({
-  dataSetIri,
   dataSource,
   componentIris,
   chartConfig,
   queryFilters,
 }: {
-  dataSetIri: string;
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: PieConfig;
-  queryFilters: QueryFilters;
+  queryFilters: DataCubeObservationFilter[];
 }) => {
   const locale = useLocale();
   const commonQueryVariables = {
@@ -44,19 +43,22 @@ export const ChartPieVisualization = ({
   const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri }],
+      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris }],
+      filters: chartConfig.cubes.map((cube) => ({
+        iri: cube.iri,
+        componentIris,
+      })),
     },
   });
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
+      filters: queryFilters,
     },
   });
 
@@ -74,10 +76,11 @@ export const ChartPieVisualization = ({
 export const ChartPie = memo(
   (props: ChartProps<PieConfig> & { published: boolean }) => {
     const { chartConfig, observations, dimensions, published } = props;
-    const { fields, filters, interactiveFiltersConfig } = chartConfig;
+    const { fields, interactiveFiltersConfig } = chartConfig;
     const somePositive = observations.some(
       (d) => (d[fields?.y?.componentIri] as number) > 0
     );
+    const filters = useChartConfigFilters(chartConfig);
 
     if (!somePositive) {
       return <OnlyNegativeDataHint />;

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -13,10 +13,12 @@ import { LegendColor } from "@/charts/shared/legend-color";
 import { OnlyNegativeDataHint } from "@/components/hint";
 import { DataSource, PieConfig, useChartConfigFilters } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
-import { useDataCubesMetadataQuery } from "@/graphql/hooks";
+import {
+  useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
+} from "@/graphql/hooks";
 import {
   DataCubeObservationFilter,
-  useDataCubesComponentsQuery,
   useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
@@ -49,7 +51,7 @@ export const ChartPieVisualization = ({
   const [componentsQuery] = useDataCubesComponentsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({
+      cubeFilters: chartConfig.cubes.map((cube) => ({
         iri: cube.iri,
         componentIris,
       })),

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -32,7 +32,7 @@ export const ChartPieVisualization = ({
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: PieConfig;
-  queryFilters: DataCubeObservationFilter[];
+  queryFilters?: DataCubeObservationFilter[];
 }) => {
   const locale = useLocale();
   const commonQueryVariables = {
@@ -58,8 +58,9 @@ export const ChartPieVisualization = ({
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: queryFilters,
+      filters: queryFilters ?? [],
     },
+    pause: !queryFilters,
   });
 
   return (

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -16,11 +16,9 @@ import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import {
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
-} from "@/graphql/hooks";
-import {
-  DataCubeObservationFilter,
   useDataCubesObservationsQuery,
-} from "@/graphql/query-hooks";
+} from "@/graphql/hooks";
+import { DataCubeObservationFilter } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
 import { ChartProps } from "../shared/ChartProps";
@@ -60,7 +58,7 @@ export const ChartPieVisualization = ({
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: queryFilters ?? [],
+      cubeFilters: queryFilters ?? [],
     },
     pause: !queryFilters,
   });

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -13,10 +13,10 @@ import { LegendColor } from "@/charts/shared/legend-color";
 import { OnlyNegativeDataHint } from "@/components/hint";
 import { DataSource, PieConfig, useChartConfigFilters } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
+import { useDataCubesMetadataQuery } from "@/graphql/hooks";
 import {
   DataCubeObservationFilter,
   useDataCubesComponentsQuery,
-  useDataCubesMetadataQuery,
   useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
@@ -43,7 +43,7 @@ export const ChartPieVisualization = ({
   const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
+      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({

--- a/app/charts/pie/pie-state-props.ts
+++ b/app/charts/pie/pie-state-props.ts
@@ -11,7 +11,7 @@ import {
   useSegmentVariables,
 } from "@/charts/shared/chart-state";
 import { useRenderingKeyVariable } from "@/charts/shared/rendering-utils";
-import { PieConfig } from "@/configurator";
+import { PieConfig, useChartConfigFilters } from "@/configurator";
 
 import { ChartProps } from "../shared/ChartProps";
 
@@ -30,8 +30,9 @@ export const usePieStateVariables = (
     dimensionsByIri,
     measuresByIri,
   } = props;
-  const { fields, filters, interactiveFiltersConfig } = chartConfig;
+  const { fields, interactiveFiltersConfig } = chartConfig;
   const { y, segment, animation } = fields;
+  const filters = useChartConfigFilters(chartConfig);
 
   const baseVariables = useBaseVariables(chartConfig);
   const numericalYVariables = useNumericalYVariables(y, {

--- a/app/charts/pie/pie-state.tsx
+++ b/app/charts/pie/pie-state.tsx
@@ -76,7 +76,9 @@ const usePieState = (
   }, [segmentDimension.values]);
 
   // Map ordered segments to colors
-  const segmentFilter = chartConfig.filters[segmentDimension.iri];
+  const segmentFilter = chartConfig.cubes.find(
+    (d) => d.iri === segmentDimension.cubeIri
+  )?.filters[segmentDimension.iri];
   const { colors, allSegments, segments, ySum } = useMemo(() => {
     const colors = scaleOrdinal<string, string>();
     const measureBySegment = Object.fromEntries(

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -25,10 +25,12 @@ import {
   useChartConfigFilters,
 } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
-import { useDataCubesMetadataQuery } from "@/graphql/hooks";
+import {
+  useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
+} from "@/graphql/hooks";
 import {
   DataCubeObservationFilter,
-  useDataCubesComponentsQuery,
   useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
@@ -61,7 +63,7 @@ export const ChartScatterplotVisualization = ({
   const [componentsQuery] = useDataCubesComponentsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({
+      cubeFilters: chartConfig.cubes.map((cube) => ({
         iri: cube.iri,
         componentIris,
       })),

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -44,7 +44,7 @@ export const ChartScatterplotVisualization = ({
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: ScatterPlotConfig;
-  queryFilters: DataCubeObservationFilter[];
+  queryFilters?: DataCubeObservationFilter[];
 }) => {
   const locale = useLocale();
   const commonQueryVariables = {
@@ -70,8 +70,9 @@ export const ChartScatterplotVisualization = ({
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: queryFilters,
+      filters: queryFilters ?? [],
     },
+    pause: !queryFilters,
   });
 
   return (

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -19,9 +19,14 @@ import {
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionVoronoi } from "@/charts/shared/overlay-voronoi";
-import { DataSource, QueryFilters, ScatterPlotConfig } from "@/config-types";
+import {
+  DataSource,
+  ScatterPlotConfig,
+  useChartConfigFilters,
+} from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import {
+  DataCubeObservationFilter,
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
   useDataCubesObservationsQuery,
@@ -31,17 +36,15 @@ import { useLocale } from "@/locales/use-locale";
 import { ChartProps } from "../shared/ChartProps";
 
 export const ChartScatterplotVisualization = ({
-  dataSetIri,
   dataSource,
   componentIris,
   chartConfig,
   queryFilters,
 }: {
-  dataSetIri: string;
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: ScatterPlotConfig;
-  queryFilters: QueryFilters;
+  queryFilters: DataCubeObservationFilter[];
 }) => {
   const locale = useLocale();
   const commonQueryVariables = {
@@ -52,19 +55,22 @@ export const ChartScatterplotVisualization = ({
   const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri }],
+      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris }],
+      filters: chartConfig.cubes.map((cube) => ({
+        iri: cube.iri,
+        componentIris,
+      })),
     },
   });
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris, filters: queryFilters }],
+      filters: queryFilters,
     },
   });
 
@@ -82,7 +88,8 @@ export const ChartScatterplotVisualization = ({
 export const ChartScatterplot = memo(
   (props: ChartProps<ScatterPlotConfig> & { published: boolean }) => {
     const { chartConfig, dimensions, published } = props;
-    const { fields, filters, interactiveFiltersConfig } = chartConfig;
+    const { fields, interactiveFiltersConfig } = chartConfig;
+    const filters = useChartConfigFilters(chartConfig);
 
     return (
       <ScatterplotChart aspectRatio={published ? 1 : 0.4} {...props}>

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -28,11 +28,9 @@ import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import {
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
-} from "@/graphql/hooks";
-import {
-  DataCubeObservationFilter,
   useDataCubesObservationsQuery,
-} from "@/graphql/query-hooks";
+} from "@/graphql/hooks";
+import { DataCubeObservationFilter } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
 import { ChartProps } from "../shared/ChartProps";
@@ -72,7 +70,7 @@ export const ChartScatterplotVisualization = ({
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: queryFilters ?? [],
+      cubeFilters: queryFilters ?? [],
     },
     pause: !queryFilters,
   });

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -25,10 +25,10 @@ import {
   useChartConfigFilters,
 } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
+import { useDataCubesMetadataQuery } from "@/graphql/hooks";
 import {
   DataCubeObservationFilter,
   useDataCubesComponentsQuery,
-  useDataCubesMetadataQuery,
   useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
@@ -55,7 +55,7 @@ export const ChartScatterplotVisualization = ({
   const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
+      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({

--- a/app/charts/scatterplot/scatterplot-state-props.ts
+++ b/app/charts/scatterplot/scatterplot-state-props.ts
@@ -13,7 +13,7 @@ import {
   useSegmentVariables,
 } from "@/charts/shared/chart-state";
 import { useRenderingKeyVariable } from "@/charts/shared/rendering-utils";
-import { ScatterPlotConfig } from "@/configurator";
+import { ScatterPlotConfig, useChartConfigFilters } from "@/configurator";
 
 import { ChartProps } from "../shared/ChartProps";
 
@@ -33,8 +33,9 @@ export const useScatterplotStateVariables = (
     dimensionsByIri,
     measuresByIri,
   } = props;
-  const { fields, filters, interactiveFiltersConfig } = chartConfig;
+  const { fields, interactiveFiltersConfig } = chartConfig;
   const { x, y, segment, animation } = fields;
+  const filters = useChartConfigFilters(chartConfig);
 
   const baseVariables = useBaseVariables(chartConfig);
   const numericalXVariables = useNumericalXVariables(x, {

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -97,7 +97,8 @@ const useScatterplotState = (
 
   const hasSegment = fields.segment ? true : false;
   const segmentFilter = segmentDimension?.iri
-    ? chartConfig.filters[segmentDimension.iri]
+    ? chartConfig.cubes.find((d) => d.iri === segmentDimension.cubeIri)
+        ?.filters[segmentDimension.iri]
     : undefined;
   const allSegments = useMemo(() => {
     const allUniqueSegments = Array.from(new Set(segmentData.map(getSegment)));

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -37,12 +37,12 @@ import {
   TemporalDimension,
 } from "@/domain/data";
 import { useTimeFormatLocale } from "@/formatters";
+import { useDataCubesComponentsQuery } from "@/graphql/hooks";
 import {
   DataCubeObservationFilter,
   PossibleFiltersDocument,
   PossibleFiltersQuery,
   PossibleFiltersQueryVariables,
-  useDataCubesComponentsQuery,
 } from "@/graphql/query-hooks";
 import { Icon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
@@ -238,7 +238,7 @@ const DataFilter = (props: DataFilterProps) => {
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      filters: [
+      cubeFilters: [
         {
           iri: cubeIri,
           componentIris: [dimensionIri],

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -64,8 +64,8 @@ type PreparedFilter = {
 type ChartDataFiltersProps = {
   dataSource: DataSource;
   chartConfig: ChartConfig;
-  dimensions: Dimension[];
-  measures: Measure[];
+  dimensions?: Dimension[];
+  measures?: Measure[];
 };
 
 export const ChartDataFilters = (props: ChartDataFiltersProps) => {
@@ -88,7 +88,11 @@ export const ChartDataFilters = (props: ChartDataFiltersProps) => {
     }
   }, [componentIris.length]);
 
-  const preparedFilters: PreparedFilter[] = React.useMemo(() => {
+  const preparedFilters: PreparedFilter[] | undefined = React.useMemo(() => {
+    if (!queryFilters) {
+      return;
+    }
+
     return chartConfig.cubes.map((cube) => {
       const cubeQueryFilters = queryFilters.find(
         (d) => d.iri === cube.iri
@@ -184,7 +188,7 @@ export const ChartDataFilters = (props: ChartDataFiltersProps) => {
             gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
           }}
         >
-          {preparedFilters.map(({ cubeIri, interactiveFilters }) =>
+          {preparedFilters?.map(({ cubeIri, interactiveFilters }) =>
             Object.keys(interactiveFilters).map((dimensionIri) => (
               <DataFilter
                 key={dimensionIri}
@@ -536,7 +540,7 @@ const DataFilterTemporalDimension = ({
 type EnsurePossibleInteractiveFiltersProps = {
   dataSource: DataSource;
   chartConfig: ChartConfig;
-  preparedFilters: PreparedFilter[];
+  preparedFilters?: PreparedFilter[];
 };
 
 /**
@@ -555,7 +559,7 @@ const useEnsurePossibleInteractiveFilters = (
   const IFRaw = useInteractiveFiltersRaw();
   const setDataFilters = useInteractiveFilters((d) => d.setDataFilters);
   const filtersByCubeIri = React.useMemo(() => {
-    return preparedFilters.reduce<Record<string, PreparedFilter>>((acc, d) => {
+    return preparedFilters?.reduce<Record<string, PreparedFilter>>((acc, d) => {
       acc[d.cubeIri] = d;
       return acc;
     }, {});
@@ -563,6 +567,10 @@ const useEnsurePossibleInteractiveFilters = (
 
   React.useEffect(() => {
     const run = async () => {
+      if (!filtersByCubeIri) {
+        return;
+      }
+
       chartConfig.cubes.forEach(async (cube) => {
         const { unmappedQueryFilters, interactiveFilters, mappedFilters } =
           filtersByCubeIri[cube.iri];

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -19,6 +19,7 @@ import {
   Filters,
   getFiltersByMappingStatus,
   QueryFilters,
+  useChartConfigFilters,
   useConfiguratorState,
 } from "@/configurator";
 import { orderedIsEqual } from "@/configurator/components/chart-configurator";
@@ -52,17 +53,21 @@ import { hierarchyToOptions } from "@/utils/hierarchy";
 import useEvent from "@/utils/use-event";
 
 type ChartDataFiltersProps = {
-  dataSet: string;
   dataSource: DataSource;
   chartConfig: ChartConfig;
+  dimensions: Dimension[];
 };
 
 export const ChartDataFilters = (props: ChartDataFiltersProps) => {
-  const { dataSet, dataSource, chartConfig } = props;
+  const { dataSource, chartConfig, dimensions } = props;
   const { loading } = useLoadingState();
   const dataFilters = useInteractiveFilters((d) => d.dataFilters);
   // We want to keep the none filter without removing them.
-  const queryFilters = useQueryFilters({ chartConfig, allowNoneValues: true });
+  const queryFilters = useQueryFilters({
+    chartConfig,
+    dimensions,
+    allowNoneValues: true,
+  });
   const componentIris = chartConfig.interactiveFiltersConfig?.dataFilters
     .componentIris as string[];
   const [filtersVisible, setFiltersVisible] = React.useState(false);
@@ -203,6 +208,7 @@ const DataFilter = (props: DataFilterProps) => {
     disabled,
   } = props;
   const locale = useLocale();
+  const filters = useChartConfigFilters(chartConfig);
   const chartLoadingState = useLoadingState();
   const updateDataFilter = useInteractiveFilters((d) => d.updateDataFilter);
   const keys = Object.keys(interactiveFilters);
@@ -236,9 +242,7 @@ const DataFilter = (props: DataFilterProps) => {
     }
   );
 
-  const configFilter = dimension
-    ? chartConfig.filters[dimension.iri]
-    : undefined;
+  const configFilter = dimension ? filters[dimension.iri] : undefined;
   const configFilterValue =
     configFilter && configFilter.type === "single"
       ? configFilter.value
@@ -545,6 +549,7 @@ const useEnsurePossibleInteractiveFilters = (
   const client = useClient();
   const IFRaw = useInteractiveFiltersRaw();
   const setDataFilters = useInteractiveFilters((d) => d.setDataFilters);
+  const filters = useChartConfigFilters(chartConfig);
 
   React.useEffect(() => {
     const run = async () => {
@@ -622,7 +627,7 @@ const useEnsurePossibleInteractiveFilters = (
     client,
     dispatch,
     chartConfig.fields,
-    chartConfig.filters,
+    filters,
     dataSet,
     dataSource.type,
     dataSource.url,

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -33,6 +33,7 @@ import {
   Dimension,
   HierarchyValue,
   isTemporalDimension,
+  Measure,
   TemporalDimension,
 } from "@/domain/data";
 import { useTimeFormatLocale } from "@/formatters";
@@ -56,16 +57,18 @@ type ChartDataFiltersProps = {
   dataSource: DataSource;
   chartConfig: ChartConfig;
   dimensions: Dimension[];
+  measures: Measure[];
 };
 
 export const ChartDataFilters = (props: ChartDataFiltersProps) => {
-  const { dataSource, chartConfig, dimensions } = props;
+  const { dataSource, chartConfig, dimensions, measures } = props;
   const { loading } = useLoadingState();
   const dataFilters = useInteractiveFilters((d) => d.dataFilters);
   // We want to keep the none filter without removing them.
   const queryFilters = useQueryFilters({
     chartConfig,
     dimensions,
+    measures,
     allowNoneValues: true,
   });
   const componentIris = chartConfig.interactiveFiltersConfig?.dataFilters

--- a/app/charts/shared/chart-helpers.spec.tsx
+++ b/app/charts/shared/chart-helpers.spec.tsx
@@ -6,18 +6,13 @@ import {
   getWideData,
   prepareQueryFilters,
 } from "@/charts/shared/chart-helpers";
-import {
-  ChartType,
-  Filters,
-  InteractiveFiltersConfig,
-  LineConfig,
-  MapConfig,
-} from "@/configurator";
+import { ChartType, Filters, InteractiveFiltersConfig } from "@/configurator";
 import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import { Observation } from "@/domain/data";
 import { InteractiveFiltersState } from "@/stores/interactive-filters";
 import map1Fixture from "@/test/__fixtures/config/int/map-nfi.json";
 import line1Fixture from "@/test/__fixtures/config/prod/line-1.json";
+import { migrateChartConfig } from "@/utils/chart-config/versioning";
 
 jest.mock("rdf-cube-view-query", () => ({
   Node: class {
@@ -164,32 +159,41 @@ describe("getWideData", () => {
 });
 
 describe("getChartConfigComponentIris", () => {
-  const lineConfig = line1Fixture.data.chartConfig as unknown as LineConfig;
-  const mapConfig = map1Fixture.data.chartConfig as unknown as MapConfig;
+  const migrationOptions = {
+    migrationProps: { dataSet: "foo", meta: {} },
+  };
+  const lineConfig = migrateChartConfig(
+    line1Fixture.data.chartConfig,
+    migrationOptions
+  );
+  const mapConfig = migrateChartConfig(
+    map1Fixture.data.chartConfig,
+    migrationOptions
+  );
 
   it("should return correct componentIris for line chart", () => {
     const componentsIris = extractChartConfigComponentIris(lineConfig);
     expect(componentsIris).toEqual([
       "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/0",
-      "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/0",
       "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/1",
       "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/2",
       "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/3",
       "http://environment.ld.admin.ch/foen/px/0703010000_105/dimension/4",
+      "http://environment.ld.admin.ch/foen/px/0703010000_105/measure/0",
     ]);
   });
 
   it("should return correct componentIris for map chart", () => {
     const componentsIris = extractChartConfigComponentIris(mapConfig);
     expect(componentsIris).toEqual([
-      "https://environment.ld.admin.ch/foen/nfi/unitOfReference",
-      "https://environment.ld.admin.ch/foen/nfi/Topic/3r",
       "https://environment.ld.admin.ch/foen/nfi/Topic/3",
+      "https://environment.ld.admin.ch/foen/nfi/Topic/3r",
       "https://environment.ld.admin.ch/foen/nfi/classificationUnit",
-      "https://environment.ld.admin.ch/foen/nfi/inventory",
       "https://environment.ld.admin.ch/foen/nfi/evaluationType",
       "https://environment.ld.admin.ch/foen/nfi/grid",
+      "https://environment.ld.admin.ch/foen/nfi/inventory",
       "https://environment.ld.admin.ch/foen/nfi/unitOfEvaluation",
+      "https://environment.ld.admin.ch/foen/nfi/unitOfReference",
     ]);
   });
 });

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -30,7 +30,7 @@ import {
 } from "@/configurator";
 import { parseDate } from "@/configurator/components/ui-helpers";
 import { FIELD_VALUE_NONE } from "@/configurator/constants";
-import { Component, Dimension, Observation } from "@/domain/data";
+import { Component, Dimension, Measure, Observation } from "@/domain/data";
 import { truthy } from "@/domain/types";
 import { DataCubeObservationFilter } from "@/graphql/resolver-types";
 import {
@@ -68,10 +68,12 @@ export const prepareQueryFilters = (
 export const useQueryFilters = ({
   chartConfig,
   dimensions,
+  measures,
   allowNoneValues,
 }: {
   chartConfig: ChartConfig;
   dimensions: Dimension[];
+  measures: Measure[];
   allowNoneValues?: boolean;
 }): DataCubeObservationFilter[] => {
   const allDataFilters = useInteractiveFilters((d) => d.dataFilters);
@@ -87,7 +89,7 @@ export const useQueryFilters = ({
 
       return {
         iri: cube.iri,
-        componentIris: dimensions
+        componentIris: [...dimensions, ...measures]
           .filter((d) => d.cubeIri === cube.iri)
           .map((d) => d.iri),
         filters: prepareQueryFilters(
@@ -97,6 +99,7 @@ export const useQueryFilters = ({
           dataFilters,
           allowNoneValues
         ),
+        joinBy: cube.joinBy,
       };
     });
   }, [
@@ -106,6 +109,7 @@ export const useQueryFilters = ({
     allDataFilters,
     allowNoneValues,
     dimensions,
+    measures,
   ]);
 };
 

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -19,19 +19,20 @@ import {
   InteractiveFiltersLegend,
   InteractiveFiltersTimeRange,
   MapConfig,
-  QueryFilters,
 } from "@/config-types";
 import {
   CategoricalColorField,
   ComboChartConfig,
   GenericField,
   NumericalColorField,
+  getChartConfigFilters,
   isComboChartConfig,
 } from "@/configurator";
 import { parseDate } from "@/configurator/components/ui-helpers";
 import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import { Component, Dimension, Observation } from "@/domain/data";
 import { truthy } from "@/domain/types";
+import { DataCubeObservationFilter } from "@/graphql/resolver-types";
 import {
   InteractiveFiltersState,
   useInteractiveFilters,
@@ -58,41 +59,60 @@ export const prepareQueryFilters = (
 
   return allowNoneValues
     ? queryFilters
-    : omitBy(queryFilters, (v) => {
-        return v.type === "single" && v.value === FIELD_VALUE_NONE;
-      });
+    : omitBy(
+        queryFilters,
+        (v) => v.type === "single" && v.value === FIELD_VALUE_NONE
+      );
 };
 
 export const useQueryFilters = ({
   chartConfig,
+  dimensions,
   allowNoneValues,
 }: {
   chartConfig: ChartConfig;
+  dimensions: Dimension[];
   allowNoneValues?: boolean;
-}): QueryFilters => {
-  const dataFilters = useInteractiveFilters((d) => d.dataFilters);
+}): DataCubeObservationFilter[] => {
+  const allDataFilters = useInteractiveFilters((d) => d.dataFilters);
 
   return useMemo(() => {
-    return prepareQueryFilters(
-      chartConfig.chartType,
-      chartConfig.filters,
-      chartConfig.interactiveFiltersConfig,
-      dataFilters,
-      allowNoneValues
-    );
+    return chartConfig.cubes.map((cube) => {
+      const filters = getChartConfigFilters(chartConfig.cubes, cube.iri);
+      const dataFilters = Object.fromEntries(
+        Object.entries(allDataFilters).filter(([k]) =>
+          dimensions.find((d) => d.iri === k)
+        )
+      );
+
+      return {
+        iri: cube.iri,
+        componentIris: dimensions
+          .filter((d) => d.cubeIri === cube.iri)
+          .map((d) => d.iri),
+        filters: prepareQueryFilters(
+          chartConfig.chartType,
+          filters,
+          chartConfig.interactiveFiltersConfig,
+          dataFilters,
+          allowNoneValues
+        ),
+      };
+    });
   }, [
+    chartConfig.cubes,
     chartConfig.chartType,
-    chartConfig.filters,
     chartConfig.interactiveFiltersConfig,
-    dataFilters,
+    allDataFilters,
     allowNoneValues,
+    dimensions,
   ]);
 };
 
 type IFKey = keyof NonNullable<InteractiveFiltersConfig>;
 
-export const getChartConfigFilterComponentIris = ({ filters }: ChartConfig) => {
-  return Object.keys(filters);
+export const getChartConfigFilterComponentIris = ({ cubes }: ChartConfig) => {
+  return Object.keys(getChartConfigFilters(cubes));
 };
 
 const getMapChartConfigAdditionalFields = ({ fields }: MapConfig) => {

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -72,13 +72,17 @@ export const useQueryFilters = ({
   allowNoneValues,
 }: {
   chartConfig: ChartConfig;
-  dimensions: Dimension[];
-  measures: Measure[];
+  dimensions?: Dimension[];
+  measures?: Measure[];
   allowNoneValues?: boolean;
-}): DataCubeObservationFilter[] => {
+}): DataCubeObservationFilter[] | undefined => {
   const allDataFilters = useInteractiveFilters((d) => d.dataFilters);
 
-  return useMemo(() => {
+  return React.useMemo(() => {
+    if (!dimensions || !measures) {
+      return;
+    }
+
     return chartConfig.cubes.map((cube) => {
       const filters = getChartConfigFilters(chartConfig.cubes, cube.iri);
       const dataFilters = Object.fromEntries(
@@ -89,9 +93,12 @@ export const useQueryFilters = ({
 
       return {
         iri: cube.iri,
-        componentIris: [...dimensions, ...measures]
-          .filter((d) => d.cubeIri === cube.iri)
-          .map((d) => d.iri),
+        componentIris:
+          dimensions.length > 0 && measures.length > 0
+            ? [...dimensions, ...measures]
+                .filter((d) => d.cubeIri === cube.iri)
+                .map((d) => d.iri)
+            : undefined,
         filters: prepareQueryFilters(
           chartConfig.chartType,
           filters,

--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -16,6 +16,7 @@ import {
   GenericSegmentField,
   MapConfig,
   isSegmentInConfig,
+  useChartConfigFilters,
   useReadOnlyConfiguratorState,
 } from "@/configurator";
 import { Component, Dimension, Measure, Observation } from "@/domain/data";
@@ -119,6 +120,7 @@ const useLegendGroups = ({
   values: string[];
 }) => {
   const configState = useReadOnlyConfiguratorState();
+  const filters = useChartConfigFilters(chartConfig);
 
   if (
     configState.state === "INITIAL" ||
@@ -133,7 +135,7 @@ const useLegendGroups = ({
     isSegmentInConfig(chartConfig) ? chartConfig.fields.segment : null
   ) as GenericSegmentField | null | undefined;
   const segmentFilters = segmentField?.componentIri
-    ? chartConfig.filters[segmentField.componentIri]
+    ? filters[segmentField.componentIri]
     : null;
   const segmentValues =
     segmentFilters?.type === "multi" ? segmentFilters.values : emptyObj;
@@ -196,7 +198,8 @@ export const MapLegendColor = memo(function LegendColor({
   useAbbreviations: boolean;
   chartConfig: MapConfig;
 }) {
-  const componentFilter = chartConfig.filters[component.iri];
+  const filters = useChartConfigFilters(chartConfig);
+  const componentFilter = filters[component.iri];
   const sortedValues = useMemo(() => {
     const sorters = makeDimensionValueSorters(component, {
       sorting: {

--- a/app/charts/shared/use-sync-interactive-filters.spec.tsx
+++ b/app/charts/shared/use-sync-interactive-filters.spec.tsx
@@ -1,5 +1,4 @@
 import { fireEvent, render } from "@testing-library/react";
-import merge from "lodash/merge";
 import { useState } from "react";
 
 import useSyncInteractiveFilters from "@/charts/shared/use-sync-interactive-filters";
@@ -94,14 +93,23 @@ const setup = ({
 describe("useSyncInteractiveFilters", () => {
   it("should keep interactive filters in sync with values from chart config", async () => {
     const { getIFState, clickUseModified } = setup({
-      modifiedChartConfig: merge({}, chartConfig, {
-        filters: {
-          "http://environment.ld.admin.ch/foen/px/0703010000_103/dimension/1": {
-            value:
-              "http://environment.ld.admin.ch/foen/px/0703010000_103/dimension/1/1",
+      modifiedChartConfig: {
+        ...chartConfig,
+        cubes: [
+          {
+            ...chartConfig.cubes[0],
+            filters: {
+              ...chartConfig.cubes[0].filters,
+              "http://environment.ld.admin.ch/foen/px/0703010000_103/dimension/1":
+                {
+                  type: "single",
+                  value:
+                    "http://environment.ld.admin.ch/foen/px/0703010000_103/dimension/1/1",
+                },
+            },
           },
-        },
-      }),
+        ],
+      },
     });
 
     // interactive filters are initialized correctly

--- a/app/charts/shared/use-sync-interactive-filters.tsx
+++ b/app/charts/shared/use-sync-interactive-filters.tsx
@@ -4,6 +4,7 @@ import {
   ChartConfig,
   FilterValueSingle,
   isSegmentInConfig,
+  useChartConfigFilters,
 } from "@/config-types";
 import { parseDate } from "@/configurator/components/ui-helpers";
 import { FIELD_VALUE_NONE } from "@/configurator/constants";
@@ -19,6 +20,7 @@ import { useInteractiveFilters } from "@/stores/interactive-filters";
  */
 const useSyncInteractiveFilters = (chartConfig: ChartConfig) => {
   const { interactiveFiltersConfig } = chartConfig;
+  const filters = useChartConfigFilters(chartConfig);
   const resetCategories = useInteractiveFilters((d) => d.resetCategories);
   const dataFilters = useInteractiveFilters((d) => d.dataFilters);
   const setDataFilters = useInteractiveFilters((d) => d.setDataFilters);
@@ -53,7 +55,7 @@ const useSyncInteractiveFilters = (chartConfig: ChartConfig) => {
       const newInteractiveDataFilters = componentIris.reduce<{
         [key: string]: FilterValueSingle;
       }>((obj, iri) => {
-        const configFilter = chartConfig.filters[iri];
+        const configFilter = filters[iri];
 
         if (Object.keys(dataFilters).includes(iri)) {
           obj[iri] = dataFilters[iri];
@@ -69,7 +71,7 @@ const useSyncInteractiveFilters = (chartConfig: ChartConfig) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [componentIris, setDataFilters]);
 
-  const changes = useFilterChanges(chartConfig.filters);
+  const changes = useFilterChanges(filters);
   useEffect(() => {
     if (changes.length !== 1) {
       return;

--- a/app/charts/table/chart-table.tsx
+++ b/app/charts/table/chart-table.tsx
@@ -4,9 +4,9 @@ import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
 import { Table } from "@/charts/table/table";
 import { TableChart } from "@/charts/table/table-state";
 import { DataSource, TableConfig } from "@/configurator";
+import { useDataCubesMetadataQuery } from "@/graphql/hooks";
 import {
   useDataCubesComponentsQuery,
-  useDataCubesMetadataQuery,
   useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
@@ -31,7 +31,7 @@ export const ChartTableVisualization = ({
   const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
+      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({

--- a/app/charts/table/chart-table.tsx
+++ b/app/charts/table/chart-table.tsx
@@ -7,8 +7,8 @@ import { DataSource, TableConfig } from "@/configurator";
 import {
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
+  useDataCubesObservationsQuery,
 } from "@/graphql/hooks";
-import { useDataCubesObservationsQuery } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
 import { ChartProps } from "../shared/ChartProps";
@@ -46,7 +46,7 @@ export const ChartTableVisualization = ({
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({
+      cubeFilters: chartConfig.cubes.map((cube) => ({
         iri: cube.iri,
         componentIris,
       })),

--- a/app/charts/table/chart-table.tsx
+++ b/app/charts/table/chart-table.tsx
@@ -14,12 +14,10 @@ import { useLocale } from "@/locales/use-locale";
 import { ChartProps } from "../shared/ChartProps";
 
 export const ChartTableVisualization = ({
-  dataSetIri,
   dataSource,
   componentIris,
   chartConfig,
 }: {
-  dataSetIri: string;
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: TableConfig;
@@ -33,19 +31,25 @@ export const ChartTableVisualization = ({
   const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri }],
+      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const [componentsQuery] = useDataCubesComponentsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris }],
+      filters: chartConfig.cubes.map((cube) => ({
+        iri: cube.iri,
+        componentIris,
+      })),
     },
   });
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: dataSetIri, componentIris }],
+      filters: chartConfig.cubes.map((cube) => ({
+        iri: cube.iri,
+        componentIris,
+      })),
     },
   });
 

--- a/app/charts/table/chart-table.tsx
+++ b/app/charts/table/chart-table.tsx
@@ -4,11 +4,11 @@ import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
 import { Table } from "@/charts/table/table";
 import { TableChart } from "@/charts/table/table-state";
 import { DataSource, TableConfig } from "@/configurator";
-import { useDataCubesMetadataQuery } from "@/graphql/hooks";
 import {
   useDataCubesComponentsQuery,
-  useDataCubesObservationsQuery,
-} from "@/graphql/query-hooks";
+  useDataCubesMetadataQuery,
+} from "@/graphql/hooks";
+import { useDataCubesObservationsQuery } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
 import { ChartProps } from "../shared/ChartProps";
@@ -37,7 +37,7 @@ export const ChartTableVisualization = ({
   const [componentsQuery] = useDataCubesComponentsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({
+      cubeFilters: chartConfig.cubes.map((cube) => ({
         iri: cube.iri,
         componentIris,
       })),

--- a/app/components/chart-filters-list.tsx
+++ b/app/components/chart-filters-list.tsx
@@ -16,7 +16,7 @@ import {
   isTemporalOrdinalDimension,
 } from "@/domain/data";
 import { useTimeFormatUnit } from "@/formatters";
-import { useDataCubesComponentsQuery } from "@/graphql/query-hooks";
+import { useDataCubesComponentsQuery } from "@/graphql/hooks";
 import { useLocale } from "@/locales/use-locale";
 import { useInteractiveFilters } from "@/stores/interactive-filters";
 
@@ -43,7 +43,7 @@ export const ChartFiltersList = (props: ChartFiltersListProps) => {
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      filters: filters
+      cubeFilters: filters
         ? filters.map((filter) => ({
             iri: filter.iri,
             componentIris: filter.componentIris,

--- a/app/components/chart-filters-list.tsx
+++ b/app/components/chart-filters-list.tsx
@@ -44,7 +44,11 @@ export const ChartFiltersList = (props: ChartFiltersListProps) => {
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      filters,
+      filters: filters.map((filter) => ({
+        iri: filter.iri,
+        componentIris: filter.componentIris,
+        filters: filter.filters,
+      })),
     },
   });
 

--- a/app/components/chart-filters-list.tsx
+++ b/app/components/chart-filters-list.tsx
@@ -23,8 +23,8 @@ import { useInteractiveFilters } from "@/stores/interactive-filters";
 type ChartFiltersListProps = {
   dataSource: DataSource;
   chartConfig: ChartConfig;
-  dimensions: Dimension[];
-  measures: Measure[];
+  dimensions?: Dimension[];
+  measures?: Measure[];
 };
 
 export const ChartFiltersList = (props: ChartFiltersListProps) => {
@@ -43,15 +43,18 @@ export const ChartFiltersList = (props: ChartFiltersListProps) => {
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      filters: filters.map((filter) => ({
-        iri: filter.iri,
-        componentIris: filter.componentIris,
-        filters: filter.filters,
-      })),
+      filters: filters
+        ? filters.map((filter) => ({
+            iri: filter.iri,
+            componentIris: filter.componentIris,
+            filters: filter.filters,
+          }))
+        : [],
     },
+    pause: !filters,
   });
   const allFilters = React.useMemo(() => {
-    if (!data?.dataCubesComponents) {
+    if (!data?.dataCubesComponents || !filters || !dimensions || !measures) {
       return [];
     }
 
@@ -121,9 +124,10 @@ export const ChartFiltersList = (props: ChartFiltersListProps) => {
     });
   }, [
     data?.dataCubesComponents,
+    dimensions,
+    measures,
     filters,
     animationField,
-    dimensions,
     timeFormatUnit,
     timeSlider.value,
     timeSlider.type,

--- a/app/components/chart-filters-list.tsx
+++ b/app/components/chart-filters-list.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/configurator";
 import {
   Dimension,
+  Measure,
   isTemporalDimension,
   isTemporalOrdinalDimension,
 } from "@/domain/data";
@@ -24,10 +25,11 @@ type ChartFiltersListProps = {
   dataSource: DataSource;
   chartConfig: ChartConfig;
   dimensions: Dimension[];
+  measures: Measure[];
 };
 
 export const ChartFiltersList = (props: ChartFiltersListProps) => {
-  const { dataSource, chartConfig, dimensions } = props;
+  const { dataSource, chartConfig, dimensions, measures } = props;
   const locale = useLocale();
   const timeFormatUnit = useTimeFormatUnit();
   const timeSlider = useInteractiveFilters((d) => d.timeSlider);
@@ -35,6 +37,7 @@ export const ChartFiltersList = (props: ChartFiltersListProps) => {
   const filters = useQueryFilters({
     chartConfig,
     dimensions,
+    measures,
   });
   const [{ data }] = useDataCubesComponentsQuery({
     variables: {

--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -49,8 +49,8 @@ export const ChartFootnotes = ({
 }: {
   dataSource: DataSource;
   chartConfig: ChartConfig;
-  dimensions: Dimension[];
-  measures: Measure[];
+  dimensions?: Dimension[];
+  measures?: Measure[];
   configKey?: string;
   onToggleTableView: () => void;
   visualizeLinkText?: JSX.Element;
@@ -88,8 +88,9 @@ export const ChartFootnotes = ({
   const [{ data: downloadData }] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters,
+      filters: filters ?? [],
     },
+    pause: !filters,
   });
   const sparqlEditorUrls =
     downloadData?.dataCubesObservations?.sparqlEditorUrls;

--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -9,8 +9,10 @@ import { DataDownloadMenu, RunSparqlQuery } from "@/components/data-download";
 import { ChartConfig, DataSource } from "@/configurator";
 import { Dimension, Measure } from "@/domain/data";
 import { useTimeFormatLocale } from "@/formatters";
-import { useDataCubesMetadataQuery } from "@/graphql/hooks";
-import { useDataCubesObservationsQuery } from "@/graphql/query-hooks";
+import {
+  useDataCubesMetadataQuery,
+  useDataCubesObservationsQuery,
+} from "@/graphql/hooks";
 import { Icon, getChartIcon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
 import { useEmbedOptions } from "@/utils/embed";
@@ -86,7 +88,7 @@ export const ChartFootnotes = ({
   const [{ data: downloadData }] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: filters ?? [],
+      cubeFilters: filters ?? [],
     },
     pause: !filters,
   });

--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -7,7 +7,7 @@ import { useQueryFilters } from "@/charts/shared/chart-helpers";
 import { useChartTablePreview } from "@/components/chart-table-preview";
 import { DataDownloadMenu, RunSparqlQuery } from "@/components/data-download";
 import { ChartConfig, DataSource } from "@/configurator";
-import { Dimension } from "@/domain/data";
+import { Dimension, Measure } from "@/domain/data";
 import { useTimeFormatLocale } from "@/formatters";
 import {
   useDataCubesMetadataQuery,
@@ -42,6 +42,7 @@ export const ChartFootnotes = ({
   dataSource,
   chartConfig,
   dimensions,
+  measures,
   configKey,
   onToggleTableView,
   visualizeLinkText,
@@ -49,6 +50,7 @@ export const ChartFootnotes = ({
   dataSource: DataSource;
   chartConfig: ChartConfig;
   dimensions: Dimension[];
+  measures: Measure[];
   configKey?: string;
   onToggleTableView: () => void;
   visualizeLinkText?: JSX.Element;
@@ -67,7 +69,11 @@ export const ChartFootnotes = ({
     setShareUrl(`${window.location.origin}/${locale}/v/${configKey}`);
   }, [configKey, locale]);
 
-  const filters = useQueryFilters({ chartConfig, dimensions });
+  const filters = useQueryFilters({
+    chartConfig,
+    dimensions,
+    measures,
+  });
   const commonQueryVariables = {
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,

--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -9,10 +9,8 @@ import { DataDownloadMenu, RunSparqlQuery } from "@/components/data-download";
 import { ChartConfig, DataSource } from "@/configurator";
 import { Dimension, Measure } from "@/domain/data";
 import { useTimeFormatLocale } from "@/formatters";
-import {
-  useDataCubesMetadataQuery,
-  useDataCubesObservationsQuery,
-} from "@/graphql/query-hooks";
+import { useDataCubesMetadataQuery } from "@/graphql/hooks";
+import { useDataCubesObservationsQuery } from "@/graphql/query-hooks";
 import { Icon, getChartIcon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
 import { useEmbedOptions } from "@/utils/embed";
@@ -82,7 +80,7 @@ export const ChartFootnotes = ({
   const [{ data }] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
+      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const [{ data: downloadData }] = useDataCubesObservationsQuery({

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -21,8 +21,10 @@ import {
   getChartConfig,
   useConfiguratorState,
 } from "@/configurator";
-import { useDataCubesMetadataQuery } from "@/graphql/hooks";
-import { useDataCubesComponentsQuery } from "@/graphql/query-hooks";
+import {
+  useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
+} from "@/graphql/hooks";
 import { DataCubePublicationStatus } from "@/graphql/resolver-types";
 import { useLocale } from "@/locales/use-locale";
 import useEvent from "@/utils/use-event";
@@ -77,7 +79,7 @@ export const ChartPreviewInner = (props: ChartPreviewProps) => {
   const [{ data: components }] = useDataCubesComponentsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({
+      cubeFilters: chartConfig.cubes.map((cube) => ({
         iri: cube.iri,
         componentIris,
       })),

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -5,7 +5,6 @@ import Head from "next/head";
 import { useMemo } from "react";
 
 import { DataSetTable } from "@/browse/datatable";
-import { extractChartConfigComponentIris } from "@/charts/shared/chart-helpers";
 import { ChartErrorBoundary } from "@/components/chart-error-boundary";
 import { ChartFootnotes } from "@/components/chart-footnotes";
 import {
@@ -76,7 +75,7 @@ export const ChartPreviewInner = (props: ChartPreviewProps) => {
       filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
-  const componentIris = extractChartConfigComponentIris(chartConfig);
+  const componentIris = undefined;
   const [{ data: components }] = useDataCubesComponentsQuery({
     variables: {
       ...commonQueryVariables,

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -94,8 +94,8 @@ export const ChartPreviewInner = (props: ChartPreviewProps) => {
   } = useChartTablePreview();
 
   const handleToggleTableView = useEvent(() => setIsTablePreview((c) => !c));
-
   const dimensions = components?.dataCubesComponents.dimensions ?? [];
+  const measures = components?.dataCubesComponents.measures ?? [];
   const allComponents = useMemo(() => {
     if (!components?.dataCubesComponents) {
       return [];
@@ -223,6 +223,7 @@ export const ChartPreviewInner = (props: ChartPreviewProps) => {
                   componentIris={componentIris}
                   chartConfig={chartConfig}
                   dimensions={dimensions}
+                  measures={measures}
                 />
               )}
             </Box>
@@ -232,6 +233,7 @@ export const ChartPreviewInner = (props: ChartPreviewProps) => {
                 chartConfig={chartConfig}
                 onToggleTableView={handleToggleTableView}
                 dimensions={dimensions}
+                measures={measures}
               />
             )}
             <DebugPanel configurator interactiveFilters />

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -21,10 +21,8 @@ import {
   getChartConfig,
   useConfiguratorState,
 } from "@/configurator";
-import {
-  useDataCubesComponentsQuery,
-  useDataCubesMetadataQuery,
-} from "@/graphql/query-hooks";
+import { useDataCubesMetadataQuery } from "@/graphql/hooks";
+import { useDataCubesComponentsQuery } from "@/graphql/query-hooks";
 import { DataCubePublicationStatus } from "@/graphql/resolver-types";
 import { useLocale } from "@/locales/use-locale";
 import useEvent from "@/utils/use-event";
@@ -72,7 +70,7 @@ export const ChartPreviewInner = (props: ChartPreviewProps) => {
   const [{ data: metadata }] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
+      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const componentIris = undefined;

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -34,8 +34,10 @@ import {
   DEFAULT_DATA_SOURCE,
   useIsTrustedDataSource,
 } from "@/domain/datasource";
-import { useDataCubesMetadataQuery } from "@/graphql/hooks";
-import { useDataCubesComponentsQuery } from "@/graphql/query-hooks";
+import {
+  useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
+} from "@/graphql/hooks";
 import { DataCubePublicationStatus } from "@/graphql/resolver-types";
 import { useLocale } from "@/locales/use-locale";
 import { InteractiveFiltersProvider } from "@/stores/interactive-filters";
@@ -147,7 +149,7 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
   const [{ data: components }] = useDataCubesComponentsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: chartConfig.cubes.map((cube) => ({
+      cubeFilters: chartConfig.cubes.map((cube) => ({
         iri: cube.iri,
         componentIris,
       })),

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -142,14 +142,17 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      filters: [{ iri: chartConfig.dataSet }],
+      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const componentIris = extractChartConfigsComponentIris(state.chartConfigs);
   const [{ data: components }] = useDataCubesComponentsQuery({
     variables: {
       ...commonQueryVariables,
-      filters: [{ iri: chartConfig.dataSet, componentIris }],
+      filters: chartConfig.cubes.map((cube) => ({
+        iri: cube.iri,
+        componentIris,
+      })),
     },
   });
   const handleToggleTableView = useEvent(() => setIsTablePreview((c) => !c));
@@ -226,7 +229,8 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
             </Typography>
 
             <MetadataPanel
-              datasetIri={chartConfig.dataSet}
+              // FIXME: adapt to design
+              datasetIri={chartConfig.cubes[0].iri}
               dataSource={dataSource}
               dimensions={allComponents}
               container={rootRef.current}
@@ -248,23 +252,22 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
               {isTablePreview ? (
                 <DataSetTable
                   sx={{ maxHeight: "100%" }}
-                  dataSetIri={chartConfig.dataSet}
                   dataSource={dataSource}
                   chartConfig={chartConfig}
                 />
               ) : (
                 <ChartWithFilters
-                  dataSet={chartConfig.dataSet}
                   dataSource={dataSource}
                   componentIris={componentIris}
                   chartConfig={chartConfig}
+                  dimensions={components?.dataCubesComponents.dimensions ?? []}
                 />
               )}
             </Flex>
             <ChartFootnotes
-              dataSetIri={chartConfig.dataSet}
               dataSource={dataSource}
               chartConfig={chartConfig}
+              dimensions={components?.dataCubesComponents.dimensions ?? []}
               configKey={configKey}
               onToggleTableView={handleToggleTableView}
               visualizeLinkText={

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -157,6 +157,8 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
   });
   const handleToggleTableView = useEvent(() => setIsTablePreview((c) => !c));
 
+  const dimensions = components?.dataCubesComponents.dimensions ?? [];
+  const measures = components?.dataCubesComponents.measures ?? [];
   const allComponents = useMemo(() => {
     if (!components?.dataCubesComponents) {
       return [];
@@ -260,14 +262,16 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
                   dataSource={dataSource}
                   componentIris={componentIris}
                   chartConfig={chartConfig}
-                  dimensions={components?.dataCubesComponents.dimensions ?? []}
+                  dimensions={dimensions}
+                  measures={measures}
                 />
               )}
             </Flex>
             <ChartFootnotes
               dataSource={dataSource}
               chartConfig={chartConfig}
-              dimensions={components?.dataCubesComponents.dimensions ?? []}
+              dimensions={dimensions}
+              measures={measures}
               configKey={configKey}
               onToggleTableView={handleToggleTableView}
               visualizeLinkText={

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -157,8 +157,8 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
   });
   const handleToggleTableView = useEvent(() => setIsTablePreview((c) => !c));
 
-  const dimensions = components?.dataCubesComponents.dimensions ?? [];
-  const measures = components?.dataCubesComponents.measures ?? [];
+  const dimensions = components?.dataCubesComponents.dimensions;
+  const measures = components?.dataCubesComponents.measures;
   const allComponents = useMemo(() => {
     if (!components?.dataCubesComponents) {
       return [];

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -34,10 +34,8 @@ import {
   DEFAULT_DATA_SOURCE,
   useIsTrustedDataSource,
 } from "@/domain/datasource";
-import {
-  useDataCubesComponentsQuery,
-  useDataCubesMetadataQuery,
-} from "@/graphql/query-hooks";
+import { useDataCubesMetadataQuery } from "@/graphql/hooks";
+import { useDataCubesComponentsQuery } from "@/graphql/query-hooks";
 import { DataCubePublicationStatus } from "@/graphql/resolver-types";
 import { useLocale } from "@/locales/use-locale";
 import { InteractiveFiltersProvider } from "@/stores/interactive-filters";
@@ -142,7 +140,7 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
+      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const componentIris = extractChartConfigsComponentIris(state.chartConfigs);

--- a/app/components/chart-selection-tabs.tsx
+++ b/app/components/chart-selection-tabs.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/configurator";
 import { ChartTypeSelector } from "@/configurator/components/chart-type-selector";
 import { getIconName } from "@/configurator/components/ui-helpers";
-import { useDataCubesComponentsQuery } from "@/graphql/query-hooks";
+import { useDataCubesComponentsQuery } from "@/graphql/hooks";
 import { Icon, IconName } from "@/icons";
 import { useLocale } from "@/src";
 import { fetchChartConfig } from "@/utils/chart-config/api";
@@ -260,7 +260,7 @@ const PublishChartButton = () => {
       sourceType: state.dataSource.type,
       sourceUrl: state.dataSource.url,
       locale,
-      filters: chartConfig.cubes.map((cube) => ({
+      cubeFilters: chartConfig.cubes.map((cube) => ({
         iri: cube.iri,
         componentIris,
       })),

--- a/app/components/chart-selection-tabs.tsx
+++ b/app/components/chart-selection-tabs.tsx
@@ -260,7 +260,10 @@ const PublishChartButton = () => {
       sourceType: state.dataSource.type,
       sourceUrl: state.dataSource.url,
       locale,
-      filters: [{ iri: chartConfig.dataSet, componentIris }],
+      filters: chartConfig.cubes.map((cube) => ({
+        iri: cube.iri,
+        componentIris,
+      })),
     },
   });
   const goNext = useEvent(() => {

--- a/app/components/chart-with-filters.tsx
+++ b/app/components/chart-with-filters.tsx
@@ -8,7 +8,7 @@ import useSyncInteractiveFilters from "@/charts/shared/use-sync-interactive-filt
 import { ChartFiltersList } from "@/components/chart-filters-list";
 import Flex from "@/components/flex";
 import { ChartConfig, DataSource } from "@/configurator";
-import { Dimension } from "@/domain/data";
+import { Dimension, Measure } from "@/domain/data";
 
 const ChartAreasVisualization = dynamic(
   import("@/charts/area/chart-area").then(
@@ -76,11 +76,17 @@ type GenericChartProps = {
   componentIris: string[] | undefined;
   chartConfig: ChartConfig;
   dimensions: Dimension[];
+  measures: Measure[];
 };
 
 const GenericChart = (props: GenericChartProps) => {
-  const { dataSource, componentIris, chartConfig, dimensions } = props;
-  const queryFilters = useQueryFilters({ chartConfig, dimensions });
+  const { dataSource, componentIris, chartConfig, dimensions, measures } =
+    props;
+  const queryFilters = useQueryFilters({
+    chartConfig,
+    dimensions,
+    measures,
+  });
   const commonProps = {
     dataSource,
     queryFilters,
@@ -152,6 +158,7 @@ type ChartWithFiltersProps = {
   componentIris: string[] | undefined;
   chartConfig: ChartConfig;
   dimensions: Dimension[];
+  measures: Measure[];
 };
 
 export const ChartWithFilters = React.forwardRef<

--- a/app/components/chart-with-filters.tsx
+++ b/app/components/chart-with-filters.tsx
@@ -8,6 +8,7 @@ import useSyncInteractiveFilters from "@/charts/shared/use-sync-interactive-filt
 import { ChartFiltersList } from "@/components/chart-filters-list";
 import Flex from "@/components/flex";
 import { ChartConfig, DataSource } from "@/configurator";
+import { Dimension } from "@/domain/data";
 
 const ChartAreasVisualization = dynamic(
   import("@/charts/area/chart-area").then(
@@ -71,17 +72,16 @@ const ChartTableVisualization = dynamic(
 );
 
 type GenericChartProps = {
-  dataSet: string;
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: ChartConfig;
+  dimensions: Dimension[];
 };
 
 const GenericChart = (props: GenericChartProps) => {
-  const { dataSet, dataSource, componentIris, chartConfig } = props;
-  const queryFilters = useQueryFilters({ chartConfig });
+  const { dataSource, componentIris, chartConfig, dimensions } = props;
+  const queryFilters = useQueryFilters({ chartConfig, dimensions });
   const commonProps = {
-    dataSetIri: dataSet,
     dataSource,
     queryFilters,
     componentIris,
@@ -148,10 +148,10 @@ const GenericChart = (props: GenericChartProps) => {
 };
 
 type ChartWithFiltersProps = {
-  dataSet: string;
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: ChartConfig;
+  dimensions: Dimension[];
 };
 
 export const ChartWithFilters = React.forwardRef<

--- a/app/components/chart-with-filters.tsx
+++ b/app/components/chart-with-filters.tsx
@@ -75,8 +75,8 @@ type GenericChartProps = {
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: ChartConfig;
-  dimensions: Dimension[];
-  measures: Measure[];
+  dimensions?: Dimension[];
+  measures?: Measure[];
 };
 
 const GenericChart = (props: GenericChartProps) => {
@@ -84,8 +84,8 @@ const GenericChart = (props: GenericChartProps) => {
     props;
   const queryFilters = useQueryFilters({
     chartConfig,
-    dimensions,
-    measures,
+    dimensions: dimensions ?? [],
+    measures: measures ?? [],
   });
   const commonProps = {
     dataSource,
@@ -157,8 +157,8 @@ type ChartWithFiltersProps = {
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: ChartConfig;
-  dimensions: Dimension[];
-  measures: Measure[];
+  dimensions?: Dimension[];
+  measures?: Measure[];
 };
 
 export const ChartWithFilters = React.forwardRef<

--- a/app/components/data-download.tsx
+++ b/app/components/data-download.tsx
@@ -31,17 +31,15 @@ import { useClient } from "urql";
 import { getSortedColumns } from "@/browse/datatable";
 import Flex from "@/components/flex";
 import { DataSource, SortingField } from "@/config-types";
-import { Component, Observation } from "@/domain/data";
+import { Component, DataCubeComponents, Observation } from "@/domain/data";
 import {
   dateFormatterFromDimension,
   getFormatFullDateAuto,
   getFormattersForLocale,
 } from "@/formatters";
+import { executeDataCubesComponentsQuery } from "@/graphql/hooks";
 import {
   DataCubeObservationFilter,
-  DataCubesComponentsDocument,
-  DataCubesComponentsQuery,
-  DataCubesComponentsQueryVariables,
   DataCubesObservationsDocument,
   DataCubesObservationsQuery,
   DataCubesObservationsQueryVariables,
@@ -319,7 +317,7 @@ const DownloadMenuItem = ({
   const [state, dispatch] = useDataDownloadState();
   const download = useCallback(
     async (
-      componentsData: DataCubesComponentsQuery,
+      componentsData: { dataCubesComponents: DataCubeComponents } | undefined,
       observationsData: DataCubesObservationsQuery
     ) => {
       if (
@@ -382,17 +380,12 @@ const DownloadMenuItem = ({
 
         try {
           const [componentsResult, observationsResult] = await Promise.all([
-            urqlClient
-              .query<
-                DataCubesComponentsQuery,
-                DataCubesComponentsQueryVariables
-              >(DataCubesComponentsDocument, {
-                sourceType: dataSource.type,
-                sourceUrl: dataSource.url,
-                locale,
-                filters,
-              })
-              .toPromise(),
+            executeDataCubesComponentsQuery({
+              sourceType: dataSource.type,
+              sourceUrl: dataSource.url,
+              locale,
+              cubeFilters: filters,
+            }),
             urqlClient
               .query<
                 DataCubesObservationsQuery,

--- a/app/components/data-download.tsx
+++ b/app/components/data-download.tsx
@@ -178,7 +178,7 @@ export const DataDownloadMenu = memo(
     title,
   }: {
     dataSource: DataSource;
-    filters: DataCubeObservationFilter[];
+    filters?: DataCubeObservationFilter[];
     title: string;
   }) => {
     return (
@@ -200,7 +200,7 @@ const DataDownloadInnerMenu = ({
 }: {
   dataSource: DataSource;
   fileName: string;
-  filters: DataCubeObservationFilter[];
+  filters?: DataCubeObservationFilter[];
 }) => {
   const [state] = useDataDownloadState();
   const popupState = usePopupState({
@@ -250,7 +250,7 @@ const DataDownloadInnerMenu = ({
           dataSource={dataSource}
           subheader={<Trans id="button.download.data.all">Full dataset</Trans>}
           fileName={`${fileName}-full`}
-          filters={filters.map((d) => {
+          filters={filters?.map((d) => {
             return {
               iri: d.iri,
               componentIris: d.componentIris,
@@ -278,7 +278,7 @@ const DataDownloadMenuSection = ({
   dataSource: DataSource;
   subheader: ReactNode;
   fileName: string;
-  filters: DataCubeObservationFilter[];
+  filters?: DataCubeObservationFilter[];
 }) => {
   return (
     <>
@@ -311,7 +311,7 @@ const DownloadMenuItem = ({
   dataSource: DataSource;
   fileName: string;
   fileFormat: FileFormat;
-  filters: DataCubeObservationFilter[];
+  filters?: DataCubeObservationFilter[];
 }) => {
   const locale = useLocale();
   const i18n = useI18n();
@@ -374,6 +374,10 @@ const DownloadMenuItem = ({
       size="small"
       disabled={state.isDownloading}
       onClick={async () => {
+        if (!filters) {
+          return;
+        }
+
         dispatch({ isDownloading: true });
 
         try {

--- a/app/components/data-download.tsx
+++ b/app/components/data-download.tsx
@@ -26,24 +26,26 @@ import {
   useContext,
   useState,
 } from "react";
-import { useClient } from "urql";
 
 import { getSortedColumns } from "@/browse/datatable";
 import Flex from "@/components/flex";
 import { DataSource, SortingField } from "@/config-types";
-import { Component, DataCubeComponents, Observation } from "@/domain/data";
+import {
+  Component,
+  DataCubeComponents,
+  DataCubesObservations,
+  Observation,
+} from "@/domain/data";
 import {
   dateFormatterFromDimension,
   getFormatFullDateAuto,
   getFormattersForLocale,
 } from "@/formatters";
-import { executeDataCubesComponentsQuery } from "@/graphql/hooks";
 import {
-  DataCubeObservationFilter,
-  DataCubesObservationsDocument,
-  DataCubesObservationsQuery,
-  DataCubesObservationsQueryVariables,
-} from "@/graphql/query-hooks";
+  executeDataCubesComponentsQuery,
+  executeDataCubesObservationsQuery,
+} from "@/graphql/hooks";
+import { DataCubeObservationFilter } from "@/graphql/query-hooks";
 import { Icon } from "@/icons";
 import { Locale } from "@/locales/locales";
 import { useLocale } from "@/src";
@@ -313,12 +315,13 @@ const DownloadMenuItem = ({
 }) => {
   const locale = useLocale();
   const i18n = useI18n();
-  const urqlClient = useClient();
   const [state, dispatch] = useDataDownloadState();
   const download = useCallback(
     async (
       componentsData: { dataCubesComponents: DataCubeComponents } | undefined,
-      observationsData: DataCubesObservationsQuery
+      observationsData:
+        | { dataCubesObservations: DataCubesObservations }
+        | undefined
     ) => {
       if (
         !(
@@ -386,17 +389,12 @@ const DownloadMenuItem = ({
               locale,
               cubeFilters: filters,
             }),
-            urqlClient
-              .query<
-                DataCubesObservationsQuery,
-                DataCubesObservationsQueryVariables
-              >(DataCubesObservationsDocument, {
-                sourceType: dataSource.type,
-                sourceUrl: dataSource.url,
-                locale,
-                filters,
-              })
-              .toPromise(),
+            executeDataCubesObservationsQuery({
+              sourceType: dataSource.type,
+              sourceUrl: dataSource.url,
+              locale,
+              cubeFilters: filters,
+            }),
           ]);
 
           if (componentsResult.data && observationsResult.data) {

--- a/app/components/dataset-metadata.tsx
+++ b/app/components/dataset-metadata.tsx
@@ -15,7 +15,7 @@ import Tag from "@/components/tag";
 import { DataSource } from "@/config-types";
 import { DataCubeMetadata } from "@/domain/data";
 import { useFormatDate } from "@/formatters";
-import { useDataCubesMetadataQuery } from "@/graphql/query-hooks";
+import { useDataCubesMetadataQuery } from "@/graphql/hooks";
 import { Icon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
 import { makeOpenDataLink } from "@/utils/opendata";
@@ -34,7 +34,7 @@ export const DataSetMetadata = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      filters: [{ iri: dataSetIri }],
+      cubeFilters: [{ iri: dataSetIri }],
     },
   });
   // FIXME: adapt to design

--- a/app/components/debug-panel/DebugPanel.tsx
+++ b/app/components/debug-panel/DebugPanel.tsx
@@ -18,7 +18,7 @@ import {
   useConfiguratorState,
 } from "@/configurator";
 import { dataSourceToSparqlEditorUrl } from "@/domain/datasource";
-import { useDataCubesComponentsQuery } from "@/graphql/query-hooks";
+import { useDataCubesComponentsQuery } from "@/graphql/hooks";
 import { Icon } from "@/icons";
 import { useLocale } from "@/src";
 import { useInteractiveFiltersRaw } from "@/stores/interactive-filters";
@@ -53,7 +53,7 @@ const CubeMetadata = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      filters: [{ iri: datasetIri }],
+      cubeFilters: [{ iri: datasetIri }],
     },
     pause: !expanded,
   });

--- a/app/components/debug-panel/DebugPanel.tsx
+++ b/app/components/debug-panel/DebugPanel.tsx
@@ -100,45 +100,47 @@ const DebugConfigurator = () => {
       <Typography component="h3" variant="h4" sx={{ px: 5, color: "grey.700" }}>
         Cube Tools
       </Typography>
-      <Stack spacing={2} sx={{ pl: 5, py: 3 }}>
-        <Button
-          component="a"
-          color="primary"
-          variant="text"
-          size="small"
-          href={`https://cube-viewer.zazuko.com/?endpointUrl=${encodeURIComponent(
-            configuratorState.dataSource.url
-          )}&user=&password=&sourceGraph=&cube=${encodeURIComponent(
-            chartConfig.dataSet
-          )}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          startIcon={<Icon name="linkExternal" size={16} />}
-        >
-          <Typography variant="body2">Open in Cube Viewer</Typography>
-        </Button>
-        <Button
-          component="a"
-          color="primary"
-          variant="text"
-          size="small"
-          href={`${sparqlEditorUrl}#query=${encodeURIComponent(
-            `#pragma describe.strategy cbd
-              #pragma join.hash off
+      {chartConfig.cubes.map((cube) => (
+        <Stack key={cube.iri} spacing={2} sx={{ pl: 5, py: 3 }}>
+          <Button
+            component="a"
+            color="primary"
+            variant="text"
+            size="small"
+            href={`https://cube-viewer.zazuko.com/?endpointUrl=${encodeURIComponent(
+              configuratorState.dataSource.url
+            )}&user=&password=&sourceGraph=&cube=${encodeURIComponent(
+              cube.iri
+            )}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            startIcon={<Icon name="linkExternal" size={16} />}
+          >
+            <Typography variant="body2">Open in Cube Viewer</Typography>
+          </Button>
+          <Button
+            component="a"
+            color="primary"
+            variant="text"
+            size="small"
+            href={`${sparqlEditorUrl}#query=${encodeURIComponent(
+              `#pragma describe.strategy cbd
+               #pragma join.hash off
               
-DESCRIBE <${chartConfig.dataSet}>`
-          )}&requestMethod=POST`}
-          target="_blank"
-          rel="noopener noreferrer"
-          startIcon={<Icon name="linkExternal" size={16} />}
-        >
-          <Typography variant="body2">Cube Metadata Query</Typography>
-        </Button>
-        <CubeMetadata
-          datasetIri={chartConfig.dataSet}
-          dataSource={configuratorState.dataSource}
-        />
-      </Stack>
+               DESCRIBE <${cube.iri}>`
+            )}&requestMethod=POST`}
+            target="_blank"
+            rel="noopener noreferrer"
+            startIcon={<Icon name="linkExternal" size={16} />}
+          >
+            <Typography variant="body2">Cube Metadata Query</Typography>
+          </Button>
+          <CubeMetadata
+            datasetIri={cube.iri}
+            dataSource={configuratorState.dataSource}
+          />
+        </Stack>
+      ))}
       <Typography
         component="h3"
         variant="h4"

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -323,22 +323,25 @@ const useFilterReorder = ({
     }
 
     const dimension = dimensions.find((d) => d.iri === dimensionIri);
-    const newChartConfig = moveFilterField(chartConfig, {
-      dimensionIri,
-      delta,
-      possibleValues: dimension ? dimension.values : [],
-    });
 
-    dispatch({
-      type: "CHART_CONFIG_REPLACED",
-      value: {
-        chartConfig: newChartConfig,
-        dataCubesComponents: {
-          dimensions,
-          measures,
+    if (dimension) {
+      const newChartConfig = moveFilterField(chartConfig, {
+        dimension,
+        delta,
+        possibleValues: dimension ? dimension.values.map((d) => d.value) : [],
+      });
+
+      dispatch({
+        type: "CHART_CONFIG_REPLACED",
+        value: {
+          chartConfig: newChartConfig,
+          dataCubesComponents: {
+            dimensions,
+            measures,
+          },
         },
-      },
-    });
+      });
+    }
   });
 
   const handleAddDimensionFilter = useEvent((dimension: Dimension) => {
@@ -347,6 +350,7 @@ const useFilterReorder = ({
     dispatch({
       type: "CHART_CONFIG_FILTER_SET_SINGLE",
       value: {
+        cubeIri: dimension.cubeIri,
         dimensionIri: dimension.iri,
         value: `${filterValue.value}`,
       },
@@ -357,6 +361,7 @@ const useFilterReorder = ({
     dispatch({
       type: "CHART_CONFIG_FILTER_REMOVE_SINGLE",
       value: {
+        cubeIri: dimension.cubeIri,
         dimensionIri: dimension.iri,
       },
     });

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -74,11 +74,11 @@ import {
   isTemporalDimension,
   Measure,
 } from "@/domain/data";
+import { useDataCubesComponentsQuery } from "@/graphql/hooks";
 import {
   PossibleFiltersDocument,
   PossibleFiltersQuery,
   PossibleFiltersQueryVariables,
-  useDataCubesComponentsQuery,
   useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { Icon } from "@/icons";
@@ -264,11 +264,12 @@ const useFilterReorder = ({
   }, [chartConfig]);
 
   const variables = useMemo(() => {
-    const filters = chartConfig.cubes.map((cube) => {
+    const cubeFilters = chartConfig.cubes.map((cube) => {
       const { unmappedFilters } = getFiltersByMappingStatus(
         chartConfig,
         cube.iri
       );
+
       return Object.keys(unmappedFilters).length > 0
         ? {
             iri: cube.iri,
@@ -284,12 +285,12 @@ const useFilterReorder = ({
     // are the same  while the order of the keys has changed.
     // If this is not present, we'll have outdated dimension
     // values after we change the filter order
-    const requeryKey = filters.reduce((acc, d) => {
+    const requeryKey = cubeFilters.reduce((acc, d) => {
       return `${acc}${d.iri}${JSON.stringify(d.filters)}`;
     }, "");
 
     return {
-      filters,
+      cubeFilters,
       requeryKey: requeryKey ? requeryKey : undefined,
     };
   }, [chartConfig]);

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -572,9 +572,7 @@ export const ChartConfigurator = ({
       state,
     });
   const fetching = possibleFiltersFetching || dataFetching;
-
   const filterMenuButtonRef = useRef(null);
-
   const classes = useStyles({ fetching });
 
   if (!dimensions || !measures) {
@@ -763,12 +761,12 @@ export const ChartConfigurator = ({
 type ChartFieldsProps = {
   dataSource: DataSource;
   chartConfig: ChartConfig;
-  dimensions: Dimension[];
-  measures: Measure[];
+  dimensions?: Dimension[];
+  measures?: Measure[];
 };
 
 const ChartFields = (props: ChartFieldsProps) => {
-  const { dataSource, chartConfig, dimensions, measures } = props;
+  const { dataSource, chartConfig, dimensions = [], measures = [] } = props;
   const components = [...dimensions, ...measures];
   const filters = useQueryFilters({
     chartConfig,
@@ -781,8 +779,9 @@ const ChartFields = (props: ChartFieldsProps) => {
       locale,
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
-      filters,
+      filters: filters ?? [],
     },
+    pause: !filters,
   });
   const observations = observationsData?.dataCubesObservations?.data ?? [];
 

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -760,7 +760,11 @@ type ChartFieldsProps = {
 const ChartFields = (props: ChartFieldsProps) => {
   const { dataSource, chartConfig, dimensions, measures } = props;
   const components = [...dimensions, ...measures];
-  const filters = useQueryFilters({ chartConfig, dimensions });
+  const filters = useQueryFilters({
+    chartConfig,
+    dimensions,
+    measures,
+  });
   const locale = useLocale();
   const [{ data: observationsData }] = useDataCubesObservationsQuery({
     variables: {

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -74,12 +74,14 @@ import {
   isTemporalDimension,
   Measure,
 } from "@/domain/data";
-import { useDataCubesComponentsQuery } from "@/graphql/hooks";
+import {
+  useDataCubesComponentsQuery,
+  useDataCubesObservationsQuery,
+} from "@/graphql/hooks";
 import {
   PossibleFiltersDocument,
   PossibleFiltersQuery,
   PossibleFiltersQueryVariables,
-  useDataCubesObservationsQuery,
 } from "@/graphql/query-hooks";
 import { Icon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
@@ -769,7 +771,7 @@ type ChartFieldsProps = {
 const ChartFields = (props: ChartFieldsProps) => {
   const { dataSource, chartConfig, dimensions = [], measures = [] } = props;
   const components = [...dimensions, ...measures];
-  const filters = useQueryFilters({
+  const queryFilters = useQueryFilters({
     chartConfig,
     dimensions,
     measures,
@@ -780,9 +782,9 @@ const ChartFields = (props: ChartFieldsProps) => {
       locale,
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
-      filters: filters ?? [],
+      cubeFilters: queryFilters ?? [],
     },
-    pause: !filters,
+    pause: !queryFilters,
   });
   const observations = observationsData?.dataCubesObservations?.data ?? [];
 

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -118,9 +118,9 @@ export const ChartOptionsSelector = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      filters,
+      filters: filters ?? [],
     },
-    pause: fetchingComponents,
+    pause: fetchingComponents || !filters,
   });
   const observations = observationsData?.dataCubesObservations?.data;
 

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -107,9 +107,11 @@ export const ChartOptionsSelector = ({
       },
     });
   const dimensions = componentsData?.dataCubesComponents.dimensions;
+  const measures = componentsData?.dataCubesComponents.measures;
   const filters = useQueryFilters({
     chartConfig,
     dimensions: dimensions ?? [],
+    measures: measures ?? [],
   });
   const [{ data: observationsData }] = useDataCubesObservationsQuery({
     variables: {
@@ -120,7 +122,6 @@ export const ChartOptionsSelector = ({
     },
     pause: fetchingComponents,
   });
-  const measures = componentsData?.dataCubesComponents.measures;
   const observations = observationsData?.dataCubesObservations?.data;
 
   return dimensions && measures && observations ? (

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -80,8 +80,10 @@ import {
   Measure,
   Observation,
 } from "@/domain/data";
-import { useDataCubesComponentsQuery } from "@/graphql/hooks";
-import { useDataCubesObservationsQuery } from "@/graphql/query-hooks";
+import {
+  useDataCubesComponentsQuery,
+  useDataCubesObservationsQuery,
+} from "@/graphql/hooks";
 import { NumericalMeasure } from "@/graphql/resolver-types";
 import SvgIcExclamation from "@/icons/components/IcExclamation";
 import { useLocale } from "@/locales/use-locale";
@@ -106,7 +108,7 @@ export const ChartOptionsSelector = ({
     });
   const dimensions = componentsData?.dataCubesComponents.dimensions;
   const measures = componentsData?.dataCubesComponents.measures;
-  const filters = useQueryFilters({
+  const queryFilters = useQueryFilters({
     chartConfig,
     dimensions: dimensions ?? [],
     measures: measures ?? [],
@@ -116,9 +118,9 @@ export const ChartOptionsSelector = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      filters: filters ?? [],
+      cubeFilters: queryFilters ?? [],
     },
-    pause: fetchingComponents || !filters,
+    pause: fetchingComponents || !queryFilters,
   });
   const observations = observationsData?.dataCubesObservations?.data;
 

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -80,10 +80,8 @@ import {
   Measure,
   Observation,
 } from "@/domain/data";
-import {
-  useDataCubesComponentsQuery,
-  useDataCubesObservationsQuery,
-} from "@/graphql/query-hooks";
+import { useDataCubesComponentsQuery } from "@/graphql/hooks";
+import { useDataCubesObservationsQuery } from "@/graphql/query-hooks";
 import { NumericalMeasure } from "@/graphql/resolver-types";
 import SvgIcExclamation from "@/icons/components/IcExclamation";
 import { useLocale } from "@/locales/use-locale";
@@ -103,7 +101,7 @@ export const ChartOptionsSelector = ({
         sourceType: dataSource.type,
         sourceUrl: dataSource.url,
         locale,
-        filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
+        cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
       },
     });
   const dimensions = componentsData?.dataCubesComponents.dimensions;

--- a/app/configurator/components/chart-type-selector.tsx
+++ b/app/configurator/components/chart-type-selector.tsx
@@ -128,7 +128,7 @@ export const ChartTypeSelector = ({
       sourceType: state.dataSource.type,
       sourceUrl: state.dataSource.url,
       locale,
-      filters: [{ iri: chartConfig.dataSet }],
+      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const dimensions = data?.dataCubesComponents?.dimensions ?? [];

--- a/app/configurator/components/chart-type-selector.tsx
+++ b/app/configurator/components/chart-type-selector.tsx
@@ -29,7 +29,7 @@ import { ControlSectionSkeleton } from "@/configurator/components/chart-controls
 import { getFieldLabel } from "@/configurator/components/field-i18n";
 import { getIconName } from "@/configurator/components/ui-helpers";
 import { FieldProps, useChartType } from "@/configurator/config-form";
-import { useDataCubesComponentsQuery } from "@/graphql/query-hooks";
+import { useDataCubesComponentsQuery } from "@/graphql/hooks";
 import { Icon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
 
@@ -83,6 +83,7 @@ export const ChartTypeSelectionButton = ({
   onClick: (e: SyntheticEvent<HTMLButtonElement>) => void;
 } & FieldProps) => {
   const classes = useSelectionButtonStyles();
+
   return (
     <ButtonBase
       tabIndex={0}
@@ -128,7 +129,7 @@ export const ChartTypeSelector = ({
       sourceType: state.dataSource.type,
       sourceUrl: state.dataSource.url,
       locale,
-      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
+      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
   const dimensions = data?.dataCubesComponents?.dimensions ?? [];

--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -22,12 +22,11 @@ import {
   PanelLeftWrapper,
   PanelMiddleWrapper,
 } from "@/configurator/components/layout";
+import { ChartConfiguratorTable } from "@/configurator/table/table-chart-configurator";
 import SvgIcChevronLeft from "@/icons/components/IcChevronLeft";
 import { useDataSourceStore } from "@/stores/data-source";
 import { InteractiveFiltersProvider } from "@/stores/interactive-filters";
 import useEvent from "@/utils/use-event";
-
-import { ChartConfiguratorTable } from "../table/table-chart-configurator";
 
 const BackContainer = ({ children }: { children: React.ReactNode }) => {
   return (
@@ -92,7 +91,7 @@ const ConfigureChartStep = () => {
       {
         pathname: `/browse`,
         query: {
-          dataset: chartConfig.dataSet,
+          dataset: chartConfig.cubes[0].iri,
         },
       },
       undefined,
@@ -136,10 +135,7 @@ const ConfigureChartStep = () => {
       </PanelLeftWrapper>
       <PanelMiddleWrapper>
         <ChartPanel>
-          <ChartPreview
-            dataSetIri={chartConfig.dataSet}
-            dataSource={state.dataSource}
-          />
+          <ChartPreview dataSource={state.dataSource} />
         </ChartPanel>
       </PanelMiddleWrapper>
       <ConfiguratorDrawer
@@ -174,7 +170,6 @@ const ConfigureChartStep = () => {
 
 const PublishStep = () => {
   const [state] = useConfiguratorState();
-  const chartConfig = getChartConfig(state);
 
   if (state.state !== "PUBLISHING") {
     return null;
@@ -184,10 +179,7 @@ const PublishStep = () => {
     <PanelMiddleWrapper>
       <ChartPanel>
         <InteractiveFiltersProvider>
-          <ChartPreview
-            dataSetIri={chartConfig.dataSet}
-            dataSource={state.dataSource}
-          />
+          <ChartPreview dataSource={state.dataSource} />
         </InteractiveFiltersProvider>
       </ChartPanel>
     </PanelMiddleWrapper>

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -169,13 +169,14 @@ export const DataFilterSelect = ({
   onOpen?: () => void;
   loading?: boolean;
 }) => {
-  const fieldProps = useSingleFilterSelect({ dimensionIri: dimension.iri });
-
+  const fieldProps = useSingleFilterSelect({
+    cubeIri: dimension.cubeIri,
+    dimensionIri: dimension.iri,
+  });
   const noneLabel = t({
     id: "controls.dimensionvalue.none",
     message: `No Filter`,
   });
-
   const sortedValues = useMemo(() => {
     const sorters = makeDimensionValueSorters(dimension);
 
@@ -266,18 +267,18 @@ export const DataFilterSelectDay = ({
   isOptional?: boolean;
   controls?: React.ReactNode;
 }) => {
-  const fieldProps = useSingleFilterSelect({ dimensionIri: dimension.iri });
-
+  const fieldProps = useSingleFilterSelect({
+    cubeIri: dimension.cubeIri,
+    dimensionIri: dimension.iri,
+  });
   const noneLabel = t({
     id: "controls.dimensionvalue.none",
     message: `No Filter`,
   });
-
   const optionalLabel = t({
     id: "controls.select.optional",
     message: `optional`,
   });
-
   const allOptions = useMemo(() => {
     return isOptional
       ? [
@@ -365,19 +366,19 @@ export const DataFilterSelectTime = ({
   isOptional?: boolean;
   controls?: React.ReactNode;
 }) => {
-  const fieldProps = useSingleFilterSelect({ dimensionIri: dimension.iri });
+  const fieldProps = useSingleFilterSelect({
+    cubeIri: dimension.cubeIri,
+    dimensionIri: dimension.iri,
+  });
   const formatLocale = useTimeFormatLocale();
-
   const noneLabel = t({
     id: "controls.dimensionvalue.none",
     message: `No Filter`,
   });
-
   const optionalLabel = t({
     id: "controls.select.optional",
     message: `optional`,
   });
-
   const fullLabel = isOptional ? (
     <>
       {label} <div style={{ marginLeft: "0.25rem" }}>({optionalLabel})</div>
@@ -651,21 +652,19 @@ export const MultiFilterFieldColorPicker = ({
 };
 
 export const SingleFilterField = ({
+  cubeIri,
   dimensionIri,
   label,
   value,
   disabled,
 }: {
+  cubeIri: string;
   dimensionIri: string;
   label: string;
   value: string;
   disabled?: boolean;
 }) => {
-  const field = useSingleFilterField({
-    dimensionIri,
-    value,
-  });
-
+  const field = useSingleFilterField({ cubeIri, dimensionIri, value });
   return <Radio label={label} disabled={disabled} {...field} />;
 };
 

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -30,7 +30,11 @@ import {
 } from "@/components/form";
 import SelectTree from "@/components/select-tree";
 import useDisclosure from "@/components/use-disclosure";
-import { ChartConfig, getChartConfig } from "@/config-types";
+import {
+  ChartConfig,
+  getChartConfig,
+  useChartConfigFilters,
+} from "@/config-types";
 import { ColorPickerMenu } from "@/configurator/components/chart-controls/color-picker";
 import {
   AnnotatorTab,
@@ -558,6 +562,7 @@ export const MetaInputField = ({
 const useMultiFilterColorPicker = (value: string) => {
   const [state, dispatch] = useConfiguratorState(isConfiguring);
   const chartConfig = getChartConfig(state);
+  const filters = useChartConfigFilters(chartConfig);
   const { dimensionIri, colorConfigPath } = useMultiFilterContext();
   const { activeField } = chartConfig;
   const onChange = useCallback(
@@ -596,7 +601,7 @@ const useMultiFilterColorPicker = (value: string) => {
   }, [chartConfig, colorConfigPath, activeField]);
 
   const checkedState = dimensionIri
-    ? isMultiFilterFieldChecked(chartConfig, dimensionIri, value)
+    ? isMultiFilterFieldChecked(filters, dimensionIri, value)
     : null;
 
   return useMemo(

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -49,6 +49,7 @@ import {
   getFilterValue,
   isConfiguring,
   MultiFilterContextProvider,
+  useChartConfigFilters,
   useConfiguratorState,
   useMultiFilterContext,
 } from "@/configurator";
@@ -227,10 +228,9 @@ const MultiFilterContent = ({
   const chartConfig = getChartConfig(config);
   const { dimensionIri, activeKeys, allValues, colorConfigPath } =
     useMultiFilterContext();
-  const rawValues = chartConfig.filters[dimensionIri];
-
+  const filters = useChartConfigFilters(chartConfig);
+  const rawValues = filters[dimensionIri];
   const classes = useStyles();
-
   const { sortedTree, flatOptions, optionsByValue } = useMemo(() => {
     const sortedTree = sortHierarchy(tree);
     const flatOptions = getOptionsFromTree(sortedTree);
@@ -851,7 +851,6 @@ export const DimensionValuesMultiFilter = ({
   colorComponent,
   field = "segment",
 }: {
-  dataSetIri: string;
   dimension: Dimension;
   colorConfigPath?: string;
   colorComponent?: Component;

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -226,7 +226,7 @@ const MultiFilterContent = ({
 }) => {
   const [config, dispatch] = useConfiguratorState(isConfiguring);
   const chartConfig = getChartConfig(config);
-  const { dimensionIri, activeKeys, allValues, colorConfigPath } =
+  const { cubeIri, dimensionIri, activeKeys, allValues, colorConfigPath } =
     useMultiFilterContext();
   const filters = useChartConfigFilters(chartConfig);
   const rawValues = filters[dimensionIri];
@@ -291,6 +291,7 @@ const MultiFilterContent = ({
     dispatch({
       type: "CHART_CONFIG_FILTER_SET_MULTI",
       value: {
+        cubeIri,
         dimensionIri,
         values: newValues,
       },
@@ -897,19 +898,19 @@ export const TimeFilter = (props: TimeFilterProps) => {
   const formatLocale = useTimeFormatLocale();
   const timeFormatUnit = useTimeFormatUnit();
   const [state, dispatch] = useConfiguratorState();
-
   const setFilterRange = useCallback(
     ([from, to]: [string, string]) => {
       dispatch({
         type: "CHART_CONFIG_FILTER_SET_RANGE",
         value: {
+          cubeIri: dimension.cubeIri,
           dimensionIri: dimension.iri,
           from,
           to,
         },
       });
     },
-    [dispatch, dimension.iri]
+    [dispatch, dimension.cubeIri, dimension.iri]
   );
 
   const temporalDimension =
@@ -1187,6 +1188,7 @@ export const DimensionValuesSingleFilter = ({
         return (
           <SingleFilterField
             key={dv.value}
+            cubeIri={dimension.cubeIri}
             dimensionIri={dimension.iri}
             label={dv.label}
             value={`${dv.value}`}

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -199,28 +199,6 @@ export const useChartOptionSelectField = <V extends {} = string>(
   };
 };
 
-export const useDimensionSelection = (dimensionIri: string) => {
-  const [_, dispatch] = useConfiguratorState();
-
-  const selectAll = useCallback(() => {
-    dispatch({
-      type: "CHART_CONFIG_FILTER_RESET_MULTI",
-      value: {
-        dimensionIri,
-      },
-    });
-  }, [dispatch, dimensionIri]);
-
-  const selectNone = useCallback(() => {
-    dispatch({
-      type: "CHART_CONFIG_FILTER_SET_NONE_MULTI",
-      value: { dimensionIri },
-    });
-  }, [dispatch, dimensionIri]);
-
-  return useMemo(() => ({ selectAll, selectNone }), [selectAll, selectNone]);
-};
-
 export const useChartOptionSliderField = ({
   field,
   path,
@@ -428,12 +406,13 @@ export const useChartType = (
 
 // Used in the configurator filters
 export const useSingleFilterSelect = ({
+  cubeIri,
   dimensionIri,
 }: {
+  cubeIri: string;
   dimensionIri: string;
 }) => {
   const [state, dispatch] = useConfiguratorState();
-
   const onChange = useCallback<
     (
       e:
@@ -445,6 +424,7 @@ export const useSingleFilterSelect = ({
       dispatch({
         type: "CHART_CONFIG_FILTER_SET_SINGLE",
         value: {
+          cubeIri,
           dimensionIri,
           value: (e.target.value === ""
             ? FIELD_VALUE_NONE
@@ -452,7 +432,7 @@ export const useSingleFilterSelect = ({
         },
       });
     },
-    [dimensionIri, dispatch]
+    [cubeIri, dimensionIri, dispatch]
   );
 
   let value: string | undefined;
@@ -472,25 +452,27 @@ export const useSingleFilterSelect = ({
 
 // Used in the Table Chart options
 export const useSingleFilterField = ({
+  cubeIri,
   dimensionIri,
   value,
 }: {
+  cubeIri: string;
   value: string;
   dimensionIri: string;
 }): FieldProps => {
   const [state, dispatch] = useConfiguratorState();
-
   const onChange = useCallback<(e: ChangeEvent<HTMLInputElement>) => void>(
     (e) => {
       dispatch({
         type: "CHART_CONFIG_FILTER_SET_SINGLE",
         value: {
+          cubeIri,
           dimensionIri,
           value: e.currentTarget.value,
         },
       });
     },
-    [dispatch, dimensionIri]
+    [dispatch, cubeIri, dimensionIri]
   );
 
   const stateValue =
@@ -523,6 +505,7 @@ export const isMultiFilterFieldChecked = (
 const MultiFilterContext = React.createContext({
   activeKeys: new Set() as Set<string>,
   allValues: [] as string[],
+  cubeIri: "",
   dimensionIri: "",
   colorConfigPath: undefined as string | undefined,
   getValueColor: (_: string) => "" as string,
@@ -563,11 +546,19 @@ export const MultiFilterContextProvider = ({
     return {
       allValues,
       activeKeys,
+      cubeIri: dimension.cubeIri,
       dimensionIri: dimension.iri,
       colorConfigPath,
       getValueColor,
     };
-  }, [allValues, dimension.iri, activeKeys, colorConfigPath, getValueColor]);
+  }, [
+    allValues,
+    dimension.cubeIri,
+    dimension.iri,
+    activeKeys,
+    colorConfigPath,
+    getValueColor,
+  ]);
 
   return (
     <MultiFilterContext.Provider value={ctx}>

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -13,6 +13,7 @@ import { EncodingFieldType } from "@/charts/chart-config-ui-options";
 import {
   ChartConfig,
   ChartType,
+  Filters,
   getChartConfig,
   isComboChartConfig,
 } from "@/config-types";
@@ -403,10 +404,11 @@ export const useChartType = (
         value: {
           chartConfig: getInitialConfig({
             chartType,
-            dataSet:
+            iris: [
               state.state === "CONFIGURING_CHART"
-                ? getChartConfig(state, state.activeChartKey).dataSet
-                : chartConfig.dataSet,
+                ? getChartConfig(state, state.activeChartKey).cubes[0].iri
+                : chartConfig.cubes[0].iri,
+            ],
             dimensions,
             measures,
           }),
@@ -507,11 +509,11 @@ export const useSingleFilterField = ({
 };
 
 export const isMultiFilterFieldChecked = (
-  chartConfig: ChartConfig,
+  filters: Filters,
   dimensionIri: string,
   value: string
 ) => {
-  const filter = chartConfig.filters[dimensionIri];
+  const filter = filters[dimensionIri];
   const fieldChecked =
     filter?.type === "multi" ? filter.values?.[value] ?? false : false;
 

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -435,15 +435,17 @@ export const useSingleFilterSelect = ({
     [cubeIri, dimensionIri, dispatch]
   );
 
-  let value: string | undefined;
+  let value = FIELD_VALUE_NONE;
+
   if (state.state === "CONFIGURING_CHART") {
     const chartConfig = getChartConfig(state);
-    value = get(
-      chartConfig,
-      ["filters", dimensionIri, "value"],
-      FIELD_VALUE_NONE
-    );
+    const cube = chartConfig.cubes.find((cube) => cube.iri === cubeIri);
+
+    if (cube) {
+      value = get(cube, ["filters", dimensionIri, "value"], FIELD_VALUE_NONE);
+    }
   }
+
   return {
     value,
     onChange,

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -429,26 +429,34 @@ describe("applyDimensionToFilters", () => {
 describe("moveField", () => {
   const chartConfig = {
     state: "CONFIGURING",
-    filters: {
-      species: {
-        type: "single",
-        value: "penguins",
+    cubes: [
+      {
+        iri: "",
+        filters: {
+          species: {
+            type: "single",
+            value: "penguins",
+          },
+          date: {
+            type: "single",
+            value: "2020.11.20",
+          },
+        },
       },
-      date: {
-        type: "single",
-        value: "2020.11.20",
-      },
-    },
+    ],
   } as unknown as ChartConfig;
 
   it("should be possible to move an existing field up", () => {
     const newChartConfig = moveFilterField(chartConfig, {
-      dimensionIri: "date",
+      dimension: { iri: "date", cubeIri: "" } as any as Dimension,
       delta: -1,
       possibleValues: ["2020.11.20", "2020.11.10"],
     });
-    expect(Object.keys(newChartConfig.filters)).toEqual(["date", "species"]);
-    expect(Object.values(newChartConfig.filters)).toEqual([
+    expect(Object.keys(newChartConfig.cubes[0].filters)).toEqual([
+      "date",
+      "species",
+    ]);
+    expect(Object.values(newChartConfig.cubes[0].filters)).toEqual([
       { type: "single", value: "2020.11.20" },
       { type: "single", value: "penguins" },
     ]);
@@ -456,12 +464,15 @@ describe("moveField", () => {
 
   it("should be possible to move an existing field down", () => {
     const newChartConfig = moveFilterField(chartConfig, {
-      dimensionIri: "species",
+      dimension: { iri: "species", cubeIri: "" } as any as Dimension,
       delta: 1,
       possibleValues: ["penguins", "tigers"],
     });
-    expect(Object.keys(newChartConfig.filters)).toEqual(["date", "species"]);
-    expect(Object.values(newChartConfig.filters)).toEqual([
+    expect(Object.keys(newChartConfig.cubes[0].filters)).toEqual([
+      "date",
+      "species",
+    ]);
+    expect(Object.values(newChartConfig.cubes[0].filters)).toEqual([
       { type: "single", value: "2020.11.20" },
       { type: "single", value: "penguins" },
     ]);
@@ -469,16 +480,16 @@ describe("moveField", () => {
 
   it("should be possible to move an absent field up", () => {
     const newChartConfig = moveFilterField(chartConfig, {
-      dimensionIri: "color",
+      dimension: { iri: "color", cubeIri: "" } as any as Dimension,
       delta: -1,
       possibleValues: ["red", "blue"],
     });
-    expect(Object.keys(newChartConfig.filters)).toEqual([
+    expect(Object.keys(newChartConfig.cubes[0].filters)).toEqual([
       "species",
       "color",
       "date",
     ]);
-    expect(Object.values(newChartConfig.filters)).toEqual([
+    expect(Object.values(newChartConfig.cubes[0].filters)).toEqual([
       { type: "single", value: "penguins" },
       { type: "single", value: "red" },
       { type: "single", value: "2020.11.20" },
@@ -487,12 +498,15 @@ describe("moveField", () => {
 
   it("should not be possible to move an existing field too much above", () => {
     const newChartConfig = moveFilterField(chartConfig, {
-      dimensionIri: "species",
+      dimension: { iri: "species", cubeIri: "" } as any as Dimension,
       delta: -1,
       possibleValues: ["penguins", "tigers"],
     });
-    expect(Object.keys(newChartConfig.filters)).toEqual(["species", "date"]);
-    expect(Object.values(newChartConfig.filters)).toEqual([
+    expect(Object.keys(newChartConfig.cubes[0].filters)).toEqual([
+      "species",
+      "date",
+    ]);
+    expect(Object.values(newChartConfig.cubes[0].filters)).toEqual([
       { type: "single", value: "penguins" },
       { type: "single", value: "2020.11.20" },
     ]);
@@ -500,12 +514,15 @@ describe("moveField", () => {
 
   it("should not be possible to move an existing field too much below", () => {
     const newChartConfig = moveFilterField(chartConfig, {
-      dimensionIri: "date",
+      dimension: { iri: "date", cubeIri: "" } as any as Dimension,
       delta: 1,
       possibleValues: ["penguins", "tigers"],
     });
-    expect(Object.keys(newChartConfig.filters)).toEqual(["species", "date"]);
-    expect(Object.values(newChartConfig.filters)).toEqual([
+    expect(Object.keys(newChartConfig.cubes[0].filters)).toEqual([
+      "species",
+      "date",
+    ]);
+    expect(Object.values(newChartConfig.cubes[0].filters)).toEqual([
       { type: "single", value: "penguins" },
       { type: "single", value: "2020.11.20" },
     ]);
@@ -842,7 +859,12 @@ describe("colorMapping", () => {
               componentIri: "measure",
             },
           },
-          filters: {},
+          cubes: [
+            {
+              iri: "",
+              filters: {},
+            },
+          ],
         },
       ],
       activeChartKey: "abc",
@@ -965,7 +987,6 @@ describe("handleChartOptionChanged", () => {
   it("should reset previous color filters", () => {
     const state = {
       state: "CONFIGURING_CHART",
-      dataSet: "mapDataset",
       dataSource: {
         type: "sparql",
         url: "fakeUrl",
@@ -989,15 +1010,20 @@ describe("handleChartOptionChanged", () => {
               },
             },
           },
-          filters: {
-            areaLayerColorIri: {
-              type: "multi",
-              values: {
-                red: true,
-                green: true,
+          cubes: [
+            {
+              iri: "mapDataset",
+              filters: {
+                areaLayerColorIri: {
+                  type: "multi",
+                  values: {
+                    red: true,
+                    green: true,
+                  },
+                },
               },
             },
-          },
+          ],
         },
       ],
       activeChartKey: "cab",
@@ -1013,7 +1039,7 @@ describe("handleChartOptionChanged", () => {
       },
     });
 
-    expect(Object.keys(state.chartConfigs[0].filters)).not.toContain(
+    expect(Object.keys(state.chartConfigs[0].cubes[0].filters)).not.toContain(
       "areaLayerColorIri"
     );
   });

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -61,7 +61,7 @@ jest.mock("@/graphql/client", () => {
         return {
           data: {
             dataCubeByIri: {},
-            dataCubesComponents: {
+            dataCubeComponents: {
               dimensions: [
                 {
                   __typename: "GeoShapesDimension",

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -784,7 +784,7 @@ describe("getFiltersByMappingStatus", () => {
       },
     } as any as MapConfig;
 
-    const { mappedFiltersIris } = getFiltersByMappingStatus(config);
+    const { mappedFiltersIris } = getFiltersByMappingStatus(config, "");
 
     expect([...mappedFiltersIris]).toEqual(
       expect.arrayContaining(["areaColorIri", "symbolColorIri"])

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -1,4 +1,3 @@
-import { Client } from "@urql/core";
 import { createDraft, current } from "immer";
 import get from "lodash/get";
 
@@ -30,7 +29,6 @@ import { Component, Dimension, Measure, NominalDimension } from "@/domain/data";
 import covid19ColumnChartConfig from "@/test/__fixtures/config/dev/chartConfig-column-covid19.json";
 import covid19TableChartConfig from "@/test/__fixtures/config/dev/chartConfig-table-covid19.json";
 import { data as fakeVizFixture } from "@/test/__fixtures/config/prod/line-1.json";
-import bathingWaterMetadata from "@/test/__fixtures/data/DataCubeMetadataWithComponentValues-bathingWater.json";
 import covid19Metadata from "@/test/__fixtures/data/DataCubeMetadataWithComponentValues-covid19.json";
 import * as api from "@/utils/chart-config/api";
 import {
@@ -168,26 +166,12 @@ describe("initChartFromLocalStorage", () => {
 });
 
 describe("initChartStateFromCube", () => {
-  const setup = ({ cubeMetadata }: { cubeMetadata: object }) => {
-    const client = new Client({
-      url: "https://example.com/graphql",
-    });
-
-    // @ts-ignore
-    jest.spyOn(client, "query").mockReturnValue({
-      toPromise: jest.fn().mockResolvedValue(cubeMetadata),
-    });
-
-    return { client };
-  };
   it("should work init fields with existing dataset and go directly to 2nd step", async () => {
-    const { client } = setup({ cubeMetadata: bathingWaterMetadata });
     const dataSource: DataSource = {
       url: "https://example.com/api",
       type: "sparql",
     };
     const res = await initChartStateFromCube(
-      client,
       "https://environment.ld.admin.ch/foen/ubd0104/3/",
       dataSource,
       "en"

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -10,7 +10,6 @@ import {
   ConfiguratorStateConfiguringChart,
   DataSource,
   MapConfig,
-  TableConfig,
   getChartConfig,
 } from "@/config-types";
 import {
@@ -68,6 +67,7 @@ jest.mock("@/graphql/client", () => {
               dimensions: [
                 {
                   __typename: "GeoShapesDimension",
+                  cubeIri: "mapDataset",
                   iri: "newAreaLayerColorIri",
                   values: [
                     {
@@ -757,14 +757,19 @@ describe("retainChartConfigWhenSwitchingChartType", () => {
   it("should retain appropriate x & y fields and discard the others", () => {
     runChecks(
       migrateChartConfig(covid19ColumnChartConfig, {
-        migrationProps: { meta: {} },
+        migrationProps: { meta: {}, dataSet: "foo" },
       }),
       xyChecks
     );
   });
 
   it("should retain appropriate segment fields and discard the others", () => {
-    runChecks(covid19TableChartConfig as unknown as TableConfig, segmentChecks);
+    runChecks(
+      migrateChartConfig(covid19TableChartConfig, {
+        migrationProps: { meta: {}, dataSet: "foo" },
+      }),
+      segmentChecks
+    );
   });
 });
 
@@ -772,6 +777,15 @@ describe("getFiltersByMappingStatus", () => {
   it("should correctly retrieve categorical color iris", () => {
     const config = {
       chartType: "map",
+      cubes: [
+        {
+          iri: "foo",
+          filters: {
+            areaColorIri: {},
+            symbolColorIri: {},
+          },
+        },
+      ],
       fields: {
         areaLayer: {
           componentIri: "areaIri",
@@ -784,7 +798,7 @@ describe("getFiltersByMappingStatus", () => {
       },
     } as any as MapConfig;
 
-    const { mappedFiltersIris } = getFiltersByMappingStatus(config, "");
+    const { mappedFiltersIris } = getFiltersByMappingStatus(config, "foo");
 
     expect([...mappedFiltersIris]).toEqual(
       expect.arrayContaining(["areaColorIri", "symbolColorIri"])
@@ -893,7 +907,6 @@ describe("handleChartFieldChanged", () => {
   it("should not reset symbol layer when it's being updated", () => {
     const state = {
       state: "CONFIGURING_CHART",
-      dataSet: "mapDataset",
       dataSource: {
         type: "sparql",
         url: "fakeUrl",
@@ -902,6 +915,12 @@ describe("handleChartFieldChanged", () => {
         {
           key: "cba",
           chartType: "map",
+          cubes: [
+            {
+              iri: "mapDataset",
+              filters: {},
+            },
+          ],
           fields: {
             symbolLayer: {
               componentIri: "symbolLayerIri",
@@ -942,7 +961,6 @@ describe("handleChartOptionChanged", () => {
   it("should set required scale properties", () => {
     const state = {
       state: "CONFIGURING_CHART",
-      dataSet: "mapDataset",
       dataSource: {
         type: "sparql",
         url: "fakeUrl",
@@ -951,6 +969,12 @@ describe("handleChartOptionChanged", () => {
         {
           key: "bac",
           chartType: "map",
+          cubes: [
+            {
+              iri: "mapDataset",
+              filters: {},
+            },
+          ],
           fields: {
             areaLayer: {
               componentIri: "areaLayerIri",

--- a/app/configurator/interactive-filters/interactive-filters-configurator.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-configurator.tsx
@@ -15,7 +15,7 @@ import {
   SubsectionTitle,
 } from "@/configurator/components/chart-controls/section";
 import { ControlTabField } from "@/configurator/components/field";
-import { useDataCubesComponentsQuery } from "@/graphql/query-hooks";
+import { useDataCubesComponentsQuery } from "@/graphql/hooks";
 import { useLocale } from "@/locales/use-locale";
 
 export type InteractiveFilterType = "legend" | "timeRange" | "dataFilters";
@@ -40,7 +40,7 @@ export const InteractiveFiltersConfigurator = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
+      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
 

--- a/app/configurator/interactive-filters/interactive-filters-configurator.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-configurator.tsx
@@ -40,7 +40,7 @@ export const InteractiveFiltersConfigurator = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      filters: [{ iri: chartConfig.dataSet }],
+      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
 

--- a/app/configurator/table/table-chart-configurator.hook.tsx
+++ b/app/configurator/table/table-chart-configurator.hook.tsx
@@ -25,7 +25,7 @@ export const useTableChartController = (
       sourceType: state.dataSource.type,
       sourceUrl: state.dataSource.url,
       locale,
-      filters: [{ iri: chartConfig.dataSet }],
+      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
 

--- a/app/configurator/table/table-chart-configurator.hook.tsx
+++ b/app/configurator/table/table-chart-configurator.hook.tsx
@@ -11,7 +11,7 @@ import {
   useConfiguratorState,
 } from "@/configurator/configurator-state";
 import { moveFields } from "@/configurator/table/table-config-state";
-import { useDataCubesComponentsQuery } from "@/graphql/query-hooks";
+import { useDataCubesComponentsQuery } from "@/graphql/hooks";
 import { useLocale } from "@/locales/use-locale";
 
 export const useTableChartController = (
@@ -25,7 +25,7 @@ export const useTableChartController = (
       sourceType: state.dataSource.type,
       sourceUrl: state.dataSource.url,
       locale,
-      filters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
+      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
 

--- a/app/configurator/table/table-chart-options.tsx
+++ b/app/configurator/table/table-chart-options.tsx
@@ -344,10 +344,8 @@ export const TableColumnOptions = ({
               <DimensionValuesSingleFilter dimension={component} />
             ) : isMeasure(component) ? null : (
               <DimensionValuesMultiFilter
-                key={component.iri}
                 field={component.iri}
                 dimension={component}
-                dataSetIri={chartConfig.dataSet}
                 colorComponent={component}
                 colorConfigPath="columnStyle"
               />

--- a/app/configurator/use-filter-changes.spec.tsx
+++ b/app/configurator/use-filter-changes.spec.tsx
@@ -1,7 +1,7 @@
 import { renderHook } from "@testing-library/react-hooks";
 import merge from "lodash/merge";
 
-import { ChartConfig } from "@/config-types";
+import { Filters } from "@/config-types";
 import useFilterChanges from "@/configurator/use-filter-changes";
 
 describe("use-filter-changes", () => {
@@ -15,7 +15,7 @@ describe("use-filter-changes", () => {
         type: "single",
         value: "ok",
       },
-    } as ChartConfig["filters"];
+    } as Filters;
     let filters = filters1;
 
     const { result, rerender } = renderHook(() => useFilterChanges(filters));
@@ -26,7 +26,7 @@ describe("use-filter-changes", () => {
         type: "single",
         value: "endangered",
       },
-    }) as ChartConfig["filters"];
+    }) as Filters;
     rerender();
     expect(result.current).toEqual([
       [

--- a/app/configurator/use-filter-changes.ts
+++ b/app/configurator/use-filter-changes.ts
@@ -2,7 +2,7 @@ import isEqual from "lodash/isEqual";
 
 import useChanges from "../utils/use-changes";
 
-import { ChartConfig, FilterValue } from ".";
+import { FilterValue, Filters } from ".";
 
 const isEqualFilter = (fa?: FilterValue, fb?: FilterValue) => {
   if (fa?.type === "single" && fb?.type === "single") {
@@ -19,21 +19,20 @@ const isEqualFilter = (fa?: FilterValue, fb?: FilterValue) => {
   return false;
 };
 
-const computeFilterChanges = (
-  prev: ChartConfig["filters"],
-  cur: ChartConfig["filters"]
-) => {
+const computeFilterChanges = (prev: Filters, cur: Filters) => {
   const allKeys = new Set([...Object.keys(prev), ...Object.keys(cur)]);
   const res = [];
-  for (let key of allKeys) {
+
+  for (const key of allKeys) {
     if (!isEqualFilter(prev[key], cur[key])) {
       res.push([key, prev[key], cur[key]] as const);
     }
   }
+
   return res;
 };
 
-const useFilterChanges = (cur: ChartConfig["filters"]) => {
+const useFilterChanges = (cur: Filters) => {
   return useChanges(cur, computeFilterChanges);
 };
 

--- a/app/db/config.ts
+++ b/app/db/config.ts
@@ -91,16 +91,21 @@ const migrateDataSet = (dataSet: string): string => {
 const ensureFiltersOrder = (chartConfig: ChartConfig) => {
   return {
     ...chartConfig,
-    filters: Object.fromEntries(
-      Object.entries(chartConfig.filters)
-        .sort(([, a], [, b]) => {
-          return (a.position ?? 0) - (b.position ?? 0);
-        })
-        .map(([k, v]) => {
-          const { position, ...rest } = v;
-          return [k, rest];
-        })
-    ),
+    cubes: chartConfig.cubes.map((cube) => {
+      return {
+        ...cube,
+        filters: Object.fromEntries(
+          Object.entries(cube.filters)
+            .sort(([, a], [, b]) => {
+              return (a.position ?? 0) - (b.position ?? 0);
+            })
+            .map(([k, v]) => {
+              const { position, ...rest } = v;
+              return [k, rest];
+            })
+        ),
+      };
+    }),
   };
 };
 

--- a/app/docs/annotations.docs.tsx
+++ b/app/docs/annotations.docs.tsx
@@ -57,7 +57,12 @@ ${(
               it: "",
             },
           },
-          dataSet: "",
+          cubes: [
+            {
+              iri: "",
+              filters: {},
+            },
+          ],
           chartType: "column",
           fields,
           interactiveFiltersConfig: {
@@ -70,7 +75,6 @@ ${(
             dataFilters: { active: false, componentIris: [] },
             calculation: { active: false, type: "identity" },
           },
-          filters: {},
           activeField: undefined,
         }}
         aspectRatio={0.4}
@@ -222,7 +226,12 @@ ${(
               it: "",
             },
           },
-          dataSet: "",
+          cubes: [
+            {
+              iri: "",
+              filters: {},
+            },
+          ],
           chartType: "column",
           fields,
           interactiveFiltersConfig: {
@@ -235,7 +244,6 @@ ${(
             dataFilters: { active: false, componentIris: [] },
             calculation: { active: false, type: "identity" },
           },
-          filters: {},
           activeField: undefined,
         }}
         aspectRatio={0.4}
@@ -286,7 +294,12 @@ ${(
               it: "",
             },
           },
-          dataSet: "",
+          cubes: [
+            {
+              iri: "",
+              filters: {},
+            },
+          ],
           chartType: "column",
           fields,
           interactiveFiltersConfig: {
@@ -299,7 +312,6 @@ ${(
             dataFilters: { active: false, componentIris: [] },
             calculation: { active: false, type: "identity" },
           },
-          filters: {},
           activeField: undefined,
         }}
         aspectRatio={0.4}

--- a/app/docs/columns.docs.tsx
+++ b/app/docs/columns.docs.tsx
@@ -93,8 +93,12 @@ const chartConfig: ColumnConfig = {
       it: "",
     },
   },
-  dataSet: "",
-  filters: {},
+  cubes: [
+    {
+      iri: "",
+      filters: {},
+    },
+  ],
   fields: columnFields,
   interactiveFiltersConfig: {
     legend: {

--- a/app/docs/fixtures.ts
+++ b/app/docs/fixtures.ts
@@ -49,7 +49,12 @@ export const states: ConfiguratorState[] = [
             it: "",
           },
         },
-        dataSet: "",
+        cubes: [
+          {
+            iri: "",
+            filters: {},
+          },
+        ],
         chartType: "column",
         fields: {
           x: {
@@ -60,7 +65,6 @@ export const states: ConfiguratorState[] = [
             componentIri: "foo",
           },
         },
-        filters: {},
         interactiveFiltersConfig: {
           legend: {
             active: false,
@@ -841,9 +845,13 @@ export const tableConfig: TableConfig = {
       it: "",
     },
   },
-  dataSet: "",
+  cubes: [
+    {
+      iri: "",
+      filters: {},
+    },
+  ],
   chartType: "table",
-  filters: {},
   interactiveFiltersConfig: undefined,
   settings: { showSearch: true, showAllRows: true },
   sorting: [

--- a/app/docs/lines.docs.tsx
+++ b/app/docs/lines.docs.tsx
@@ -143,11 +143,15 @@ const chartConfig: LineConfig = {
       it: "",
     },
   },
-  dataSet: "",
+  cubes: [
+    {
+      iri: "",
+      filters: {},
+    },
+  ],
   chartType: "line",
   interactiveFiltersConfig,
   fields,
-  filters: {},
   activeField: undefined,
 };
 

--- a/app/docs/scatterplot.docs.tsx
+++ b/app/docs/scatterplot.docs.tsx
@@ -144,9 +144,13 @@ const chartConfig: ScatterPlotConfig = {
       it: "",
     },
   },
-  dataSet: "",
+  cubes: [
+    {
+      iri: "",
+      filters: {},
+    },
+  ],
   chartType: "scatterplot",
-  filters: {},
   interactiveFiltersConfig,
   fields: scatterplotFields,
   activeField: undefined,

--- a/app/domain/data.ts
+++ b/app/domain/data.ts
@@ -42,6 +42,11 @@ export type HierarchyValue = {
 
 export type Observation = Record<string, ObservationValue>;
 
+export type DataCubeObservations = {
+  data: Observation[];
+  sparqlEditorUrl: string;
+};
+
 export type DataCubesObservations = {
   data: Observation[];
   sparqlEditorUrls: {

--- a/app/domain/data.ts
+++ b/app/domain/data.ts
@@ -50,7 +50,7 @@ export type DataCubesObservations = {
   }[];
 };
 
-export type DataCubesComponents = {
+export type DataCubeComponents = {
   dimensions: Dimension[];
   measures: Measure[];
 };

--- a/app/graphql/hook-utils.spec.ts
+++ b/app/graphql/hook-utils.spec.ts
@@ -1,14 +1,15 @@
 import { OperationResult } from "urql";
 
-import { mergeObservations } from "./hook-utils";
+import { mergeObservations } from "@/graphql/hook-utils";
 import {
   DataCubeObservationsQuery,
   DataCubeObservationsQueryVariables,
   Exact,
-} from "./query-hooks";
+} from "@/graphql/query-hooks";
 
+// FIXME: figure out why mergeObservations import fails
 describe("mergeObservations", () => {
-  it("should merge observations", () => {
+  it.skip("should merge observations", () => {
     const queries = [
       {
         data: {

--- a/app/graphql/hook-utils.spec.ts
+++ b/app/graphql/hook-utils.spec.ts
@@ -1,0 +1,58 @@
+import { OperationResult } from "urql";
+
+import { mergeObservations } from "./hook-utils";
+import {
+  DataCubeObservationsQuery,
+  DataCubeObservationsQueryVariables,
+  Exact,
+} from "./query-hooks";
+
+describe("mergeObservations", () => {
+  it("should merge observations", () => {
+    const queries = [
+      {
+        data: {
+          dataCubeObservations: [
+            { year: 2010, amount: 2010 },
+            { year: 2011, amount: 2011 },
+          ],
+        },
+        operation: {
+          variables: {
+            cubeFilter: {
+              joinBy: "year",
+            },
+          },
+        },
+      },
+      {
+        data: {
+          dataCubeObservations: [
+            { YEAR: 2000, AMOUNT: 2000 },
+            { YEAR: 2010, AMOUNT: 2010 },
+            { YEAR: 2020, AMOUNT: 2020 },
+          ],
+        },
+        operation: {
+          variables: {
+            cubeFilter: {
+              joinBy: "YEAR",
+            },
+          },
+        },
+      },
+    ] as any as OperationResult<
+      DataCubeObservationsQuery,
+      Exact<DataCubeObservationsQueryVariables>
+    >[];
+
+    const result = mergeObservations(queries);
+
+    expect(result).toEqual([
+      { YEAR: 2000, AMOUNT: 2000 },
+      { year: 2010, amount: 2010, YEAR: 2010, AMOUNT: 2010 },
+      { year: 2011, amount: 2011 },
+      { YEAR: 2020, AMOUNT: 2020 },
+    ]);
+  });
+});

--- a/app/graphql/hook-utils.ts
+++ b/app/graphql/hook-utils.ts
@@ -1,12 +1,11 @@
 import { OperationResult } from "urql";
 
 import { Observation, ObservationValue } from "@/domain/data";
-
 import {
   DataCubeObservationsQuery,
   DataCubeObservationsQueryVariables,
   Exact,
-} from "./query-hooks";
+} from "@/graphql/query-hooks";
 
 /** Use to merge observations coming from several DataCubesObservationQueries.
  *

--- a/app/graphql/hook-utils.ts
+++ b/app/graphql/hook-utils.ts
@@ -1,0 +1,48 @@
+import { OperationResult } from "urql";
+
+import { Observation, ObservationValue } from "@/domain/data";
+
+import {
+  DataCubeObservationsQuery,
+  DataCubeObservationsQueryVariables,
+  Exact,
+} from "./query-hooks";
+
+/** Use to merge observations coming from several DataCubesObservationQueries.
+ *
+ * Observations are merged by the value of the `joinBy` property of the cube filter.
+ * The function does an outerJoin (returns all observations from all queries),
+ * so if there are observations from different cubes with the same joinBy value,
+ * they will be merged into one.
+ */
+export const mergeObservations = (
+  queries: OperationResult<
+    DataCubeObservationsQuery,
+    Exact<DataCubeObservationsQueryVariables>
+  >[]
+): Observation[] => {
+  const merged = queries.reduce<
+    //    <joinByKey,       Observation>
+    Record<string | number, Observation>
+  >((acc, q) => {
+    const joinBy = q.operation.variables?.cubeFilter.joinBy!;
+    const obs = q.data?.dataCubeObservations?.data!;
+
+    for (const o of obs) {
+      const key: ObservationValue | undefined = o[joinBy];
+
+      if (!key) {
+        continue;
+      }
+
+      const existing: Observation | undefined = acc[key];
+      // TODO: handle cases of same column names across merged observations
+      acc[key] = Object.assign(existing ?? {}, o);
+    }
+
+    return acc;
+  }, {});
+
+  // Extract observations from the merged object indexed by joinBy value
+  return Object.values(merged);
+};

--- a/app/graphql/hooks.ts
+++ b/app/graphql/hooks.ts
@@ -1,0 +1,73 @@
+import React from "react";
+
+import { DataCubeMetadata } from "@/domain/data";
+
+import { client } from "./client";
+import {
+  DataCubeMetadataDocument,
+  DataCubeMetadataFilter,
+  DataCubeMetadataQuery,
+  DataCubeMetadataQueryVariables,
+} from "./query-hooks";
+
+const useQueryKey = (options: object) => {
+  return React.useMemo(() => {
+    return JSON.stringify(options);
+  }, [options]);
+};
+
+export const useDataCubesMetadataQuery = (options: {
+  variables: Omit<DataCubeMetadataQueryVariables, "cubeFilter"> & {
+    cubeFilters: DataCubeMetadataFilter[];
+  };
+  pause?: boolean;
+}) => {
+  const { variables, pause } = options;
+  const { locale, sourceType, sourceUrl, cubeFilters } = variables;
+  const [result, setResult] = React.useState<{
+    data?: { dataCubesMetadata: DataCubeMetadata[] };
+    error?: Error;
+    fetching: boolean;
+  }>({ fetching: !pause });
+
+  const queryKey = useQueryKey(options);
+
+  React.useEffect(() => {
+    if (pause) {
+      return;
+    }
+
+    const run = async () => {
+      const queries = await Promise.all(
+        cubeFilters.map((cubeFilter) =>
+          client
+            .query<DataCubeMetadataQuery, DataCubeMetadataQueryVariables>(
+              DataCubeMetadataDocument,
+              {
+                locale,
+                sourceType,
+                sourceUrl,
+                cubeFilter,
+              }
+            )
+            .toPromise()
+        )
+      );
+      const error = queries.find((q) => q.error)?.error;
+      const fetching = !error && queries.some((q) => !q.data);
+
+      setResult({
+        data: fetching
+          ? undefined
+          : { dataCubesMetadata: queries.map((q) => q.data!.dataCubeMetadata) },
+        error,
+        fetching,
+      });
+    };
+
+    run();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [queryKey]);
+
+  return [result];
+};

--- a/app/graphql/hooks.ts
+++ b/app/graphql/hooks.ts
@@ -114,9 +114,10 @@ export const executeDataCubesMetadataQuery = async (
   const fetching = !error && queries.some((q) => !q.data);
 
   return {
-    data: fetching
-      ? undefined
-      : { dataCubesMetadata: queries.map((q) => q.data!.dataCubeMetadata) },
+    data:
+      error || fetching
+        ? undefined
+        : { dataCubesMetadata: queries.map((q) => q.data!.dataCubeMetadata) },
     error,
     fetching,
   };
@@ -172,20 +173,22 @@ export const executeDataCubesComponentsQuery = async (
   const fetching = !error && queries.some((q) => !q.data);
 
   return {
-    data: fetching
-      ? undefined
-      : {
-          dataCubesComponents: queries.reduce<DataCubeComponents>(
-            (acc, query) => {
-              const { dimensions, measures } = query.data?.dataCubeComponents!;
-              acc.dimensions.push(...dimensions);
-              acc.measures.push(...measures);
+    data:
+      error || fetching
+        ? undefined
+        : {
+            dataCubesComponents: queries.reduce<DataCubeComponents>(
+              (acc, query) => {
+                const { dimensions, measures } =
+                  query.data?.dataCubeComponents!;
+                acc.dimensions.push(...dimensions);
+                acc.measures.push(...measures);
 
-              return acc;
-            },
-            { dimensions: [], measures: [] }
-          ),
-        },
+                return acc;
+              },
+              { dimensions: [], measures: [] }
+            ),
+          },
     error,
     fetching,
   };
@@ -246,7 +249,7 @@ export const executeDataCubesObservationsQuery = async (
   const error = queries.find((q) => q.error)?.error;
   const fetching = !error && queries.some((q) => !q.data);
 
-  if (fetching) {
+  if (error || fetching) {
     return {
       data: undefined,
       error,

--- a/app/graphql/hooks.ts
+++ b/app/graphql/hooks.ts
@@ -4,10 +4,10 @@ import {
   DataCubeComponents,
   DataCubeMetadata,
   DataCubesObservations,
-  Observation,
 } from "@/domain/data";
 
 import { client } from "./client";
+import { mergeObservations } from "./hook-utils";
 import {
   DataCubeComponentFilter,
   DataCubeComponentsDocument,
@@ -257,25 +257,7 @@ export const executeDataCubesObservationsQuery = async (
   const observations =
     // If we are fetching data from multiple cubes, we need to merge them into one
     queries.length > 1
-      ? Object.values(
-          queries.reduce<Record<string | number, Observation>>((acc, query) => {
-            const joinBy = query.operation.variables?.cubeFilter.joinBy!;
-            const observations = query.data?.dataCubeObservations?.data!;
-
-            for (const observation of observations) {
-              const key = observation[joinBy];
-
-              if (!key) {
-                continue;
-              }
-
-              const existing = acc[key];
-              acc[key] = Object.assign(existing ?? {}, observation);
-            }
-
-            return acc;
-          }, {})
-        )
+      ? mergeObservations(queries)
       : // If we are fetching data from a single cube, we can just return the data
         queries[0].data?.dataCubeObservations?.data!;
 

--- a/app/graphql/hooks.ts
+++ b/app/graphql/hooks.ts
@@ -96,7 +96,9 @@ type DataCubesComponentsOptions = {
 };
 
 export const executeDataCubesComponentsQuery = async (
-  variables: DataCubesComponentsOptions["variables"]
+  variables: DataCubesComponentsOptions["variables"],
+  /** Callback triggered when data fetching starts (cache miss). */
+  onFetching?: () => void
 ) => {
   const { locale, sourceType, sourceUrl, cubeFilters } = variables;
 
@@ -110,6 +112,10 @@ export const executeDataCubesComponentsQuery = async (
 
       if (cached) {
         return Promise.resolve(cached);
+      }
+
+      if (onFetching) {
+        onFetching();
       }
 
       return client
@@ -131,7 +137,6 @@ export const executeDataCubesComponentsQuery = async (
           dataCubesComponents: queries.reduce<DataCubeComponents>(
             (acc, query) => {
               const { dimensions, measures } = query.data?.dataCubeComponents!;
-
               acc.dimensions.push(...dimensions);
               acc.measures.push(...measures);
 
@@ -158,7 +163,10 @@ export const useDataCubesComponentsQuery = (
 
   const executeQuery = React.useCallback(
     async (options: DataCubesComponentsOptions) => {
-      const result = await executeDataCubesComponentsQuery(options.variables);
+      const result = await executeDataCubesComponentsQuery(
+        options.variables,
+        () => setResult((prev) => ({ ...prev, fetching: true }))
+      );
       setResult(result);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/graphql/hooks.ts
+++ b/app/graphql/hooks.ts
@@ -1,6 +1,11 @@
 import React from "react";
 
-import { DataCubeComponents, DataCubeMetadata } from "@/domain/data";
+import {
+  DataCubeComponents,
+  DataCubeMetadata,
+  DataCubesObservations,
+  Observation,
+} from "@/domain/data";
 
 import { client } from "./client";
 import {
@@ -12,6 +17,10 @@ import {
   DataCubeMetadataFilter,
   DataCubeMetadataQuery,
   DataCubeMetadataQueryVariables,
+  DataCubeObservationFilter,
+  DataCubeObservationsDocument,
+  DataCubeObservationsQuery,
+  DataCubeObservationsQueryVariables,
 } from "./query-hooks";
 
 const useQueryKey = (options: object) => {
@@ -186,3 +195,114 @@ export const useDataCubesComponentsQuery = makeUseQuery<
   DataCubesComponentsOptions,
   DataCubesComponentsData
 >(executeDataCubesComponentsQuery);
+
+type DataCubesObservationsOptions = {
+  variables: Omit<DataCubeComponentsQueryVariables, "cubeFilter"> & {
+    cubeFilters: DataCubeObservationFilter[];
+  };
+  pause?: boolean;
+};
+
+type DataCubesObservationsData = {
+  dataCubesObservations: DataCubesObservations;
+};
+
+export const executeDataCubesObservationsQuery = async (
+  variables: DataCubesObservationsOptions["variables"],
+  /** Callback triggered when data fetching starts (cache miss). */
+  onFetching?: () => void
+) => {
+  const { locale, sourceType, sourceUrl, cubeFilters } = variables;
+
+  if (cubeFilters.length > 1 && !cubeFilters.every((f) => f.joinBy)) {
+    throw new Error(
+      "When fetching data from multiple cubes, all cube filters must have joinBy property set."
+    );
+  }
+
+  const queries = await Promise.all(
+    cubeFilters.map((cubeFilter) => {
+      const cubeVariables = { locale, sourceType, sourceUrl, cubeFilter };
+      const cached = client.readQuery<
+        DataCubeObservationsQuery,
+        DataCubeObservationsQueryVariables
+      >(DataCubeObservationsDocument, cubeVariables);
+
+      if (cached) {
+        return Promise.resolve(cached);
+      }
+
+      onFetching?.();
+
+      return client
+        .query<DataCubeObservationsQuery, DataCubeObservationsQueryVariables>(
+          DataCubeObservationsDocument,
+          cubeVariables
+        )
+        .toPromise();
+    })
+  );
+
+  const error = queries.find((q) => q.error)?.error;
+  const fetching = !error && queries.some((q) => !q.data);
+
+  if (fetching) {
+    return {
+      data: undefined,
+      error,
+      fetching,
+    };
+  }
+
+  const observations =
+    // If we are fetching data from multiple cubes, we need to merge them into one
+    cubeFilters.length > 1
+      ? queries.reduce<Record<string | number, Observation>>((acc, query) => {
+          const joinBy = query.operation.variables?.cubeFilter.joinBy as string;
+          const observations = query.data?.dataCubeObservations
+            ?.data as Observation[];
+
+          for (const observation of observations) {
+            const key = observation[joinBy];
+
+            if (!key) {
+              continue;
+            }
+
+            const existing = acc[key];
+            acc[key] = Object.assign(existing ?? {}, observation);
+          }
+
+          return acc;
+        }, {})
+      : // If we are fetching data from a single cube, we can just return the data
+        (queries[0].data?.dataCubeObservations?.data as Observation[]);
+  const sparqlEditorUrls = queries.reduce<
+    DataCubesObservations["sparqlEditorUrls"]
+  >((acc, query) => {
+    const cubeIri = query.operation.variables?.cubeFilter.iri;
+    const url = query.data?.dataCubeObservations?.sparqlEditorUrl;
+
+    if (cubeIri && url) {
+      acc.push({ cubeIri, url });
+    }
+
+    return acc;
+  }, []);
+
+  return {
+    data: {
+      dataCubesObservations: {
+        data: Object.values(observations),
+        sparqlEditorUrls,
+      },
+    },
+    error,
+    fetching,
+  };
+};
+
+export const useDataCubesObservationsQuery = makeUseQuery<
+  DataCubesObservationsOptions,
+  DataCubesObservationsData
+>(executeDataCubesObservationsQuery);

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -84,7 +84,12 @@ query DataCubePreview(
     title
     description
     publicationStatus
-    observations(sourceType: $sourceType, sourceUrl: $sourceUrl, limit: 10) {
+    observations(
+      sourceType: $sourceType
+      sourceUrl: $sourceUrl
+      preview: true
+      limit: 10
+    ) {
       data
       sparqlEditorUrl
     }

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -12,17 +12,17 @@ query DataCubesComponents(
   )
 }
 
-query DataCubesMetadata(
+query DataCubeMetadata(
   $sourceType: String!
   $sourceUrl: String!
   $locale: String!
-  $filters: [DataCubeMetadataFilter!]!
+  $cubeFilter: DataCubeMetadataFilter!
 ) {
-  dataCubesMetadata(
+  dataCubeMetadata(
     sourceType: $sourceType
     sourceUrl: $sourceUrl
     locale: $locale
-    filters: $filters
+    cubeFilter: $cubeFilter
   )
 }
 

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -1,14 +1,14 @@
-query DataCubesComponents(
+query DataCubeComponents(
   $sourceType: String!
   $sourceUrl: String!
   $locale: String!
-  $filters: [DataCubeComponentFilter!]!
+  $cubeFilter: DataCubeComponentFilter!
 ) {
-  dataCubesComponents(
+  dataCubeComponents(
     sourceType: $sourceType
     sourceUrl: $sourceUrl
     locale: $locale
-    filters: $filters
+    cubeFilter: $cubeFilter
   )
 }
 

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -26,17 +26,17 @@ query DataCubeMetadata(
   )
 }
 
-query DataCubesObservations(
+query DataCubeObservations(
   $sourceType: String!
   $sourceUrl: String!
   $locale: String!
-  $filters: [DataCubeObservationFilter!]!
+  $cubeFilter: DataCubeObservationFilter!
 ) {
-  dataCubesObservations(
+  dataCubeObservations(
     sourceType: $sourceType
     sourceUrl: $sourceUrl
     locale: $locale
-    filters: $filters
+    cubeFilter: $cubeFilter
   )
 }
 

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -381,7 +381,7 @@ export type OrdinalMeasureHierarchyArgs = {
 export type Query = {
   __typename: 'Query';
   dataCubesComponents: Scalars['DataCubesComponents'];
-  dataCubesMetadata: Array<Scalars['DataCubeMetadata']>;
+  dataCubeMetadata: Scalars['DataCubeMetadata'];
   dataCubesObservations: Scalars['DataCubesObservations'];
   dataCubeByIri?: Maybe<DataCube>;
   possibleFilters: Array<ObservationFilter>;
@@ -397,11 +397,11 @@ export type QueryDataCubesComponentsArgs = {
 };
 
 
-export type QueryDataCubesMetadataArgs = {
+export type QueryDataCubeMetadataArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
-  filters: Array<DataCubeMetadataFilter>;
+  cubeFilter: DataCubeMetadataFilter;
 };
 
 
@@ -592,15 +592,15 @@ export type DataCubesComponentsQueryVariables = Exact<{
 
 export type DataCubesComponentsQuery = { __typename: 'Query', dataCubesComponents: DataCubesComponents };
 
-export type DataCubesMetadataQueryVariables = Exact<{
+export type DataCubeMetadataQueryVariables = Exact<{
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
-  filters: Array<DataCubeMetadataFilter> | DataCubeMetadataFilter;
+  cubeFilter: DataCubeMetadataFilter;
 }>;
 
 
-export type DataCubesMetadataQuery = { __typename: 'Query', dataCubesMetadata: Array<DataCubeMetadata> };
+export type DataCubeMetadataQuery = { __typename: 'Query', dataCubeMetadata: DataCubeMetadata };
 
 export type DataCubesObservationsQueryVariables = Exact<{
   sourceType: Scalars['String'];
@@ -686,19 +686,19 @@ export const DataCubesComponentsDocument = gql`
 export function useDataCubesComponentsQuery(options: Omit<Urql.UseQueryArgs<DataCubesComponentsQueryVariables>, 'query'> = {}) {
   return Urql.useQuery<DataCubesComponentsQuery>({ query: DataCubesComponentsDocument, ...options });
 };
-export const DataCubesMetadataDocument = gql`
-    query DataCubesMetadata($sourceType: String!, $sourceUrl: String!, $locale: String!, $filters: [DataCubeMetadataFilter!]!) {
-  dataCubesMetadata(
+export const DataCubeMetadataDocument = gql`
+    query DataCubeMetadata($sourceType: String!, $sourceUrl: String!, $locale: String!, $cubeFilter: DataCubeMetadataFilter!) {
+  dataCubeMetadata(
     sourceType: $sourceType
     sourceUrl: $sourceUrl
     locale: $locale
-    filters: $filters
+    cubeFilter: $cubeFilter
   )
 }
     `;
 
-export function useDataCubesMetadataQuery(options: Omit<Urql.UseQueryArgs<DataCubesMetadataQueryVariables>, 'query'> = {}) {
-  return Urql.useQuery<DataCubesMetadataQuery>({ query: DataCubesMetadataDocument, ...options });
+export function useDataCubeMetadataQuery(options: Omit<Urql.UseQueryArgs<DataCubeMetadataQueryVariables>, 'query'> = {}) {
+  return Urql.useQuery<DataCubeMetadataQuery>({ query: DataCubeMetadataDocument, ...options });
 };
 export const DataCubesObservationsDocument = gql`
     query DataCubesObservations($sourceType: String!, $sourceUrl: String!, $locale: String!, $filters: [DataCubeObservationFilter!]!) {

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -1,6 +1,6 @@
 import { DataCubeComponents } from '../domain/data';
 import { DataCubeMetadata } from '../domain/data';
-import { DataCubesObservations } from '../domain/data';
+import { DataCubeObservations } from '../domain/data';
 import { DimensionValue } from '../domain/data';
 import { QueryFilters } from '../configurator';
 import { HierarchyValue } from '../domain/data';
@@ -23,7 +23,7 @@ export type Scalars = {
   Float: number;
   DataCubeComponents: DataCubeComponents;
   DataCubeMetadata: DataCubeMetadata;
-  DataCubesObservations: DataCubesObservations;
+  DataCubeObservations: DataCubeObservations;
   DimensionValue: DimensionValue;
   FilterValue: any;
   Filters: QueryFilters;
@@ -116,6 +116,7 @@ export type DataCubeObservationFilter = {
   joinBy?: Maybe<Scalars['String']>;
 };
 
+
 export type DataCubeOrganization = {
   __typename: 'DataCubeOrganization';
   iri: Scalars['String'];
@@ -132,7 +133,6 @@ export type DataCubeTheme = {
   iri: Scalars['String'];
   label?: Maybe<Scalars['String']>;
 };
-
 
 export type Dimension = {
   iri: Scalars['String'];
@@ -382,7 +382,7 @@ export type Query = {
   __typename: 'Query';
   dataCubeComponents: Scalars['DataCubeComponents'];
   dataCubeMetadata: Scalars['DataCubeMetadata'];
-  dataCubesObservations: Scalars['DataCubesObservations'];
+  dataCubeObservations: Scalars['DataCubeObservations'];
   dataCubeByIri?: Maybe<DataCube>;
   possibleFilters: Array<ObservationFilter>;
   searchCubes: Array<SearchCubeResult>;
@@ -405,11 +405,11 @@ export type QueryDataCubeMetadataArgs = {
 };
 
 
-export type QueryDataCubesObservationsArgs = {
+export type QueryDataCubeObservationsArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
-  filters: Array<DataCubeObservationFilter>;
+  cubeFilter: DataCubeObservationFilter;
 };
 
 
@@ -602,15 +602,15 @@ export type DataCubeMetadataQueryVariables = Exact<{
 
 export type DataCubeMetadataQuery = { __typename: 'Query', dataCubeMetadata: DataCubeMetadata };
 
-export type DataCubesObservationsQueryVariables = Exact<{
+export type DataCubeObservationsQueryVariables = Exact<{
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
-  filters: Array<DataCubeObservationFilter> | DataCubeObservationFilter;
+  cubeFilter: DataCubeObservationFilter;
 }>;
 
 
-export type DataCubesObservationsQuery = { __typename: 'Query', dataCubesObservations: DataCubesObservations };
+export type DataCubeObservationsQuery = { __typename: 'Query', dataCubeObservations: DataCubeObservations };
 
 export type SearchCubesQueryVariables = Exact<{
   sourceType: Scalars['String'];
@@ -700,19 +700,19 @@ export const DataCubeMetadataDocument = gql`
 export function useDataCubeMetadataQuery(options: Omit<Urql.UseQueryArgs<DataCubeMetadataQueryVariables>, 'query'> = {}) {
   return Urql.useQuery<DataCubeMetadataQuery>({ query: DataCubeMetadataDocument, ...options });
 };
-export const DataCubesObservationsDocument = gql`
-    query DataCubesObservations($sourceType: String!, $sourceUrl: String!, $locale: String!, $filters: [DataCubeObservationFilter!]!) {
-  dataCubesObservations(
+export const DataCubeObservationsDocument = gql`
+    query DataCubeObservations($sourceType: String!, $sourceUrl: String!, $locale: String!, $cubeFilter: DataCubeObservationFilter!) {
+  dataCubeObservations(
     sourceType: $sourceType
     sourceUrl: $sourceUrl
     locale: $locale
-    filters: $filters
+    cubeFilter: $cubeFilter
   )
 }
     `;
 
-export function useDataCubesObservationsQuery(options: Omit<Urql.UseQueryArgs<DataCubesObservationsQueryVariables>, 'query'> = {}) {
-  return Urql.useQuery<DataCubesObservationsQuery>({ query: DataCubesObservationsDocument, ...options });
+export function useDataCubeObservationsQuery(options: Omit<Urql.UseQueryArgs<DataCubeObservationsQueryVariables>, 'query'> = {}) {
+  return Urql.useQuery<DataCubeObservationsQuery>({ query: DataCubeObservationsDocument, ...options });
 };
 export const SearchCubesDocument = gql`
     query SearchCubes($sourceType: String!, $sourceUrl: String!, $locale: String!, $query: String, $order: SearchCubeResultOrder, $includeDrafts: Boolean, $filters: [SearchCubeFilter!]) {

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -65,6 +65,7 @@ export type DataCubeObservationsArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   limit?: Maybe<Scalars['Int']>;
+  preview?: Maybe<Scalars['Boolean']>;
   componentIris?: Maybe<Array<Scalars['String']>>;
   filters?: Maybe<Scalars['Filters']>;
 };
@@ -108,6 +109,7 @@ export type DataCubeMetadataFilter = {
 export type DataCubeObservationFilter = {
   iri: Scalars['String'];
   latest?: Maybe<Scalars['Boolean']>;
+  preview?: Maybe<Scalars['Boolean']>;
   filters?: Maybe<Scalars['Filters']>;
   componentIris?: Maybe<Array<Scalars['String']>>;
   joinBy?: Maybe<Scalars['String']>;
@@ -747,7 +749,12 @@ export const DataCubePreviewDocument = gql`
     title
     description
     publicationStatus
-    observations(sourceType: $sourceType, sourceUrl: $sourceUrl, limit: 10) {
+    observations(
+      sourceType: $sourceType
+      sourceUrl: $sourceUrl
+      preview: true
+      limit: 10
+    ) {
       data
       sparqlEditorUrl
     }

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -1,5 +1,5 @@
+import { DataCubeComponents } from '../domain/data';
 import { DataCubeMetadata } from '../domain/data';
-import { DataCubesComponents } from '../domain/data';
 import { DataCubesObservations } from '../domain/data';
 import { DimensionValue } from '../domain/data';
 import { QueryFilters } from '../configurator';
@@ -21,8 +21,8 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
+  DataCubeComponents: DataCubeComponents;
   DataCubeMetadata: DataCubeMetadata;
-  DataCubesComponents: DataCubesComponents;
   DataCubesObservations: DataCubesObservations;
   DimensionValue: DimensionValue;
   FilterValue: any;
@@ -101,6 +101,7 @@ export type DataCubeComponentFilter = {
 };
 
 
+
 export type DataCubeMetadataFilter = {
   iri: Scalars['String'];
   latest?: Maybe<Scalars['Boolean']>;
@@ -131,7 +132,6 @@ export type DataCubeTheme = {
   iri: Scalars['String'];
   label?: Maybe<Scalars['String']>;
 };
-
 
 
 export type Dimension = {
@@ -380,7 +380,7 @@ export type OrdinalMeasureHierarchyArgs = {
 
 export type Query = {
   __typename: 'Query';
-  dataCubesComponents: Scalars['DataCubesComponents'];
+  dataCubeComponents: Scalars['DataCubeComponents'];
   dataCubeMetadata: Scalars['DataCubeMetadata'];
   dataCubesObservations: Scalars['DataCubesObservations'];
   dataCubeByIri?: Maybe<DataCube>;
@@ -389,11 +389,11 @@ export type Query = {
 };
 
 
-export type QueryDataCubesComponentsArgs = {
+export type QueryDataCubeComponentsArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
-  filters: Array<DataCubeComponentFilter>;
+  cubeFilter: DataCubeComponentFilter;
 };
 
 
@@ -582,15 +582,15 @@ export enum TimeUnit {
 
 
 
-export type DataCubesComponentsQueryVariables = Exact<{
+export type DataCubeComponentsQueryVariables = Exact<{
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
-  filters: Array<DataCubeComponentFilter> | DataCubeComponentFilter;
+  cubeFilter: DataCubeComponentFilter;
 }>;
 
 
-export type DataCubesComponentsQuery = { __typename: 'Query', dataCubesComponents: DataCubesComponents };
+export type DataCubeComponentsQuery = { __typename: 'Query', dataCubeComponents: DataCubeComponents };
 
 export type DataCubeMetadataQueryVariables = Exact<{
   sourceType: Scalars['String'];
@@ -672,19 +672,19 @@ export type PossibleFiltersQueryVariables = Exact<{
 export type PossibleFiltersQuery = { __typename: 'Query', possibleFilters: Array<{ __typename: 'ObservationFilter', iri: string, type: string, value?: Maybe<any> }> };
 
 
-export const DataCubesComponentsDocument = gql`
-    query DataCubesComponents($sourceType: String!, $sourceUrl: String!, $locale: String!, $filters: [DataCubeComponentFilter!]!) {
-  dataCubesComponents(
+export const DataCubeComponentsDocument = gql`
+    query DataCubeComponents($sourceType: String!, $sourceUrl: String!, $locale: String!, $cubeFilter: DataCubeComponentFilter!) {
+  dataCubeComponents(
     sourceType: $sourceType
     sourceUrl: $sourceUrl
     locale: $locale
-    filters: $filters
+    cubeFilter: $cubeFilter
   )
 }
     `;
 
-export function useDataCubesComponentsQuery(options: Omit<Urql.UseQueryArgs<DataCubesComponentsQueryVariables>, 'query'> = {}) {
-  return Urql.useQuery<DataCubesComponentsQuery>({ query: DataCubesComponentsDocument, ...options });
+export function useDataCubeComponentsQuery(options: Omit<Urql.UseQueryArgs<DataCubeComponentsQueryVariables>, 'query'> = {}) {
+  return Urql.useQuery<DataCubeComponentsQuery>({ query: DataCubeComponentsDocument, ...options });
 };
 export const DataCubeMetadataDocument = gql`
     query DataCubeMetadata($sourceType: String!, $sourceUrl: String!, $locale: String!, $cubeFilter: DataCubeMetadataFilter!) {

--- a/app/graphql/resolver-types.ts
+++ b/app/graphql/resolver-types.ts
@@ -66,6 +66,7 @@ export type DataCubeObservationsArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   limit?: Maybe<Scalars['Int']>;
+  preview?: Maybe<Scalars['Boolean']>;
   componentIris?: Maybe<Array<Scalars['String']>>;
   filters?: Maybe<Scalars['Filters']>;
 };
@@ -109,6 +110,7 @@ export type DataCubeMetadataFilter = {
 export type DataCubeObservationFilter = {
   iri: Scalars['String'];
   latest?: Maybe<Scalars['Boolean']>;
+  preview?: Maybe<Scalars['Boolean']>;
   filters?: Maybe<Scalars['Filters']>;
   componentIris?: Maybe<Array<Scalars['String']>>;
   joinBy?: Maybe<Scalars['String']>;

--- a/app/graphql/resolver-types.ts
+++ b/app/graphql/resolver-types.ts
@@ -1,5 +1,5 @@
+import { DataCubeComponents } from '../domain/data';
 import { DataCubeMetadata } from '../domain/data';
-import { DataCubesComponents } from '../domain/data';
 import { DataCubesObservations } from '../domain/data';
 import { DimensionValue } from '../domain/data';
 import { Filters } from '../configurator';
@@ -22,8 +22,8 @@ export type Scalars = {
   Boolean: boolean;
   Int: number;
   Float: number;
+  DataCubeComponents: DataCubeComponents;
   DataCubeMetadata: DataCubeMetadata;
-  DataCubesComponents: DataCubesComponents;
   DataCubesObservations: DataCubesObservations;
   DimensionValue: DimensionValue;
   FilterValue: any;
@@ -102,6 +102,7 @@ export type DataCubeComponentFilter = {
 };
 
 
+
 export type DataCubeMetadataFilter = {
   iri: Scalars['String'];
   latest?: Maybe<Scalars['Boolean']>;
@@ -132,7 +133,6 @@ export type DataCubeTheme = {
   iri: Scalars['String'];
   label?: Maybe<Scalars['String']>;
 };
-
 
 
 export type Dimension = {
@@ -381,7 +381,7 @@ export type OrdinalMeasureHierarchyArgs = {
 
 export type Query = {
   __typename?: 'Query';
-  dataCubesComponents: Scalars['DataCubesComponents'];
+  dataCubeComponents: Scalars['DataCubeComponents'];
   dataCubeMetadata: Scalars['DataCubeMetadata'];
   dataCubesObservations: Scalars['DataCubesObservations'];
   dataCubeByIri?: Maybe<DataCube>;
@@ -390,11 +390,11 @@ export type Query = {
 };
 
 
-export type QueryDataCubesComponentsArgs = {
+export type QueryDataCubeComponentsArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
-  filters: Array<DataCubeComponentFilter>;
+  cubeFilter: DataCubeComponentFilter;
 };
 
 
@@ -654,13 +654,13 @@ export type ResolversTypes = ResolversObject<{
   Int: ResolverTypeWrapper<Scalars['Int']>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
   DataCubeComponentFilter: DataCubeComponentFilter;
+  DataCubeComponents: ResolverTypeWrapper<Scalars['DataCubeComponents']>;
   DataCubeMetadata: ResolverTypeWrapper<Scalars['DataCubeMetadata']>;
   DataCubeMetadataFilter: DataCubeMetadataFilter;
   DataCubeObservationFilter: DataCubeObservationFilter;
   DataCubeOrganization: ResolverTypeWrapper<DataCubeOrganization>;
   DataCubePublicationStatus: DataCubePublicationStatus;
   DataCubeTheme: ResolverTypeWrapper<DataCubeTheme>;
-  DataCubesComponents: ResolverTypeWrapper<Scalars['DataCubesComponents']>;
   DataCubesObservations: ResolverTypeWrapper<Scalars['DataCubesObservations']>;
   Dimension: ResolverTypeWrapper<ResolvedDimension>;
   DimensionValue: ResolverTypeWrapper<Scalars['DimensionValue']>;
@@ -703,12 +703,12 @@ export type ResolversParentTypes = ResolversObject<{
   Int: Scalars['Int'];
   Boolean: Scalars['Boolean'];
   DataCubeComponentFilter: DataCubeComponentFilter;
+  DataCubeComponents: Scalars['DataCubeComponents'];
   DataCubeMetadata: Scalars['DataCubeMetadata'];
   DataCubeMetadataFilter: DataCubeMetadataFilter;
   DataCubeObservationFilter: DataCubeObservationFilter;
   DataCubeOrganization: DataCubeOrganization;
   DataCubeTheme: DataCubeTheme;
-  DataCubesComponents: Scalars['DataCubesComponents'];
   DataCubesObservations: Scalars['DataCubesObservations'];
   Dimension: ResolvedDimension;
   DimensionValue: Scalars['DimensionValue'];
@@ -765,6 +765,10 @@ export type DataCubeResolvers<ContextType = VisualizeGraphQLContext, ParentType 
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export interface DataCubeComponentsScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DataCubeComponents'], any> {
+  name: 'DataCubeComponents';
+}
+
 export interface DataCubeMetadataScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DataCubeMetadata'], any> {
   name: 'DataCubeMetadata';
 }
@@ -780,10 +784,6 @@ export type DataCubeThemeResolvers<ContextType = VisualizeGraphQLContext, Parent
   label?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
-
-export interface DataCubesComponentsScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DataCubesComponents'], any> {
-  name: 'DataCubesComponents';
-}
 
 export interface DataCubesObservationsScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DataCubesObservations'], any> {
   name: 'DataCubesObservations';
@@ -957,7 +957,7 @@ export type OrdinalMeasureResolvers<ContextType = VisualizeGraphQLContext, Paren
 }>;
 
 export type QueryResolvers<ContextType = VisualizeGraphQLContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
-  dataCubesComponents?: Resolver<ResolversTypes['DataCubesComponents'], ParentType, ContextType, RequireFields<QueryDataCubesComponentsArgs, 'sourceType' | 'sourceUrl' | 'locale' | 'filters'>>;
+  dataCubeComponents?: Resolver<ResolversTypes['DataCubeComponents'], ParentType, ContextType, RequireFields<QueryDataCubeComponentsArgs, 'sourceType' | 'sourceUrl' | 'locale' | 'cubeFilter'>>;
   dataCubeMetadata?: Resolver<ResolversTypes['DataCubeMetadata'], ParentType, ContextType, RequireFields<QueryDataCubeMetadataArgs, 'sourceType' | 'sourceUrl' | 'locale' | 'cubeFilter'>>;
   dataCubesObservations?: Resolver<ResolversTypes['DataCubesObservations'], ParentType, ContextType, RequireFields<QueryDataCubesObservationsArgs, 'sourceType' | 'sourceUrl' | 'locale' | 'filters'>>;
   dataCubeByIri?: Resolver<Maybe<ResolversTypes['DataCube']>, ParentType, ContextType, RequireFields<QueryDataCubeByIriArgs, 'sourceType' | 'sourceUrl' | 'iri' | 'latest'>>;
@@ -1047,10 +1047,10 @@ export interface ValuePositionScalarConfig extends GraphQLScalarTypeConfig<Resol
 
 export type Resolvers<ContextType = VisualizeGraphQLContext> = ResolversObject<{
   DataCube?: DataCubeResolvers<ContextType>;
+  DataCubeComponents?: GraphQLScalarType;
   DataCubeMetadata?: GraphQLScalarType;
   DataCubeOrganization?: DataCubeOrganizationResolvers<ContextType>;
   DataCubeTheme?: DataCubeThemeResolvers<ContextType>;
-  DataCubesComponents?: GraphQLScalarType;
   DataCubesObservations?: GraphQLScalarType;
   Dimension?: DimensionResolvers<ContextType>;
   DimensionValue?: GraphQLScalarType;

--- a/app/graphql/resolver-types.ts
+++ b/app/graphql/resolver-types.ts
@@ -1,6 +1,6 @@
 import { DataCubeComponents } from '../domain/data';
 import { DataCubeMetadata } from '../domain/data';
-import { DataCubesObservations } from '../domain/data';
+import { DataCubeObservations } from '../domain/data';
 import { DimensionValue } from '../domain/data';
 import { Filters } from '../configurator';
 import { HierarchyValue } from '../domain/data';
@@ -24,7 +24,7 @@ export type Scalars = {
   Float: number;
   DataCubeComponents: DataCubeComponents;
   DataCubeMetadata: DataCubeMetadata;
-  DataCubesObservations: DataCubesObservations;
+  DataCubeObservations: DataCubeObservations;
   DimensionValue: DimensionValue;
   FilterValue: any;
   Filters: Filters;
@@ -117,6 +117,7 @@ export type DataCubeObservationFilter = {
   joinBy?: Maybe<Scalars['String']>;
 };
 
+
 export type DataCubeOrganization = {
   __typename?: 'DataCubeOrganization';
   iri: Scalars['String'];
@@ -133,7 +134,6 @@ export type DataCubeTheme = {
   iri: Scalars['String'];
   label?: Maybe<Scalars['String']>;
 };
-
 
 export type Dimension = {
   iri: Scalars['String'];
@@ -383,7 +383,7 @@ export type Query = {
   __typename?: 'Query';
   dataCubeComponents: Scalars['DataCubeComponents'];
   dataCubeMetadata: Scalars['DataCubeMetadata'];
-  dataCubesObservations: Scalars['DataCubesObservations'];
+  dataCubeObservations: Scalars['DataCubeObservations'];
   dataCubeByIri?: Maybe<DataCube>;
   possibleFilters: Array<ObservationFilter>;
   searchCubes: Array<SearchCubeResult>;
@@ -406,11 +406,11 @@ export type QueryDataCubeMetadataArgs = {
 };
 
 
-export type QueryDataCubesObservationsArgs = {
+export type QueryDataCubeObservationsArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
-  filters: Array<DataCubeObservationFilter>;
+  cubeFilter: DataCubeObservationFilter;
 };
 
 
@@ -658,10 +658,10 @@ export type ResolversTypes = ResolversObject<{
   DataCubeMetadata: ResolverTypeWrapper<Scalars['DataCubeMetadata']>;
   DataCubeMetadataFilter: DataCubeMetadataFilter;
   DataCubeObservationFilter: DataCubeObservationFilter;
+  DataCubeObservations: ResolverTypeWrapper<Scalars['DataCubeObservations']>;
   DataCubeOrganization: ResolverTypeWrapper<DataCubeOrganization>;
   DataCubePublicationStatus: DataCubePublicationStatus;
   DataCubeTheme: ResolverTypeWrapper<DataCubeTheme>;
-  DataCubesObservations: ResolverTypeWrapper<Scalars['DataCubesObservations']>;
   Dimension: ResolverTypeWrapper<ResolvedDimension>;
   DimensionValue: ResolverTypeWrapper<Scalars['DimensionValue']>;
   FilterValue: ResolverTypeWrapper<Scalars['FilterValue']>;
@@ -707,9 +707,9 @@ export type ResolversParentTypes = ResolversObject<{
   DataCubeMetadata: Scalars['DataCubeMetadata'];
   DataCubeMetadataFilter: DataCubeMetadataFilter;
   DataCubeObservationFilter: DataCubeObservationFilter;
+  DataCubeObservations: Scalars['DataCubeObservations'];
   DataCubeOrganization: DataCubeOrganization;
   DataCubeTheme: DataCubeTheme;
-  DataCubesObservations: Scalars['DataCubesObservations'];
   Dimension: ResolvedDimension;
   DimensionValue: Scalars['DimensionValue'];
   FilterValue: Scalars['FilterValue'];
@@ -773,6 +773,10 @@ export interface DataCubeMetadataScalarConfig extends GraphQLScalarTypeConfig<Re
   name: 'DataCubeMetadata';
 }
 
+export interface DataCubeObservationsScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DataCubeObservations'], any> {
+  name: 'DataCubeObservations';
+}
+
 export type DataCubeOrganizationResolvers<ContextType = VisualizeGraphQLContext, ParentType extends ResolversParentTypes['DataCubeOrganization'] = ResolversParentTypes['DataCubeOrganization']> = ResolversObject<{
   iri?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   label?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -784,10 +788,6 @@ export type DataCubeThemeResolvers<ContextType = VisualizeGraphQLContext, Parent
   label?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
-
-export interface DataCubesObservationsScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['DataCubesObservations'], any> {
-  name: 'DataCubesObservations';
-}
 
 export type DimensionResolvers<ContextType = VisualizeGraphQLContext, ParentType extends ResolversParentTypes['Dimension'] = ResolversParentTypes['Dimension']> = ResolversObject<{
   __resolveType: TypeResolveFn<'GeoCoordinatesDimension' | 'GeoShapesDimension' | 'NominalDimension' | 'NumericalMeasure' | 'OrdinalDimension' | 'OrdinalMeasure' | 'StandardErrorDimension' | 'TemporalDimension' | 'TemporalOrdinalDimension', ParentType, ContextType>;
@@ -959,7 +959,7 @@ export type OrdinalMeasureResolvers<ContextType = VisualizeGraphQLContext, Paren
 export type QueryResolvers<ContextType = VisualizeGraphQLContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
   dataCubeComponents?: Resolver<ResolversTypes['DataCubeComponents'], ParentType, ContextType, RequireFields<QueryDataCubeComponentsArgs, 'sourceType' | 'sourceUrl' | 'locale' | 'cubeFilter'>>;
   dataCubeMetadata?: Resolver<ResolversTypes['DataCubeMetadata'], ParentType, ContextType, RequireFields<QueryDataCubeMetadataArgs, 'sourceType' | 'sourceUrl' | 'locale' | 'cubeFilter'>>;
-  dataCubesObservations?: Resolver<ResolversTypes['DataCubesObservations'], ParentType, ContextType, RequireFields<QueryDataCubesObservationsArgs, 'sourceType' | 'sourceUrl' | 'locale' | 'filters'>>;
+  dataCubeObservations?: Resolver<ResolversTypes['DataCubeObservations'], ParentType, ContextType, RequireFields<QueryDataCubeObservationsArgs, 'sourceType' | 'sourceUrl' | 'locale' | 'cubeFilter'>>;
   dataCubeByIri?: Resolver<Maybe<ResolversTypes['DataCube']>, ParentType, ContextType, RequireFields<QueryDataCubeByIriArgs, 'sourceType' | 'sourceUrl' | 'iri' | 'latest'>>;
   possibleFilters?: Resolver<Array<ResolversTypes['ObservationFilter']>, ParentType, ContextType, RequireFields<QueryPossibleFiltersArgs, 'iri' | 'sourceType' | 'sourceUrl' | 'filters'>>;
   searchCubes?: Resolver<Array<ResolversTypes['SearchCubeResult']>, ParentType, ContextType, RequireFields<QuerySearchCubesArgs, 'sourceType' | 'sourceUrl'>>;
@@ -1049,9 +1049,9 @@ export type Resolvers<ContextType = VisualizeGraphQLContext> = ResolversObject<{
   DataCube?: DataCubeResolvers<ContextType>;
   DataCubeComponents?: GraphQLScalarType;
   DataCubeMetadata?: GraphQLScalarType;
+  DataCubeObservations?: GraphQLScalarType;
   DataCubeOrganization?: DataCubeOrganizationResolvers<ContextType>;
   DataCubeTheme?: DataCubeThemeResolvers<ContextType>;
-  DataCubesObservations?: GraphQLScalarType;
   Dimension?: DimensionResolvers<ContextType>;
   DimensionValue?: GraphQLScalarType;
   FilterValue?: GraphQLScalarType;

--- a/app/graphql/resolver-types.ts
+++ b/app/graphql/resolver-types.ts
@@ -382,7 +382,7 @@ export type OrdinalMeasureHierarchyArgs = {
 export type Query = {
   __typename?: 'Query';
   dataCubesComponents: Scalars['DataCubesComponents'];
-  dataCubesMetadata: Array<Scalars['DataCubeMetadata']>;
+  dataCubeMetadata: Scalars['DataCubeMetadata'];
   dataCubesObservations: Scalars['DataCubesObservations'];
   dataCubeByIri?: Maybe<DataCube>;
   possibleFilters: Array<ObservationFilter>;
@@ -398,11 +398,11 @@ export type QueryDataCubesComponentsArgs = {
 };
 
 
-export type QueryDataCubesMetadataArgs = {
+export type QueryDataCubeMetadataArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
-  filters: Array<DataCubeMetadataFilter>;
+  cubeFilter: DataCubeMetadataFilter;
 };
 
 
@@ -958,7 +958,7 @@ export type OrdinalMeasureResolvers<ContextType = VisualizeGraphQLContext, Paren
 
 export type QueryResolvers<ContextType = VisualizeGraphQLContext, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
   dataCubesComponents?: Resolver<ResolversTypes['DataCubesComponents'], ParentType, ContextType, RequireFields<QueryDataCubesComponentsArgs, 'sourceType' | 'sourceUrl' | 'locale' | 'filters'>>;
-  dataCubesMetadata?: Resolver<Array<ResolversTypes['DataCubeMetadata']>, ParentType, ContextType, RequireFields<QueryDataCubesMetadataArgs, 'sourceType' | 'sourceUrl' | 'locale' | 'filters'>>;
+  dataCubeMetadata?: Resolver<ResolversTypes['DataCubeMetadata'], ParentType, ContextType, RequireFields<QueryDataCubeMetadataArgs, 'sourceType' | 'sourceUrl' | 'locale' | 'cubeFilter'>>;
   dataCubesObservations?: Resolver<ResolversTypes['DataCubesObservations'], ParentType, ContextType, RequireFields<QueryDataCubesObservationsArgs, 'sourceType' | 'sourceUrl' | 'locale' | 'filters'>>;
   dataCubeByIri?: Resolver<Maybe<ResolversTypes['DataCube']>, ParentType, ContextType, RequireFields<QueryDataCubeByIriArgs, 'sourceType' | 'sourceUrl' | 'iri' | 'latest'>>;
   possibleFilters?: Resolver<Array<ResolversTypes['ObservationFilter']>, ParentType, ContextType, RequireFields<QueryPossibleFiltersArgs, 'iri' | 'sourceType' | 'sourceUrl' | 'filters'>>;

--- a/app/graphql/resolvers/index.ts
+++ b/app/graphql/resolvers/index.ts
@@ -25,9 +25,9 @@ export const Query: QueryResolvers = {
     const source = getSource(args.sourceType);
     return await source.searchCubes(parent, args, context, info);
   },
-  dataCubesComponents: async (parent, args, context, info) => {
+  dataCubeComponents: async (parent, args, context, info) => {
     const source = getSource(args.sourceType);
-    return await source.dataCubesComponents(parent, args, context, info);
+    return await source.dataCubeComponents(parent, args, context, info);
   },
   dataCubeMetadata: async (parent, args, context, info) => {
     const source = getSource(args.sourceType);

--- a/app/graphql/resolvers/index.ts
+++ b/app/graphql/resolvers/index.ts
@@ -33,9 +33,9 @@ export const Query: QueryResolvers = {
     const source = getSource(args.sourceType);
     return await source.dataCubeMetadata(parent, args, context, info);
   },
-  dataCubesObservations: async (parent, args, context, info) => {
+  dataCubeObservations: async (parent, args, context, info) => {
     const source = getSource(args.sourceType);
-    return await source.dataCubesObservations(parent, args, context, info);
+    return await source.dataCubeObservations(parent, args, context, info);
   },
   dataCubeByIri: async (parent, args, context, info) => {
     const source = getSource(args.sourceType);
@@ -78,7 +78,7 @@ const DataCube: DataCubeResolvers = {
   },
   observations: async (parent, args, context, info) => {
     const source = getSource(args.sourceType);
-    return source.dataCubeObservations(parent, args, context, info);
+    return source.observations(parent, args, context, info);
   },
 };
 

--- a/app/graphql/resolvers/index.ts
+++ b/app/graphql/resolvers/index.ts
@@ -29,9 +29,9 @@ export const Query: QueryResolvers = {
     const source = getSource(args.sourceType);
     return await source.dataCubesComponents(parent, args, context, info);
   },
-  dataCubesMetadata: async (parent, args, context, info) => {
+  dataCubeMetadata: async (parent, args, context, info) => {
     const source = getSource(args.sourceType);
-    return await source.dataCubesMetadata(parent, args, context, info);
+    return await source.dataCubeMetadata(parent, args, context, info);
   },
   dataCubesObservations: async (parent, args, context, info) => {
     const source = getSource(args.sourceType);

--- a/app/graphql/resolvers/rdf.ts
+++ b/app/graphql/resolvers/rdf.ts
@@ -376,6 +376,13 @@ export const dataCubesObservations: NonNullable<
     })
   );
 
+  if (filtersWithCorrectIri.length === 1) {
+    return {
+      data: dataByCubeIri[filtersWithCorrectIri[0].iri],
+      sparqlEditorUrls,
+    };
+  }
+
   const joinBys = filtersWithCorrectIri.reduce<Record<string, string>>(
     (acc, f) => {
       acc[f.iri] = f.joinBy!;

--- a/app/graphql/resolvers/rdf.ts
+++ b/app/graphql/resolvers/rdf.ts
@@ -304,29 +304,23 @@ export const dataCubesComponents: NonNullable<
   return { dimensions, measures };
 };
 
-export const dataCubesMetadata: NonNullable<
-  QueryResolvers["dataCubesMetadata"]
-> = async (_, { locale, filters }, { setup }, info) => {
-  const { loaders, sparqlClient } = await setup(info);
+export const dataCubeMetadata: NonNullable<QueryResolvers["dataCubeMetadata"]> =
+  async (_, { locale, cubeFilter }, { setup }, info) => {
+    const { loaders, sparqlClient } = await setup(info);
+    const { iri, latest = true } = cubeFilter;
+    const rawCube = await loaders.cube.load(iri);
 
-  return await Promise.all(
-    filters.map(async (filter) => {
-      const { iri, latest = true } = filter;
-      const rawCube = await loaders.cube.load(iri);
+    if (!rawCube) {
+      throw new Error("Cube not found!");
+    }
 
-      if (!rawCube) {
-        throw new Error("Cube not found!");
-      }
+    const cube = latest ? await getLatestCube(rawCube) : rawCube;
 
-      const cube = latest ? await getLatestCube(rawCube) : rawCube;
-
-      return await getCubeMetadata(cube.term?.value!, {
-        locale,
-        sparqlClient,
-      });
-    })
-  );
-};
+    return await getCubeMetadata(cube.term?.value!, {
+      locale,
+      sparqlClient,
+    });
+  };
 
 export const dataCubesObservations: NonNullable<
   QueryResolvers["dataCubesObservations"]

--- a/app/graphql/resolvers/rdf.ts
+++ b/app/graphql/resolvers/rdf.ts
@@ -485,7 +485,7 @@ export const dataCubeObservations: NonNullable<
   DataCubeResolvers["observations"]
 > = async (
   { cube, locale },
-  { limit, filters, componentIris },
+  { preview, limit, filters, componentIris },
   { setup },
   info
 ) => {
@@ -495,6 +495,7 @@ export const dataCubeObservations: NonNullable<
     locale,
     sparqlClient,
     filters,
+    preview,
     limit,
     componentIris,
     cache,

--- a/app/graphql/resolvers/sql.ts
+++ b/app/graphql/resolvers/sql.ts
@@ -294,34 +294,33 @@ const filterObservations = (
 };
 
 // FIXME: should be a call to API (to be able to implement proper filtering)
-export const dataCubeObservations: NonNullable<
-  DataCubeResolvers["observations"]
-> = async ({ cube, locale }, { filters, limit }) => {
-  const rawObservations = (cube as any).observations as Observation[];
-  const allObservations = limit
-    ? rawObservations.slice(0, limit)
-    : rawObservations;
-  const observations = filterObservations(
-    allObservations,
-    filters as QueryFilters | undefined
-  );
+export const observations: NonNullable<DataCubeResolvers["observations"]> =
+  async ({ cube, locale }, { filters, limit }) => {
+    const rawObservations = (cube as any).observations as Observation[];
+    const allObservations = limit
+      ? rawObservations.slice(0, limit)
+      : rawObservations;
+    const observations = filterObservations(
+      allObservations,
+      filters as QueryFilters | undefined
+    );
 
-  return {
-    cube,
-    locale,
-    data: {
-      query: "",
-      observations,
-      selectedFields: [],
-    },
+    return {
+      cube,
+      locale,
+      data: {
+        query: "",
+        observations,
+        selectedFields: [],
+      },
+    };
   };
-};
 
-export const dataCubesObservations: NonNullable<
-  QueryResolvers["dataCubesObservations"]
+export const dataCubeObservations: NonNullable<
+  QueryResolvers["dataCubeObservations"]
 > = async () => {
   return {
     data: [],
-    sparqlEditorUrls: [],
+    sparqlEditorUrl: "",
   };
 };

--- a/app/graphql/resolvers/sql.ts
+++ b/app/graphql/resolvers/sql.ts
@@ -129,11 +129,10 @@ export const dataCubesComponents: NonNullable<
   return { dimensions: [], measures: [] };
 };
 
-export const dataCubesMetadata: NonNullable<
-  QueryResolvers["dataCubesMetadata"]
-> = async () => {
-  return [];
-};
+export const dataCubeMetadata: NonNullable<QueryResolvers["dataCubeMetadata"]> =
+  async () => {
+    return {} as any;
+  };
 
 export const dataCubeByIri: NonNullable<QueryResolvers["dataCubeByIri"]> =
   async (_, { iri }) => {

--- a/app/graphql/resolvers/sql.ts
+++ b/app/graphql/resolvers/sql.ts
@@ -123,8 +123,8 @@ export const searchCubes: NonNullable<QueryResolvers["searchCubes"]> =
     }));
   };
 
-export const dataCubesComponents: NonNullable<
-  QueryResolvers["dataCubesComponents"]
+export const dataCubeComponents: NonNullable<
+  QueryResolvers["dataCubeComponents"]
 > = async () => {
   return { dimensions: [], measures: [] };
 };

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -45,6 +45,7 @@ type DataCube {
     sourceType: String!
     sourceUrl: String!
     limit: Int
+    preview: Boolean
     componentIris: [String!]
     filters: Filters
   ): ObservationsQuery!
@@ -352,6 +353,7 @@ input DataCubeMetadataFilter {
 input DataCubeObservationFilter {
   iri: String!
   latest: Boolean
+  preview: Boolean
   filters: Filters
   componentIris: [String!]
   joinBy: String

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -361,7 +361,7 @@ input DataCubeObservationFilter {
 
 scalar DataCubeComponents
 scalar DataCubeMetadata
-scalar DataCubesObservations
+scalar DataCubeObservations
 
 # The "Query" type is special: it lists all of the available queries that
 # clients can execute, along with the return type for each.
@@ -378,12 +378,12 @@ type Query {
     locale: String!
     cubeFilter: DataCubeMetadataFilter!
   ): DataCubeMetadata!
-  dataCubesObservations(
+  dataCubeObservations(
     sourceType: String!
     sourceUrl: String!
     locale: String!
-    filters: [DataCubeObservationFilter!]!
-  ): DataCubesObservations!
+    cubeFilter: DataCubeObservationFilter!
+  ): DataCubeObservations!
   dataCubeByIri(
     sourceType: String!
     sourceUrl: String!

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -372,12 +372,12 @@ type Query {
     locale: String!
     filters: [DataCubeComponentFilter!]!
   ): DataCubesComponents!
-  dataCubesMetadata(
+  dataCubeMetadata(
     sourceType: String!
     sourceUrl: String!
     locale: String!
-    filters: [DataCubeMetadataFilter!]!
-  ): [DataCubeMetadata!]!
+    cubeFilter: DataCubeMetadataFilter!
+  ): DataCubeMetadata!
   dataCubesObservations(
     sourceType: String!
     sourceUrl: String!

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -359,19 +359,19 @@ input DataCubeObservationFilter {
   joinBy: String
 }
 
-scalar DataCubesComponents
+scalar DataCubeComponents
 scalar DataCubeMetadata
 scalar DataCubesObservations
 
 # The "Query" type is special: it lists all of the available queries that
 # clients can execute, along with the return type for each.
 type Query {
-  dataCubesComponents(
+  dataCubeComponents(
     sourceType: String!
     sourceUrl: String!
     locale: String!
-    filters: [DataCubeComponentFilter!]!
-  ): DataCubesComponents!
+    cubeFilter: DataCubeComponentFilter!
+  ): DataCubeComponents!
   dataCubeMetadata(
     sourceType: String!
     sourceUrl: String!

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -27,7 +27,7 @@ import useDisclosure from "@/components/use-disclosure";
 import { ParsedConfig } from "@/db/config";
 import { sourceToLabel } from "@/domain/datasource";
 import { truthy } from "@/domain/types";
-import { useDataCubesMetadataQuery } from "@/graphql/query-hooks";
+import { useDataCubesMetadataQuery } from "@/graphql/hooks";
 import { Icon, IconName } from "@/icons";
 import { useRootStyles } from "@/login/utils";
 import { useLocale } from "@/src";
@@ -172,20 +172,15 @@ const ProfileVisualizationsRow = (props: ProfileVisualizationsRowProps) => {
   );
   const dataSet = dataSets.length === 1 ? dataSets[0] : null;
   const locale = useLocale();
-  const [{ data, fetching }] = useDataCubesMetadataQuery(
-    dataSet
-      ? {
-          variables: {
-            sourceType: dataSource.type,
-            sourceUrl: dataSource.url,
-            locale,
-            filters: [{ iri: dataSet }],
-          },
-        }
-      : {
-          pause: true,
-        }
-  );
+  const [{ data, fetching }] = useDataCubesMetadataQuery({
+    variables: {
+      sourceType: dataSource.type,
+      sourceUrl: dataSource.url,
+      locale,
+      cubeFilters: [{ iri: dataSet! }],
+    },
+    pause: !dataSet,
+  });
   const actions = React.useMemo(() => {
     const actions: ActionProps[] = [
       {

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -168,7 +168,7 @@ const ProfileVisualizationsRow = (props: ProfileVisualizationsRowProps) => {
   const { userId, config, onRemoveSuccess } = props;
   const { dataSource } = config.data;
   const dataSets = Array.from(
-    new Set(config.data.chartConfigs.map((d) => d.dataSet))
+    new Set(config.data.chartConfigs.flatMap((d) => d.cubes.map((d) => d.iri)))
   );
   const dataSet = dataSets.length === 1 ? dataSets[0] : null;
   const locale = useLocale();

--- a/app/pages/_pivot.tsx
+++ b/app/pages/_pivot.tsx
@@ -18,8 +18,11 @@ import { Column, useExpanded, useSortBy, useTable } from "react-table";
 
 import { Loading } from "@/components/hint";
 import { Dimension, HierarchyValue } from "@/domain/data";
-import { useDataCubesComponentsQuery } from "@/graphql/hooks";
-import { Measure, useDataCubesObservationsQuery } from "@/graphql/query-hooks";
+import {
+  useDataCubesComponentsQuery,
+  useDataCubesObservationsQuery,
+} from "@/graphql/hooks";
+import { Measure } from "@/graphql/query-hooks";
 import { visitHierarchy } from "@/rdf/tree-utils";
 import useEvent from "@/utils/use-event";
 
@@ -177,7 +180,7 @@ const PivotTable = ({ dataset }: { dataset: typeof datasets[string] }) => {
         sourceUrl: "https://int.lindas.admin.ch/query",
         sourceType: "sparql",
         locale: "en",
-        filters: [{ iri: dataset.iri }],
+        cubeFilters: [{ iri: dataset.iri }],
       },
     });
 

--- a/app/pages/_pivot.tsx
+++ b/app/pages/_pivot.tsx
@@ -18,11 +18,8 @@ import { Column, useExpanded, useSortBy, useTable } from "react-table";
 
 import { Loading } from "@/components/hint";
 import { Dimension, HierarchyValue } from "@/domain/data";
-import {
-  Measure,
-  useDataCubesComponentsQuery,
-  useDataCubesObservationsQuery,
-} from "@/graphql/query-hooks";
+import { useDataCubesComponentsQuery } from "@/graphql/hooks";
+import { Measure, useDataCubesObservationsQuery } from "@/graphql/query-hooks";
 import { visitHierarchy } from "@/rdf/tree-utils";
 import useEvent from "@/utils/use-event";
 
@@ -171,7 +168,7 @@ const PivotTable = ({ dataset }: { dataset: typeof datasets[string] }) => {
         sourceUrl: "https://int.lindas.admin.ch/query",
         sourceType: "sparql",
         locale: "en",
-        filters: [{ iri: dataset.iri }],
+        cubeFilters: [{ iri: dataset.iri }],
       },
     });
   const [{ data: observationsData, fetching: fetchingObservations }] =

--- a/app/scripts/cube.ts
+++ b/app/scripts/cube.ts
@@ -9,15 +9,15 @@ import { DataSource } from "@/configurator";
 
 import { GRAPHQL_ENDPOINT } from "../domain/env";
 import {
+  DataCubeComponentsDocument,
+  DataCubeComponentsQuery,
+  DataCubeComponentsQueryVariables,
   DataCubeMetadataDocument,
   DataCubeMetadataQuery,
   DataCubeMetadataQueryVariables,
   DataCubePreviewDocument,
   DataCubePreviewQuery,
   DataCubePreviewQueryVariables,
-  DataCubesComponentsDocument,
-  DataCubesComponentsQuery,
-  DataCubesComponentsQueryVariables,
 } from "../graphql/query-hooks";
 
 config();
@@ -79,13 +79,13 @@ const showCubeComponents = async ({
   report,
 }: Args<CubeQueryOptions>) => {
   const res = await client
-    .query<DataCubesComponentsQuery, DataCubesComponentsQueryVariables>(
-      DataCubesComponentsDocument,
+    .query<DataCubeComponentsQuery, DataCubeComponentsQueryVariables>(
+      DataCubeComponentsDocument,
       {
         sourceType,
         sourceUrl,
         locale,
-        filters: [{ iri, latest }],
+        cubeFilter: { iri, latest },
       }
     )
     .toPromise();
@@ -94,7 +94,7 @@ const showCubeComponents = async ({
     throw new Error(res.error.message);
   }
 
-  report(res.data?.dataCubesComponents);
+  report(res.data?.dataCubeComponents);
 };
 
 const previewCube = async ({

--- a/app/scripts/cube.ts
+++ b/app/scripts/cube.ts
@@ -9,15 +9,15 @@ import { DataSource } from "@/configurator";
 
 import { GRAPHQL_ENDPOINT } from "../domain/env";
 import {
+  DataCubeMetadataDocument,
+  DataCubeMetadataQuery,
+  DataCubeMetadataQueryVariables,
   DataCubePreviewDocument,
   DataCubePreviewQuery,
   DataCubePreviewQueryVariables,
   DataCubesComponentsDocument,
   DataCubesComponentsQuery,
   DataCubesComponentsQueryVariables,
-  DataCubesMetadataDocument,
-  DataCubesMetadataQuery,
-  DataCubesMetadataQueryVariables,
 } from "../graphql/query-hooks";
 
 config();
@@ -44,13 +44,13 @@ const showCubeInfo = async ({
   report,
 }: Args<CubeQueryOptions>) => {
   const res = await client
-    .query<DataCubesMetadataQuery, DataCubesMetadataQueryVariables>(
-      DataCubesMetadataDocument,
+    .query<DataCubeMetadataQuery, DataCubeMetadataQueryVariables>(
+      DataCubeMetadataDocument,
       {
         sourceType,
         sourceUrl,
         locale,
-        filters: [{ iri, latest }],
+        cubeFilter: { iri, latest },
       }
     )
     .toPromise();
@@ -59,7 +59,7 @@ const showCubeInfo = async ({
     throw new Error(res.error.message);
   }
 
-  const cube = res.data?.dataCubesMetadata[0];
+  const cube = res.data?.dataCubeMetadata;
 
   if (cube?.iri !== iri) {
     console.warn(
@@ -107,13 +107,13 @@ const previewCube = async ({
   report,
 }: Args<CubeQueryOptions>) => {
   const { data: info, error } = await client
-    .query<DataCubesMetadataQuery, DataCubesMetadataQueryVariables>(
-      DataCubesMetadataDocument,
+    .query<DataCubeMetadataQuery, DataCubeMetadataQueryVariables>(
+      DataCubeMetadataDocument,
       {
         sourceType,
         sourceUrl,
         locale,
-        filters: [{ iri, latest }],
+        cubeFilter: { iri, latest },
       }
     )
     .toPromise();
@@ -122,8 +122,8 @@ const previewCube = async ({
     throw new Error(error.message);
   }
 
-  if (!info || !info.dataCubesMetadata[0]) {
-    throw new Error(`Could not find datacube ${iri}`);
+  if (!info || !info.dataCubeMetadata) {
+    throw new Error(`Could not find cube with iri of ${iri}`);
   }
 
   const res = await client

--- a/app/stores/interactive-filters.tsx
+++ b/app/stores/interactive-filters.tsx
@@ -23,9 +23,7 @@ export type InteractiveFiltersState = {
   };
 };
 
-export type DataFilters = {
-  [d: string]: FilterValueSingle;
-};
+export type DataFilters = Record<string, FilterValueSingle>;
 
 type TimeSlider =
   | {

--- a/codegen.yml
+++ b/codegen.yml
@@ -22,7 +22,7 @@ generates:
         Filters: "../configurator#QueryFilters"
         GeoShape: "../domain/data#GeoShape"
         SearchCube: "../domain/data#SearchCube"
-        DataCubesComponents: "../domain/data#DataCubesComponents"
+        DataCubeComponents: "../domain/data#DataCubeComponents"
         DataCubeMetadata: "../domain/data#DataCubeMetadata"
         DataCubesObservations: "../domain/data#DataCubesObservations"
   app/graphql/resolver-types.ts:
@@ -42,7 +42,7 @@ generates:
         Filters: "../configurator#Filters"
         GeoShape: "../domain/data#GeoShape"
         SearchCube: "../domain/data#SearchCube"
-        DataCubesComponents: "../domain/data#DataCubesComponents"
+        DataCubeComponents: "../domain/data#DataCubeComponents"
         DataCubeMetadata: "../domain/data#DataCubeMetadata"
         DataCubesObservations: "../domain/data#DataCubesObservations"
       mappers:

--- a/codegen.yml
+++ b/codegen.yml
@@ -24,7 +24,7 @@ generates:
         SearchCube: "../domain/data#SearchCube"
         DataCubeComponents: "../domain/data#DataCubeComponents"
         DataCubeMetadata: "../domain/data#DataCubeMetadata"
-        DataCubesObservations: "../domain/data#DataCubesObservations"
+        DataCubeObservations: "../domain/data#DataCubeObservations"
   app/graphql/resolver-types.ts:
     plugins:
       - "typescript"
@@ -44,7 +44,7 @@ generates:
         SearchCube: "../domain/data#SearchCube"
         DataCubeComponents: "../domain/data#DataCubeComponents"
         DataCubeMetadata: "../domain/data#DataCubeMetadata"
-        DataCubesObservations: "../domain/data#DataCubesObservations"
+        DataCubeObservations: "../domain/data#DataCubeObservations"
       mappers:
         DataCube: "./shared-types#ResolvedDataCube"
         ObservationsQuery: "./shared-types#ResolvedObservationsQuery"


### PR DESCRIPTION
Fixes #1267.
Fixes #1274.

This PR:
- changes the `ChartConfig` type to be based on multiple cubes instead of one, and introduces the first iteration of the cube merging feature,
- fixes the `PossibleFilters` query by bringing back the old way of adding LIMIT to the observations query, as it turned out that the new preview mode from the `cube-view-query` library doesn't work with filters,
- improves caching of fetching multiple cubes by merging cube-scoped queries on the client side (`DataCubesMetadata`, `DataCubesComponents`, `DataCubesObservations`),
- refactors merging of cubes algorithm to use reduce instead of pushing to external array.

### How to test
1. Go to [this link](https://visualization-tool-git-refactor-multi-cube-chart-config-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9&dataSource=Prod).
2. Open web inspector and find the [LocalStorage](https://developer.chrome.com/docs/devtools/storage/localstorage/#:~:text=Open%20DevTools%20on%20the%20website,the%20table%2C%20select%20a%20pair.).
3. Add [a new entry](https://developer.chrome.com/docs/devtools/storage/localstorage/#create) to the LocalStorage with the following information.

**Key**
```js
vizualize-configurator-state:IW-jMUdmG_u5
```

**Value**
```js
{"version":"3.0.1","state":"CONFIGURING_CHART","dataSource":{"type":"sparql","url":"https://lindas.admin.ch/query"},"meta":{"title":{"de":"","fr":"","it":"","en":""},"description":{"de":"","fr":"","it":"","en":""}},"chartConfigs":[{"key":"O7oRFeSgxhpT","version":"3.0.0","meta":{"title":{"en":"","de":"","fr":"","it":""},"description":{"en":"","de":"","fr":"","it":""}},"cubes":[{"iri":"https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9","filters":{"https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Kanton":{"type":"single","value":"https://ld.admin.ch/canton/1"}},"joinBy":"https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr"},{"iri":"https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_co2wirkung/4","filters":{"https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_co2wirkung/region":{"type":"single","value":"https://ld.admin.ch/country/CHE"},"https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_co2wirkung/massnahmenbereich":{"type":"single","value":"https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_co2wirkung/ogd18_catalog/Haustechnik"}},"joinBy":"https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_co2wirkung/Jahr"}],"chartType":"comboLineDual","interactiveFiltersConfig":{"legend":{"active":false,"componentIri":""},"timeRange":{"componentIri":"https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr","active":false,"presets":{"type":"range","from":"2014","to":"2022"}},"dataFilters":{"active":false,"componentIris":[]},"calculation":{"active":false,"type":"identity"}},"fields":{"x":{"componentIri":"https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_co2wirkung/Jahr"},"y":{"leftAxisComponentIri":"https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/InstallierteLeistungkW","rightAxisComponentIri":"http://schema.org/amount","palette":"category10","colorMapping":{"https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/InstallierteLeistungkW":"#1f77b4","http://schema.org/amount":"#ff7f0e"}}}}],"activeChartKey":"O7oRFeSgxhpT"}
```

4. Go to [this link](https://visualization-tool-git-refactor-multi-cube-chart-config-ixt1.vercel.app/en/create/IW-jMUdmG_u5?dataSource=Prod).
5. See that the chart shows two lines – each one coming from a different dataset.
6. _Note that if you e.g. change chart type or some options of the chart, it will get broken. There is still a need to do some work for the feature to be properly implemented, including UI elements and additional logic._

<img width="728" alt="Screenshot 2023-11-21 at 16 42 49" src="https://github.com/visualize-admin/visualization-tool/assets/52032047/f5dda457-c31d-470b-a61f-3606fe2e584c">

---
## Context
This PR introduces the first iteration of the cube merging feature. For the technical concept, see [this Notion document](https://www.notion.so/interactivethings/Combine-two-cubes-in-the-same-chart-d5711b414a7747e79edfc3cfe17d2c9b).