### PR TITLE
fix: Dataset migration

### DIFF
--- a/app/db/config.ts
+++ b/app/db/config.ts
@@ -80,12 +80,12 @@ export const removeConfig = async ({
   });
 };
 
-const migrateDataSet = (dataSet: string): string => {
-  if (dataSet.includes("https://environment.ld.admin.ch/foen/nfi")) {
-    return dataSet.replace(/None-None-/, "");
+const migrateCubeIri = (iri: string): string => {
+  if (iri.includes("https://environment.ld.admin.ch/foen/nfi")) {
+    return iri.replace(/None-None-/, "");
   }
 
-  return dataSet;
+  return iri;
 };
 
 const ensureFiltersOrder = (chartConfig: ChartConfig) => {
@@ -127,7 +127,13 @@ const parseDbConfig = (
       ...migratedData,
       chartConfigs: migratedData.chartConfigs
         .map(ensureFiltersOrder)
-        .map((d: any) => ({ ...d, dataSet: migrateDataSet(d.dataSet) })),
+        .map((chartConfig: ChartConfig) => ({
+          ...chartConfig,
+          cubes: chartConfig.cubes.map((cube) => ({
+            ...cube,
+            iri: migrateCubeIri(cube.iri),
+          })),
+        })),
     },
   };
 };


### PR DESCRIPTION
This PR fixes dataset migrations. The problem should not appear again, as now the `chartConfig` is typed, as it should have been, since it's migrated to the latest version already.