### PR TITLE
chore: Disable Sentry in development

### DIFF
--- a/app/sentry.client.config.js
+++ b/app/sentry.client.config.js
@@ -6,14 +6,16 @@ import * as Sentry from "@sentry/nextjs";
 
 import { BUILD_VERSION, SENTRY_DSN, SENTRY_ENV } from "./domain/env";
 
-Sentry.init({
-  dsn: SENTRY_DSN,
-  environment: SENTRY_ENV,
-  release: `visualization-tool@${BUILD_VERSION}`,
-  tracesSampleRate: 1.0,
-  ignoreErrors: [
-    // The ResizeObserver error is actually not problematic
-    // @see https://forum.sentry.io/t/resizeobserver-loop-limit-exceeded/8402
-    "ResizeObserver loop",
-  ],
-});
+if (process.env.NODE_ENV !== "development") {
+  Sentry.init({
+    dsn: SENTRY_DSN,
+    environment: SENTRY_ENV,
+    release: `visualization-tool@${BUILD_VERSION}`,
+    tracesSampleRate: 1.0,
+    ignoreErrors: [
+      // The ResizeObserver error is actually not problematic
+      // @see https://forum.sentry.io/t/resizeobserver-loop-limit-exceeded/8402
+      "ResizeObserver loop",
+    ],
+  });
+}

--- a/app/sentry.edge.config.js
+++ b/app/sentry.edge.config.js
@@ -6,9 +6,11 @@ import * as Sentry from "@sentry/nextjs";
 
 import { BUILD_VERSION, SENTRY_DSN, SENTRY_ENV } from "./domain/env";
 
-Sentry.init({
-  dsn: SENTRY_DSN,
-  environment: SENTRY_ENV,
-  release: `visualization-tool@${BUILD_VERSION}`,
-  tracesSampleRate: 1.0,
-});
+if (process.env.NODE_ENV !== "development") {
+  Sentry.init({
+    dsn: SENTRY_DSN,
+    environment: SENTRY_ENV,
+    release: `visualization-tool@${BUILD_VERSION}`,
+    tracesSampleRate: 1.0,
+  });
+}

--- a/app/sentry.server.config.js
+++ b/app/sentry.server.config.js
@@ -6,19 +6,21 @@ import * as Sentry from "@sentry/nextjs";
 
 import { BUILD_VERSION, SENTRY_DSN, SENTRY_ENV } from "./domain/env";
 
-Sentry.init({
-  dsn: SENTRY_DSN,
-  environment: SENTRY_ENV,
-  release: `visualization-tool@${BUILD_VERSION}`,
-  tracesSampleRate: 1.0,
-  instrumenter: {
-    patch: (mod, path, logger) => {
-      // Ignore auth calls to prevent 405 Keycloak errors.
-      if (path?.includes("auth")) {
-        return null;
-      }
+if (process.env.NODE_ENV !== "development") {
+  Sentry.init({
+    dsn: SENTRY_DSN,
+    environment: SENTRY_ENV,
+    release: `visualization-tool@${BUILD_VERSION}`,
+    tracesSampleRate: 1.0,
+    instrumenter: {
+      patch: (mod, path, logger) => {
+        // Ignore auth calls to prevent 405 Keycloak errors.
+        if (path?.includes("auth")) {
+          return null;
+        }
 
-      return mod;
+        return mod;
+      },
     },
-  },
-});
+  });
+}


### PR DESCRIPTION
To reduce noise in Sentry, we should only focus on logging the things in deployed instances of the application.