### PR TITLE
fix: Better scope pragmas to fix data cube preview query

### DIFF
--- a/app/components/debug-panel/DebugPanel.tsx
+++ b/app/components/debug-panel/DebugPanel.tsx
@@ -125,8 +125,7 @@ const DebugConfigurator = () => {
             size="small"
             href={`${sparqlEditorUrl}#query=${encodeURIComponent(
               `#pragma describe.strategy cbd
-               #pragma join.hash off
-              
+
                DESCRIBE <${cube.iri}>`
             )}&requestMethod=POST`}
             target="_blank"

--- a/app/graphql/context.tsx
+++ b/app/graphql/context.tsx
@@ -10,9 +10,9 @@ import { LRUCache } from "typescript-lru-cache";
 import { SPARQL_GEO_ENDPOINT } from "@/domain/env";
 import { Awaited } from "@/domain/types";
 import { Timings } from "@/gql-flamegraph/resolvers";
-import { createSource } from "@/rdf/create-source";
+import { createSource, pragmas } from "@/rdf/create-source";
 import { ExtendedCube } from "@/rdf/extended-cube";
-import { timed, TimingCallback } from "@/utils/timed";
+import { TimingCallback, timed } from "@/utils/timed";
 
 import { createCubeDimensionValuesLoader } from "../rdf/queries";
 import {
@@ -27,7 +27,7 @@ import { RequestQueryMeta } from "./query-meta";
 export const MAX_BATCH_SIZE = 500;
 
 export const getRawCube = async (sparqlClient: ParsingClient, iri: string) => {
-  const source = createSource(sparqlClient);
+  const source = createSource(sparqlClient, pragmas);
   const cube = new ExtendedCube({
     parent: source,
     term: rdf.namedNode(iri),

--- a/app/rdf/create-source.ts
+++ b/app/rdf/create-source.ts
@@ -6,11 +6,14 @@ export const pragmas = `#pragma describe.strategy cbd
 #pragma join.hash off
 `;
 
-export const createSource = (sparqlClient: ParsingClient) => {
+export const createSource = (
+  sparqlClient: ParsingClient,
+  queryPrefix?: string
+) => {
   return new Source({
     client: sparqlClient,
     queryOperation: "postUrlencoded",
-    queryPrefix: pragmas,
+    queryPrefix,
     sourceGraph: rdf.defaultGraph(),
   });
 };

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -9,7 +9,7 @@ import { LRUCache } from "typescript-lru-cache";
 
 import { PromiseValue, truthy } from "@/domain/types";
 import { DataCubeComponentFilter } from "@/graphql/resolver-types";
-import { pragmas } from "@/rdf/create-source";
+import { createSource, pragmas } from "@/rdf/create-source";
 import { ExtendedCube } from "@/rdf/extended-cube";
 
 import { FilterValueMulti, Filters } from "../configurator";
@@ -609,6 +609,14 @@ export const getCubeObservations = async ({
     dimensions: observationDimensions,
     filters: observationFilters,
   });
+
+  // In order to fix an error with cartesian products introduced in preview query
+  // when using #pragma join.hash off, we need to have a clean source without
+  // decorating the sparql client. However we still need to keep the pragmas
+  // for the full query, to vastly improve performance.
+  observationsView.getMainSource = preview
+    ? () => createSource(sparqlClient)
+    : cubeView.getMainSource;
 
   const { query, observationsRaw } = await fetchViewObservations({
     preview,

--- a/app/rdf/query-literals.ts
+++ b/app/rdf/query-literals.ts
@@ -1,6 +1,6 @@
 import { SELECT, sparql } from "@tpluscode/sparql-builder";
 import uniqBy from "lodash/uniqBy";
-import { NamedNode, Literal } from "rdf-js";
+import { Literal, NamedNode } from "rdf-js";
 import ParsingClient from "sparql-http-client/ParsingClient";
 import { LRUCache } from "typescript-lru-cache";
 

--- a/app/typings/rdf.d.ts
+++ b/app/typings/rdf.d.ts
@@ -116,6 +116,7 @@ declare module "rdf-cube-view-query" {
     addDimension(dimension: Dimension): View;
     createDimension(options: $FixMe): Dimension;
     setDefaultColumns(): void;
+    getMainSource(): Source;
   }
 
   export type SourceOptions = NodeInit & {


### PR DESCRIPTION
This PR attempts to better scope pragmas when fetching the cube preview by using a clean Source, without pragmas, as having `#pragma join.hash off` breaks previews for some cubes for yet unknown reasons (see e.g. https://test.visualize.admin.ch/en/browse?previous=%7B%7D&dataset=https%3A%2F%2Fenvironment.ld.admin.ch%2Ffoen%2Fnfi%2Fnfi_C-94%2Fcube%2F2023-1&dataSource=Prod).

### Context
For more information see [this conversation on Zulip](https://zulip.zazuko.com/#narrow/stream/40-bafu-ext/topic/performance/near/377890).

### Notes
I aimed for a simple solution by overriding `getMainSource`  View's method, which might not be ideal, but:
- I didn't see a better, simple way of doing so (we can't just pass a clean Source into the View constructor, as [this is how it's retrieved internally](https://github.com/zazuko/rdf-cube-view-query/blob/9acb62a2bd5e50a4febf8f871f3e52935c151a62/lib/View.js#L403-L417) – taking the source of the first dimension, instead of the one tied to Source),
- this might be a temporary workaround until Stardog releases a new version (https://zulip.zazuko.com/#narrow/stream/40-bafu-ext/topic/performance/near/378807).

### How to test
1. Go to the deployment preview.
2. Look at the homepage examples to see if they load fast (<5 s).
3. Go to dataset browse page.
4. Change data source to PROD.
5. Search for a `NFI: Topics by ownership` cube.
6. Open the preview.
7. See that only 10 observations are loaded.
8. See [the same cube preview on TEST](https://test.visualize.admin.ch/en/browse?previous=%7B%7D&dataset=https%3A%2F%2Fenvironment.ld.admin.ch%2Ffoen%2Fnfi%2Fnfi_C-94%2Fcube%2F2023-1&dataSource=Prod) and see that 1530 observations are loaded there.