### PR TITLE
chore: Update k6 performance tests II

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -21,6 +21,7 @@ jobs:
             -e K6_PROMETHEUS_RW_USERNAME=${{ secrets.K6_PROMETHEUS_RW_USERNAME }}
             -e K6_PROMETHEUS_RW_PASSWORD=${{ secrets.K6_PROMETHEUS_RW_PASSWORD }}
             -e K6_PROMETHEUS_RW_SERVER_URL=${{ secrets.K6_PROMETHEUS_RW_SERVER_URL }}
+            -e K6_PROMETHEUS_RW_TREND_STATS=avg
           run: |
             k6 run -o experimental-prometheus-rw --tag testid=DataCubeComponents --env ENV=test --env CUBE_IRI=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9 --env CUBE_LABEL=Photovoltaikanlagen/9 - </root/k6/performance-tests/graphql/DataCubeComponents.js &&
             k6 run -o experimental-prometheus-rw --tag testid=DataCubeComponents --env ENV=test --env CUBE_IRI=https://environment.ld.admin.ch/foen/nfi/nfi_C-20/cube/2023-3 --env CUBE_LABEL=NFI/2023-3 - </root/k6/performance-tests/graphql/DataCubeComponents.js &&

--- a/k6/performance-tests/generate-github-action.js
+++ b/k6/performance-tests/generate-github-action.js
@@ -54,6 +54,7 @@ jobs:
             -e K6_PROMETHEUS_RW_USERNAME=\${{ secrets.K6_PROMETHEUS_RW_USERNAME }}
             -e K6_PROMETHEUS_RW_PASSWORD=\${{ secrets.K6_PROMETHEUS_RW_PASSWORD }}
             -e K6_PROMETHEUS_RW_SERVER_URL=\${{ secrets.K6_PROMETHEUS_RW_SERVER_URL }}
