### PR TITLE
fix: Issues with copying published charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 
 - Fixes
   - SingleURLs layout mode now correctly publishes charts
+  - Scatterplot is now correctly initialized with non-empty segment
+  - Changes of segment dimension now correctly update chart config which prevents errors with copying published charts
 
 # [3.26.3] - 2024-03-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
   - SingleURLs layout mode now correctly publishes charts
   - Scatterplot is now correctly initialized with non-empty segment
   - Changes of segment dimension now correctly update chart config which prevents errors with copying published charts
+  - Temporal segment is no longer carried over when switching from scatterplot to column chart if it was already used as X axis
 
 # [3.26.3] - 2024-03-05
 

--- a/app/charts/chart-config-ui-options.spec.ts
+++ b/app/charts/chart-config-ui-options.spec.ts
@@ -1,4 +1,5 @@
-import { ColumnConfig } from "@/configurator";
+import { ColumnConfig, ScatterPlotConfig } from "@/configurator";
+import { DEFAULT_CATEGORICAL_PALETTE_NAME } from "@/palettes";
 
 import { defaultSegmentOnChange } from "./chart-config-ui-options";
 
@@ -26,5 +27,24 @@ describe("defaultSegmentOnChange", () => {
       selectedValues: [],
     });
     expect(filters).toEqual({ iri: { type: "single", value: "value" } });
+  });
+
+  it("should correctly modify segment", () => {
+    const chartConfig = { fields: {} } as any as ScatterPlotConfig;
+    defaultSegmentOnChange("iri", {
+      field: "segment",
+      chartConfig,
+      dimensions: [],
+      measures: [],
+      initializing: false,
+      selectedValues: [],
+    });
+    expect(Object.keys(chartConfig.fields)).toEqual(["segment"]);
+    expect(chartConfig.fields.segment).toEqual(
+      expect.objectContaining({
+        componentIri: "iri",
+        palette: DEFAULT_CATEGORICAL_PALETTE_NAME,
+      })
+    );
   });
 });

--- a/app/charts/chart-config-ui-options.ts
+++ b/app/charts/chart-config-ui-options.ts
@@ -476,10 +476,7 @@ export const defaultSegmentOnChange: OnEncodingChange<
   | ScatterPlotConfig
   | PieConfig
   | TableConfig
