### PR TITLE
fix: Remove extra published_state property in the configurator state

### DIFF
--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -1134,7 +1134,6 @@ const Config = t.type(
     layout: Layout,
     chartConfigs: t.array(ChartConfig),
     activeChartKey: t.string,
-    published_state: t.string,
   },
   "Config"
 );
@@ -1153,7 +1152,6 @@ const ConfiguratorStateInitial = t.type({
   state: t.literal("INITIAL"),
   version: t.string,
   dataSource: DataSource,
-  published_state: t.string,
 });
 export type ConfiguratorStateInitial = t.TypeOf<
   typeof ConfiguratorStateInitial
@@ -1166,7 +1164,6 @@ const ConfiguratorStateSelectingDataSet = t.type({
   chartConfigs: t.undefined,
   layout: t.undefined,
   activeChartKey: t.undefined,
-  published_state: t.string,
 });
 export type ConfiguratorStateSelectingDataSet = t.TypeOf<
   typeof ConfiguratorStateSelectingDataSet

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -334,7 +334,6 @@ const INITIAL_STATE: ConfiguratorState = {
   version: CONFIGURATOR_STATE_VERSION,
   state: "INITIAL",
   dataSource: DEFAULT_DATA_SOURCE,
-  published_state: PUBLISHED_STATE.DRAFT,
 };
 
 const EMPTY_STATE: ConfiguratorStateSelectingDataSet = {
@@ -345,7 +344,6 @@ const EMPTY_STATE: ConfiguratorStateSelectingDataSet = {
   chartConfigs: undefined,
   layout: undefined,
   activeChartKey: undefined,
-  published_state: PUBLISHED_STATE.DRAFT,
 };
 
 const getCachedComponents = (
@@ -653,7 +651,6 @@ const transitionStepNext = (
           version: CONFIGURATOR_STATE_VERSION,
           state: "CONFIGURING_CHART",
           dataSource: draft.dataSource,
-          published_state: draft.published_state,
           layout: {
             type: "tab",
             meta: {

--- a/app/docs/columns.docs.tsx
+++ b/app/docs/columns.docs.tsx
@@ -41,7 +41,6 @@ ${(
         },
         chartConfigs: [chartConfig],
         activeChartKey: "scatterplot",
-        published_state: "PUBLISHED",
       }}
     >
       <InteractiveFiltersProvider>

--- a/app/docs/fixtures.ts
+++ b/app/docs/fixtures.ts
@@ -10,7 +10,6 @@ export const states: ConfiguratorState[] = [
     state: "SELECTING_DATASET",
     version: CONFIGURATOR_STATE_VERSION,
     dataSource: DEFAULT_DATA_SOURCE,
-    published_state: "PUBLISHED",
     chartConfigs: undefined,
     layout: undefined,
     activeChartKey: undefined,
@@ -19,7 +18,6 @@ export const states: ConfiguratorState[] = [
     state: "CONFIGURING_CHART",
     version: CONFIGURATOR_STATE_VERSION,
     dataSource: DEFAULT_DATA_SOURCE,
-    published_state: "PUBLISHED",
     layout: {
       type: "tab",
       meta: {

--- a/app/docs/lines.docs.tsx
+++ b/app/docs/lines.docs.tsx
@@ -33,7 +33,6 @@ ${(
         version: CONFIGURATOR_STATE_VERSION,
         state: "PUBLISHED",
         dataSource: { type: "sparql", url: "" },
-        published_state: "PUBLISHED",
         layout: {
           type: "tab",
           meta: {

--- a/app/docs/scatterplot.docs.tsx
+++ b/app/docs/scatterplot.docs.tsx
@@ -36,7 +36,6 @@ ${(
         version: CONFIGURATOR_STATE_VERSION,
         state: "PUBLISHED",
         dataSource: { type: "sparql", url: "" },
-        published_state: "PUBLISHED",
         layout: {
           type: "tab",
           meta: {

--- a/app/utils/chart-config/versioning.spec.ts
+++ b/app/utils/chart-config/versioning.spec.ts
@@ -5,7 +5,14 @@ import {
   MapConfig,
 } from "@/config-types";
 
-import { migrateChartConfig } from "./versioning";
+import {
+  chartConfigMigrations,
+  CHART_CONFIG_VERSION,
+  configuratorStateMigrations,
+  CONFIGURATOR_STATE_VERSION,
+  migrateChartConfig,
+  upOrDown,
+} from "./versioning";
 
 const CONFIGURATOR_STATE = {
   meta: {
@@ -158,5 +165,23 @@ describe("config migrations", () => {
     expect(
       migratedOldConfig.interactiveFiltersConfig?.timeRange.componentIri
     ).toEqual("");
+  });
+});
+
+describe("last version", () => {
+  it("should have a version superior to the last migration (configurator state)", () => {
+    const direction = upOrDown(
+      CONFIGURATOR_STATE_VERSION,
+      configuratorStateMigrations[configuratorStateMigrations.length - 1].to
+    );
+    expect(direction).toBe("same");
+  });
+
+  it("should have a version superior to the last migration (chart config)", () => {
+    const direction = upOrDown(
+      CHART_CONFIG_VERSION,
+      chartConfigMigrations[chartConfigMigrations.length - 1].to
+    );
+    expect(direction).toBe("same");
   });
 });

--- a/app/utils/chart-config/versioning.ts
+++ b/app/utils/chart-config/versioning.ts
@@ -1,4 +1,3 @@
-import { PUBLISHED_STATE } from "@prisma/client";
 import produce from "immer";
 
 import { mapValueIrisToColor } from "@/configurator/components/ui-helpers";
@@ -990,25 +989,6 @@ const configuratorStateMigrations: Migration[] = [
           },
         };
         delete draft.layout;
-      });
-    },
-  },
-  {
-    description: "ALL + published_state",
-    from: "3.1.0",
-    to: "3.2.0",
-    up: (config) => {
-      const newConfig = { ...config, version: "3.2.0" };
-
-      return produce(newConfig, (draft: any) => {
-        draft.published_state = PUBLISHED_STATE.PUBLISHED;
-      });
-    },
-    down: (config) => {
-      const newConfig = { ...config, version: "3.1.0" };
-
-      return produce(newConfig, (draft: any) => {
-        delete draft.published_state;
       });
     },
   },

--- a/app/utils/chart-config/versioning.ts
+++ b/app/utils/chart-config/versioning.ts
@@ -14,7 +14,7 @@ type Migration = {
 
 export const CHART_CONFIG_VERSION = "3.0.0";
 
-const chartConfigMigrations: Migration[] = [
+export const chartConfigMigrations: Migration[] = [
   {
     description: `MAP
     baseLayer {
@@ -814,7 +814,7 @@ export const migrateChartConfig = makeMigrate(chartConfigMigrations, {
 
 export const CONFIGURATOR_STATE_VERSION = "3.1.0";
 
-const configuratorStateMigrations: Migration[] = [
+export const configuratorStateMigrations: Migration[] = [
   {
     description: "ALL",
     from: "1.0.0",
@@ -1049,7 +1049,7 @@ function makeMigrate(
   };
 }
 
-const upOrDown = (
+export const upOrDown = (
   fromVersion: string,
   toVersion: string
 ): "up" | "down" | "same" => {


### PR DESCRIPTION
Made a silly mistake where I put published_state in the config and also
in the configurator state. Published_state should only be in the config,
not the state.

This resulted in old charts not being able to edited/copied/viewed due
to missing property while decoding configurator state.

Fix https://github.com/visualize-admin/visualization-tool/issues/1354