+            -e K6_PROMETHEUS_RW_TREND_STATS=avg
           run: |
             ${commands}`;
 

--- a/k6/performance-tests/graphql/DataCubeComponents.js
+++ b/k6/performance-tests/graphql/DataCubeComponents.js
@@ -39,7 +39,7 @@ const variables = {
 
 /** @type {import("k6/options").Options} */
 export const options = {
-  iterations: 1,
+  iterations: 2,
 };
 
 const headers = {

--- a/k6/performance-tests/graphql/DataCubeComponents.js
+++ b/k6/performance-tests/graphql/DataCubeComponents.js
@@ -57,7 +57,17 @@ export default function Components() {
     { headers }
   );
 
-  if (!check(res, { "Status code must be 200": (res) => res.status == 200 })) {
-    fail("Status code was *not* 200!");
-  }
+  check(res, {
+    "Response must have data": (res) => {
+      const body = res.json();
+      return (
+        body.data &&
+        body.data.dataCubeComponents &&
+        body.data.dataCubeComponents.dimensions &&
+        body.data.dataCubeComponents.dimensions.length > 0 &&
+        body.data.dataCubeComponents.measures &&
+        body.data.dataCubeComponents.measures.length > 0
+      );
+    },
+  });
 }

--- a/k6/performance-tests/graphql/DataCubeComponents.js
+++ b/k6/performance-tests/graphql/DataCubeComponents.js
@@ -16,9 +16,17 @@ const query = `query DataCubeComponents(
   )
 }`;
 
+const metadataByCubeIri = {
+  "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9":
+    {},
+  "https://environment.ld.admin.ch/foen/nfi/nfi_C-20/cube/2023-3": {},
+  "https://energy.ld.admin.ch/elcom/electricityprice": {},
+};
+
 const env = __ENV.ENV;
 const cubeIri = __ENV.CUBE_IRI;
 const cubeLabel = __ENV.CUBE_LABEL;
+const metadata = metadataByCubeIri[cubeIri];
 
 const variables = {
   locale: "en",

--- a/k6/performance-tests/graphql/DataCubeMetadata.js
+++ b/k6/performance-tests/graphql/DataCubeMetadata.js
@@ -39,7 +39,7 @@ const variables = {
 
 /** @type {import("k6/options").Options} */
 export const options = {
-  iterations: 1,
+  iterations: 2,
 };
 
 const headers = {

--- a/k6/performance-tests/graphql/DataCubeMetadata.js
+++ b/k6/performance-tests/graphql/DataCubeMetadata.js
@@ -16,9 +16,17 @@ const query = `query DataCubeMetadata(
   )
 }`;
 
+const metadataByCubeIri = {
+  "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9":
+    {},
+  "https://environment.ld.admin.ch/foen/nfi/nfi_C-20/cube/2023-3": {},
+  "https://energy.ld.admin.ch/elcom/electricityprice": {},
+};
+
 const env = __ENV.ENV;
 const cubeIri = __ENV.CUBE_IRI;
 const cubeLabel = __ENV.CUBE_LABEL;
+const metadata = metadataByCubeIri[cubeIri];
 
 const variables = {
   locale: "en",

--- a/k6/performance-tests/graphql/DataCubeMetadata.js
+++ b/k6/performance-tests/graphql/DataCubeMetadata.js
@@ -57,7 +57,14 @@ export default function Components() {
     { headers }
   );
 
-  if (!check(res, { "Status code must be 200": (res) => res.status == 200 })) {
-    fail("Status code was *not* 200!");
-  }
+  check(res, {
+    "Response must have data": (res) => {
+      const body = res.json();
+      return (
+        body.data &&
+        body.data.dataCubeMetadata &&
+        body.data.dataCubeMetadata.iri === cubeIri
+      );
+    },
+  });
 }

--- a/k6/performance-tests/graphql/DataCubeObservations.js
+++ b/k6/performance-tests/graphql/DataCubeObservations.js
@@ -16,64 +16,75 @@ const query = `query DataCubeObservations(
   )
 }`;
 
-const cubeFilterByCubeIri = {
+const metadataByCubeIri = {
   "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9":
     {
-      iri: "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9",
-      filters: {
-        "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Kanton":
-          {
-            type: "single",
-            value: "https://ld.admin.ch/canton/1",
-          },
+      cubeFilter: {
+        iri: "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9",
+        filters: {
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Kanton":
+            {
+              type: "single",
+              value: "https://ld.admin.ch/canton/1",
+            },
+        },
       },
     },
   "https://environment.ld.admin.ch/foen/nfi/nfi_C-20/cube/2023-3": {
-    iri: "https://environment.ld.admin.ch/foen/nfi/nfi_C-20/cube/2023-3",
-    filters: {
-      "https://environment.ld.admin.ch/foen/nfi/unitOfReference": {
-        type: "single",
-        value: "https://ld.admin.ch/country/CHE",
-      },
-      "https://environment.ld.admin.ch/foen/nfi/classificationUnit": {
-        type: "single",
-        value:
-          "https://environment.ld.admin.ch/foen/nfi/ClassificationUnit/Total",
-      },
-      "https://environment.ld.admin.ch/foen/nfi/inventory": {
-        type: "single",
-        value: "https://environment.ld.admin.ch/foen/nfi/Inventory/150",
-      },
-      "https://environment.ld.admin.ch/foen/nfi/unitOfEvaluation": {
-        type: "single",
-        value: "https://environment.ld.admin.ch/foen/nfi/UnitOfEvaluation/2382",
-      },
-      "https://environment.ld.admin.ch/foen/nfi/evaluationType": {
-        type: "single",
-        value: "https://environment.ld.admin.ch/foen/nfi/EvaluationType/1",
+    cubeFilter: {
+      iri: "https://environment.ld.admin.ch/foen/nfi/nfi_C-20/cube/2023-3",
+      filters: {
+        "https://environment.ld.admin.ch/foen/nfi/unitOfReference": {
+          type: "single",
+          value: "https://ld.admin.ch/country/CHE",
+        },
+        "https://environment.ld.admin.ch/foen/nfi/classificationUnit": {
+          type: "single",
+          value:
+            "https://environment.ld.admin.ch/foen/nfi/ClassificationUnit/Total",
+        },
+        "https://environment.ld.admin.ch/foen/nfi/inventory": {
+          type: "single",
+          value: "https://environment.ld.admin.ch/foen/nfi/Inventory/150",
+        },
+        "https://environment.ld.admin.ch/foen/nfi/unitOfEvaluation": {
+          type: "single",
+          value:
+            "https://environment.ld.admin.ch/foen/nfi/UnitOfEvaluation/2382",
+        },
+        "https://environment.ld.admin.ch/foen/nfi/evaluationType": {
+          type: "single",
+          value: "https://environment.ld.admin.ch/foen/nfi/EvaluationType/1",
+        },
       },
     },
   },
   "https://energy.ld.admin.ch/elcom/electricityprice": {
-    iri: "https://energy.ld.admin.ch/elcom/electricityprice",
-    filters: {
-      "https://energy.ld.admin.ch/elcom/electricityprice/dimension/municipality":
-        {
+    cubeFilter: {
+      iri: "https://energy.ld.admin.ch/elcom/electricityprice",
+      filters: {
+        "https://energy.ld.admin.ch/elcom/electricityprice/dimension/municipality":
+          {
+            type: "single",
+            value: "https://ld.admin.ch/municipality/1",
+          },
+        "https://energy.ld.admin.ch/elcom/electricityprice/dimension/category":
+          {
+            type: "single",
+            value:
+              "https://energy.ld.admin.ch/elcom/electricityprice/category/C1",
+          },
+        "https://energy.ld.admin.ch/elcom/electricityprice/dimension/operator":
+          {
+            type: "single",
+            value:
+              "https://energy.ld.admin.ch/elcom/electricityprice/operator/486",
+          },
+        "https://energy.ld.admin.ch/elcom/electricityprice/dimension/product": {
           type: "single",
-          value: "https://ld.admin.ch/municipality/1",
+          value:
+            "https://energy.ld.admin.ch/elcom/electricityprice/product/standard",
         },
-      "https://energy.ld.admin.ch/elcom/electricityprice/dimension/category": {
-        type: "single",
-        value: "https://energy.ld.admin.ch/elcom/electricityprice/category/C1",
-      },
-      "https://energy.ld.admin.ch/elcom/electricityprice/dimension/operator": {
-        type: "single",
-        value: "https://energy.ld.admin.ch/elcom/electricityprice/operator/486",
-      },
-      "https://energy.ld.admin.ch/elcom/electricityprice/dimension/product": {
-        type: "single",
-        value:
-          "https://energy.ld.admin.ch/elcom/electricityprice/product/standard",
       },
     },
   },
@@ -82,12 +93,13 @@ const cubeFilterByCubeIri = {
 const env = __ENV.ENV;
 const cubeIri = __ENV.CUBE_IRI;
 const cubeLabel = __ENV.CUBE_LABEL;
+const metadata = metadataByCubeIri[cubeIri];
 
 const variables = {
   locale: "en",
   sourceType: "sparql",
   sourceUrl: "https://lindas.admin.ch/query",
-  cubeFilter: cubeFilterByCubeIri[cubeIri],
+  cubeFilter: metadata.cubeFilter,
 };
 
 /** @type {import("k6/options").Options} */

--- a/k6/performance-tests/graphql/DataCubeObservations.js
+++ b/k6/performance-tests/graphql/DataCubeObservations.js
@@ -104,7 +104,7 @@ const variables = {
 
 /** @type {import("k6/options").Options} */
 export const options = {
-  iterations: 1,
+  iterations: 2,
 };
 
 const headers = {

--- a/k6/performance-tests/graphql/DataCubeObservations.js
+++ b/k6/performance-tests/graphql/DataCubeObservations.js
@@ -122,7 +122,16 @@ export default function Observations() {
     { headers }
   );
 
-  if (!check(res, { "Status code must be 200": (res) => res.status == 200 })) {
-    fail("Status code was *not* 200!");
-  }
+  check(res, {
+    "Response must have data": (res) => {
+      const body = res.json();
+      return (
+        body.data &&
+        body.data.dataCubeObservations &&
+        body.data.dataCubeObservations &&
+        body.data.dataCubeObservations.data.length > 0 &&
+        body.data.dataCubeObservations.sparqlEditorUrl
+      );
+    },
+  });
 }

--- a/k6/performance-tests/graphql/DataCubePreview.js
+++ b/k6/performance-tests/graphql/DataCubePreview.js
@@ -40,7 +40,7 @@ const variables = {
 
 /** @type {import("k6/options").Options} */
 export const options = {
-  iterations: 1,
+  iterations: 2,
 };
 
 const headers = {

--- a/k6/performance-tests/graphql/DataCubePreview.js
+++ b/k6/performance-tests/graphql/DataCubePreview.js
@@ -58,7 +58,19 @@ export default function Components() {
     { headers }
   );
 
-  if (!check(res, { "Status code must be 200": (res) => res.status == 200 })) {
-    fail("Status code was *not* 200!");
-  }
+  check(res, {
+    "Response must have data": (res) => {
+      const body = res.json();
+      return (
+        body.data &&
+        body.data.dataCubePreview &&
+        body.data.dataCubePreview.dimensions &&
+        body.data.dataCubePreview.dimensions.length > 0 &&
+        body.data.dataCubePreview.measures &&
+        body.data.dataCubePreview.measures.length > 0 &&
+        body.data.dataCubePreview.observations &&
+        body.data.dataCubePreview.observations.length > 0
+      );
+    },
+  });
 }

--- a/k6/performance-tests/graphql/DataCubePreview.js
+++ b/k6/performance-tests/graphql/DataCubePreview.js
@@ -16,9 +16,17 @@ const query = `query DataCubePreview(
   )
 }`;
 
+const metadataByCubeIri = {
+  "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9":
+    {},
+  "https://environment.ld.admin.ch/foen/nfi/nfi_C-20/cube/2023-3": {},
+  "https://energy.ld.admin.ch/elcom/electricityprice": {},
+};
+
 const env = __ENV.ENV;
 const cubeIri = __ENV.CUBE_IRI;
 const cubeLabel = __ENV.CUBE_LABEL;
+const metadata = metadataByCubeIri[cubeIri];
 
 const variables = {
   locale: "en",

--- a/k6/performance-tests/graphql/PossibleFilters.js
+++ b/k6/performance-tests/graphql/PossibleFilters.js
@@ -98,7 +98,7 @@ const variables = {
 
 /** @type {import("k6/options").Options} */
 export const options = {
-  iterations: 1,
+  iterations: 2,
 };
 
 const headers = {

--- a/k6/performance-tests/graphql/PossibleFilters.js
+++ b/k6/performance-tests/graphql/PossibleFilters.js
@@ -116,7 +116,14 @@ export default function Observations() {
     { headers }
   );
 
-  if (!check(res, { "Status code must be 200": (res) => res.status == 200 })) {
-    fail("Status code was *not* 200!");
-  }
+  check(res, {
+    "Response must have data": (res) => {
+      const body = res.json();
+      return (
+        body.data &&
+        body.data.possibleFilters &&
+        body.data.possibleFilters.length > 0
+      );
+    },
+  });
 }

--- a/k6/performance-tests/graphql/PossibleFilters.js
+++ b/k6/performance-tests/graphql/PossibleFilters.js
@@ -20,7 +20,7 @@ const query = `query PossibleFilters(
   }
 }`;
 
-const cubeFilterByCubeIri = {
+const metadataByCubeIri = {
   "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9":
     {
       iri: "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9",
@@ -86,13 +86,14 @@ const cubeFilterByCubeIri = {
 const env = __ENV.ENV;
 const cubeIri = __ENV.CUBE_IRI;
 const cubeLabel = __ENV.CUBE_LABEL;
+const metadata = metadataByCubeIri[cubeIri];
 
 const variables = {
   iri: cubeIri,
   locale: "en",
   sourceType: "sparql",
   sourceUrl: "https://lindas.admin.ch/query",
-  filters: cubeFilterByCubeIri[cubeIri],
+  filters: metadata.filters,
 };
 
 /** @type {import("k6/options").Options} */


### PR DESCRIPTION
This PR:
- increases number of test iterations from 1 to 2 to decrease number of false-positives (long query duration caused by some factor not related to code change),
- adds `k6_http_req_duration_avg` metric to the payload sent to Prometheus (average request duration computed from 2 iterations),
- adds data correctness checks to every GQL performance test.

These changes are coordinated with accompanying changes to Grafana dashboard.