### PR TITLE
fix: Table issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 - Fixes
   - Interactive filters and table previews now work correctly in dashboard layout layouts
   - Table filters are now applied correctly again
+  - Select elements for table column styles are not empty by default anymore
+  - Disabled `Interactive` toggle for temporal dimensions used in column charts, as they don't support interactive filters
 - Performance
   - Significantly improved performance of dataset previews
 - Maintenance

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -1135,7 +1135,7 @@ export const getTimeFilterOptions = (props: GetTimeFilterOptionsProps) => {
   };
 };
 
-export const InteractiveTimeRangeToggle = (
+const InteractiveTimeRangeToggle = (
   props: Omit<FormControlLabelProps, "control" | "label">
 ) => {
   const { checked, toggle } = useInteractiveTimeRangeToggle();

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -188,7 +188,7 @@ export const useChartOptionSelectField = <V extends {} = string>(
   if (state.state === "CONFIGURING_CHART") {
     value = get(
       getChartConfig(state),
-      `fields.${field}.${path}`,
+      `fields["${field}"].${path}`,
       FIELD_VALUE_NONE
     );
   }

--- a/app/configurator/table/table-chart-options.tsx
+++ b/app/configurator/table/table-chart-options.tsx
@@ -376,7 +376,11 @@ export const TableColumnOptions = ({
                 id={`select-single-filter-time`}
               />
             ) : (
-              <TimeFilter key={component.iri} dimension={component} />
+              <TimeFilter
+                key={component.iri}
+                dimension={component}
+                disableInteractiveFilters
+              />
             )}
           </ControlSectionContent>
         </ControlSection>


### PR DESCRIPTION
This PR:
- disables "Interactive" toggle for temporal dimension in table charts, as we can't use interactive filters with tables,
- fixes empty select elements in tables.

### How to test
**Fixed version (PR)**
1. Go to [this link](https://visualization-tool-git-fix-tables-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9&dataSource=Prod).
2. Switch to a table chart.
3. Select Kanton column.
4. See that the select elements are filled.
<img width="328" alt="Screenshot 2024-02-20 at 15 17 04" src="https://github.com/visualize-admin/visualization-tool/assets/52032047/347a2be3-1ee0-4de0-8ea2-98a959cc0149">

5. Go to Jahr der Vergütung column.
6. See that the "Interactive" toggle is not here.

**Broken version (TEST, INT, PROD)**
Go to [this link](https://visualize.admin.ch/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9) and repeat the steps above to see how the state is currently broken.