### PR TITLE
fix: Observations creation in dataset preview

### DIFF
--- a/app/rdf/query-cube-preview.spec.ts
+++ b/app/rdf/query-cube-preview.spec.ts
@@ -10,6 +10,7 @@ jest.mock("@zazuko/cube-hierarchy-query/index", () => ({}));
 
 describe("dataset preview", () => {
   const dim = rdf.blankNode();
+  const genericDim = rdf.blankNode();
   const measure = rdf.blankNode();
   const observation = rdf.namedNode(
     "https://environment.ld.admin.ch/foen/gefahren-waldbrand-warnung/observation/336>"
@@ -23,6 +24,8 @@ describe("dataset preview", () => {
       )
     ),
     rdf.quad(dim, ns.schema.name, rdf.literal("Region")),
+    rdf.quad(genericDim, ns.sh.path, ns.schema.name),
+    rdf.quad(genericDim, ns.schema.name, rdf.literal("Name")),
     rdf.quad(
       measure,
       ns.sh.path,
@@ -87,14 +90,18 @@ describe("dataset preview", () => {
         latest: true,
       }
     );
-    const dim = dimensions[0];
+    const dim = dimensions.find(
+      (d) =>
+        d.iri ===
+        "https://environment.ld.admin.ch/foen/gefahren-waldbrand-warnung/region"
+    );
 
-    expect(dim.iri).toEqual(
+    expect(dim?.iri).toEqual(
       "https://environment.ld.admin.ch/foen/gefahren-waldbrand-warnung/region"
     );
-    expect(dim.label).toEqual("Region");
-    expect(dim.values).toHaveLength(1);
-    expect(dim.values[0].position).toEqual(3);
+    expect(dim?.label).toEqual("Region");
+    expect(dim?.values).toHaveLength(1);
+    expect(dim?.values[0].position).toEqual(3);
 
     const measure = measures[0];
 
@@ -103,9 +110,10 @@ describe("dataset preview", () => {
     );
     expect(measure.label).toEqual("Danger ratings");
 
+    expect(observations).toHaveLength(1);
     const obs = observations[0];
 
-    expect(obs[dim.iri]).toEqual("Bern");
+    expect(obs[dim?.iri ?? ""]).toEqual("Bern");
     expect(obs[measure.iri]).toEqual("considerable danger");
   });
 });

--- a/app/rdf/query-cube-preview.ts
+++ b/app/rdf/query-cube-preview.ts
@@ -155,7 +155,12 @@ CONSTRUCT {
   }, {} as Record<string, { values: DimensionValue[]; dataType: NamedNode }>);
   // Only take quads that use dimension iris as predicates (observation values)
   const qUniqueObservations = uniqBy(
-    qs.filter(({ predicate: p }) => qsDims.some((q) => q.object.equals(p))),
+    qs.filter(
+      ({ subject: s, predicate: p }) =>
+        // Exclude situations where the subject is a blank node (e.g. dimension IRI
+        // is not unique, but something like ns.schema.name)
+        s.termType !== "BlankNode" && qsDims.some((q) => q.object.equals(p))
+    ),
     ({ subject: s }) => s.value
   );
   qUniqueObservations.forEach(({ subject: s }) => {


### PR DESCRIPTION
We need to account for a fact that sometimes dimension can have a generic iri, like `schema:name` – when creating observations, we need to bypass subjects of `BlankNode` type.

### How to test
1. Go to [deployment preview](https://visualization-tool-git-fix-dataset-preview-generic-07a3d2-ixt1.vercel.app/en/browse?previous=%7B%7D&dataset=https%3A%2F%2Ftransport.ld.admin.ch%2Ffoca%2FFOCA_Air_traffic_statistics_movements%2F3&dataSource=Prod) and see that it's not broken.
3. Go to [TEST](https://test.visualize.admin.ch/en/browse?previous=%7B%22order%22%3A%22CREATED_DESC%22%2C%22search%22%3A%22%22%7D&dataset=https%3A%2F%2Ftransport.ld.admin.ch%2Ffoca%2FFOCA_Air_traffic_statistics_movements%2F3&dataSource=Prod) and see that it's broken.