### PR TITLE
fix: Include dataSource in new visualization link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 
 - Features
   - Localized cube landing pages are now supported (dcat:landingPage) 🌎
+- Fixes
+  - Copying a link to a new visualization from a dataset preview now correctly includes a data source
 
 # [3.24.2] - 2023-11-28
 

--- a/app/browser/dataset-preview.tsx
+++ b/app/browser/dataset-preview.tsx
@@ -11,6 +11,7 @@ import { DataDownloadMenu, RunSparqlQuery } from "@/components/data-download";
 import Flex from "@/components/flex";
 import { HintRed, Loading, LoadingDataError } from "@/components/hint";
 import { DataSource } from "@/config-types";
+import { sourceToLabel } from "@/domain/datasource";
 import { useDataCubesComponentsQuery } from "@/graphql/hooks";
 import { useDataCubePreviewQuery } from "@/graphql/query-hooks";
 import { DataCubePublicationStatus } from "@/graphql/resolver-types";
@@ -162,7 +163,9 @@ export const DataSetPreview = ({
             {dataCubeByIri.title}
           </Typography>
           <Link
-            href={`/create/new?cube=${dataCubeByIri.iri}`}
+            href={`/create/new?cube=${
+              dataCubeByIri.iri
+            }&dataSource=${sourceToLabel(dataSource)}`}
             passHref
             legacyBehavior
           >


### PR DESCRIPTION
Fixes #1289.

### How to test
1. Go to [this link](https://visualization-tool-git-fix-add-datasource-when-copy-0d3e63-ixt1.vercel.app/en/browse?previous=%7B%22order%22%3A%22SCORE%22%2C%22search%22%3A%22photo%22%7D&dataset=https%3A%2F%2Fenergy.ld.admin.ch%2Fsfoe%2Fbfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen%2F14&dataSource=Int).
2. Copy the link from "Start a visualization" button.
3. ✅ See that the link includes data source at the end (`&dataSource=Int`).
4. Go to [the corresponding link on TEST](https://test.visualize.admin.ch/en/browse?previous=%7B%22order%22%3A%22SCORE%22%2C%22search%22%3A%22photo%22%7D&dataset=https%3A%2F%2Fenergy.ld.admin.ch%2Fsfoe%2Fbfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen%2F14&dataSource=Int).
5. Copy the link from "Start a visualization" button.
6. ❌ See that the link is broken and doesn't include data source at the end.