### PR TITLE
fix: Segmentation / filtering issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 
 ## Unreleased
 
-Nothing yet.
+- Fixes
+  - Conslidated behavior of setting initial filters (top-most hierarchy value) when filter was not present and multi-filter was removed
+  - Fixed switching between segmentation dimensions in column charts
 
 # [3.24.1] - 2023-11-13
 

--- a/app/charts/chart-config-ui-options.ts
+++ b/app/charts/chart-config-ui-options.ts
@@ -685,12 +685,8 @@ const chartConfigOptionsUISpec: ChartSpecs = {
         filters: true,
         sorting: COLUMN_SEGMENT_SORTING,
         onChange: (iri, options) => {
-          const { chartConfig, dimensions, measures, initializing } = options;
+          const { chartConfig, dimensions, measures } = options;
           defaultSegmentOnChange(iri, options);
-
-          if (!initializing) {
-            return;
-          }
 
           const components = [...dimensions, ...measures];
           const segment: ColumnSegmentField = get(

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -8,6 +8,7 @@ import {
   ColumnConfig,
   ConfiguratorStateConfiguringChart,
   DataSource,
+  Filters,
   MapConfig,
   getChartConfig,
 } from "@/config-types";
@@ -296,8 +297,34 @@ describe("applyDimensionToFilters", () => {
       expect(initialFilters).toEqual(expectedFilters);
     });
 
-    it("should select top-most hierarchy value by default", () => {
+    it("should select top-most hierarchy value by default when no filter was present", () => {
       const initialFilters = {};
+      const expectedFilters = {
+        nominalDimensionIri: {
+          type: "single",
+          value: "switzerland",
+        },
+      };
+
+      applyNonTableDimensionToFilters({
+        filters: initialFilters,
+        dimension: keyDimensionWithHierarchy,
+        isField: false,
+      });
+
+      expect(initialFilters).toEqual(expectedFilters);
+    });
+
+    it("should select top-most hierarchy value by default when multi-filter was present", () => {
+      const initialFilters: Filters = {
+        nominalDimensionIri: {
+          type: "multi",
+          values: {
+            brienz: true,
+            switzerland: true,
+          },
+        },
+      };
       const expectedFilters = {
         nominalDimensionIri: {
           type: "single",

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -564,17 +564,18 @@ export const applyNonTableDimensionToFilters = ({
           delete filters[dimension.iri];
         }
         break;
+      // Multi-filters are not allowed in the left panel.
       case "multi":
         if (!isField) {
-          // Multi-filters are not allowed in the left panel.
-          // TODO: currently, the filters are sorted by their keys, which in some
-          // cases are IRIs - so if a multi-filter is applied, the default behavior
-          // is to use the first value from selected values, which isn't the same value
-          // as expected by looking at the UI (where filters are sorted alphabetically).
+          const hierarchyTopMost = dimension.hierarchy
+            ? findInHierarchy(dimension.hierarchy, (v) => !!v.hasValue)
+            : undefined;
+          const filterValue = hierarchyTopMost
+            ? hierarchyTopMost.value
+            : Object.keys(currentFilter.values)[0] ?? dimension.values[0].value;
           filters[dimension.iri] = {
             type: "single",
-            value:
-              Object.keys(currentFilter.values)[0] ?? dimension.values[0].value,
+            value: filterValue,
           };
         }
         break;

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -437,18 +437,16 @@ export const moveFilterField = produce(
 );
 
 export const deriveFiltersFromFields = produce(
-  (chartConfig: ChartConfig, components: Component[]) => {
-    const { chartType, fields, cubes } = chartConfig;
-
-    if (chartType === "table") {
+  (draft: ChartConfig, components: Component[]) => {
+    if (draft.chartType === "table") {
       // As dimensions in tables behave differently than in other chart types,
       // they need to be handled in a different way.
-      const hiddenFieldIris = getHiddenFieldIris(fields);
-      const groupedDimensionIris = getGroupedFieldIris(fields);
+      const hiddenFieldIris = getHiddenFieldIris(draft.fields);
+      const groupedDimensionIris = getGroupedFieldIris(draft.fields);
       const isHidden = (iri: string) => hiddenFieldIris.has(iri);
       const isGrouped = (iri: string) => groupedDimensionIris.has(iri);
 
-      cubes.forEach((cube) => {
+      draft.cubes.forEach((cube) => {
         const cubeComponents = components.filter(
           (component) => component.cubeIri === cube.iri
         );
@@ -467,10 +465,10 @@ export const deriveFiltersFromFields = produce(
         });
       });
     } else {
-      const fieldDimensionIris = getFieldComponentIris(fields);
+      const fieldDimensionIris = getFieldComponentIris(draft.fields);
       const isField = (iri: string) => fieldDimensionIris.has(iri);
 
-      cubes.forEach((cube) => {
+      draft.cubes.forEach((cube) => {
         const cubeComponents = components.filter(
           (component) => component.cubeIri === cube.iri
         );
@@ -494,8 +492,6 @@ export const deriveFiltersFromFields = produce(
         });
       });
     }
-
-    return chartConfig;
   }
 );
 
@@ -1000,7 +996,11 @@ const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
           action.value.locale
         );
         const dimensions = dataCubesComponents?.dimensions ?? [];
-        deriveFiltersFromFields(chartConfig, dimensions);
+        const newConfig = deriveFiltersFromFields(chartConfig, dimensions);
+        const index = draft.chartConfigs.findIndex(
+          (d) => d.key === chartConfig.key
+        );
+        draft.chartConfigs[index] = newConfig;
 
         if (
           action.value.field === "segment" &&


### PR DESCRIPTION
Fixes #1256.

This PR:
- consolidates handling of multi-filters (by setting top-most hierarchy value by default),
- fixes setting filter values when removing fields,
- fixes changing segmentation component in column charts.