### PR TITLE
chore: Increase GQL API timeout duration (Vercel)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Nothing yet.
 
 - Fixes
   - The application no longer breaks in specific cases when filters were re-loaded
+- Maintenance
+  - Increased timeout duration for GQL API (Vercel deployments)
 
 # [3.26.1] - 2024-02-22
 

--- a/app/pages/api/graphql.ts
+++ b/app/pages/api/graphql.ts
@@ -47,6 +47,8 @@ export const config = {
   api: {
     bodyParser: false,
   },
+  // see https://vercel.com/docs/functions/configuring-functions/duration
+  maxDuration: 60,
 };
 
 const start = server.start();


### PR DESCRIPTION
This PR increases GQL API timeout duration from [default 15s](https://vercel.com/docs/functions/runtimes#max-duration) to 60s (see https://vercel.com/docs/functions/configuring-functions/duration), so larger cubes should also load in deployment previews.