### PR TITLE
Fix: Publish chart from copy

### DIFF
--- a/app/components/chart-selection-tabs.tsx
+++ b/app/components/chart-selection-tabs.tsx
@@ -348,7 +348,6 @@ export const SaveDraftButton = ({
       if (config?.user_id && loggedInId) {
         const updated = await updatePublishedStateMut.mutate({
           data: state,
-          user_id: loggedInId,
           published_state: PUBLISHED_STATE.DRAFT,
           key: config.key,
         });

--- a/app/components/confirmation-dialog.tsx
+++ b/app/components/confirmation-dialog.tsx
@@ -8,7 +8,6 @@ import {
   DialogContentText,
   DialogProps,
   DialogTitle,
-  Typography,
 } from "@mui/material";
 import React from "react";
 
@@ -36,14 +35,12 @@ const ConfirmationDialog = ({
       maxWidth="xs"
       {...props}
     >
-      <DialogTitle>
-        <Typography variant="h3">
-          {title ??
-            t({
-              id: "login.profile.chart.confirmation.default",
-              message: "Are you sure you want to perform this action?",
-            })}
-        </Typography>
+      <DialogTitle sx={{ typography: "h3" }}>
+        {title ??
+          t({
+            id: "login.profile.chart.confirmation.default",
+            message: "Are you sure you want to perform this action?",
+          })}
       </DialogTitle>
       {text && (
         <DialogContent>

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -1127,17 +1127,20 @@ const Layout = t.intersection([
 export type Layout = t.TypeOf<typeof Layout>;
 export type LayoutType = Layout["type"];
 
-const Config = t.type(
-  {
-    version: t.string,
-    dataSource: DataSource,
-    layout: Layout,
-    chartConfigs: t.array(ChartConfig),
-    activeChartKey: t.string,
-  },
-  "Config"
-);
-[];
+const Config = t.intersection([
+  t.type(
+    {
+      version: t.string,
+      dataSource: DataSource,
+      layout: Layout,
+      chartConfigs: t.array(ChartConfig),
+      activeChartKey: t.string,
+    },
+    "Config"
+  ),
+  t.partial({ key: t.string }),
+]);
+
 export type Config = t.TypeOf<typeof Config>;
 
 export const isValidConfig = (config: unknown): config is Config => {

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -113,12 +113,13 @@ describe("initChartStateFromChart", () => {
   it("should fetch work if existing chart is valid", async () => {
     setup({
       chartConfig: {
-        data: fakeVizFixture,
+        data: { ...fakeVizFixture, key: "abcde" },
       },
     });
     // @ts-ignore
     const { key, activeChartKey, chartConfigs, ...rest } =
       await initChartStateFromChartCopy("abcde");
+    expect(key).toBe(undefined);
     const { key: chartConfigKey, ...chartConfig } = chartConfigs[0];
     const {
       key: migratedKey,

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -1904,7 +1904,6 @@ async function publishState(
         ? updateConfig({
             data: preparedConfig,
             key: dbConfig.key,
-            user_id: user.id,
             published_state: PUBLISHED_STATE.PUBLISHED,
           })
         : createConfig({

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -1461,6 +1461,8 @@ export const initChartStateFromChartCopy = async (
   const config = await fetchChartConfig(fromChartId);
 
   if (config?.data) {
+    // Do not keep the previous chart key
+    delete config.data.key;
     return migrateConfiguratorState({
       ...config.data,
       state: "CONFIGURING_CHART",

--- a/app/db/config.ts
+++ b/app/db/config.ts
@@ -47,12 +47,10 @@ export const createConfig = async ({
 export const updateConfig = async ({
   key,
   data,
-  user_id,
   published_state,
 }: {
   key: string;
   data: Prisma.ConfigUpdateInput["data"];
-  user_id: User["id"];
   published_state: Prisma.ConfigUpdateInput["published_state"];
 }): Promise<{ key: string }> => {
   return await prisma.config.update({
@@ -62,7 +60,6 @@ export const updateConfig = async ({
     data: {
       key,
       data,
-      user_id,
       updated_at: new Date(),
       published_state: published_state,
     },

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -206,7 +206,6 @@ const RenameDialog = ({
 
       await updateConfigMut.mutate({
         key: config.key,
-        user_id: userId,
         data: {
           ...config.data,
           chartConfigs: config.data.chartConfigs.map((x, i) => ({
@@ -388,7 +387,6 @@ const ProfileVisualizationsRow = (props: ProfileVisualizationsRowProps) => {
             onClick: async () => {
               await updateConfigMut.mutate({
                 key: config.key,
-                user_id: userId,
                 data: {
                   ...config.data,
                   state: "PUBLISHING",
@@ -443,7 +441,6 @@ const ProfileVisualizationsRow = (props: ProfileVisualizationsRowProps) => {
     openRename,
     removeConfigMut,
     updateConfigMut,
-    userId,
   ]);
 
   const chartTitle = React.useMemo(() => {

--- a/app/themes/federal.tsx
+++ b/app/themes/federal.tsx
@@ -1,5 +1,5 @@
 import { Fade, Grow } from "@mui/material";
-import { Breakpoint, createTheme, Theme } from "@mui/material/styles";
+import { Breakpoint, Theme, createTheme } from "@mui/material/styles";
 import merge from "lodash/merge";
 import omit from "lodash/omit";
 
@@ -402,6 +402,11 @@ theme.components = {
     styleOverrides: {
       root: {
         padding: "30px",
+        paddingBottom: "16px",
+
+        "&&": {
+          lineHeight: "1.5",
+        },
       },
     },
   },

--- a/app/utils/chart-config/api.ts
+++ b/app/utils/chart-config/api.ts
@@ -23,7 +23,6 @@ type CreateConfigOptions = {
 
 type UpdateConfigOptions = {
   key: string;
-  user_id: number;
   published_state?: PUBLISHED_STATE;
   data: ConfiguratorState;
 };
@@ -61,7 +60,7 @@ export const createConfig = async (options: CreateConfigOptions) => {
 };
 
 export const updateConfig = async (options: UpdateConfigOptions) => {
-  const { key, user_id, published_state } = options;
+  const { key, published_state } = options;
 
   return apiFetch<InferAPIResponse<typeof apiConfigUpdate, "POST">>(
     "/api/config-update",
@@ -69,7 +68,6 @@ export const updateConfig = async (options: UpdateConfigOptions) => {
       method: "POST",
       data: prepareForServer({
         key,
-        user_id,
         data: {
           key,
           ...options.data,


### PR DESCRIPTION
Fixing #1379.

When copying over a chart, the key was not removed, and due to small changes in how chart were published, we would try to create a new chart config under the "old" key, leading to an error.

Now, since the key is removed from the config after it has been copied, the new key is correctly used.