### PR TITLE
fix: Most recent date filter needs to take other filters into account

### DIFF
--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -353,7 +353,7 @@ export const Select = ({
     <LoadingMenuPaperContext.Provider value={loading}>
       <Box sx={{ width: "100%", ...sx }}>
         {label && (
-          <Label htmlFor={id} smaller sx={{ my: 1 }}>
+          <Label htmlFor={id} smaller sx={{ my: "6px" }}>
             {label}
             {controls}
           </Label>

--- a/app/components/select-tree.tsx
+++ b/app/components/select-tree.tsx
@@ -481,7 +481,7 @@ function SelectTree({
   return (
     <div>
       {label && (
-        <Label htmlFor={id!} smaller sx={{ my: 1 }}>
+        <Label htmlFor={id!} smaller sx={{ my: "6px" }}>
           {label} {controls}
         </Label>
       )}

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -354,6 +354,7 @@ export const DataFilterTemporal = (props: DataFilterTemporalProps) => {
             <FormControlLabel
               control={
                 <MUISwitch
+                  size="small"
                   checked={usesMostRecentDate}
                   onChange={() =>
                     fieldProps.onChange({

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -367,8 +367,13 @@ export const DataFilterTemporal = (props: DataFilterTemporalProps) => {
                   }
                 />
               }
-              // FIXME: adapt to design, translate
-              label={<Typography variant="caption">Use most recent</Typography>}
+              label={
+                <Typography variant="caption">
+                  <Trans id="controls.filter.use-most-recent">
+                    Use most recent
+                  </Trans>
+                </Typography>
+              }
               sx={{ mr: 0 }}
             />
           </FormGroup>

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -80,6 +80,7 @@ import {
   HierarchyValue,
   ObservationValue,
   TemporalDimension,
+  isTemporalOrdinalDimension,
 } from "@/domain/data";
 import { useTimeFormatLocale } from "@/formatters";
 import { TimeUnit } from "@/graphql/query-hooks";
@@ -240,11 +241,56 @@ export const DataFilterSelect = ({
     );
   }
 
+  const canUseMostRecentValue = isTemporalOrdinalDimension(dimension);
+  const usesMostRecentValue = isDynamicMaxValue(fieldProps.value);
+  const maxValue = sortedValues[sortedValues.length - 1].value;
+
   return (
     <Select
       id={id}
-      label={<FieldLabel label={label} isOptional={isOptional} />}
-      disabled={disabled}
+      label={
+        canUseMostRecentValue ? (
+          <Flex
+            sx={{
+              width: "100%",
+              justifyContent: "space-between",
+              alignItems: "center",
+            }}
+          >
+            <FieldLabel label={label} isOptional={isOptional} />
+            <FormGroup>
+              <FormControlLabel
+                control={
+                  <MUISwitch
+                    size="small"
+                    checked={usesMostRecentValue}
+                    onChange={() =>
+                      fieldProps.onChange({
+                        target: {
+                          value: usesMostRecentValue
+                            ? `${maxValue}`
+                            : VISUALIZE_MAX_VALUE,
+                        },
+                      })
+                    }
+                  />
+                }
+                label={
+                  <Typography variant="caption">
+                    <Trans id="controls.filter.use-most-recent">
+                      Use most recent
+                    </Trans>
+                  </Typography>
+                }
+                sx={{ mr: 0 }}
+              />
+            </FormGroup>
+          </Flex>
+        ) : (
+          <FieldLabel label={label} isOptional={isOptional} />
+        )
+      }
+      disabled={disabled || usesMostRecentValue}
       options={allValues}
       sortOptions={false}
       controls={controls}
@@ -253,6 +299,7 @@ export const DataFilterSelect = ({
       onOpen={handleOpen}
       loading={loading}
       {...fieldProps}
+      value={usesMostRecentValue ? maxValue : fieldProps.value}
     />
   );
 };
@@ -349,7 +396,6 @@ export const DataFilterTemporal = (props: DataFilterTemporalProps) => {
               </OpenMetadataPanelWrapper>
             }
           />
-          {/* FIXME: adapt to design */}
           <FormGroup>
             <FormControlLabel
               control={

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -369,6 +369,7 @@ export const DataFilterTemporal = (props: DataFilterTemporalProps) => {
               }
               // FIXME: adapt to design, translate
               label={<Typography variant="caption">Use most recent</Typography>}
+              sx={{ mr: 0 }}
             />
           </FormGroup>
         </Flex>

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -421,7 +421,6 @@ msgstr "Beschreibung hinzufügen"
 #: app/charts/shared/chart-data-filters.tsx
 #: app/configurator/components/field.tsx
 #: app/configurator/components/field.tsx
-#: app/configurator/components/field.tsx
 msgid "controls.dimensionvalue.none"
 msgstr "Kein Filter"
 
@@ -440,6 +439,10 @@ msgstr "Alle auswählen"
 #: app/configurator/components/filters.tsx
 msgid "controls.filter.select.none"
 msgstr "Alle abwählen"
+
+#: app/configurator/components/field.tsx
+msgid "controls.filter.use-most-recent"
+msgstr "Letztes Datum verwenden"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.filters.interactive.calculation"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -421,7 +421,6 @@ msgstr "Description"
 #: app/charts/shared/chart-data-filters.tsx
 #: app/configurator/components/field.tsx
 #: app/configurator/components/field.tsx
-#: app/configurator/components/field.tsx
 msgid "controls.dimensionvalue.none"
 msgstr "No Filter"
 
@@ -440,6 +439,10 @@ msgstr "Select all"
 #: app/configurator/components/filters.tsx
 msgid "controls.filter.select.none"
 msgstr "Select none"
+
+#: app/configurator/components/field.tsx
+msgid "controls.filter.use-most-recent"
+msgstr "Use most recent"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.filters.interactive.calculation"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -421,7 +421,6 @@ msgstr "Description"
 #: app/charts/shared/chart-data-filters.tsx
 #: app/configurator/components/field.tsx
 #: app/configurator/components/field.tsx
-#: app/configurator/components/field.tsx
 msgid "controls.dimensionvalue.none"
 msgstr "Aucune filtre"
 
@@ -440,6 +439,10 @@ msgstr "Tout sélectionner"
 #: app/configurator/components/filters.tsx
 msgid "controls.filter.select.none"
 msgstr "Tout déselectionner"
+
+#: app/configurator/components/field.tsx
+msgid "controls.filter.use-most-recent"
+msgstr "Utiliser le plus récent"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.filters.interactive.calculation"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -421,7 +421,6 @@ msgstr "Descrizione"
 #: app/charts/shared/chart-data-filters.tsx
 #: app/configurator/components/field.tsx
 #: app/configurator/components/field.tsx
-#: app/configurator/components/field.tsx
 msgid "controls.dimensionvalue.none"
 msgstr "Nessun filtro"
 
@@ -440,6 +439,10 @@ msgstr "Seleziona tutti"
 #: app/configurator/components/filters.tsx
 msgid "controls.filter.select.none"
 msgstr "Deseleziona tutto"
+
+#: app/configurator/components/field.tsx
+msgid "controls.filter.use-most-recent"
+msgstr "Usare il più recente"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.filters.interactive.calculation"

--- a/app/rdf/query-dimension-values.ts
+++ b/app/rdf/query-dimension-values.ts
@@ -8,6 +8,7 @@ import { Literal, NamedNode, Term } from "rdf-js";
 import { ParsingClient } from "sparql-http-client/ParsingClient";
 import { LRUCache } from "typescript-lru-cache";
 
+import { isDynamicMaxValue } from "@/configurator/components/field";
 import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import { parseObservationValue } from "@/domain/data";
 import { pragmas } from "@/rdf/create-source";
@@ -124,6 +125,14 @@ const getFilterOrder = (filter: Filters[number]) => {
   }
 };
 
+type LoadDimensionValuesProps = {
+  datasetIri: Term | undefined;
+  dimension: CubeDimension;
+  cube: ExtendedCube;
+  sparqlClient: ParsingClient;
+  filters?: Filters;
+};
+
 /**
  * Load dimension values.
  *
@@ -131,74 +140,19 @@ const getFilterOrder = (filter: Filters[number]) => {
  *
  */
 export async function loadDimensionValues(
-  {
-    datasetIri,
-    dimension,
-    cube,
-    sparqlClient,
-  }: {
-    datasetIri: Term | undefined;
-    dimension: CubeDimension;
-    cube: ExtendedCube;
-    sparqlClient: ParsingClient;
-  },
-  filters?: Filters
+  props: LoadDimensionValuesProps
 ): Promise<Array<Literal | NamedNode>> {
+  const { datasetIri, dimension, cube, sparqlClient, filters } = props;
   const dimensionIri = dimension.path;
-  const allFiltersList = filters ? Object.entries(filters) : [];
-  const filterList =
-    // Consider filters before the current filter to fetch the values for
-    // the current filter
-    sortBy(
-      allFiltersList.slice(
-        0,
-        allFiltersList.findIndex(([iri]) => iri == dimensionIri?.value)
-      ),
-      ([, filterValue]) => getFilterOrder(filterValue)
-    );
+  const filterList = filters
+    ? getFiltersList(filters, dimensionIri?.value)
+    : [];
 
   const query = SELECT.DISTINCT`?value`.WHERE`
     ${datasetIri} ${cubeNs.observationSet} ?observationSet .
     ?observationSet ${cubeNs.observation} ?observation .
     ?observation ${dimensionIri} ?value .
-    ${
-      filters
-        ? filterList.map(([iri, value], idx) => {
-            const filterDimension = cube.dimensions.find(
-              (d) => d.path?.value === iri
-            );
-
-            if (!filterDimension || dimensionIri?.value === iri) {
-              return "";
-            }
-
-            if (value.type === "single" && value.value === FIELD_VALUE_NONE) {
-              return "";
-            }
-
-            // Ignore range filters for now.
-            if (value.type === "range") {
-              return "";
-            }
-            const versioned = filterDimension
-              ? dimensionIsVersioned(filterDimension)
-              : false;
-
-            return sparql`${
-              versioned
-                ? sparql`?dimension${idx} ${ns.schema.sameAs} ?dimension_unversioned${idx}.`
-                : ""
-            }
-            ?observation <${iri}> ?dimension${idx}.
-            ${formatFilterIntoSparqlFilter(
-              value,
-              filterDimension,
-              versioned,
-              idx
-            )}`;
-          })
-        : ""
-    }
+    ${getQueryFilters(filterList, cube, dimensionIri?.value)}
   `.prologue`${pragmas}`;
 
   let result: Array<DimensionValue> = [];
@@ -208,11 +162,99 @@ export async function loadDimensionValues(
       operation: "postUrlencoded",
     })) as unknown as Array<DimensionValue>;
   } catch {
-    console.warn(`Failed to fetch dimension values for ${datasetIri}.`);
+    console.warn(`Failed to fetch dimension values for ${datasetIri}!`);
   } finally {
     return result.map((d) => d.value);
   }
 }
+
+/**
+ * Load max dimension value.
+ *
+ * Filters on other dimensions can be passed.
+ *
+ */
+export async function loadMaxDimensionValue(
+  props: LoadDimensionValuesProps
+): Promise<Array<Literal | NamedNode>> {
+  const { datasetIri, dimension, cube, sparqlClient, filters } = props;
+  const dimensionIri = dimension.path;
+  const filterList = filters
+    ? getFiltersList(filters, dimensionIri?.value)
+    : [];
+
+  const query = SELECT`(MAX(?value) as ?value)`.WHERE`
+    ${datasetIri} ${cubeNs.observationSet} ?observationSet .
+    ?observationSet ${cubeNs.observation} ?observation .
+    ?observation ${dimensionIri} ?value .
+    ${getQueryFilters(filterList, cube, dimensionIri?.value)}
+  `.prologue`${pragmas}`;
+
+  let result: Array<DimensionValue> = [];
+
+  try {
+    result = (await query.execute(sparqlClient.query, {
+      operation: "postUrlencoded",
+    })) as unknown as Array<DimensionValue>;
+  } catch {
+    console.warn(`Failed to fetch max dimension value for ${datasetIri}!`);
+  } finally {
+    return result.map((d) => d.value);
+  }
+}
+
+const getFiltersList = (filters: Filters, dimensionIri: string | undefined) => {
+  const entries = Object.entries(filters);
+  // Consider filters before the current filter to fetch the values for
+  // the current filter
+  return sortBy(
+    entries.slice(
+      0,
+      entries.findIndex(([iri]) => iri == dimensionIri)
+    ),
+    ([, v]) => getFilterOrder(v)
+  );
+};
+
+const getQueryFilters = (
+  filtersList: ReturnType<typeof getFiltersList>,
+  cube: ExtendedCube,
+  dimensionIri: string | undefined
+) => {
+  return filtersList.length > 0
+    ? filtersList.map(([iri, value], i) => {
+        const dimension = cube.dimensions.find((d) => d.path?.value === iri);
+
+        // Ignore the current dimension
+        if (!dimension || dimensionIri === iri) {
+          return "";
+        }
+
+        // Ignore filters with no value or with the special value
+        if (
+          value.type === "single" &&
+          (value.value === FIELD_VALUE_NONE || isDynamicMaxValue(value.value))
+        ) {
+          return "";
+        }
+
+        // Ignore range filters for now
+        if (value.type === "range") {
+          return "";
+        }
+
+        const versioned = dimension ? dimensionIsVersioned(dimension) : false;
+
+        return sparql`${
+          versioned
+            ? sparql`?dimension${i} ${ns.schema.sameAs} ?dimension_unversioned${i}.`
+            : ""
+        }
+      ?observation <${iri}> ?dimension${i}.
+      ${formatFilterIntoSparqlFilter(value, dimension, versioned, i)}`;
+      })
+    : "";
+};
 
 type MinMaxResult = [{ minValue: LiteralExt; maxValue: LiteralExt }];
 

--- a/app/themes/federal.tsx
+++ b/app/themes/federal.tsx
@@ -637,12 +637,17 @@ theme.components = {
   },
   MuiSwitch: {
     styleOverrides: {
-      root: {
-        width: 28,
-        height: 16,
-        padding: 0,
-
+      root: ({ ownerState }) => ({
         display: "flex",
+        ...(ownerState.size === "small" && {
+          width: 24,
+          height: 12,
+        }),
+        ...(ownerState.size === "medium" && {
+          width: 28,
+          height: 16,
+        }),
+        padding: 0,
 
         "& .MuiSwitch-switchBase": {
           padding: 2,
@@ -661,8 +666,14 @@ theme.components = {
         },
         "& .MuiSwitch-thumb": {
           backgroundColor: theme.palette.background.paper,
-          width: 12,
-          height: 12,
+          ...(ownerState.size === "small" && {
+            width: 8,
+            height: 8,
+          }),
+          ...(ownerState.size === "medium" && {
+            width: 12,
+            height: 12,
+          }),
           borderRadius: 6,
           transition: theme.transitions.create(["width"], {
             duration: 200,
@@ -683,7 +694,7 @@ theme.components = {
             transform: "translateX(9px)",
           },
         },
-      },
+      }),
     },
   },
   MuiTableCell: {


### PR DESCRIPTION
Closes #1310
Closes #1317

The initial implementation of most recent date filter didn't take other filters into account – we were simply taking max date for a given dimension, even if such selection led to missing data.

This PR fixes this by querying max date taking other filters into account, to effectively take "most recent date with data for current filter selection".

It also enables this logic for `TemporalOrdinalDimensions`.

### How to test
1. Go to [this link](https://visualization-tool-git-fix-most-recent-date-filter-ixt1.vercel.app/en/create/new?cube=https://environment.ld.admin.ch/foen/ubd0104/6&dataSource=Prod).
2. Change chart type to a pie chart.
3. Toggle "Use most recent" in the date filter.
4. See that the selected date equals to 09.09.2021.
5. Repeat the same process on INT.
6. See that the chart has no observations. The date is equal to 09.09.2021, however in the background it was equal to 27.09.2021 (max date for the whole dataset, see [this observations query](https://s.zazuko.com/2eFS1gh)).