### PR TITLE
feat: Temporal ordinal dimension is taken as second priority when inferring x-axis for columns

### DIFF
--- a/app/charts/index.spec.ts
+++ b/app/charts/index.spec.ts
@@ -1,5 +1,6 @@
 import { ColumnConfig, TableFields } from "@/configurator";
 import { Dimension, Measure } from "@/domain/data";
+import { TimeUnit } from "@/graphql/resolver-types";
 import { RDFCubeViewQueryMock } from "@/test/cube-view-query-mock";
 
 import bathingWaterData from "../test/__fixtures/data/DataCubeMetadataWithComponentValues-bathingWater.json";
@@ -12,6 +13,56 @@ import {
 } from "./index";
 
 RDFCubeViewQueryMock;
+
+const mockDimensions: Record<string, Dimension> = {
+  geoCoordinates: {
+    __typename: "GeoCoordinatesDimension",
+    cubeIri: "https://cube-iri",
+    isKeyDimension: true,
+    values: [],
+    iri: "geo-coordinates-dimension-iri",
+    isNumerical: false,
+    label: "Geo coordinates dimension",
+  },
+  ordinal: {
+    __typename: "OrdinalDimension",
+    cubeIri: "https://cube-iri",
+    isKeyDimension: true,
+    values: [],
+    iri: "ordinal-dimension-iri",
+    isNumerical: true,
+    label: "Ordinal dimension",
+  },
+  temporal: {
+    __typename: "TemporalDimension",
+    cubeIri: "https://cube-iri",
+    isKeyDimension: true,
+    values: [],
+    timeFormat: "%Y",
+    timeUnit: TimeUnit.Year,
+    iri: "temporal-dimension-iri",
+    isNumerical: true,
+    label: "Temporal dimension",
+  },
+  temporalOrdinal: {
+    __typename: "TemporalOrdinalDimension",
+    cubeIri: "https://cube-iri",
+    isKeyDimension: true,
+    values: [],
+    iri: "temporal-ordinal-dimension-iri",
+    isNumerical: true,
+    label: "Temporal ordinal dimension",
+  },
+  ordinal2: {
+    __typename: "OrdinalDimension",
+    cubeIri: "https://cube-iri",
+    isKeyDimension: true,
+    values: [],
+    iri: "ordinal-dimension-2-iri",
+    isNumerical: false,
+    label: "Ordinal dimension 2",
+  },
+};
 
 describe("initial config", () => {
   it("should create an initial table config with column order based on dimension order", () => {
@@ -38,6 +89,41 @@ describe("initial config", () => {
       ["https://environment.ld.admin.ch/foen/nfi/grid", 6],
       ["https://environment.ld.admin.ch/foen/nfi/evaluationType", 7],
     ]);
+  });
+
+  it("should create an initial column config having x axis correctly inferred (temporal ordinal)", () => {
+    const config = getInitialConfig({
+      chartType: "column",
+      iris: ["https://environment.ld.admin.ch/foen/nfi"],
+      dimensions: [
+        mockDimensions.geoCoordinates,
+        mockDimensions.ordinal,
+        mockDimensions.temporalOrdinal,
+        mockDimensions.ordinal2,
+      ],
+      measures: forestAreaData.data.dataCubeByIri.measures as any as Measure[],
+    }) as ColumnConfig;
+
+    expect(config.fields.x.componentIri).toEqual(
+      "temporal-ordinal-dimension-iri"
+    );
+  });
+
+  it("should create an initial column config having x axis correctly inferred (temporal > temporal ordinal)", () => {
+    const config = getInitialConfig({
+      chartType: "column",
+      iris: ["https://environment.ld.admin.ch/foen/nfi"],
+      dimensions: [
+        mockDimensions.geoCoordinates,
+        mockDimensions.ordinal,
+        mockDimensions.temporalOrdinal,
+        mockDimensions.temporal,
+        mockDimensions.ordinal2,
+      ],
+      measures: forestAreaData.data.dataCubeByIri.measures as any as Measure[],
+    }) as ColumnConfig;
+
+    expect(config.fields.x.componentIri).toEqual("temporal-dimension-iri");
   });
 });
 

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -73,6 +73,7 @@ import {
   Measure,
   NumericalMeasure,
 } from "@/domain/data";
+import { truthy } from "@/domain/types";
 import {
   DEFAULT_CATEGORICAL_PALETTE_NAME,
   getDefaultCategoricalPaletteName,
@@ -139,12 +140,16 @@ export const chartTypesOrder: { [k in ChartType]: number } = {
  */
 const findPreferredDimension = (
   dimensions: Component[],
-  preferredType?: DimensionType
+  preferredTypes?: DimensionType[]
 ) => {
   const dim =
-    dimensions.find(
-      (d) => d.__typename === preferredType && d.isKeyDimension
-    ) ??
+    preferredTypes
+      ?.map((preferredType) =>
+        dimensions.find(
+          (d) => d.__typename === preferredType && d.isKeyDimension
+        )
+      )
+      .filter(truthy)[0] ??
     dimensions.find((d) => d.isKeyDimension) ??
     dimensions[0];
 
@@ -379,7 +384,7 @@ export const getInitialConfig = (
     case "column":
       const columnXComponentIri = findPreferredDimension(
         sortBy(dimensions, (d) => (isGeoDimension(d) ? 1 : -1)),
-        "TemporalDimension"
+        ["TemporalDimension", "TemporalOrdinalDimension"]
       ).iri;
 
       return {


### PR DESCRIPTION
fix #1373

When creating a column chart, we take either temporal or temporal ordinal dimension as default
for x axis.

This can be verified with NFI cubes where the "Inventory" dimension is a Temporal Ordinal Dimension.

For ex: `/en/browse?dataset=https%3A%2F%2Fenvironment.ld.admin.ch%2Ffoen%2Fnfi%2Fnfi_T-6.1%40bundesamt-fuer-umwelt%2Fcube%2F2024-1&dataSource=Test`

