### PR TITLE
feat: Single URLs layout

### DIFF
--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -311,7 +311,7 @@ export const getInitialSymbolLayer = ({
   };
 };
 
-const META: Meta = {
+export const META: Meta = {
   title: {
     en: "",
     de: "",

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -70,6 +70,8 @@ export const ChartPreview = (props: ChartPreviewProps) => {
 
   return layout.type === "dashboard" && !editing ? (
     <DashboardPreview dataSource={dataSource} layoutType={layout.layout} />
+  ) : layout.type === "singleURLs" ? (
+    <SingleURLsPreview dataSource={dataSource} />
   ) : (
     <ChartTablePreviewProvider>
       <ChartWrapper editing={editing} layoutType={layout.type}>
@@ -243,6 +245,32 @@ const DndChartPreview = (props: DndChartPreviewProps) => {
         />
       </ChartWrapper>
     </ChartTablePreviewProvider>
+  );
+};
+
+const SingleURLsPreview = (props: ChartPreviewProps) => {
+  const { dataSource } = props;
+  const [state] = useConfiguratorState(hasChartConfigs);
+
+  const renderChart = React.useCallback(
+    (chartConfig: ChartConfig) => (
+      <ChartTablePreviewProvider>
+        <ChartWrapper>
+          <ChartPreviewInner
+            dataSource={dataSource}
+            chartKey={chartConfig.key}
+          />
+        </ChartWrapper>
+      </ChartTablePreviewProvider>
+    ),
+    [dataSource]
+  );
+
+  return (
+    <ChartPanelLayoutVertical
+      chartConfigs={state.chartConfigs}
+      renderChart={renderChart}
+    />
   );
 };
 

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -271,12 +271,8 @@ const SingleURLsPreview = (props: SingleURLsPreviewProps) => {
               actionElementSlot={
                 <Checkbox
                   checked={checked}
+                  disabled={keys.length === 1 && checked}
                   onChange={() => {
-                    // At least one chart must be publishable
-                    if (keys.length === 1 && checked) {
-                      return;
-                    }
-
                     dispatch({
                       type: "LAYOUT_CHANGED",
                       value: {

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -34,6 +34,7 @@ import {
 import { ChartWithFilters } from "@/components/chart-with-filters";
 import DebugPanel from "@/components/debug-panel";
 import Flex from "@/components/flex";
+import { Checkbox } from "@/components/form";
 import { HintYellow } from "@/components/hint";
 import { MetadataPanel } from "@/components/metadata-panel";
 import {
@@ -71,7 +72,7 @@ export const ChartPreview = (props: ChartPreviewProps) => {
   return layout.type === "dashboard" && !editing ? (
     <DashboardPreview dataSource={dataSource} layoutType={layout.layout} />
   ) : layout.type === "singleURLs" ? (
-    <SingleURLsPreview dataSource={dataSource} />
+    <SingleURLsPreview dataSource={dataSource} layout={layout} />
   ) : (
     <ChartTablePreviewProvider>
       <ChartWrapper editing={editing} layoutType={layout.type}>
@@ -171,7 +172,7 @@ const DashboardPreview = (props: DashboardPreviewProps) => {
             <ChartPreviewInner
               dataSource={dataSource}
               chartKey={activeChartKey}
-              dragHandleSlot={<DragHandle dragging />}
+              actionElementSlot={<DragHandle dragging />}
             />
           </ChartWrapper>
         </DragOverlay>
@@ -235,7 +236,7 @@ const DndChartPreview = (props: DndChartPreviewProps) => {
         <ChartPreviewInner
           dataSource={dataSource}
           chartKey={chartKey}
-          dragHandleSlot={
+          actionElementSlot={
             <DragHandle
               {...listeners}
               ref={setActivatorNodeRef}
@@ -248,22 +249,55 @@ const DndChartPreview = (props: DndChartPreviewProps) => {
   );
 };
 
-const SingleURLsPreview = (props: ChartPreviewProps) => {
-  const { dataSource } = props;
-  const [state] = useConfiguratorState(hasChartConfigs);
+type SingleURLsPreviewProps = ChartPreviewProps & {
+  layout: Extract<Layout, { type: "singleURLs" }>;
+};
 
+const SingleURLsPreview = (props: SingleURLsPreviewProps) => {
+  const { dataSource, layout } = props;
+  const [state, dispatch] = useConfiguratorState(hasChartConfigs);
   const renderChart = React.useCallback(
-    (chartConfig: ChartConfig) => (
-      <ChartTablePreviewProvider>
-        <ChartWrapper>
-          <ChartPreviewInner
-            dataSource={dataSource}
-            chartKey={chartConfig.key}
-          />
-        </ChartWrapper>
-      </ChartTablePreviewProvider>
-    ),
-    [dataSource]
+    (chartConfig: ChartConfig) => {
+      const checked = layout.publishableChartKeys.includes(chartConfig.key);
+      const { publishableChartKeys: keys } = layout;
+      const { key } = chartConfig;
+
+      return (
+        <ChartTablePreviewProvider>
+          <ChartWrapper>
+            <ChartPreviewInner
+              dataSource={dataSource}
+              chartKey={chartConfig.key}
+              actionElementSlot={
+                <Checkbox
+                  checked={checked}
+                  onChange={() => {
+                    // At least one chart must be publishable
+                    if (keys.length === 1 && checked) {
+                      return;
+                    }
+
+                    dispatch({
+                      type: "LAYOUT_CHANGED",
+                      value: {
+                        ...layout,
+                        publishableChartKeys: checked
+                          ? keys.filter((k) => k !== key)
+                          : state.chartConfigs
+                              .map((c) => c.key)
+                              .filter((k) => keys.includes(k) || k === key),
+                      },
+                    });
+                  }}
+                  label=""
+                />
+              }
+            />
+          </ChartWrapper>
+        </ChartTablePreviewProvider>
+      );
+    },
+    [dataSource, dispatch, layout, state.chartConfigs]
   );
 
   return (
@@ -276,12 +310,13 @@ const SingleURLsPreview = (props: ChartPreviewProps) => {
 
 type ChartPreviewInnerProps = ChartPreviewProps & {
   chartKey?: string | null;
-  dragHandleSlot?: React.ReactNode;
+  actionElementSlot?: React.ReactNode;
   disableMetadataPanel?: boolean;
 };
 
 export const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
-  const { dataSource, chartKey, dragHandleSlot, disableMetadataPanel } = props;
+  const { dataSource, chartKey, actionElementSlot, disableMetadataPanel } =
+    props;
   const [state, dispatch] = useConfiguratorState();
   const chartConfig = getChartConfig(state, chartKey);
   const locale = useLocale();
@@ -421,7 +456,7 @@ export const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
                               top={96}
                             />
                           )}
-                          {dragHandleSlot}
+                          {actionElementSlot}
                         </Flex>
                       </Flex>
                       {(state.state === "CONFIGURING_CHART" ||

--- a/app/components/debug-panel/index.tsx
+++ b/app/components/debug-panel/index.tsx
@@ -9,7 +9,7 @@ import { DebugPanelProps } from "./DebugPanel";
 const LazyDebugPanel = dynamic(() => import("./DebugPanel"), { ssr: false });
 
 const DebugPanel = (props: DebugPanelProps) => {
-  const shouldShow = flag("debug") || process.env.NODE_ENV === "development";
+  const shouldShow = flag("debug") ?? process.env.NODE_ENV === "development";
 
   if (!shouldShow) {
     return null;

--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -206,7 +206,7 @@ export const Checkbox = ({
   className,
 }: CheckboxProps) => (
   <FormControlLabel
-    label={label || "-"}
+    label={label}
     htmlFor={`${name}`}
     disabled={disabled}
     className={className}

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -1118,6 +1118,11 @@ const Layout = t.intersection([
       layout: t.union([t.literal("vertical"), t.literal("tall")]),
       meta: Meta,
     }),
+    t.type({
+      type: t.literal("singleURLs"),
+      publishableChartKeys: t.array(t.string),
+      meta: Meta,
+    }),
   ]),
 ]);
 export type Layout = t.TypeOf<typeof Layout>;

--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/router";
 import React from "react";
 
 import { SelectDatasetStep } from "@/browser/select-dataset-step";
+import { META } from "@/charts";
 import { ChartPreview } from "@/components/chart-preview";
 import { PublishChartButton } from "@/components/chart-selection-tabs";
 import { HEADER_HEIGHT } from "@/components/header";
@@ -298,7 +299,9 @@ const LayoutingStep = () => {
                   publishableChartKeys: state.chartConfigs.map(
                     (chartConfig) => chartConfig.key
                   ),
-                  meta: state.layout.meta,
+                  // Clear the meta data, as it's not used in singleURLs layout,
+                  // but makes the types more consistent
+                  meta: META,
                   activeField: undefined,
                 },
               });
@@ -320,38 +323,40 @@ const LayoutingStep = () => {
         <LayoutConfigurator />
       </PanelBodyWrapper>
       <PanelBodyWrapper type="M">
-        <Box
-          sx={{
-            display: "flex",
-            flexDirection: "column",
-            gap: 1,
-            mt: 3,
-            mb: 4,
-          }}
-        >
-          <Title
-            text={state.layout.meta.title[locale]}
-            onClick={() => {
-              if (state.layout.activeField !== "title") {
-                dispatch({
-                  type: "LAYOUT_ACTIVE_FIELD_CHANGED",
-                  value: "title",
-                });
-              }
+        {state.layout.type !== "singleURLs" && (
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 1,
+              mt: 3,
+              mb: 4,
             }}
-          />
-          <Description
-            text={state.layout.meta.description[locale]}
-            onClick={() => {
-              if (state.layout.activeField !== "description") {
-                dispatch({
-                  type: "LAYOUT_ACTIVE_FIELD_CHANGED",
-                  value: "description",
-                });
-              }
-            }}
-          />
-        </Box>
+          >
+            <Title
+              text={state.layout.meta.title[locale]}
+              onClick={() => {
+                if (state.layout.activeField !== "title") {
+                  dispatch({
+                    type: "LAYOUT_ACTIVE_FIELD_CHANGED",
+                    value: "title",
+                  });
+                }
+              }}
+            />
+            <Description
+              text={state.layout.meta.description[locale]}
+              onClick={() => {
+                if (state.layout.activeField !== "description") {
+                  dispatch({
+                    type: "LAYOUT_ACTIVE_FIELD_CHANGED",
+                    value: "description",
+                  });
+                }
+              }}
+            />
+          </Box>
+        )}
         <ChartPreview dataSource={state.dataSource} />
       </PanelBodyWrapper>
       <ConfiguratorDrawer

--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -1,5 +1,5 @@
 import { Trans } from "@lingui/macro";
-import { SxProps } from "@mui/material";
+import { SxProps, Typography } from "@mui/material";
 import Box from "@mui/material/Box";
 import Button, { ButtonProps } from "@mui/material/Button";
 import { useRouter } from "next/router";
@@ -225,8 +225,14 @@ const LayoutingStep = () => {
     return null;
   }
 
+  const isSingleURLs = state.layout.type === "singleURLs";
+
   return (
-    <PanelLayout type="LM" sx={{ background: (t) => t.palette.muted.main }}>
+    <PanelLayout
+      // SingleURLs layout doesn't have an options panel
+      type={isSingleURLs ? "M" : "LM"}
+      sx={{ background: (t) => t.palette.muted.main }}
+    >
       <PanelHeaderLayout type="LMR">
         <PanelHeaderWrapper type="L">
           <BackContainer>
@@ -319,45 +325,70 @@ const LayoutingStep = () => {
           <PublishChartButton />
         </PanelHeaderWrapper>
       </PanelHeaderLayout>
-      <PanelBodyWrapper type="L">
-        <LayoutConfigurator />
-      </PanelBodyWrapper>
+      {!isSingleURLs && (
+        <PanelBodyWrapper type="L">
+          <LayoutConfigurator />
+        </PanelBodyWrapper>
+      )}
       <PanelBodyWrapper type="M">
-        {state.layout.type !== "singleURLs" && (
+        <Box
+          sx={
+            isSingleURLs
+              ? {
+                  width: "100%",
+                  maxWidth: { xs: "100%", lg: 1280 },
+                  mx: "auto",
+                }
+              : {}
+          }
+        >
           <Box
             sx={{
               display: "flex",
               flexDirection: "column",
               gap: 1,
               mt: 3,
-              mb: 4,
+              mb: isSingleURLs ? 6 : 4,
             }}
           >
-            <Title
-              text={state.layout.meta.title[locale]}
-              onClick={() => {
-                if (state.layout.activeField !== "title") {
-                  dispatch({
-                    type: "LAYOUT_ACTIVE_FIELD_CHANGED",
-                    value: "title",
-                  });
-                }
-              }}
-            />
-            <Description
-              text={state.layout.meta.description[locale]}
-              onClick={() => {
-                if (state.layout.activeField !== "description") {
-                  dispatch({
-                    type: "LAYOUT_ACTIVE_FIELD_CHANGED",
-                    value: "description",
-                  });
-                }
-              }}
-            />
+            {isSingleURLs ? (
+              <Typography
+                variant="h3"
+                sx={{ fontWeight: "normal", color: "secondary.active" }}
+              >
+                <Trans id="controls.layout.singleURLs.publish">
+                  Select the charts to publish separately.
+                </Trans>
+              </Typography>
+            ) : (
+              <>
+                <Title
+                  text={state.layout.meta.title[locale]}
+                  onClick={() => {
+                    if (state.layout.activeField !== "title") {
+                      dispatch({
+                        type: "LAYOUT_ACTIVE_FIELD_CHANGED",
+                        value: "title",
+                      });
+                    }
+                  }}
+                />
+                <Description
+                  text={state.layout.meta.description[locale]}
+                  onClick={() => {
+                    if (state.layout.activeField !== "description") {
+                      dispatch({
+                        type: "LAYOUT_ACTIVE_FIELD_CHANGED",
+                        value: "description",
+                      });
+                    }
+                  }}
+                />
+              </>
+            )}
           </Box>
-        )}
-        <ChartPreview dataSource={state.dataSource} />
+          <ChartPreview dataSource={state.dataSource} />
+        </Box>
       </PanelBodyWrapper>
       <ConfiguratorDrawer
         anchor="left"

--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -283,6 +283,27 @@ const LayoutingStep = () => {
               });
             }}
           />
+          <IconButton
+            label="layoutSingleURLs"
+            checked={state.layout.type === "singleURLs"}
+            onClick={() => {
+              if (state.layout.type === "singleURLs") {
+                return;
+              }
+
+              dispatch({
+                type: "LAYOUT_CHANGED",
+                value: {
+                  type: "singleURLs",
+                  publishableChartKeys: state.chartConfigs.map(
+                    (chartConfig) => chartConfig.key
+                  ),
+                  meta: state.layout.meta,
+                  activeField: undefined,
+                },
+              });
+            }}
+          />
         </PanelHeaderWrapper>
         <PanelHeaderWrapper
           type="R"

--- a/app/configurator/components/field-i18n.ts
+++ b/app/configurator/components/field-i18n.ts
@@ -172,6 +172,10 @@ const fieldLabels = {
     id: "controls.layout.dashboard",
     message: "Dashboard",
   }),
+  "controls.layout.singleURLs": defineMessage({
+    id: "controls.layout.singleURLs",
+    message: "Single URLs",
+  }),
   "controls.layout.tall": defineMessage({
     id: "controls.layout.tall",
     message: "Tall",
@@ -379,6 +383,8 @@ export function getFieldLabel(field: string): string {
       return i18n._(fieldLabels["controls.layout.tall"]);
     case "layoutVertical":
       return i18n._(fieldLabels["controls.layout.vertical"]);
+    case "layoutSingleURLs":
+      return i18n._(fieldLabels["controls.layout.singleURLs"]);
 
     // Languages
     case "en":

--- a/app/configurator/components/ui-helpers.ts
+++ b/app/configurator/components/ui-helpers.ts
@@ -208,6 +208,8 @@ export const getIconName = (name: string): IconName => {
       return "time";
     case "animation":
       return "animation";
+    case "layoutSingleURLs":
+      return "layoutSingleURLs";
     case "layoutTab":
       return "layoutTab";
     case "layoutDashboard":

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -1630,7 +1630,7 @@ const ConfiguratorStateProviderInternal = (
 
                   // Do not use Promise.all here, as we want to publish the charts in order
                   // and not in parallel and keep the current tab open with first chart
-                  reversedChartKeys.forEach(async (chartKey, i) => {
+                  return reversedChartKeys.forEach(async (chartKey, i) => {
                     const preparedConfig = preparePublishingState(
                       {
                         ...state,

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -4,7 +4,7 @@ import pickBy from "lodash/pickBy";
 import setWith from "lodash/setWith";
 import sortBy from "lodash/sortBy";
 import unset from "lodash/unset";
-import { useRouter } from "next/router";
+import { NextRouter, useRouter } from "next/router";
 import { Dispatch, createContext, useContext, useEffect, useMemo } from "react";
 import { Reducer, useImmerReducer } from "use-immer";
 
@@ -1622,74 +1622,70 @@ const ConfiguratorStateProviderInternal = (
         case "PUBLISHING":
           (async () => {
             try {
-              let dbConfig: ParsedConfig | undefined;
-              const key = getRouterChartId(asPath);
+              switch (state.layout.type) {
+                case "singleURLs": {
+                  const reversedChartKeys = state.layout.publishableChartKeys
+                    .slice()
+                    .reverse();
 
-              if (key && user) {
-                const config = await fetchChartConfig(key);
+                  // Do not use Promise.all here, as we want to publish the charts in order
+                  // and not in parallel and keep the current tab open with first chart
+                  reversedChartKeys.forEach(async (chartKey, i) => {
+                    const preparedConfig = preparePublishingState(
+                      {
+                        ...state,
+                        // Ensure that the layout is reset to single-chart mode
+                        layout: {
+                          type: "tab",
+                          meta: state.layout.meta,
+                          activeField: undefined,
+                        },
+                      },
+                      state.chartConfigs.filter(
+                        (d) => d.key === chartKey
+                      ) as ChartConfig[]
+                    );
 
-                if (config && config.user_id === user.id) {
-                  dbConfig = config;
+                    const result = await createConfig(preparedConfig);
+
+                    if (i < reversedChartKeys.length - 1) {
+                      // Open new tab for each chart, except the first one
+                      return window.open(
+                        `/${locale}/v/${result.key}`,
+                        "_blank"
+                      );
+                    }
+
+                    await handlePublishSuccess(result.key, push);
+                  });
+                }
+                default: {
+                  let dbConfig: ParsedConfig | undefined;
+                  const key = getRouterChartId(asPath);
+
+                  if (key && user) {
+                    const config = await fetchChartConfig(key);
+
+                    if (config && config.user_id === user.id) {
+                      dbConfig = config;
+                    }
+                  }
+
+                  const preparedConfig = preparePublishingState(
+                    state,
+                    state.chartConfigs
+                  );
+
+                  const result = await (dbConfig && user
+                    ? updateConfig(preparedConfig, {
+                        key: dbConfig.key,
+                        userId: user.id,
+                      })
+                    : createConfig(preparedConfig));
+
+                  await handlePublishSuccess(result.key, push);
                 }
               }
-
-              const preparedConfig: ConfiguratorStatePublishing = {
-                ...state,
-                chartConfigs: [
-                  ...state.chartConfigs.map((chartConfig) => {
-                    return {
-                      ...chartConfig,
-                      cubes: chartConfig.cubes.map((cube) => {
-                        return {
-                          ...cube,
-                          // Ensure that the filters are in the correct order, as JSON
-                          // does not guarantee order (and we need this as interactive
-                          // filters are dependent on the order of the filters).
-                          filters: Object.fromEntries(
-                            Object.entries(cube.filters).map(([k, v], i) => {
-                              return [k, { ...v, position: i }];
-                            })
-                          ),
-                        };
-                      }),
-                    };
-                  }),
-                ],
-                // Technically, we do not need to store the active chart key, as
-                // it's only used in the edit mode, but it makes it easier to manage
-                // the state when retrieving the chart from the database. Potentially,
-                // it might also be useful for other things in the future (e.g. when we
-                // have multiple charts in the "stepper mode", and we'd like to start
-                // the story from a specific point and e.g. toggle back and forth between
-                // the different charts).
-                activeChartKey: state.chartConfigs[0].key,
-              };
-
-              const result = await (dbConfig && user
-                ? updateConfig(preparedConfig, {
-                    key: dbConfig.key,
-                    userId: user.id,
-                  })
-                : createConfig(preparedConfig));
-
-              /**
-               * EXPERIMENTAL: Post back created chart ID to opener and close window.
-               *
-               * This allows the chart creation workflow to be integrated with other tools like a CMS
-               */
-
-              // FIXME: Check for more than just opener?
-              const opener = window.opener;
-              if (opener) {
-                opener.postMessage(`CHART_ID:${result.key}`, "*");
-                window.close();
-                return;
-              }
-
-              await push({
-                pathname: `/v/${result.key}`,
-                query: { publishSuccess: true },
-              });
             } catch (e) {
               console.error(e);
               dispatch({ type: "PUBLISH_FAILED" });
@@ -1719,6 +1715,67 @@ const ConfiguratorStateProviderInternal = (
       {children}
     </ConfiguratorStateContext.Provider>
   );
+};
+
+const preparePublishingState = (
+  state: ConfiguratorStatePublishing,
+  chartConfigs: ChartConfig[]
+): ConfiguratorStatePublishing => {
+  return {
+    ...state,
+    chartConfigs: [
+      ...chartConfigs.map((chartConfig) => {
+        return {
+          ...chartConfig,
+          cubes: chartConfig.cubes.map((cube) => {
+            return {
+              ...cube,
+              // Ensure that the filters are in the correct order, as JSON
+              // does not guarantee order (and we need this as interactive
+              // filters are dependent on the order of the filters).
+              filters: Object.fromEntries(
+                Object.entries(cube.filters).map(([k, v], i) => {
+                  return [k, { ...v, position: i }];
+                })
+              ),
+            };
+          }),
+        };
+      }),
+    ],
+    // Technically, we do not need to store the active chart key, as
+    // it's only used in the edit mode, but it makes it easier to manage
+    // the state when retrieving the chart from the database. Potentially,
+    // it might also be useful for other things in the future (e.g. when we
+    // have multiple charts in the "stepper mode", and we'd like to start
+    // the story from a specific point and e.g. toggle back and forth between
+    // the different charts).
+    activeChartKey: state.chartConfigs[0].key,
+  };
+};
+
+const handlePublishSuccess = async (
+  chartId: string,
+  push: NextRouter["push"]
+) => {
+  /**
+   * EXPERIMENTAL: Post back created chart ID to opener and close window.
+   *
+   * This allows the chart creation workflow to be integrated with other tools like a CMS
+   */
+
+  // FIXME: Check for more than just opener?
+  const opener = window.opener;
+  if (opener) {
+    opener.postMessage(`CHART_ID:${chartId}`, "*");
+    window.close();
+    return;
+  }
+
+  await push({
+    pathname: `/v/${chartId}`,
+    query: { publishSuccess: true },
+  });
 };
 
 type ConfiguratorStateProviderProps = React.PropsWithChildren<{

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -1643,7 +1643,8 @@ const ConfiguratorStateProviderInternal = (
                       },
                       state.chartConfigs.filter(
                         (d) => d.key === chartKey
-                      ) as ChartConfig[]
+                      ) as ChartConfig[],
+                      chartKey
                     );
 
                     const result = await createConfig(preparedConfig);
@@ -1719,7 +1720,8 @@ const ConfiguratorStateProviderInternal = (
 
 const preparePublishingState = (
   state: ConfiguratorStatePublishing,
-  chartConfigs: ChartConfig[]
+  chartConfigs: ChartConfig[],
+  activeChartKey?: string
 ): ConfiguratorStatePublishing => {
   return {
     ...state,
@@ -1750,7 +1752,7 @@ const preparePublishingState = (
     // have multiple charts in the "stepper mode", and we'd like to start
     // the story from a specific point and e.g. toggle back and forth between
     // the different charts).
-    activeChartKey: state.chartConfigs[0].key,
+    activeChartKey: activeChartKey ?? state.chartConfigs[0].key,
   };
 };
 

--- a/app/icons/components/IcLayoutSingleURLs.tsx
+++ b/app/icons/components/IcLayoutSingleURLs.tsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+
+function SvgIcLayoutSingleURLs(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      width="1em"
+      height="1m"
+      {...props}
+    >
+      <path
+        fill="currentColor"
+        fill-rule="evenodd"
+        d="M21.9994 17.9824V4H4.9375V5L21.1068 4.99937V17.9824H21.9994ZM19.9994 6V19.9824H19.1068V6.99937L2.9375 7V6H19.9994ZM2 7.98438H18V20.9844H2V7.98438Z"
+      />
+    </svg>
+  );
+}
+
+export default SvgIcLayoutSingleURLs;

--- a/app/icons/components/index.tsx
+++ b/app/icons/components/index.tsx
@@ -69,6 +69,7 @@ import { default as Indeterminate } from "@/icons/components/IcIndeterminate";
 import { default as Info } from "@/icons/components/IcInfo";
 import { default as Laptop } from "@/icons/components/IcLaptop";
 import { default as LayoutDashboard } from "@/icons/components/IcLayoutDashboard";
+import { default as LayoutSingleURLs } from "@/icons/components/IcLayoutSingleURLs";
 import { default as LayoutTab } from "@/icons/components/IcLayoutTab";
 import { default as LayoutTall } from "@/icons/components/IcLayoutTall";
 import { default as LayoutVertical } from "@/icons/components/IcLayoutVertical";
@@ -216,6 +217,7 @@ export const Icons = {
   info: Info,
   laptop: Laptop,
   layoutDashboard: LayoutDashboard,
+  layoutSingleURLs: LayoutSingleURLs,
   layoutTall: LayoutTall,
   layoutTab: LayoutTab,
   layoutVertical: LayoutVertical,

--- a/app/icons/svg/ic_layout_single_urls.svg
+++ b/app/icons/svg/ic_layout_single_urls.svg
@@ -1,0 +1,19 @@
+<svg
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <g id="Icons/24dp/ic_layout_single">
+    <g id="ic_table">
+      <path
+        id="Combined Shape"
+        fill-rule="evenodd"
+        clip-rule="evenodd"
+        d="M21.9994 17.9824V4H4.9375V5L21.1068 4.99937V17.9824H21.9994ZM19.9994 6V19.9824H19.1068V6.99937L2.9375 7V6H19.9994ZM2 7.98438H18V20.9844H2V7.98438Z"
+        fill="#454545"
+      />
+    </g>
+  </g>
+</svg>

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -441,6 +441,7 @@ msgid "controls.filter.select.none"
 msgstr "Alle abwählen"
 
 #: app/configurator/components/field.tsx
+#: app/configurator/components/field.tsx
 msgid "controls.filter.use-most-recent"
 msgstr "Letztes Datum verwenden"
 
@@ -537,6 +538,10 @@ msgstr "Italienisch"
 #: app/configurator/components/field-i18n.ts
 msgid "controls.layout.dashboard"
 msgstr "Dashboard"
+
+#: app/configurator/components/field-i18n.ts
+msgid "controls.layout.singleURLs"
+msgstr "Einzelne URLs"
 
 #: app/configurator/components/field-i18n.ts
 msgid "controls.layout.tab"
@@ -674,6 +679,7 @@ msgstr "Spalten"
 msgid "controls.section.columnstyle"
 msgstr "Spaltenstil"
 
+#: app/components/chart-filters-list.tsx
 #: app/configurator/components/chart-configurator.tsx
 msgid "controls.section.data.filters"
 msgstr "Filter"

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -543,6 +543,10 @@ msgstr "Dashboard"
 msgid "controls.layout.singleURLs"
 msgstr "Einzelne URLs"
 
+#: app/configurator/components/configurator.tsx
+msgid "controls.layout.singleURLs.publish"
+msgstr "Wählen Sie die separat zu veröffentlichenden Diagramme aus."
+
 #: app/configurator/components/field-i18n.ts
 msgid "controls.layout.tab"
 msgstr "Tab Layout"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -441,6 +441,7 @@ msgid "controls.filter.select.none"
 msgstr "Select none"
 
 #: app/configurator/components/field.tsx
+#: app/configurator/components/field.tsx
 msgid "controls.filter.use-most-recent"
 msgstr "Use most recent"
 
@@ -537,6 +538,10 @@ msgstr "Italian"
 #: app/configurator/components/field-i18n.ts
 msgid "controls.layout.dashboard"
 msgstr "Dashboard"
+
+#: app/configurator/components/field-i18n.ts
+msgid "controls.layout.singleURLs"
+msgstr "Single URLs"
 
 #: app/configurator/components/field-i18n.ts
 msgid "controls.layout.tab"
@@ -674,6 +679,7 @@ msgstr "Columns"
 msgid "controls.section.columnstyle"
 msgstr "Column Style"
 
+#: app/components/chart-filters-list.tsx
 #: app/configurator/components/chart-configurator.tsx
 msgid "controls.section.data.filters"
 msgstr "Filters"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -543,6 +543,10 @@ msgstr "Dashboard"
 msgid "controls.layout.singleURLs"
 msgstr "Single URLs"
 
+#: app/configurator/components/configurator.tsx
+msgid "controls.layout.singleURLs.publish"
+msgstr "Select the charts to publish separately."
+
 #: app/configurator/components/field-i18n.ts
 msgid "controls.layout.tab"
 msgstr "Tab Layout"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -543,6 +543,10 @@ msgstr "Dashboard"
 msgid "controls.layout.singleURLs"
 msgstr "URL uniques"
 
+#: app/configurator/components/configurator.tsx
+msgid "controls.layout.singleURLs.publish"
+msgstr "Sélectionner les graphiques à publier séparément."
+
 #: app/configurator/components/field-i18n.ts
 msgid "controls.layout.tab"
 msgstr "Tab Layout"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -441,6 +441,7 @@ msgid "controls.filter.select.none"
 msgstr "Tout déselectionner"
 
 #: app/configurator/components/field.tsx
+#: app/configurator/components/field.tsx
 msgid "controls.filter.use-most-recent"
 msgstr "Utiliser le plus récent"
 
@@ -537,6 +538,10 @@ msgstr "Italien"
 #: app/configurator/components/field-i18n.ts
 msgid "controls.layout.dashboard"
 msgstr "Dashboard"
+
+#: app/configurator/components/field-i18n.ts
+msgid "controls.layout.singleURLs"
+msgstr "URL uniques"
 
 #: app/configurator/components/field-i18n.ts
 msgid "controls.layout.tab"
@@ -674,6 +679,7 @@ msgstr "Colonnes"
 msgid "controls.section.columnstyle"
 msgstr "Style de la colonne"
 
+#: app/components/chart-filters-list.tsx
 #: app/configurator/components/chart-configurator.tsx
 msgid "controls.section.data.filters"
 msgstr "Filtres"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -543,6 +543,10 @@ msgstr "Dashboard"
 msgid "controls.layout.singleURLs"
 msgstr "URL singolo"
 
+#: app/configurator/components/configurator.tsx
+msgid "controls.layout.singleURLs.publish"
+msgstr "Selezionare i grafici da pubblicare separatamente."
+
 #: app/configurator/components/field-i18n.ts
 msgid "controls.layout.tab"
 msgstr "Tab Layout"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -441,6 +441,7 @@ msgid "controls.filter.select.none"
 msgstr "Deseleziona tutto"
 
 #: app/configurator/components/field.tsx
+#: app/configurator/components/field.tsx
 msgid "controls.filter.use-most-recent"
 msgstr "Usare il più recente"
 
@@ -537,6 +538,10 @@ msgstr "Italiano"
 #: app/configurator/components/field-i18n.ts
 msgid "controls.layout.dashboard"
 msgstr "Dashboard"
+
+#: app/configurator/components/field-i18n.ts
+msgid "controls.layout.singleURLs"
+msgstr "URL singolo"
 
 #: app/configurator/components/field-i18n.ts
 msgid "controls.layout.tab"
@@ -674,6 +679,7 @@ msgstr "Colonne"
 msgid "controls.section.columnstyle"
 msgstr "Stile della colonna"
 
+#: app/components/chart-filters-list.tsx
 #: app/configurator/components/chart-configurator.tsx
 msgid "controls.section.data.filters"
 msgstr "Filtri"


### PR DESCRIPTION
Closes #1325.

This PR introduces a single URLs layout mode, where user can publish several charts separately.

A new browser tab is opened for every chart, instead of the first one, which behaves in a regular way (goes to `/v/chart-id?publishSuccess=true` page).

### How to test
⚠️ **Publishing possible to test when deployed to TEST.**
1. Go to [the preview link](https://visualization-tool-git-feat-single-urls-layout-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9&dataSource=Prod&flag__layoutStep=true) (only to test the non-publishing behavior) or to [TEST link](https://test.visualize.admin.ch/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9&dataSource=Prod&flag__layoutStep=true) (once merged).
2. Add more charts.
3. Proceed to layout options.
4. Change layout mode to Single URLs.
5. See that it's possible to check charts to be published separately.
6. Click Publish button and see that every selected chart has been published in a different tab, with unique URL.