### PR TITLE
fix: SingleURLs publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 
 ## Unreleased
 
-Nothing yet.
+- Fixes
+  - SingleURLs layout mode now correctly publishes charts
 
 # [3.26.3] - 2024-03-05
 

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -8,6 +8,7 @@ import {
   ColumnConfig,
   ComboLineDualConfig,
   ConfiguratorStateConfiguringChart,
+  ConfiguratorStatePublishing,
   DataSource,
   Filters,
   getChartConfig,
@@ -26,6 +27,7 @@ import {
   initChartStateFromCube,
   initChartStateFromLocalStorage,
   moveFilterField,
+  publishState,
   setRangeFilter,
   updateColorMapping,
 } from "@/configurator/configurator-state";
@@ -55,6 +57,7 @@ jest.mock("rdf-cube-view-query", () => ({
 }));
 
 jest.mock("@/utils/chart-config/api", () => ({
+  createConfig: jest.fn(),
   fetchChartConfig: jest.fn(),
 }));
 
@@ -1199,5 +1202,31 @@ describe("filtering", () => {
       { time2: { type: "range", from: "2010", to: "2014" } },
       { time3: { type: "range", from: "2010", to: "2014" } },
     ]);
+  });
+});
+
+describe("publishing chart config", () => {
+  it("should run correct number of times in singleURLs layout mode", async () => {
+    const key = "ABC";
+    const publishableChartKeys = ["A", "C"];
+    const state = {
+      state: "PUBLISHING",
+      key,
+      layout: {
+        type: "singleURLs",
+        publishableChartKeys,
+      },
+      chartConfigs: [
+        { key: "A", cubes: [] },
+        { key: "B", cubes: [] },
+        { key: "C", cubes: [] },
+      ],
+    } as any as ConfiguratorStatePublishing;
+
+    const cb = jest.fn();
+    await publishState({} as any, key, state, async (_, i) => cb(i));
+    expect(cb.mock.calls.map((c) => c[0])).toEqual(
+      Array.from({ length: publishableChartKeys.length }, (_, i) => i + 1)
+    );
   });
 });

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -1856,7 +1856,7 @@ async function publishState(
   key: string,
   state: Extract<ConfiguratorState, { state: "PUBLISHING" }>,
 
-  /** Will be called for all config that have been shared (multiple one in case of layout:singleURLs) */
+  /** Will be called for all configs that have been shared (multiple ones in case of layout:singleURLs) */
   onSaveConfig: (savedConfig: { key: string }, i: number, total: number) => void
 ) {
   switch (state.layout.type) {
@@ -1885,8 +1885,8 @@ async function publishState(
           data: preparedConfig,
           published_state: PUBLISHED_STATE.PUBLISHED,
         });
+        onSaveConfig(result, i + 1, reversedChartKeys.length);
 
-        onSaveConfig(result, i, reversedChartKeys.length);
         return result;
       });
     default:

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -1629,34 +1629,24 @@ const ConfiguratorStateProviderInternal = (
           (async () => {
             try {
               const key = getRouterChartId(asPath);
+
               if (!key) {
                 return;
               }
-              switch (state.layout.type) {
-                case "singleURLs": {
-                  return publishState(
-                    user,
-                    key,
-                    state,
-                    async (result, i, total) => {
-                      if (i < total) {
-                        // Open new tab for each chart, except the first one
-                        return window.open(
-                          `/${locale}/v/${result.key}`,
-                          "_blank"
-                        );
-                      } else {
-                        await handlePublishSuccess(result.key, push);
-                      }
-                    }
-                  );
+
+              return publishState(
+                user,
+                key,
+                state,
+                async (result, i, total) => {
+                  if (state.layout.type === "singleURLs" && i < total) {
+                    // Open new tab for each chart, except the first one
+                    return window.open(`/${locale}/v/${result.key}`, "_blank");
+                  }
+
+                  await handlePublishSuccess(result.key, push);
                 }
-                default: {
-                  return publishState(user, key, state, async (result) => {
-                    await handlePublishSuccess(result.key, push);
-                  });
-                }
-              }
+              );
             } catch (e) {
               console.error(e);
               dispatch({ type: "PUBLISH_FAILED" });

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -1841,7 +1841,7 @@ export type ConfiguratorStateWithChartConfigs =
   | ConfiguratorStatePublishing
   | ConfiguratorStatePublished;
 
-async function publishState(
+export async function publishState(
   user: ReturnType<typeof useUser>,
   key: string,
   state: Extract<ConfiguratorState, { state: "PUBLISHING" }>,


### PR DESCRIPTION
Fixes #1384.

### How to test
1. Go to [this link](https://visualization-tool-git-fix-single-urls-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9&dataSource=Prod).
2. Add a second chart.
3. Proceed to layout options.
4. Switch to Separate URLs layout.
5. Publish.
6. See that the first chart replaced the current page and second chart was opened in a new tab.