-> = (
-  iri,
-  { chartConfig, dimensions, measures, initializing, selectedValues }
-) => {
+> = (iri, { chartConfig, dimensions, measures, selectedValues }) => {
   const components = [...dimensions, ...measures];
   const component = components.find((d) => d.iri === iri);
   const palette = getDefaultCategoricalPaletteName(
@@ -493,19 +490,16 @@ export const defaultSegmentOnChange: OnEncodingChange<
     dimensionValues: component ? component.values : selectedValues,
   });
 
-  if (initializing) {
+  if (chartConfig.fields.segment && "palette" in chartConfig.fields.segment) {
+    chartConfig.fields.segment.componentIri = iri;
+    chartConfig.fields.segment.colorMapping = colorMapping;
+  } else {
     chartConfig.fields.segment = {
       componentIri: iri,
       palette,
       sorting: DEFAULT_SORTING,
       colorMapping,
     };
-  } else if (
-    chartConfig.fields.segment &&
-    "palette" in chartConfig.fields.segment
-  ) {
-    chartConfig.fields.segment.componentIri = iri;
-    chartConfig.fields.segment.colorMapping = colorMapping;
   }
 
   if (!selectedValues.length || !component) {

--- a/app/charts/chart-config-ui-options.ts
+++ b/app/charts/chart-config-ui-options.ts
@@ -163,7 +163,7 @@ const onColorComponentIriChange: OnEncodingOptionChange<string, MapConfig> = (
   iri,
   { chartConfig, dimensions, measures, field }
 ) => {
-  const basePath = `fields.${field}`;
+  const basePath = `fields["${field}"]`;
   const components = [...dimensions, ...measures];
   let newField: ColorField = DEFAULT_FIXED_COLOR_FIELD;
   const component = components.find((d) => d.iri === iri);

--- a/app/charts/index.spec.ts
+++ b/app/charts/index.spec.ts
@@ -125,6 +125,24 @@ describe("initial config", () => {
 
     expect(config.fields.x.componentIri).toEqual("temporal-dimension-iri");
   });
+
+  it("should create an initial scatterplot config having segment correctly defined", () => {
+    const config = getInitialConfig({
+      chartType: "scatterplot",
+      iris: ["https://environment.ld.admin.ch/foen/nfi"],
+      dimensions: [
+        mockDimensions.geoCoordinates,
+        mockDimensions.ordinal,
+        mockDimensions.temporalOrdinal,
+        mockDimensions.temporal,
+        mockDimensions.ordinal2,
+      ],
+      measures: forestAreaData.data.dataCubeByIri.measures as any as Measure[],
+    }) as ColumnConfig;
+
+    expect(config.fields.segment).toBeDefined();
+    expect((config.fields as any).palette).toBeUndefined();
+  });
 });
 
 describe("possible chart types", () => {

--- a/app/charts/index.spec.ts
+++ b/app/charts/index.spec.ts
@@ -1,4 +1,4 @@
-import { ColumnConfig, TableFields } from "@/configurator";
+import { ColumnConfig, ScatterPlotConfig, TableFields } from "@/configurator";
 import { Dimension, Measure } from "@/domain/data";
 import { TimeUnit } from "@/graphql/resolver-types";
 import { RDFCubeViewQueryMock } from "@/test/cube-view-query-mock";
@@ -265,5 +265,143 @@ describe("chart type switch", () => {
     expect(
       newConfig.interactiveFiltersConfig?.dataFilters.componentIris
     ).toEqual([]);
+  });
+
+  it("should not carry over not-allowed segment", () => {
+    const oldChartConfig = {
+      key: "Mudrp4YuP8Ki",
+      version: "3.0.0",
+      meta: {
+        title: {
+          en: "",
+          de: "",
+          fr: "",
+          it: "",
+        },
+        description: {
+          en: "",
+          de: "",
+          fr: "",
+          it: "",
+        },
+      },
+      cubes: [
+        {
+          iri: "https://environment.ld.admin.ch/foen/ubd000502/4",
+          filters: {
+            "https://environment.ld.admin.ch/foen/ubd000502/gas": {
+              type: "single",
+              value: "https://ld.admin.ch/cube/dimension/testdimension/test1",
+            },
+            "https://environment.ld.admin.ch/foen/ubd000502/sektorid": {
+              type: "single",
+              value:
+                "https://environment.ld.admin.ch/vocabulary/ghg_emission_sectors_co2_ordinance/3",
+            },
+          },
+        },
+      ],
+      activeField: "segment",
+      chartType: "scatterplot",
+      interactiveFiltersConfig: {
+        legend: {
+          active: false,
+          componentIri: "",
+        },
+        timeRange: {
+          active: false,
+          componentIri: "https://environment.ld.admin.ch/foen/ubd000502/jahr",
+          presets: {
+            type: "range",
+            from: "",
+            to: "",
+          },
+        },
+        dataFilters: {
+          active: false,
+          componentIris: [],
+        },
+        calculation: {
+          active: false,
+          type: "identity",
+        },
+      },
+      fields: {
+        x: {
+          componentIri: "https://environment.ld.admin.ch/foen/ubd000502/werte",
+        },
+        y: {
+          componentIri:
+            "https://environment.ld.admin.ch/foen/ubd000502/werteNichtGerundet",
+        },
+        segment: {
+          componentIri: "https://environment.ld.admin.ch/foen/ubd000502/jahr",
+          palette: "category10",
+          sorting: {
+            sortingType: "byAuto",
+            sortingOrder: "asc",
+          },
+          colorMapping: {
+            "1990": "#1f77b4",
+            "1991": "#ff7f0e",
+            "1992": "#2ca02c",
+            "1993": "#d62728",
+            "1994": "#9467bd",
+            "1995": "#8c564b",
+            "1996": "#e377c2",
+            "1997": "#7f7f7f",
+            "1998": "#bcbd22",
+            "1999": "#17becf",
+            "2000": "#1f77b4",
+            "2001": "#ff7f0e",
+            "2002": "#2ca02c",
+            "2003": "#d62728",
+            "2004": "#9467bd",
+            "2005": "#8c564b",
+            "2006": "#e377c2",
+            "2007": "#7f7f7f",
+            "2008": "#bcbd22",
+            "2009": "#17becf",
+            "2010": "#1f77b4",
+            "2011": "#ff7f0e",
+            "2012": "#2ca02c",
+            "2013": "#d62728",
+            "2014": "#9467bd",
+            "2015": "#8c564b",
+            "2016": "#e377c2",
+            "2017": "#7f7f7f",
+            "2018": "#bcbd22",
+            "2019": "#17becf",
+            "2020": "#1f77b4",
+            "2021": "#ff7f0e",
+          },
+        },
+      },
+    } as any as ScatterPlotConfig;
+
+    const newChartConfig = getChartConfigAdjustedToChartType({
+      chartConfig: oldChartConfig,
+      newChartType: "column",
+      dimensions: [
+        { iri: "https://environment.ld.admin.ch/foen/ubd000502/jahr" },
+        { iri: "https://environment.ld.admin.ch/foen/ubd000502/gas" },
+        { iri: "https://environment.ld.admin.ch/foen/ubd000502/sektorid" },
+      ] as any as Dimension[],
+      measures: [
+        {
+          __typename: "NumericalMeasure",
+          iri: "https://environment.ld.admin.ch/foen/ubd000502/werte",
+        },
+        {
+          __typename: "NumericalMeasure",
+          iri: "https://environment.ld.admin.ch/foen/ubd000502/werteNichtGerundet",
+        },
+      ] as any as Measure[],
+    }) as ColumnConfig;
+
+    expect(newChartConfig.fields.segment).toBeUndefined();
+    expect(newChartConfig.fields.x.componentIri).not.toEqual(
+      oldChartConfig.fields.x.componentIri
+    );
   });
 });

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -922,8 +922,12 @@ const chartConfigsAdjusters: ChartConfigsAdjusters = {
               type: disableStacked(yMeasure) ? "grouped" : "stacked",
             };
           }
-          // Otherwise we are dealing with a segment field.
-        } else {
+          // Otherwise we are dealing with a segment field. We shouldn't take
+          // the segment from oldValue if the component has already been used as
+          // x axis.
+        } else if (
+          newChartConfig.fields.x.componentIri !== oldValue.componentIri
+        ) {
           const oldSegment = oldValue as Exclude<typeof oldValue, TableFields>;
           newSegment = {
             ...oldSegment,

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -495,12 +495,14 @@ export const getInitialConfig = (
           },
           ...(scatterplotSegmentComponent
             ? {
-                componentIri: scatterplotSegmentComponent.iri,
-                palette: scatterplotPalette,
-                colorMapping: mapValueIrisToColor({
+                segment: {
+                  componentIri: scatterplotSegmentComponent.iri,
                   palette: scatterplotPalette,
-                  dimensionValues: scatterplotSegmentComponent.values,
-                }),
+                  colorMapping: mapValueIrisToColor({
+                    palette: scatterplotPalette,
+                    dimensionValues: scatterplotSegmentComponent.values,
+                  }),
+                },
               }
             : {}),
         },

--- a/app/configurator/components/chart-controls/color-ramp.tsx
+++ b/app/configurator/components/chart-controls/color-ramp.tsx
@@ -91,7 +91,7 @@ export const ColorRampField = ({
     return { palettes, defaultPalette };
   }, []);
 
-  const currentPaletteName = get(chartConfig, `fields.${field}.${path}`) as
+  const currentPaletteName = get(chartConfig, `fields["${field}"].${path}`) as
     | DivergingPaletteType
     | SequentialPaletteType;
 

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -1172,12 +1172,12 @@ const ChartFieldMultiFilter = ({
 }) => {
   const colorComponentIri = get(
     chartConfig,
-    `fields.${field}.color.componentIri`
+    `fields["${field}"].color.componentIri`
   );
   const colorComponent = [...dimensions, ...measures].find(
     (d) => d.iri === colorComponentIri
   );
-  const colorType = get(chartConfig, `fields.${field}.color.type`) as
+  const colorType = get(chartConfig, `fields["${field}"].color.type`) as
     | ColorFieldType
     | undefined;
 

--- a/e2e/filters.spec.ts
+++ b/e2e/filters.spec.ts
@@ -18,6 +18,13 @@ describe("Filters", () => {
 
     await filters.locator("label").first().waitFor({ timeout: 30_000 });
 
+    const inputs = await filters.locator("input[name^=select-single-filter]");
+    const inputsCount = await inputs.count();
+
+    for (let i = 0; i < inputsCount; i++) {
+      await expect(inputs.nth(i)).not.toBeDisabled();
+    }
+
     const labels = filters.locator("label[for^=select-single-filter]");
 
     const texts = await labels.allTextContents();


### PR DESCRIPTION
Fixes #1321.

## How to test
### PR deployment (ok)
1. Go to [this link](https://visualization-tool-git-fix-wrong-config-props-setting-ixt1.vercel.app/en/create/new?cube=https://environment.ld.admin.ch/foen/ubd000502/4&dataSource=Prod).
2. Change chart type to scatterplot.
3. ✅ See that the segment is initialized automatically with `Hierarchy` dimension.
4. Change segment dimension to `Year`.
5. Publish.
6. Click on `Copy and edit this visualization`.
7. ✅ See that the chart correctly loaded into the editor mode.
8. Switch to a column chart.
9. ✅ See that the segment is empty.

### TEST (not ok)
1. Go to [this link](https://test.visualize.admin.ch/en/create/new?cube=https://environment.ld.admin.ch/foen/ubd000502/4&dataSource=Prod).
2. Change chart type to scatterplot.
3. ❌ See that no segment is selected by default.
4. Select `Hierarchy` dimension as a new segment.
5. Switch to `Year` dimension as a new segment.
6. Publish.
7. Click on `Copy and edit this visualization`.
8. ❌ See that it's not possible to copy the chart (due to wrong chart config we are redirected to a browse page).
---
1. Go to [this link](https://test.visualize.admin.ch/en/create/new?cube=https://environment.ld.admin.ch/foen/ubd000502/4&dataSource=Prod).
2. Change chart type to scatterplot.
3. Switch to `Year` dimension as a new segment.
4. Switch to a column chart.
5. ❌ See that `Year` is both used as X axis and segmentation field.