### PR TITLE
Add dataset section

### DIFF
--- a/.github/workflows/lint-types.yml
+++ b/.github/workflows/lint-types.yml
@@ -1,4 +1,4 @@
-name: Lint & Types
+name: Lint & Typecheck & Test
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  lint:
+  lint-typecheck-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/app/browser/dataset-browse.tsx
+++ b/app/browser/dataset-browse.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   Button,
   ButtonBase,
+  CardProps,
   Link as MUILink,
   LinkProps as MUILinkProps,
   Stack,
@@ -18,7 +19,7 @@ import uniqBy from "lodash/uniqBy";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { stringify } from "qs";
-import React, { useMemo, useState } from "react";
+import React, { ComponentProps, useMemo, useState } from "react";
 
 import Flex, { FlexProps } from "@/components/flex";
 import { Checkbox, MinimalisticSelect, SearchField } from "@/components/form";
@@ -743,12 +744,16 @@ export const DatasetResults = ({
   fetching,
   error,
   cubes,
-  rowActions,
+  datasetResultProps,
 }: {
   fetching: boolean;
   error: any;
   cubes: SearchCubeResult[];
-  rowActions?: (r: PartialSearchCube) => React.ReactNode;
+  datasetResultProps?: ({
+    cube,
+  }: {
+    cube: SearchCube;
+  }) => Partial<DatasetResultProps>;
 }) => {
   if (fetching) {
     return (
@@ -785,7 +790,7 @@ export const DatasetResults = ({
           dataCube={cube}
           highlightedTitle={highlightedTitle}
           highlightedDescription={highlightedDescription}
-          rowActions={rowActions}
+          {...datasetResultProps?.({ cube })}
         />
       ))}
     </>
@@ -804,7 +809,7 @@ const useResultStyles = makeStyles((theme: Theme) => ({
     boxShadow: "none",
   },
 
-  title: {
+  titleClickable: {
     display: "inline-block",
     cursor: "pointer",
     "&:hover": {
@@ -837,6 +842,7 @@ type ResultProps = {
   highlightedDescription?: string | null;
   showTags?: boolean;
   rowActions?: (r: PartialSearchCube) => React.ReactNode;
+  disableTitleLink?: boolean;
 };
 
 export const DatasetResult = ({
@@ -845,7 +851,9 @@ export const DatasetResult = ({
   highlightedDescription,
   showTags,
   rowActions,
-}: ResultProps) => {
+  disableTitleLink,
+  ...cardProps
+}: ResultProps & CardProps) => {
   const {
     iri,
     publicationStatus,
@@ -858,7 +866,7 @@ export const DatasetResult = ({
   const isDraft = publicationStatus === DataCubePublicationStatus.Draft;
   const router = useRouter();
 
-  const handleClick = useEvent(() => {
+  const handleTitleClick = useEvent(() => {
     const browseParams = getBrowseParamsFromQuery(router.query);
     router.push(
       {
@@ -875,7 +883,12 @@ export const DatasetResult = ({
   const classes = useResultStyles();
 
   return (
-    <MotionCard {...smoothPresenceProps} elevation={1} className={classes.root}>
+    <MotionCard
+      elevation={1}
+      {...smoothPresenceProps}
+      {...cardProps}
+      className={`${classes.root} ${cardProps.className ?? ""}`}
+    >
       <Stack spacing={2} sx={{ mb: 6, alignItems: "flex-start" }}>
         <Flex
           sx={{
@@ -897,9 +910,9 @@ export const DatasetResult = ({
         <Typography
           component="div"
           variant="body1"
-          onClick={handleClick}
-          color="primary.main"
-          className={classes.title}
+          onClick={disableTitleLink ? undefined : handleTitleClick}
+          color={disableTitleLink ? "text.primary" : "primary.main"}
+          className={disableTitleLink ? "" : `${classes.titleClickable}`}
         >
           {highlightedTitle ? (
             <Box
@@ -982,6 +995,8 @@ export const DatasetResult = ({
     </MotionCard>
   );
 };
+
+export type DatasetResultProps = ComponentProps<typeof DatasetResult>;
 
 DatasetResult.defaultProps = {
   showTags: true,

--- a/app/browser/dataset-browse.tsx
+++ b/app/browser/dataset-browse.tsx
@@ -38,7 +38,6 @@ import {
   DataCubeOrganization,
   DataCubeTheme,
   SearchCubeResultOrder,
-  SearchCubesQuery,
 } from "@/graphql/query-hooks";
 import {
   DataCubePublicationStatus,
@@ -744,10 +743,12 @@ export const DatasetResults = ({
   fetching,
   error,
   cubes,
+  rowActions,
 }: {
   fetching: boolean;
   error: any;
   cubes: SearchCubeResult[];
+  rowActions?: (r: PartialSearchCube) => React.ReactNode;
 }) => {
   if (fetching) {
     return (
@@ -784,6 +785,7 @@ export const DatasetResults = ({
           dataCube={cube}
           highlightedTitle={highlightedTitle}
           highlightedDescription={highlightedDescription}
+          rowActions={rowActions}
         />
       ))}
     </>
@@ -819,20 +821,22 @@ export const DateFormat = ({ date }: { date: string }) => {
   return <>{formatted}</>;
 };
 
+export type PartialSearchCube = Pick<
+  SearchCube,
+  | "iri"
+  | "publicationStatus"
+  | "title"
+  | "description"
+  | "datePublished"
+  | "themes"
+  | "creator"
+>;
 type ResultProps = {
-  dataCube: Pick<
-    SearchCubesQuery["searchCubes"][0]["cube"],
-    | "iri"
-    | "publicationStatus"
-    | "title"
-    | "description"
-    | "datePublished"
-    | "themes"
-    | "creator"
-  >;
+  dataCube: PartialSearchCube;
   highlightedTitle?: string | null;
   highlightedDescription?: string | null;
   showTags?: boolean;
+  rowActions?: (r: PartialSearchCube) => React.ReactNode;
 };
 
 export const DatasetResult = ({
@@ -840,6 +844,7 @@ export const DatasetResult = ({
   highlightedTitle,
   highlightedDescription,
   showTags,
+  rowActions,
 }: ResultProps) => {
   const {
     iri,
@@ -973,6 +978,7 @@ export const DatasetResult = ({
           </Link>
         ) : null}
       </Flex>
+      {rowActions?.(dataCube)}
     </MotionCard>
   );
 };

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -2,7 +2,7 @@ import { memo } from "react";
 
 import { Areas } from "@/charts/area/areas";
 import { AreaChart } from "@/charts/area/areas-state";
-import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
+import { ChartDataWrapper } from "@/charts/chart-data-wrapper";
 import { AxisHeightLinear } from "@/charts/shared/axis-height-linear";
 import { AxisTime, AxisTimeDomain } from "@/charts/shared/axis-width-time";
 import { BrushTime } from "@/charts/shared/brush";
@@ -16,13 +16,7 @@ import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import { AreaConfig, DataSource } from "@/config-types";
-import {
-  useDataCubesComponentsQuery,
-  useDataCubesMetadataQuery,
-  useDataCubesObservationsQuery,
-} from "@/graphql/hooks";
 import { DataCubeObservationFilter } from "@/graphql/query-hooks";
-import { useLocale } from "@/locales/use-locale";
 
 import { ChartProps } from "../shared/ChartProps";
 
@@ -37,42 +31,11 @@ export const ChartAreasVisualization = ({
   queryFilters?: DataCubeObservationFilter[];
   componentIris: string[] | undefined;
 }) => {
-  const locale = useLocale();
-  const commonQueryVariables = {
-    sourceType: dataSource.type,
-    sourceUrl: dataSource.url,
-    locale,
-  };
-  const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
-    },
-  });
-  const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: chartConfig.cubes.map((cube) => ({
-        iri: cube.iri,
-        componentIris,
-        joinBy: cube.joinBy,
-        loadValues: true,
-      })),
-    },
-  });
-  const [observationsQuery] = useDataCubesObservationsQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: queryFilters ?? [],
-    },
-    pause: !queryFilters,
-  });
-
   return (
-    <ChartLoadingWrapper
-      metadataQuery={metadataQuery}
-      componentsQuery={componentsQuery}
-      observationsQuery={observationsQuery}
+    <ChartDataWrapper
+      dataSource={dataSource}
+      componentIris={componentIris}
+      queryFilters={queryFilters}
       chartConfig={chartConfig}
       Component={ChartAreas}
     />

--- a/app/charts/chart-data-wrapper.tsx
+++ b/app/charts/chart-data-wrapper.tsx
@@ -2,9 +2,9 @@ import { Box } from "@mui/material";
 import keyBy from "lodash/keyBy";
 import React from "react";
 
-import { ChartProps } from "@/charts/shared/ChartProps";
 import { A11yTable } from "@/charts/shared/a11y-table";
 import { useLoadingState } from "@/charts/shared/chart-loading-state";
+import { ChartProps } from "@/charts/shared/ChartProps";
 import Flex from "@/components/flex";
 import {
   Loading,
@@ -23,7 +23,12 @@ import { useLocale } from "@/src";
 
 type ElementProps<RE> = RE extends React.ElementType<infer P> ? P : never;
 
-export const ChartLoadingWrapper = <
+/**
+ * Responsible for fetching the data for the chart.
+ * - Provides observations, dimensions and measures to the chart Component
+ * - Handles loading & error state
+ */
+export const ChartDataWrapper = <
   TChartConfig extends ChartConfig,
   TOtherProps,
   TChartComponent extends React.ElementType

--- a/app/charts/chart-data-wrapper.tsx
+++ b/app/charts/chart-data-wrapper.tsx
@@ -39,6 +39,9 @@ export const ChartDataWrapper = <
   componentIris,
   dataSource,
   queryFilters,
+
+  fetching: fetchingProp = false,
+  error: errorProp,
 }: {
   chartConfig: TChartConfig;
   Component: TChartComponent;
@@ -49,6 +52,12 @@ export const ChartDataWrapper = <
   componentIris?: string[];
   dataSource: DataSource;
   queryFilters?: DataCubeObservationFilter[];
+
+  fetching?: boolean;
+  /* Use this if extra data is loaded and the possible error must be shown by ChartDataWrapper*/
+
+  /* Use this if extra data is loaded and the possible error must be shown by ChartDataWrapper*/
+  error?: Error;
 }) => {
   const chartLoadingState = useLoadingState();
 
@@ -105,7 +114,10 @@ export const ChartDataWrapper = <
   const measures = componentsData?.dataCubesComponents.measures;
 
   const fetching =
-    fetchingMetadata || fetchingComponents || fetchingObservations;
+    fetchingProp ||
+    fetchingMetadata ||
+    fetchingComponents ||
+    fetchingObservations;
 
   React.useEffect(() => {
     chartLoadingState.set("data", fetching);
@@ -153,12 +165,18 @@ export const ChartDataWrapper = <
         ) : null}
       </Box>
     );
-  } else if (metadataError || componentsError || observationsError) {
+  } else if (
+    errorProp ||
+    metadataError ||
+    componentsError ||
+    observationsError
+  ) {
     return (
       <Flex sx={{ flexDirection: "column", gap: 3 }}>
         {metadataError && <Error message={metadataError.message} />}
         {componentsError && <Error message={componentsError.message} />}
         {observationsError && <Error message={observationsError.message} />}
+        {errorProp && <Error message={errorProp.message} />}
       </Flex>
     );
   } else {

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -1,6 +1,6 @@
 import { memo } from "react";
 
-import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
+import { ChartDataWrapper } from "@/charts/chart-data-wrapper";
 import { Columns, ErrorWhiskers } from "@/charts/column/columns";
 import {
   ColumnsGrouped,
@@ -46,7 +46,7 @@ export const ChartColumnsVisualization = ({
   queryFilters?: DataCubeObservationFilter[];
 }) => {
   return (
-    <ChartLoadingWrapper
+    <ChartDataWrapper
       dataSource={dataSource}
       componentIris={componentIris}
       queryFilters={queryFilters}

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -30,13 +30,7 @@ import {
   useChartConfigFilters,
 } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
-import {
-  useDataCubesComponentsQuery,
-  useDataCubesMetadataQuery,
-  useDataCubesObservationsQuery,
-} from "@/graphql/hooks";
 import { DataCubeObservationFilter } from "@/graphql/query-hooks";
-import { useLocale } from "@/locales/use-locale";
 
 import { ChartProps } from "../shared/ChartProps";
 
@@ -51,42 +45,11 @@ export const ChartColumnsVisualization = ({
   chartConfig: ColumnConfig;
   queryFilters?: DataCubeObservationFilter[];
 }) => {
-  const locale = useLocale();
-  const commonQueryVariables = {
-    sourceType: dataSource.type,
-    sourceUrl: dataSource.url,
-    locale,
-  };
-  const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
-    },
-  });
-  const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: chartConfig.cubes.map((cube) => ({
-        iri: cube.iri,
-        componentIris,
-        joinBy: cube.joinBy,
-        loadValues: true,
-      })),
-    },
-  });
-  const [observationsQuery] = useDataCubesObservationsQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: queryFilters ?? [],
-    },
-    pause: !queryFilters,
-  });
-
   return (
     <ChartLoadingWrapper
-      metadataQuery={metadataQuery}
-      componentsQuery={componentsQuery}
-      observationsQuery={observationsQuery}
+      dataSource={dataSource}
+      componentIris={componentIris}
+      queryFilters={queryFilters}
       chartConfig={chartConfig}
       Component={ChartColumns}
     />

--- a/app/charts/combo/chart-combo-line-column.tsx
+++ b/app/charts/combo/chart-combo-line-column.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
+import { ChartDataWrapper } from "@/charts/chart-data-wrapper";
 import { InteractionColumns } from "@/charts/column/overlay-columns";
 import { AxisHeightLinearDual } from "@/charts/combo/axis-height-linear-dual";
 import { ComboLineColumn } from "@/charts/combo/combo-line-column";
@@ -28,7 +28,7 @@ export const ChartComboLineColumnVisualization = (
 ) => {
   const { dataSource, componentIris, chartConfig, queryFilters } = props;
   return (
-    <ChartLoadingWrapper
+    <ChartDataWrapper
       dataSource={dataSource}
       componentIris={componentIris}
       queryFilters={queryFilters}

--- a/app/charts/combo/chart-combo-line-column.tsx
+++ b/app/charts/combo/chart-combo-line-column.tsx
@@ -12,13 +12,7 @@ import { HoverDotMultiple } from "@/charts/shared/interaction/hover-dots-multipl
 import { Ruler } from "@/charts/shared/interaction/ruler";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { ComboLineColumnConfig, DataSource } from "@/config-types";
-import {
-  useDataCubesComponentsQuery,
-  useDataCubesMetadataQuery,
-  useDataCubesObservationsQuery,
-} from "@/graphql/hooks";
 import { DataCubeObservationFilter } from "@/graphql/query-hooks";
-import { useLocale } from "@/locales/use-locale";
 
 import { ChartProps } from "../shared/ChartProps";
 
@@ -33,42 +27,11 @@ export const ChartComboLineColumnVisualization = (
   props: ChartComboLineColumnVisualizationProps
 ) => {
   const { dataSource, componentIris, chartConfig, queryFilters } = props;
-  const locale = useLocale();
-  const commonQueryVariables = {
-    sourceType: dataSource.type,
-    sourceUrl: dataSource.url,
-    locale,
-  };
-  const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
-    },
-  });
-  const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: chartConfig.cubes.map((cube) => ({
-        iri: cube.iri,
-        componentIris,
-        joinBy: cube.joinBy,
-        loadValues: true,
-      })),
-    },
-  });
-  const [observationsQuery] = useDataCubesObservationsQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: queryFilters ?? [],
-    },
-    pause: !queryFilters,
-  });
-
   return (
     <ChartLoadingWrapper
-      metadataQuery={metadataQuery}
-      componentsQuery={componentsQuery}
-      observationsQuery={observationsQuery}
+      dataSource={dataSource}
+      componentIris={componentIris}
+      queryFilters={queryFilters}
       chartConfig={chartConfig}
       Component={ChartComboLineColumn}
     />

--- a/app/charts/combo/chart-combo-line-dual.tsx
+++ b/app/charts/combo/chart-combo-line-dual.tsx
@@ -12,13 +12,7 @@ import { Ruler } from "@/charts/shared/interaction/ruler";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import { ComboLineDualConfig, DataSource } from "@/config-types";
-import {
-  useDataCubesComponentsQuery,
-  useDataCubesMetadataQuery,
-  useDataCubesObservationsQuery,
-} from "@/graphql/hooks";
 import { DataCubeObservationFilter } from "@/graphql/query-hooks";
-import { useLocale } from "@/locales/use-locale";
 
 import { ChartProps } from "../shared/ChartProps";
 
@@ -32,44 +26,11 @@ type ChartComboLineDualVisualizationProps = {
 export const ChartComboLineDualVisualization = (
   props: ChartComboLineDualVisualizationProps
 ) => {
-  const { dataSource, componentIris, chartConfig, queryFilters } = props;
-  const locale = useLocale();
-  const commonQueryVariables = {
-    sourceType: dataSource.type,
-    sourceUrl: dataSource.url,
-    locale,
-  };
-  const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
-    },
-  });
-  const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: chartConfig.cubes.map((cube) => ({
-        iri: cube.iri,
-        componentIris,
-        joinBy: cube.joinBy,
-        loadValues: true,
-      })),
-    },
-  });
-  const [observationsQuery] = useDataCubesObservationsQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: queryFilters ?? [],
-    },
-    pause: !queryFilters,
-  });
-
   return (
     <ChartLoadingWrapper
-      metadataQuery={metadataQuery}
-      componentsQuery={componentsQuery}
-      observationsQuery={observationsQuery}
-      chartConfig={chartConfig}
+      chartConfig={props.chartConfig}
+      dataSource={props.dataSource}
+      queryFilters={props.queryFilters}
       Component={ChartComboLineDual}
     />
   );

--- a/app/charts/combo/chart-combo-line-dual.tsx
+++ b/app/charts/combo/chart-combo-line-dual.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
+import { ChartDataWrapper } from "@/charts/chart-data-wrapper";
 import { AxisHeightLinearDual } from "@/charts/combo/axis-height-linear-dual";
 import { ComboLineDual } from "@/charts/combo/combo-line-dual";
 import { ComboLineDualChart } from "@/charts/combo/combo-line-dual-state";
@@ -27,7 +27,7 @@ export const ChartComboLineDualVisualization = (
   props: ChartComboLineDualVisualizationProps
 ) => {
   return (
-    <ChartLoadingWrapper
+    <ChartDataWrapper
       chartConfig={props.chartConfig}
       dataSource={props.dataSource}
       queryFilters={props.queryFilters}

--- a/app/charts/combo/chart-combo-line-single.tsx
+++ b/app/charts/combo/chart-combo-line-single.tsx
@@ -17,13 +17,7 @@ import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import { ComboLineSingleConfig, DataSource } from "@/config-types";
-import {
-  useDataCubesComponentsQuery,
-  useDataCubesMetadataQuery,
-  useDataCubesObservationsQuery,
-} from "@/graphql/hooks";
 import { DataCubeObservationFilter } from "@/graphql/query-hooks";
-import { useLocale } from "@/locales/use-locale";
 
 import { ChartProps } from "../shared/ChartProps";
 
@@ -38,42 +32,12 @@ export const ChartComboLineSingleVisualization = (
   props: ChartComboLineSingleVisualizationProps
 ) => {
   const { dataSource, componentIris, chartConfig, queryFilters } = props;
-  const locale = useLocale();
-  const commonQueryVariables = {
-    sourceType: dataSource.type,
-    sourceUrl: dataSource.url,
-    locale,
-  };
-  const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
-    },
-  });
-  const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: chartConfig.cubes.map((cube) => ({
-        iri: cube.iri,
-        componentIris,
-        joinBy: cube.joinBy,
-        loadValues: true,
-      })),
-    },
-  });
-  const [observationsQuery] = useDataCubesObservationsQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: queryFilters ?? [],
-    },
-    pause: !queryFilters,
-  });
 
   return (
     <ChartLoadingWrapper
-      metadataQuery={metadataQuery}
-      componentsQuery={componentsQuery}
-      observationsQuery={observationsQuery}
+      dataSource={dataSource}
+      componentIris={componentIris}
+      queryFilters={queryFilters}
       chartConfig={chartConfig}
       Component={ChartComboLineSingle}
     />

--- a/app/charts/combo/chart-combo-line-single.tsx
+++ b/app/charts/combo/chart-combo-line-single.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
+import { ChartDataWrapper } from "@/charts/chart-data-wrapper";
 import { ComboLineSingle } from "@/charts/combo/combo-line-single";
 import { ComboLineSingleChart } from "@/charts/combo/combo-line-single-state";
 import { AxisHeightLinear } from "@/charts/shared/axis-height-linear";
@@ -34,7 +34,7 @@ export const ChartComboLineSingleVisualization = (
   const { dataSource, componentIris, chartConfig, queryFilters } = props;
 
   return (
-    <ChartLoadingWrapper
+    <ChartDataWrapper
       dataSource={dataSource}
       componentIris={componentIris}
       queryFilters={queryFilters}

--- a/app/charts/index.spec.ts
+++ b/app/charts/index.spec.ts
@@ -135,6 +135,7 @@ describe("possible chart types", () => {
         .dimensions as any as Dimension[],
       measures: bathingWaterData.data.dataCubeByIri
         .measures as any as Measure[],
+      cubeCount: 1,
     }).sort();
 
     expect(possibleChartTypes).toEqual(expectedChartTypes);
@@ -144,6 +145,7 @@ describe("possible chart types", () => {
     const possibleChartTypes = getPossibleChartTypes({
       dimensions: [],
       measures: [{ __typename: "NumericalMeasure" }] as any,
+      cubeCount: 1,
     });
 
     expect(possibleChartTypes).toEqual(["table"]);
@@ -153,6 +155,7 @@ describe("possible chart types", () => {
     const possibleChartTypes = getPossibleChartTypes({
       dimensions: [{ __typename: "GeoShapesDimension" }] as any,
       measures: [{ __typename: "NumericalMeasure" }] as any,
+      cubeCount: 1,
     }).sort();
 
     expect(possibleChartTypes).toEqual(["column", "map", "pie", "table"]);
@@ -165,6 +168,7 @@ describe("possible chart types", () => {
         { __typename: "NumericalMeasure", unit: "m" },
         { __typename: "NumericalMeasure", unit: "cm" },
       ] as any,
+      cubeCount: 1,
     });
 
     expect(possibleChartTypes).not.toContain("comboLineSingle");

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -1293,6 +1293,9 @@ const chartConfigsAdjusters: ChartConfigsAdjusters = {
               cube.filters[iri] = value;
             }
           }
+          if (oldCube.joinBy !== undefined) {
+            cube.joinBy = oldCube.joinBy;
+          }
         }
       });
     },

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -119,18 +119,26 @@ export const comboChartTypes: ComboChartType[] = [
   ...comboDifferentUnitChartTypes,
 ];
 
-export const chartTypesOrder: { [k in ChartType]: number } = {
-  column: 0,
-  line: 1,
-  area: 2,
-  scatterplot: 3,
-  pie: 4,
-  map: 5,
-  table: 6,
-  comboLineSingle: 7,
-  comboLineDual: 8,
-  comboLineColumn: 9,
-};
+type ChartOrder = { [k in ChartType]: number };
+export function getChartTypeOrder({
+  cubeCount,
+}: {
+  cubeCount: number;
+}): ChartOrder {
+  const multiCubeBoost = cubeCount > 1 ? -100 : 0;
+  return {
+    column: 0,
+    line: 1,
+    area: 2,
+    scatterplot: 3,
+    pie: 4,
+    map: 5,
+    table: 6,
+    comboLineSingle: 7 + multiCubeBoost,
+    comboLineDual: 8 + multiCubeBoost,
+    comboLineColumn: 9 + multiCubeBoost,
+  };
+}
 
 /**
  * Finds the "best" dimension based on a preferred type (e.g. TemporalDimension) and Key Dimension
@@ -1903,10 +1911,12 @@ export const getPossibleChartTypes = ({
   dimensions,
   measures,
   allowedChartTypes,
+  cubeCount,
 }: {
   dimensions: Dimension[];
   measures: Measure[];
   allowedChartTypes?: ChartType[];
+  cubeCount: number;
 }): ChartType[] => {
   const numericalMeasures = measures.filter(isNumericalMeasure);
   const ordinalMeasures = measures.filter(isOrdinalMeasure);
@@ -1963,6 +1973,7 @@ export const getPossibleChartTypes = ({
     possibles.push("map");
   }
 
+  const chartTypesOrder = getChartTypeOrder({ cubeCount });
   return chartTypes
     .filter(
       (d) =>

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -1,6 +1,6 @@
 import { memo } from "react";
 
-import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
+import { ChartDataWrapper } from "@/charts/chart-data-wrapper";
 import { Lines } from "@/charts/line/lines";
 import { LineChart } from "@/charts/line/lines-state";
 import { AxisHeightLinear } from "@/charts/shared/axis-height-linear";
@@ -33,7 +33,7 @@ export const ChartLinesVisualization = ({
   queryFilters?: DataCubeObservationFilter[];
 }) => {
   return (
-    <ChartLoadingWrapper
+    <ChartDataWrapper
       dataSource={dataSource}
       componentIris={componentIris}
       queryFilters={queryFilters}

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -17,13 +17,7 @@ import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import { DataSource, LineConfig } from "@/config-types";
-import {
-  useDataCubesComponentsQuery,
-  useDataCubesMetadataQuery,
-  useDataCubesObservationsQuery,
-} from "@/graphql/hooks";
 import { DataCubeObservationFilter } from "@/graphql/query-hooks";
-import { useLocale } from "@/locales/use-locale";
 
 import { ChartProps } from "../shared/ChartProps";
 
@@ -38,42 +32,11 @@ export const ChartLinesVisualization = ({
   chartConfig: LineConfig;
   queryFilters?: DataCubeObservationFilter[];
 }) => {
-  const locale = useLocale();
-  const commonQueryVariables = {
-    sourceType: dataSource.type,
-    sourceUrl: dataSource.url,
-    locale,
-  };
-  const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
-    },
-  });
-  const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: chartConfig.cubes.map((cube) => ({
-        iri: cube.iri,
-        componentIris,
-        joinBy: cube.joinBy,
-        loadValues: true,
-      })),
-    },
-  });
-  const [observationsQuery] = useDataCubesObservationsQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: queryFilters ?? [],
-    },
-    pause: !queryFilters,
-  });
-
   return (
     <ChartLoadingWrapper
-      metadataQuery={metadataQuery}
-      componentsQuery={componentsQuery}
-      observationsQuery={observationsQuery}
+      dataSource={dataSource}
+      componentIris={componentIris}
+      queryFilters={queryFilters}
       chartConfig={chartConfig}
       Component={ChartLines}
     />

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -148,9 +148,9 @@ export const ChartMapVisualization = ({
     <NoGeometriesHint />
   ) : (
     <ChartLoadingWrapper
-      metadataQuery={metadataQuery}
-      componentsQuery={componentsQuery}
-      observationsQuery={observationsQueryResp}
+      dataSource={dataSource}
+      componentIris={componentIris}
+      queryFilters={queryFilters}
       Component={ChartMap}
       ComponentProps={{ shapes, coordinates }}
       chartConfig={chartConfig}

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -1,6 +1,6 @@
 import { memo } from "react";
 
-import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
+import { ChartDataWrapper } from "@/charts/chart-data-wrapper";
 import { MapComponent } from "@/charts/map/map";
 import { MapLegend } from "@/charts/map/map-legend";
 import { MapChart } from "@/charts/map/map-state";
@@ -147,7 +147,7 @@ export const ChartMapVisualization = ({
   return displayNoDataError ? (
     <NoGeometriesHint />
   ) : (
-    <ChartLoadingWrapper
+    <ChartDataWrapper
       dataSource={dataSource}
       componentIris={componentIris}
       queryFilters={queryFilters}

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -1,6 +1,6 @@
 import { memo } from "react";
 
-import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
+import { ChartDataWrapper } from "@/charts/chart-data-wrapper";
 import { Pie } from "@/charts/pie/pie";
 import { PieChart } from "@/charts/pie/pie-state";
 import {
@@ -29,7 +29,7 @@ export const ChartPieVisualization = ({
   queryFilters?: DataCubeObservationFilter[];
 }) => {
   return (
-    <ChartLoadingWrapper
+    <ChartDataWrapper
       dataSource={dataSource}
       componentIris={componentIris}
       queryFilters={queryFilters}

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -13,13 +13,7 @@ import { LegendColor } from "@/charts/shared/legend-color";
 import { OnlyNegativeDataHint } from "@/components/hint";
 import { DataSource, PieConfig, useChartConfigFilters } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
-import {
-  useDataCubesComponentsQuery,
-  useDataCubesMetadataQuery,
-  useDataCubesObservationsQuery,
-} from "@/graphql/hooks";
 import { DataCubeObservationFilter } from "@/graphql/query-hooks";
-import { useLocale } from "@/locales/use-locale";
 
 import { ChartProps } from "../shared/ChartProps";
 
@@ -34,42 +28,11 @@ export const ChartPieVisualization = ({
   chartConfig: PieConfig;
   queryFilters?: DataCubeObservationFilter[];
 }) => {
-  const locale = useLocale();
-  const commonQueryVariables = {
-    sourceType: dataSource.type,
-    sourceUrl: dataSource.url,
-    locale,
-  };
-  const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
-    },
-  });
-  const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: chartConfig.cubes.map((cube) => ({
-        iri: cube.iri,
-        componentIris,
-        joinBy: cube.joinBy,
-        loadValues: true,
-      })),
-    },
-  });
-  const [observationsQuery] = useDataCubesObservationsQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: queryFilters ?? [],
-    },
-    pause: !queryFilters,
-  });
-
   return (
     <ChartLoadingWrapper
-      metadataQuery={metadataQuery}
-      componentsQuery={componentsQuery}
-      observationsQuery={observationsQuery}
+      dataSource={dataSource}
+      componentIris={componentIris}
+      queryFilters={queryFilters}
       chartConfig={chartConfig}
       Component={ChartPie}
     />

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -25,13 +25,7 @@ import {
   useChartConfigFilters,
 } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
-import {
-  useDataCubesComponentsQuery,
-  useDataCubesMetadataQuery,
-  useDataCubesObservationsQuery,
-} from "@/graphql/hooks";
 import { DataCubeObservationFilter } from "@/graphql/query-hooks";
-import { useLocale } from "@/locales/use-locale";
 
 import { ChartProps } from "../shared/ChartProps";
 
@@ -46,42 +40,11 @@ export const ChartScatterplotVisualization = ({
   chartConfig: ScatterPlotConfig;
   queryFilters?: DataCubeObservationFilter[];
 }) => {
-  const locale = useLocale();
-  const commonQueryVariables = {
-    sourceType: dataSource.type,
-    sourceUrl: dataSource.url,
-    locale,
-  };
-  const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
-    },
-  });
-  const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: chartConfig.cubes.map((cube) => ({
-        iri: cube.iri,
-        componentIris,
-        joinBy: cube.joinBy,
-        loadValues: true,
-      })),
-    },
-  });
-  const [observationsQuery] = useDataCubesObservationsQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: queryFilters ?? [],
-    },
-    pause: !queryFilters,
-  });
-
   return (
     <ChartLoadingWrapper
-      metadataQuery={metadataQuery}
-      componentsQuery={componentsQuery}
-      observationsQuery={observationsQuery}
+      dataSource={dataSource}
+      componentIris={componentIris}
+      queryFilters={queryFilters}
       Component={ChartScatterplot}
       chartConfig={chartConfig}
     />

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -1,6 +1,6 @@
 import { memo } from "react";
 
-import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
+import { ChartDataWrapper } from "@/charts/chart-data-wrapper";
 import { Scatterplot } from "@/charts/scatterplot/scatterplot";
 import { ScatterplotChart } from "@/charts/scatterplot/scatterplot-state";
 import {
@@ -41,7 +41,7 @@ export const ChartScatterplotVisualization = ({
   queryFilters?: DataCubeObservationFilter[];
 }) => {
   return (
-    <ChartLoadingWrapper
+    <ChartDataWrapper
       dataSource={dataSource}
       componentIris={componentIris}
       queryFilters={queryFilters}

--- a/app/charts/table/chart-table.tsx
+++ b/app/charts/table/chart-table.tsx
@@ -1,6 +1,6 @@
 import { memo } from "react";
 
-import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
+import { ChartDataWrapper } from "@/charts/chart-data-wrapper";
 import { Table } from "@/charts/table/table";
 import { TableChart } from "@/charts/table/table-state";
 import { DataSource, TableConfig } from "@/configurator";
@@ -17,7 +17,7 @@ export const ChartTableVisualization = ({
   chartConfig: TableConfig;
 }) => {
   return (
-    <ChartLoadingWrapper
+    <ChartDataWrapper
       dataSource={dataSource}
       componentIris={componentIris}
       Component={ChartTable}

--- a/app/charts/table/chart-table.tsx
+++ b/app/charts/table/chart-table.tsx
@@ -4,12 +4,6 @@ import { ChartLoadingWrapper } from "@/charts/chart-loading-wrapper";
 import { Table } from "@/charts/table/table";
 import { TableChart } from "@/charts/table/table-state";
 import { DataSource, TableConfig } from "@/configurator";
-import {
-  useDataCubesComponentsQuery,
-  useDataCubesMetadataQuery,
-  useDataCubesObservationsQuery,
-} from "@/graphql/hooks";
-import { useLocale } from "@/locales/use-locale";
 
 import { ChartProps } from "../shared/ChartProps";
 
@@ -22,45 +16,10 @@ export const ChartTableVisualization = ({
   componentIris: string[] | undefined;
   chartConfig: TableConfig;
 }) => {
-  const locale = useLocale();
-  const commonQueryVariables = {
-    sourceType: dataSource.type,
-    sourceUrl: dataSource.url,
-    locale,
-  };
-  const [metadataQuery] = useDataCubesMetadataQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
-    },
-  });
-  const [componentsQuery] = useDataCubesComponentsQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: chartConfig.cubes.map((cube) => ({
-        iri: cube.iri,
-        componentIris,
-        joinBy: cube.joinBy,
-        loadValues: true,
-      })),
-    },
-  });
-  const [observationsQuery] = useDataCubesObservationsQuery({
-    variables: {
-      ...commonQueryVariables,
-      cubeFilters: chartConfig.cubes.map((cube) => ({
-        iri: cube.iri,
-        componentIris,
-        filters: cube.filters,
-      })),
-    },
-  });
-
   return (
     <ChartLoadingWrapper
-      metadataQuery={metadataQuery}
-      componentsQuery={componentsQuery}
-      observationsQuery={observationsQuery}
+      dataSource={dataSource}
+      componentIris={componentIris}
       Component={ChartTable}
       chartConfig={chartConfig}
     />

--- a/app/components/chart-selection-tabs.tsx
+++ b/app/components/chart-selection-tabs.tsx
@@ -504,6 +504,21 @@ type TabsInnerProps = {
   onChartSwitch?: (key: string) => void;
 };
 
+/**
+ * The Tabs component clones its children adding extra properties, expecting that we use Tab components.
+ * Since we either use a Draggable or a div, we must not forward directly the properties.
+ * Forwarding the props directly to a DOM node would result in for example "textColor" not being a valid HTML prop.
+ */
+const PassthroughTab = ({
+  children,
+  value: _value,
+}: {
+  children: React.ReactNode;
+  value?: string;
+}) => {
+  return <>{children}</>;
+};
+
 const TabsInner = (props: TabsInnerProps) => {
   const {
     data,
@@ -553,54 +568,57 @@ const TabsInner = (props: TabsInnerProps) => {
                 sx={{ top: 1 }}
               >
                 {data.map((d, i) => (
-                  <Draggable key={d.key} draggableId={d.key} index={i}>
-                    {(provided, snapshot) => {
-                      const { style } = provided.draggableProps;
-                      // Limit the drag movement to the x-axis.
-                      const transform = style?.transform
-                        ? `${style.transform.split(",")[0]}, 0px)`
-                        : undefined;
-
-                      return (
-                        <VisualizeTab
-                          ref={provided.innerRef}
-                          {...provided.draggableProps}
-                          {...provided.dragHandleProps}
-                          style={{ ...style, transform, opacity: 1 }}
-                          component="div"
-                          key={d.key}
-                          value={`${i}`}
-                          className={`${
-                            // We need to add the "selected" class ourselves since we are wrapping
-                            // the tabs by Draggable.
-                            i === activeTabIndex ? "Mui-selected" : ""
-                          }`}
-                          sx={{
-                            px: 0,
-                            minWidth: "fit-content",
-                          }}
-                          label={
-                            <TabContent
-                              iconName={getIconName(d.chartType)}
-                              chartKey={d.key}
-                              editable={editable}
-                              draggable={draggable}
-                              active={d.active}
-                              dragging={snapshot.isDragging}
-                              onEditClick={(e) => {
-                                onChartEdit?.(e, d.key);
-                              }}
-                              onSwitchClick={() => {
-                                onChartSwitch?.(d.key);
-                              }}
-                            />
-                          }
-                        />
-                      );
-                    }}
-                  </Draggable>
+                  <PassthroughTab key={d.key} value={`${i}`}>
+                    <Draggable draggableId={d.key} index={i}>
+                      {(provided, snapshot) => {
+                        const { style } = provided.draggableProps;
+                        // Limit the drag movement to the x-axis.
+                        const transform = style?.transform
+                          ? `${style.transform.split(",")[0]}, 0px)`
+                          : undefined;
+                        return (
+                          <VisualizeTab
+                            ref={provided.innerRef}
+                            {...provided.draggableProps}
+                            {...provided.dragHandleProps}
+                            style={{ ...style, transform, opacity: 1 }}
+                            component="div"
+                            key={d.key}
+                            value={`${i}`}
+                            className={`${
+                              // We need to add the "selected" class ourselves since we are wrapping
+                              // the tabs by Draggable.
+                              i === activeTabIndex ? "Mui-selected" : ""
+                            }`}
+                            sx={{
+                              px: 0,
+                              minWidth: "fit-content",
+                            }}
+                            label={
+                              <TabContent
+                                iconName={getIconName(d.chartType)}
+                                chartKey={d.key}
+                                editable={editable}
+                                draggable={draggable}
+                                active={d.active}
+                                dragging={snapshot.isDragging}
+                                onEditClick={(e) => {
+                                  onChartEdit?.(e, d.key);
+                                }}
+                                onSwitchClick={() => {
+                                  onChartSwitch?.(d.key);
+                                }}
+                              />
+                            }
+                          />
+                        );
+                      }}
+                    </Draggable>
+                  </PassthroughTab>
                 ))}
-                <div style={{ opacity: 0 }}>{provided.placeholder}</div>
+                <PassthroughTab>
+                  <div style={{ opacity: 0 }}>{provided.placeholder}</div>
+                </PassthroughTab>
 
                 {addable && (
                   <VisualizeTab

--- a/app/components/presence.tsx
+++ b/app/components/presence.tsx
@@ -2,7 +2,7 @@ import { Box, Card } from "@mui/material";
 import { Transition, motion } from "framer-motion";
 
 export const MotionBox = motion(Box);
-export const MotionCard = motion(Card);
+export const MotionCard = motion(Card) as typeof Card;
 
 export const DURATION = 0.4;
 

--- a/app/components/rename-dialog.tsx
+++ b/app/components/rename-dialog.tsx
@@ -54,7 +54,6 @@ export const RenameDialog = ({
 
       await updateConfigMut.mutate({
         key: config.key,
-        user_id: userId,
         data: {
           ...config.data,
           chartConfigs: config.data.chartConfigs.map((x, i) => ({

--- a/app/components/rename-dialog.tsx
+++ b/app/components/rename-dialog.tsx
@@ -1,0 +1,162 @@
+import { t, Trans } from "@lingui/macro";
+import { LoadingButton, TabContext, TabList, TabPanel } from "@mui/lab";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogProps,
+  DialogTitle,
+  Divider,
+  Tab,
+  TextField,
+  Typography,
+  useEventCallback,
+} from "@mui/material";
+import { FormEvent, useState } from "react";
+
+import { ParsedConfig } from "@/db/config";
+import { useUserConfigs } from "@/domain/user-configs";
+import { Locale } from "@/locales/locales";
+import { updateConfig } from "@/utils/chart-config/api";
+import { useMutate } from "@/utils/use-fetch-data";
+
+export const RenameDialog = ({
+  config,
+  locale,
+  onClose,
+  userId,
+  ...props
+}: {
+  config: ParsedConfig;
+  locale: Locale;
+  onClose: () => void;
+  userId: number;
+} & Omit<DialogProps, "onClose">) => {
+  const { invalidate: invalidateUserConfigs } = useUserConfigs();
+  const [renameIndex, setRenameIndex] = useState(0);
+
+  const updateConfigMut = useMutate(updateConfig);
+
+  const handleRename = useEventCallback(
+    async (ev: FormEvent<HTMLFormElement>) => {
+      const formData = Array.from(new FormData(ev.currentTarget)).reduce(
+        (acc, [key, value]) => {
+          const [_field, indexS, lang] = key.split(".");
+          const index = Number(indexS);
+          acc[index] = acc[index] || ({} as Record<string, string>);
+          acc[index][lang as Locale] = `${value}`;
+          return acc;
+        },
+        [] as Record<Locale, string>[]
+      );
+      ev.preventDefault();
+
+      await updateConfigMut.mutate({
+        key: config.key,
+        user_id: userId,
+        data: {
+          ...config.data,
+          chartConfigs: config.data.chartConfigs.map((x, i) => ({
+            ...x,
+            meta: {
+              ...x.meta,
+              title: formData[i],
+            },
+          })),
+        },
+      });
+
+      invalidateUserConfigs();
+      onClose?.();
+    }
+  );
+
+  return (
+    <Dialog {...props} fullWidth>
+      <form style={{ display: "contents" }} onSubmit={handleRename}>
+        <DialogTitle>
+          <Trans id="profile.chart.rename-dialog.title">
+            Rename the visualization
+          </Trans>
+        </DialogTitle>
+        <DialogContent>
+          <Typography variant="body2">
+            <Trans id="profile.chart.rename-dialog.description">
+              Enhance chart clarity with a clear title; a good title helps
+              understanding chart content.
+            </Trans>
+          </Typography>
+          <TabContext value={`${renameIndex}`}>
+            <TabList onChange={(_ev, newTab) => setRenameIndex(newTab)}>
+              {config.data.chartConfigs.map((x, i) => {
+                return (
+                  <Tab
+                    key={i}
+                    value={`${i}`}
+                    label={
+                      <span>
+                        {x.meta.title[locale] !== ""
+                          ? x.meta.title[locale]
+                          : t({ id: "annotation.add.title" })}
+                      </span>
+                    }
+                  />
+                );
+              })}
+            </TabList>
+            <Divider sx={{ mb: "1rem" }} />
+            {config.data.chartConfigs.map((x, i) => {
+              return (
+                <TabPanel
+                  value={`${i}`}
+                  key={i}
+                  sx={{
+                    gap: "1rem",
+                    display: "flex",
+                    flexDirection: "column",
+                  }}
+                >
+                  <TextField
+                    name={`title.${i}.de`}
+                    label={t({ id: "controls.language.german" })}
+                    defaultValue={x.meta.title.de}
+                  />
+                  <TextField
+                    name={`title.${i}.fr`}
+                    label={t({ id: "controls.language.french" })}
+                    defaultValue={x.meta.title.fr}
+                  />
+                  <TextField
+                    name={`title.${i}.it`}
+                    label={t({ id: "controls.language.italian" })}
+                    defaultValue={x.meta.title.it}
+                  />
+                  <TextField
+                    name={`title.${i}.en`}
+                    label={t({ id: "controls.language.english" })}
+                    defaultValue={x.meta.title.en}
+                  />
+                </TabPanel>
+              );
+            })}
+          </TabContext>
+        </DialogContent>
+        <DialogActions sx={{ pb: 6, pr: 6 }}>
+          <Button variant="outlined" onClick={onClose}>
+            Cancel
+          </Button>
+          <LoadingButton
+            sx={{ minWidth: "auto" }}
+            loading={updateConfigMut.status === "fetching"}
+            variant="contained"
+            color="primary"
+            type="submit"
+          >
+            OK
+          </LoadingButton>
+        </DialogActions>
+      </form>
+    </Dialog>
+  );
+};

--- a/app/configurator/components/add-dataset-dialog.tsx
+++ b/app/configurator/components/add-dataset-dialog.tsx
@@ -256,7 +256,6 @@ const useAddDataset = () => {
       currentComponents: DataCubeComponents;
       otherCube: PartialSearchCube;
     }) => {
-      debugger;
       const iri = otherCube.iri;
       setLoading(true);
       try {

--- a/app/configurator/components/add-dataset-dialog.tsx
+++ b/app/configurator/components/add-dataset-dialog.tsx
@@ -139,7 +139,15 @@ export const DatasetDialog = ({
   const { loading, addDataset } = useAddDataset();
 
   return (
-    <Dialog {...props} onClose={handleClose} maxWidth="lg" fullWidth>
+    <Dialog
+      {...props}
+      onClose={handleClose}
+      maxWidth="lg"
+      fullWidth
+      PaperProps={{
+        sx: { minHeight: "calc(100vh - calc(30px * 2))" },
+      }}
+    >
       <DialogCloseButton onClick={(ev) => handleClose(ev, "escapeKeyDown")} />
       <DialogTitle sx={{ typography: "h2" }}>
         {t({

--- a/app/configurator/components/add-dataset-dialog.tsx
+++ b/app/configurator/components/add-dataset-dialog.tsx
@@ -1,0 +1,114 @@
+import { t } from "@lingui/macro";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogProps,
+  DialogTitle,
+  InputAdornment,
+  TextField,
+  useEventCallback,
+} from "@mui/material";
+import { FormEvent, useMemo, useState } from "react";
+import { ObjectInspector } from "react-inspector";
+
+import { DatasetResults } from "@/browser/dataset-browse";
+import { ConfiguratorStateConfiguringChart } from "@/configurator";
+import { useDataCubesComponentsQuery } from "@/graphql/hooks";
+import {
+  SearchCubeResultOrder,
+  useSearchCubesQuery,
+} from "@/graphql/query-hooks";
+import SvgIcSearch from "@/icons/components/IcSearch";
+import { useLocale } from "@/locales/use-locale";
+
+export const DatasetDialog = ({
+  state,
+  ...props
+}: { state: ConfiguratorStateConfiguringChart } & DialogProps) => {
+  const [query, setQuery] = useState("");
+  const locale = useLocale();
+
+  const commonQueryVariables = {
+    sourceType: state.dataSource.type,
+    sourceUrl: state.dataSource.url,
+    locale,
+  };
+  const [cubesComponentQuery] = useDataCubesComponentsQuery({
+    variables: {
+      ...commonQueryVariables,
+      cubeFilters: state.chartConfigs[0].cubes.map((cube) => ({
+        iri: cube.iri,
+      })),
+    },
+  });
+
+  const relevantDimensions = useMemo(() => {
+    return (
+      cubesComponentQuery.data?.dataCubesComponents.dimensions.filter((x) => {
+        return x.__typename === "TemporalDimension";
+      }) ?? []
+    );
+  }, [cubesComponentQuery.data?.dataCubesComponents.dimensions]);
+  const [searchQuery] = useSearchCubesQuery({
+    variables: {
+      sourceType: state.dataSource.type,
+      sourceUrl: state.dataSource.url,
+      locale,
+      query: query,
+      order: SearchCubeResultOrder.Score,
+      includeDrafts: false,
+      filters: relevantDimensions.flatMap((rd) =>
+        rd.__typename === "TemporalDimension"
+          ? [{ type: "TemporalDimension", value: rd.timeUnit }]
+          : []
+      ),
+    },
+    pause: !cubesComponentQuery.data || relevantDimensions.length === 0,
+  });
+  const handleSubmit = (ev: FormEvent<HTMLFormElement>) => {
+    ev.preventDefault();
+    const formdata = Object.fromEntries(
+      new FormData(ev.currentTarget).entries()
+    );
+    setQuery(formdata.name as string);
+  };
+  const handleClose: DialogProps["onClose"] = useEventCallback((ev) => {
+    props.onClose?.(ev, "escapeKeyDown");
+    setQuery("");
+  });
+  return (
+    <Dialog {...props} onClose={handleClose} maxWidth="lg" fullWidth>
+      <DialogTitle sx={{ typography: "h2" }}>
+        {t({
+          id: "chart.datasets.add-dataset-dialog.title",
+          message: "Select dataset with shared dimensions",
+        })}
+      </DialogTitle>
+      <DialogContent>
+        <ObjectInspector data={cubesComponentQuery} />
+        <form onSubmit={handleSubmit}>
+          <TextField
+            name="search"
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <SvgIcSearch />
+                </InputAdornment>
+              ),
+            }}
+            placeholder={t({ id: "dataset.search.placeholder" })}
+          />
+          <Button color="primary" variant="outlined" type="submit">
+            {t({ id: "dataset.search.label" })}
+          </Button>
+        </form>
+        <DatasetResults
+          cubes={searchQuery.data?.searchCubes ?? []}
+          fetching={searchQuery.fetching}
+          error={searchQuery.error}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -806,7 +806,34 @@ export const ChartConfigurator = ({
       {chartConfig.chartType !== "table" && (
         <InteractiveFiltersConfigurator state={state} />
       )}
+      <ChooseDatasetsControlSection chartConfig={chartConfig} />
     </>
+  );
+};
+
+const ChooseDatasetsControlSection = ({
+  chartConfig,
+}: {
+  chartConfig: ChartConfig;
+}) => {
+  return (
+    <ControlSection collapse>
+      <SubsectionTitle titleId="controls-data" gutterBottom={false}>
+        <Trans id="controls.section.datasets.title">Datasets</Trans>{" "}
+        <FiltersBadge sx={{ ml: "auto", mr: 4 }} />
+      </SubsectionTitle>
+      <ControlSectionContent
+        aria-labelledby="controls-data"
+        data-testid="configurator-filters"
+      >
+        {chartConfig.cubes.map((x) => {
+          return <div key={x.iri}>{x.iri}</div>;
+        })}
+        {chartConfig.cubes.length === 1 ? (
+          <Button variant="contained">Add</Button>
+        ) : null}
+      </ControlSectionContent>
+    </ControlSection>
   );
 };
 

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -888,16 +888,18 @@ const ChooseDatasetsControlSection = () => {
                   <Typography variant="caption">{x.title}</Typography>
                 </div>
                 <div>
-                  <IconButton
-                    onClick={() =>
-                      dispatch({
-                        type: "DATASET_REMOVE",
-                        value: { locale, iri: x.iri },
-                      })
-                    }
-                  >
-                    <SvgIcTrash />
-                  </IconButton>
+                  {cubes.length > 1 ? (
+                    <IconButton
+                      onClick={() =>
+                        dispatch({
+                          type: "DATASET_REMOVE",
+                          value: { locale, iri: x.iri },
+                        })
+                      }
+                    >
+                      <SvgIcTrash />
+                    </IconButton>
+                  ) : null}
                 </div>
               </Box>
             );

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -80,6 +80,7 @@ import {
   Measure,
 } from "@/domain/data";
 import { truthy } from "@/domain/types";
+import { flag } from "@/flags";
 import {
   useDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
@@ -814,12 +815,12 @@ export const ChartConfigurator = ({
       {chartConfig.chartType !== "table" && (
         <InteractiveFiltersConfigurator state={state} />
       )}
-      <ChooseDatasetsControlSection />
+      {flag("add-dataset") ? <DatasetsControlSection /> : null}
     </>
   );
 };
 
-const ChooseDatasetsControlSection = () => {
+const DatasetsControlSection = () => {
   const [state, dispatch] = useConfiguratorState(isConfiguring);
   const locale = useLocale();
   const commonQueryVariables = {

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -851,7 +851,7 @@ const DatasetsControlSection = () => {
   return (
     <ControlSection collapse>
       <SubsectionTitle titleId="controls-data" gutterBottom={false}>
-        <Trans id="controls.section.datasets.title">Datasets</Trans>{" "}
+        <Trans id="controls.section.datasets.title">Data Sources</Trans>{" "}
         <FiltersBadge sx={{ ml: "auto", mr: 4 }} />
       </SubsectionTitle>
       <ControlSectionContent

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -92,6 +92,7 @@ import {
 } from "@/graphql/query-hooks";
 import { Icon } from "@/icons";
 import SvgIcAdd from "@/icons/components/IcAdd";
+import SvgIcTrash from "@/icons/components/IcTrash";
 import { useLocale } from "@/locales/use-locale";
 import useEvent from "@/utils/use-event";
 
@@ -813,16 +814,13 @@ export const ChartConfigurator = ({
       {chartConfig.chartType !== "table" && (
         <InteractiveFiltersConfigurator state={state} />
       )}
-      <ChooseDatasetsControlSection state={state} />
+      <ChooseDatasetsControlSection />
     </>
   );
 };
 
-const ChooseDatasetsControlSection = ({
-  state,
-}: {
-  state: ConfiguratorStateConfiguringChart;
-}) => {
+const ChooseDatasetsControlSection = () => {
+  const [state, dispatch] = useConfiguratorState(isConfiguring);
   const locale = useLocale();
   const commonQueryVariables = {
     sourceType: state.dataSource.type,
@@ -839,7 +837,9 @@ const ChooseDatasetsControlSection = ({
   const [metadataQuery] = useDataCubesMetadataQuery({
     variables: {
       ...commonQueryVariables,
-      cubeFilters: cubes.map((cube) => ({ iri: cube.iri })),
+      cubeFilters: cubes.map((cube) => ({
+        iri: cube.iri,
+      })),
     },
   });
   const {
@@ -867,15 +867,39 @@ const ChooseDatasetsControlSection = ({
         >
           {metadataQuery.data?.dataCubesMetadata.map((x) => {
             return (
-              <div key={x.iri}>
-                <Link href={`/browse?dataset=${x.iri}`} passHref>
-                  <MuiLink color="primary" underline="none" variant="caption">
-                    Dataset
-                  </MuiLink>
-                </Link>
-                <br />
-                <Typography variant="caption">{x.title}</Typography>
-              </div>
+              <Box
+                display="flex"
+                alignItems="center"
+                justifyContent="space-between"
+                key={x.iri}
+              >
+                <div>
+                  <Link href={`/browse?dataset=${x.iri}`} passHref>
+                    <MuiLink
+                      color="primary"
+                      underline="none"
+                      variant="caption"
+                      component="span"
+                    >
+                      Dataset
+                    </MuiLink>
+                  </Link>
+                  <br />
+                  <Typography variant="caption">{x.title}</Typography>
+                </div>
+                <div>
+                  <IconButton
+                    onClick={() =>
+                      dispatch({
+                        type: "DATASET_REMOVE",
+                        value: { locale, iri: x.iri },
+                      })
+                    }
+                  >
+                    <SvgIcTrash />
+                  </IconButton>
+                </div>
+              </Box>
             );
           })}
         </Box>

--- a/app/configurator/components/chart-type-selector.tsx
+++ b/app/configurator/components/chart-type-selector.tsx
@@ -11,7 +11,6 @@ import { makeStyles } from "@mui/styles";
 import React from "react";
 
 import {
-  chartTypes,
   comboChartTypes,
   getPossibleChartTypes,
   regularChartTypes,
@@ -84,8 +83,7 @@ export const ChartTypeSelector = (props: ChartTypeSelectorProps) => {
   const possibleChartTypes = getPossibleChartTypes({
     dimensions,
     measures,
-    allowedChartTypes:
-      chartConfig.cubes.length > 1 ? comboChartTypes : chartTypes,
+    cubeCount: chartConfig.cubes.length,
   });
 
   return (

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -66,41 +66,11 @@ jest.mock("@/utils/chart-config/api", () => ({
 jest.mock("@/graphql/client", () => {
   return {
     client: {
-      readQuery: () => {
-        return {
-          data: {
-            dataCubeByIri: {},
-            dataCubeComponents: {
-              dimensions: [
-                {
-                  __typename: "GeoShapesDimension",
-                  cubeIri: "mapDataset",
-                  iri: "newAreaLayerColorIri",
-                  values: [
-                    {
-                      value: "orange",
-                      label: "orange",
-                      color: "rgb(255, 153, 0)",
-                    },
-                  ],
-                },
-                {
-                  __typename: "GeoCoordinatesDimension",
-                  iri: "symbolLayerIri",
-                  values: [{ value: "x", label: "y" }],
-                },
-              ],
-              measures: [
-                {
-                  __typename: "NumericalMeasure",
-                  iri: "measure",
-                },
-              ],
-            },
-          },
-          operation: {},
-        };
-      },
+      readQuery: jest.fn().mockImplementation(() => ({
+        data: {
+          dataCubeComponents: getCachedComponentsMock.geoAndNumerical,
+        },
+      })),
     },
   };
 });
@@ -931,6 +901,9 @@ describe("colorMapping", () => {
   });
 
   it("should use dimension colors if present", () => {
+    getCachedComponents.mockImplementation(
+      () => getCachedComponentsMock.geoAndNumerical
+    );
     const state = {
       state: "CONFIGURING_CHART",
       dataSource: {
@@ -978,6 +951,9 @@ describe("colorMapping", () => {
 
 describe("handleChartFieldChanged", () => {
   it("should not reset symbol layer when it's being updated", () => {
+    getCachedComponents.mockImplementation(
+      () => getCachedComponentsMock.geoAndNumerical
+    );
     const state = {
       state: "CONFIGURING_CHART",
       dataSource: {

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -623,6 +623,7 @@ const getInitialConfiguringConfigBasedOnCube = ({
   const possibleChartTypes = getPossibleChartTypes({
     dimensions: dataCubesComponents.dimensions,
     measures: dataCubesComponents.measures,
+    cubeCount: cubeIris.length,
   });
   const chartConfig = deriveFiltersFromFields(
     getInitialConfig({

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -1426,6 +1426,11 @@ export const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
             })),
           locale
         );
+        if (!dataCubesComponents) {
+          throw new Error(
+            "Error while removing dataset: Could not find cached dataCubesComponents"
+          );
+        }
 
         const result = getInitialConfigBasedOnCube({
           dataCubesComponents,

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -855,7 +855,7 @@ export const handleChartFieldChanged = (
   } = action.value;
   const f = get(chartConfig.fields, field);
   const dataCubesComponents = getCachedComponents(
-    draft,
+    draft.dataSource,
     chartConfig.cubes.map((cube) => ({
       iri: cube.iri,
       joinBy: cube.joinBy,
@@ -912,7 +912,7 @@ export const handleChartOptionChanged = (
     const chartConfig = getChartConfig(draft);
     const updatePath = field === null ? path : `fields["${field}"].${path}`;
     const dataCubesComponents = getCachedComponents(
-      draft,
+      draft.dataSource,
       chartConfig.cubes.map((cube) => ({
         iri: cube.iri,
         joinBy: cube.joinBy,
@@ -1071,7 +1071,7 @@ export const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
         const { locale, chartKey, chartType } = action.value;
         const chartConfig = getChartConfig(draft, chartKey);
         const dataCubesComponents = getCachedComponents(
-          draft,
+          draft.dataSource,
           chartConfig.cubes.map((cube) => ({
             iri: cube.iri,
             joinBy: cube.joinBy,
@@ -1117,7 +1117,7 @@ export const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
         const chartConfig = getChartConfig(draft);
         delete (chartConfig.fields as GenericFields)[action.value.field];
         const dataCubesComponents = getCachedComponents(
-          draft,
+          draft.dataSource,
           chartConfig.cubes.map((cube) => ({
             iri: cube.iri,
             joinBy: cube.joinBy,
@@ -1352,7 +1352,7 @@ export const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       if (draft.state === "CONFIGURING_CHART") {
         const chartConfig = getChartConfig(draft);
         const dataCubesComponents = getCachedComponents(
-          draft,
+          draft.dataSource,
           chartConfig.cubes.map((cube) => ({
             iri: cube.iri,
             joinBy: cube.joinBy,
@@ -1415,7 +1415,7 @@ export const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
         const { locale } = action.value;
         const removedCubeIri = action.value.iri;
         const dataCubesComponents = getCachedComponents(
-          draft,
+          draft.dataSource,
           chartConfig.cubes
             .filter((c) => c.iri !== removedCubeIri)
             .map((cube) => ({

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -629,6 +629,56 @@ export const applyNonTableDimensionToFilters = ({
   }
 };
 
+const getInitialConfigBasedOnCube = ({
+  dataCubesComponents,
+  cubeIris,
+  dataSource,
+}: {
+  cubeIris: string[];
+  dataCubesComponents: DataCubeComponents;
+  dataSource: DataSource;
+}): ConfiguratorState => {
+  const possibleChartTypes = getPossibleChartTypes({
+    dimensions: dataCubesComponents.dimensions,
+    measures: dataCubesComponents.measures,
+  });
+  const chartConfig = deriveFiltersFromFields(
+    getInitialConfig({
+      chartType: possibleChartTypes[0],
+      iris: cubeIris,
+      dimensions: dataCubesComponents.dimensions,
+      measures: dataCubesComponents.measures,
+    }),
+    dataCubesComponents.dimensions
+  );
+
+  return {
+    version: CONFIGURATOR_STATE_VERSION,
+    state: "CONFIGURING_CHART",
+    dataSource: dataSource,
+    layout: {
+      type: "tab",
+      meta: {
+        title: {
+          de: "",
+          en: "",
+          fr: "",
+          it: "",
+        },
+        description: {
+          de: "",
+          en: "",
+          fr: "",
+          it: "",
+        },
+      },
+      activeField: undefined,
+    },
+    chartConfigs: [chartConfig],
+    activeChartKey: chartConfig.key,
+  };
+};
+
 const transitionStepNext = (
   draft: ConfiguratorState,
   options: {
@@ -641,45 +691,11 @@ const transitionStepNext = (
   switch (draft.state) {
     case "SELECTING_DATASET":
       if (cubeIris) {
-        const possibleChartTypes = getPossibleChartTypes({
-          dimensions: dataCubesComponents.dimensions,
-          measures: dataCubesComponents.measures,
-        });
-        const chartConfig = deriveFiltersFromFields(
-          getInitialConfig({
-            chartType: possibleChartTypes[0],
-            iris: cubeIris,
-            dimensions: dataCubesComponents.dimensions,
-            measures: dataCubesComponents.measures,
-          }),
-          dataCubesComponents.dimensions
-        );
-
-        return {
-          version: CONFIGURATOR_STATE_VERSION,
-          state: "CONFIGURING_CHART",
+        return getInitialConfigBasedOnCube({
+          cubeIris,
+          dataCubesComponents,
           dataSource: draft.dataSource,
-          layout: {
-            type: "tab",
-            meta: {
-              title: {
-                de: "",
-                en: "",
-                fr: "",
-                it: "",
-              },
-              description: {
-                de: "",
-                en: "",
-                fr: "",
-                it: "",
-              },
-            },
-            activeField: undefined,
-          },
-          chartConfigs: [chartConfig],
-          activeChartKey: chartConfig.key,
-        };
+        });
       }
       break;
     case "CONFIGURING_CHART":

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -87,8 +87,6 @@ import { createChartId } from "@/utils/create-chart-id";
 import { getRouterChartId } from "@/utils/router/helpers";
 import { unreachableError } from "@/utils/unreachable";
 
-import { getCachedComponents } from "../urql-cache";
-
 export type ConfiguratorStateAction =
   | {
       type: "INITIALIZED";

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -1,5 +1,5 @@
 import { PUBLISHED_STATE } from "@prisma/client";
-import produce, { current } from "immer";
+import produce, { Draft, current } from "immer";
 import get from "lodash/get";
 import pickBy from "lodash/pickBy";
 import setWith from "lodash/setWith";
@@ -1052,7 +1052,7 @@ export const setRangeFilter = (
   }
 };
 
-export const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
+const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
   draft,
   action
 ) => {
@@ -1489,6 +1489,17 @@ export const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       throw unreachableError(action);
   }
 };
+
+/** Turn this on for the reducer to log state, action and result */
+const reducerLogging = false;
+const withLogging = <TState, TAction>(reducer: Reducer<TState, TAction>) => {
+  return (state: Draft<TState>, action: TAction) => {
+    const res = reducer(state, action);
+    console.log(state, action, res);
+    return res;
+  };
+};
+export const reducer = reducerLogging ? withLogging(reducer_) : reducer_;
 
 const ConfiguratorStateContext = createContext<
   [ConfiguratorState, Dispatch<ConfiguratorStateAction>] | undefined

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -611,7 +611,7 @@ export const applyNonTableDimensionToFilters = ({
   }
 };
 
-const getInitialConfigBasedOnCube = ({
+const getInitialConfiguringConfigBasedOnCube = ({
   dataCubesComponents,
   cubeIris,
   dataSource,
@@ -673,7 +673,7 @@ const transitionStepNext = (
   switch (draft.state) {
     case "SELECTING_DATASET":
       if (cubeIris) {
-        return getInitialConfigBasedOnCube({
+        return getInitialConfiguringConfigBasedOnCube({
           cubeIris,
           dataCubesComponents,
           dataSource: draft.dataSource,
@@ -1430,7 +1430,7 @@ export const reducer: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
           );
         }
 
-        const result = getInitialConfigBasedOnCube({
+        const result = getInitialConfiguringConfigBasedOnCube({
           dataCubesComponents,
           dataSource: draft.dataSource,
           cubeIris: chartConfig.cubes

--- a/app/flags/flag.tsx
+++ b/app/flags/flag.tsx
@@ -63,7 +63,7 @@ const initFromSearchParams = (locationSearch: string) => {
   for (const [param, value] of Object.entries(params)) {
     if (param.startsWith(FLAG_PREFIX) && typeof value === "string") {
       try {
-        flag(param.substr(FLAG_PREFIX.length), JSON.parse(value));
+        flag(param.substring(FLAG_PREFIX.length), JSON.parse(value));
       } catch (e) {
         console.error(e);
       }

--- a/app/graphql/hook-utils.ts
+++ b/app/graphql/hook-utils.ts
@@ -4,7 +4,6 @@ import { OperationResult } from "urql";
 import { Dimension, Observation, ObservationValue } from "@/domain/data";
 import {
   DataCubeComponentsQuery,
-  DataCubeComponentsQueryVariables,
   DataCubeObservationsQuery,
   DataCubeObservationsQueryVariables,
   Exact,
@@ -16,22 +15,16 @@ export const JOIN_BY_DIMENSION_IRI = "joinBy";
  * a new joinBy dimension with values from all joinBy dimensions.
  */
 export const joinDimensions = (
-  queries: OperationResult<
-    DataCubeComponentsQuery,
-    Exact<DataCubeComponentsQueryVariables>
-  >[]
+  fetchedDataCubeComponents: {
+    dataCubeComponents: DataCubeComponentsQuery["dataCubeComponents"];
+    joinBy: string | undefined | null;
+  }[]
 ) => {
   const joinByDimensions: Dimension[] = [];
   const dimensions: Dimension[] = [];
 
-  for (const q of queries) {
-    if (!q.data?.dataCubeComponents) {
-      continue;
-    }
-
-    const { dimensions: queryDimensions } = q.data.dataCubeComponents;
-
-    const joinBy = q.operation.variables?.cubeFilter.joinBy;
+  for (const { dataCubeComponents, joinBy } of fetchedDataCubeComponents) {
+    const { dimensions: queryDimensions } = dataCubeComponents;
     const joinByDimension = queryDimensions.find((d) => d.iri === joinBy);
 
     if (!joinByDimension) {

--- a/app/graphql/hook-utils.ts
+++ b/app/graphql/hook-utils.ts
@@ -36,14 +36,12 @@ export const joinDimensions = (
 
     if (!joinByDimension) {
       dimensions.push(...queryDimensions);
-
-      continue;
+    } else {
+      joinByDimensions.push(joinByDimension);
+      dimensions.push(
+        ...queryDimensions.filter((d) => d.iri !== joinByDimension.iri)
+      );
     }
-
-    joinByDimensions.push(joinByDimension);
-    dimensions.push(
-      ...queryDimensions.filter((d) => d.iri !== joinByDimension.iri)
-    );
   }
 
   if (joinByDimensions.length > 1) {

--- a/app/graphql/hooks.mock.ts
+++ b/app/graphql/hooks.mock.ts
@@ -1,0 +1,76 @@
+import { DataCubesComponentsOptions } from "@/graphql/hooks";
+
+export const useDataCubesComponentsQueryVariables: Record<
+  string,
+  DataCubesComponentsOptions["variables"]
+> = {
+  oneCube: {
+    sourceType: "sparql",
+    sourceUrl: "https://lindas.admin.ch/query",
+    locale: "de",
+    cubeFilters: [
+      {
+        iri: "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_energiewirkung/6",
+        componentIris: [
+          "http://schema.org/amount",
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_energiewirkung/Jahr",
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_energiewirkung/massnahmenbereich",
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_energiewirkung/region",
+        ],
+        filters: {
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_energiewirkung/region":
+            { type: "single", value: "https://ld.admin.ch/country/CHE" },
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_energiewirkung/massnahmenbereich":
+            {
+              type: "single",
+              value:
+                "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_energiewirkung/ogd18_catalog/Haustechnik",
+            },
+        },
+        loadValues: true,
+      },
+    ],
+  },
+  twoCubes: {
+    sourceType: "sparql",
+    sourceUrl: "https://lindas.admin.ch/query",
+    locale: "de",
+    cubeFilters: [
+      {
+        iri: "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_energiewirkung/6",
+        componentIris: [
+          "http://schema.org/amount",
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_energiewirkung/Jahr",
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_energiewirkung/massnahmenbereich",
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_energiewirkung/region",
+        ],
+        filters: {
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_energiewirkung/region":
+            { type: "single", value: "https://ld.admin.ch/country/CHE" },
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_energiewirkung/massnahmenbereich":
+            {
+              type: "single",
+              value:
+                "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_energiewirkung/ogd18_catalog/Haustechnik",
+            },
+        },
+        joinBy:
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_energiewirkung/Jahr",
+        loadValues: true,
+      },
+      {
+        iri: "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9",
+        componentIris: [
+          "http://schema.org/amount",
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_energiewirkung/Jahr",
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_energiewirkung/massnahmenbereich",
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_energiewirkung/region",
+        ],
+        filters: {},
+        joinBy:
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr",
+        loadValues: true,
+      },
+    ],
+  },
+};

--- a/app/graphql/hooks.spec.tsx
+++ b/app/graphql/hooks.spec.tsx
@@ -1,0 +1,199 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { renderHook } from "@testing-library/react-hooks";
+
+import { useDataCubesComponentsQueryVariables } from "@/graphql/hooks.mock";
+import { Response } from "@/test/utils";
+
+import { makeUseQuery, useDataCubesComponentsQuery } from "./hooks"; // Assuming your makeUseQuery function is in a separate file
+
+describe("makeUseQuery", () => {
+  const mockQuery = jest.fn().mockImplementation(() => {
+    return new Promise((resolve) => {
+      resolve({ data: "mock data", fetching: false });
+    });
+  });
+
+  const useMockQuery = makeUseQuery(mockQuery);
+
+  afterEach(() => {
+    mockQuery.mockClear();
+  });
+
+  const TestComponent = ({ variables }: { variables: any }) => {
+    const [result] = useMockQuery({ variables });
+    return <div data-testid="result">{result.data ?? "loading"}</div>;
+  };
+
+  it("should return eventually the result of the executeQuery callback", async () => {
+    const { getByTestId } = render(
+      <TestComponent variables={{ cubeIri: "example1" }} />
+    );
+
+    expect(getByTestId("result").innerHTML).toEqual("loading");
+    await waitFor(() =>
+      expect(getByTestId("result").innerHTML).toEqual("mock data")
+    );
+  });
+
+  it("should not re-execute the query if data is available", async () => {
+    const { getByTestId, rerender } = render(
+      <TestComponent variables={{ cubeIri: "example1" }} />
+    );
+    expect(getByTestId("result").innerHTML).toContain("loading");
+    await waitFor(() =>
+      expect(getByTestId("result").innerHTML).toEqual("mock data")
+    );
+
+    // Re-rendering without changing variables should not trigger the query again, and
+    // the data should immediately be available
+    rerender(<TestComponent variables={{ cubeIri: "example1" }} />);
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(getByTestId("result").innerHTML).toContain("mock data");
+  });
+
+  it("if the key changes between hook calls, it should not return the existing data", async () => {
+    const { getByTestId, rerender } = render(
+      <TestComponent variables={{ cubeIri: "example1" }} />
+    );
+    expect(getByTestId("result").innerHTML).toContain("loading");
+    await waitFor(() =>
+      expect(getByTestId("result").innerHTML).toEqual("mock data")
+    );
+
+    // content has been loaded, changing the key
+    rerender(<TestComponent variables={{ cubeIri: "example2" }} />);
+    expect(getByTestId("result").innerHTML).toContain("loading");
+
+    // Wait for some time to ensure no data is loaded
+    await waitFor(() => expect(mockQuery).toHaveBeenCalledTimes(2));
+    await waitFor(() =>
+      expect(getByTestId("result").innerHTML).toEqual("mock data")
+    );
+
+    // Re-rendering without changing variables should not trigger the query again, and
+    // the data should immediately be available
+    rerender(<TestComponent variables={{ cubeIri: "example2" }} />);
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    expect(getByTestId("result").innerHTML).toContain("mock data");
+  });
+});
+
+const sleep = (duration: number) =>
+  new Promise((resolve) => setTimeout(resolve, duration));
+
+describe("useComponentsQuery", () => {
+  it("should work", async () => {
+    global.fetch = async (
+      _url: RequestInfo | URL,
+      options: RequestInit | undefined
+    ) => {
+      if (!options?.body) {
+        throw new Error("Must receive a body");
+      }
+
+      const reqBody = JSON.parse(options.body.toString());
+      const isGebaudeCube = reqBody.variables.cubeFilter.iri.includes(
+        "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_energiewirkung/6"
+      );
+      await sleep(1);
+      return new Response(
+        JSON.stringify({
+          data: {
+            dataCubeComponents: {
+              dimensions: isGebaudeCube
+                ? [
+                    {
+                      iri: "https://gebaude",
+                    },
+                    {
+                      iri: "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_energiewirkung/Jahr",
+                    },
+                  ]
+                : [
+                    {
+                      iri: "https://eletrik",
+                    },
+                    {
+                      iri: "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr",
+                    },
+                  ],
+              measures: [],
+            },
+          },
+        })
+      );
+    };
+    await act(async () => {
+      // Load for two cubes
+      const hook = renderHook((props) => useDataCubesComponentsQuery(props), {
+        initialProps: {
+          variables: useDataCubesComponentsQueryVariables.twoCubes,
+        },
+      });
+
+      // At init, we are already fetching
+      expect(hook.result.current[0].fetching).toBe(true);
+      await hook.waitForNextUpdate();
+
+      // Then the request is sent
+      expect(hook.result.current[0].fetching).toBe(true);
+      await hook.waitForNextUpdate();
+
+      // We have received the update
+      expect(hook.result.current[0].fetching).toBe(false);
+      const dimensions =
+        hook.result.current[0].data?.dataCubesComponents.dimensions;
+
+      // The joinBy dimensions have been fused
+      expect(dimensions && dimensions.length).toBe(3);
+
+      expect(dimensions).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "cubeIri": "joinBy",
+            "iri": "joinBy",
+            "isJoinByDimension": true,
+            "label": "joinBy",
+            "originalIris": Array [
+              Object {
+                "cubeIri": undefined,
+                "dimensionIri": "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_energiewirkung/Jahr",
+              },
+              Object {
+                "cubeIri": undefined,
+                "dimensionIri": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr",
+              },
+            ],
+            "values": Array [
+              undefined,
+              undefined,
+            ],
+          },
+          Object {
+            "iri": "https://gebaude",
+          },
+          Object {
+            "iri": "https://eletrik",
+          },
+        ]
+      `);
+
+      hook.rerender({
+        variables: useDataCubesComponentsQueryVariables.oneCube,
+      });
+      expect(hook.result.current[0].data).toBe(null);
+      await hook.waitForNextUpdate();
+      expect(hook.result.current[0].data).toEqual({
+        dataCubesComponents: {
+          dimensions: [
+            { iri: "https://gebaude" },
+            {
+              iri: "https://energy.ld.admin.ch/sfoe/bfe_ogd18_gebaeudeprogramm_energiewirkung/Jahr",
+            },
+          ],
+          measures: [],
+        },
+      });
+    });
+  });
+});

--- a/app/graphql/hooks.spec.tsx
+++ b/app/graphql/hooks.spec.tsx
@@ -81,7 +81,7 @@ describe("makeUseQuery", () => {
 const sleep = (duration: number) =>
   new Promise((resolve) => setTimeout(resolve, duration));
 
-describe("useComponentsQuery", () => {
+describe.skip("useComponentsQuery", () => {
   it("should work", async () => {
     global.fetch = async (
       _url: RequestInfo | URL,

--- a/app/graphql/hooks.ts
+++ b/app/graphql/hooks.ts
@@ -65,7 +65,7 @@ const makeUseQuery =
 
       executeQuery(options);
       // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [queryKey]);
+    }, [queryKey, options.pause]);
 
     return [result, executeQuery] as const;
   };

--- a/app/graphql/hooks.ts
+++ b/app/graphql/hooks.ts
@@ -29,7 +29,7 @@ const useQueryKey = (options: object) => {
   }, [options]);
 };
 
-const makeUseQuery =
+export const makeUseQuery =
   <T extends { variables: object; pause?: boolean }, V>(
     executeQueryFn: (
       options: T["variables"],
@@ -42,17 +42,23 @@ const makeUseQuery =
   ) =>
   (options: T) => {
     const [result, setResult] = React.useState<{
-      data?: V;
+      data?: V | null;
+      queryKey: string | null;
       error?: Error;
       fetching: boolean;
-    }>({ fetching: !options.pause });
+    }>({ fetching: !options.pause, queryKey: null, data: null });
     const queryKey = useQueryKey(options);
     const executeQuery = React.useCallback(
       async (options: T) => {
         const result = await executeQueryFn(options.variables, () =>
-          setResult((prev) => ({ ...prev, fetching: true }))
+          setResult((prev) => ({
+            ...prev,
+            fetching: true,
+            data: prev.queryKey === queryKey ? prev.data : null,
+            queryKey,
+          }))
         );
-        setResult(result);
+        setResult({ ...result, queryKey });
       },
       // eslint-disable-next-line react-hooks/exhaustive-deps
       [queryKey]
@@ -67,7 +73,9 @@ const makeUseQuery =
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [queryKey, options.pause]);
 
-    return [result, executeQuery] as const;
+    const { data, ...rest } = result;
+    const res = { ...rest, data: result.queryKey === queryKey ? data : null };
+    return [res, executeQuery] as const;
   };
 
 type DataCubesMetadataOptions = {
@@ -128,7 +136,7 @@ export const useDataCubesMetadataQuery = makeUseQuery<
   DataCubesMetadataData
 >(executeDataCubesMetadataQuery);
 
-type DataCubesComponentsOptions = {
+export type DataCubesComponentsOptions = {
   variables: Omit<DataCubeComponentsQueryVariables, "cubeFilter"> & {
     cubeFilters: DataCubeComponentFilter[];
   };
@@ -154,7 +162,13 @@ export const executeDataCubesComponentsQuery = async (
 
   const queries = await Promise.all(
     cubeFilters.map((cubeFilter) => {
-      const cubeVariables = { locale, sourceType, sourceUrl, cubeFilter };
+      const cubeVariables = {
+        locale,
+        sourceType,
+        sourceUrl,
+        cubeFilter,
+      };
+
       const cached = client.readQuery<
         DataCubeComponentsQuery,
         DataCubeComponentsQueryVariables

--- a/app/graphql/hooks.ts
+++ b/app/graphql/hooks.ts
@@ -211,6 +211,7 @@ export const executeDataCubesComponentsQuery = async (
   };
 };
 
+/** Fetches components/dimensions along with the values */
 export const useDataCubesComponentsQuery = makeUseQuery<
   DataCubesComponentsOptions,
   DataCubesComponentsData

--- a/app/graphql/hooks.ts
+++ b/app/graphql/hooks.ts
@@ -216,7 +216,14 @@ export const executeDataCubesComponentsQuery = async (
   return {
     data: {
       dataCubesComponents: {
-        dimensions: joinDimensions(queries),
+        dimensions: joinDimensions(
+          queries
+            .filter((x) => x.data)
+            .map((q) => ({
+              dataCubeComponents: q.data?.dataCubeComponents!,
+              joinBy: q.operation.variables?.cubeFilter.joinBy!,
+            }))
+        ),
         measures: queries.flatMap((q) => q.data?.dataCubeComponents.measures!),
       },
     },

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -1,19 +1,25 @@
-import { DataCubeComponents } from '../domain/data';
-import { DataCubeMetadata } from '../domain/data';
-import { DataCubeObservations } from '../domain/data';
-import { DataCubePreview } from '../domain/data';
-import { DimensionValue } from '../domain/data';
-import { Filters } from '../configurator';
-import { HierarchyValue } from '../domain/data';
-import { Observation } from '../domain/data';
-import { RawObservation } from '../domain/data';
-import { SearchCube } from '../domain/data';
-import gql from 'graphql-tag';
-import * as Urql from 'urql';
+import gql from "graphql-tag";
+import * as Urql from "urql";
+import { Filters } from "../configurator";
+import {
+  DataCubeComponents,
+  DataCubeMetadata,
+  DataCubeObservations,
+  DataCubePreview,
+  DimensionValue,
+  HierarchyValue,
+  Observation,
+  RawObservation,
+  SearchCube,
+} from "../domain/data";
 export type Maybe<T> = T | null;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type Exact<T extends { [key: string]: unknown }> = {
+  [K in keyof T]: T[K];
+};
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> &
+  { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> &
+  { [SubKey in K]: Maybe<T[SubKey]> };
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -39,21 +45,21 @@ export type Scalars = {
 };
 
 export type DataCube = {
-  __typename: 'DataCube';
-  iri: Scalars['String'];
-  identifier?: Maybe<Scalars['String']>;
-  title: Scalars['String'];
-  version?: Maybe<Scalars['String']>;
-  contactName?: Maybe<Scalars['String']>;
-  contactEmail?: Maybe<Scalars['String']>;
+  __typename: "DataCube";
+  iri: Scalars["String"];
+  identifier?: Maybe<Scalars["String"]>;
+  title: Scalars["String"];
+  version?: Maybe<Scalars["String"]>;
+  contactName?: Maybe<Scalars["String"]>;
+  contactEmail?: Maybe<Scalars["String"]>;
   creator?: Maybe<DataCubeOrganization>;
-  landingPage?: Maybe<Scalars['String']>;
-  workExamples?: Maybe<Array<Maybe<Scalars['String']>>>;
-  publisher?: Maybe<Scalars['String']>;
-  description?: Maybe<Scalars['String']>;
-  datePublished?: Maybe<Scalars['String']>;
-  dateModified?: Maybe<Scalars['String']>;
-  expires?: Maybe<Scalars['String']>;
+  landingPage?: Maybe<Scalars["String"]>;
+  workExamples?: Maybe<Array<Maybe<Scalars["String"]>>>;
+  publisher?: Maybe<Scalars["String"]>;
+  description?: Maybe<Scalars["String"]>;
+  datePublished?: Maybe<Scalars["String"]>;
+  dateModified?: Maybe<Scalars["String"]>;
+  expires?: Maybe<Scalars["String"]>;
   publicationStatus: DataCubePublicationStatus;
   dimensions: Array<Dimension>;
   dimensionByIri?: Maybe<Dimension>;
@@ -61,769 +67,895 @@ export type DataCube = {
   themes: Array<DataCubeTheme>;
 };
 
+export type DataCubeObservationsArgs = {
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  limit?: Maybe<Scalars["Int"]>;
+  preview?: Maybe<Scalars["Boolean"]>;
+  componentIris?: Maybe<Array<Scalars["String"]>>;
+  filters?: Maybe<Scalars["Filters"]>;
+};
 
 export type DataCubeDimensionsArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  componentIris?: Maybe<Array<Scalars['String']>>;
-  disableValuesLoad?: Maybe<Scalars['Boolean']>;
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  componentIris?: Maybe<Array<Scalars["String"]>>;
+  disableValuesLoad?: Maybe<Scalars["Boolean"]>;
 };
-
 
 export type DataCubeDimensionByIriArgs = {
-  iri: Scalars['String'];
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
+  iri: Scalars["String"];
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
 };
 
-
 export type DataCubeMeasuresArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  componentIris?: Maybe<Array<Scalars['String']>>;
-  disableValuesLoad?: Maybe<Scalars['Boolean']>;
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  componentIris?: Maybe<Array<Scalars["String"]>>;
+  disableValuesLoad?: Maybe<Scalars["Boolean"]>;
 };
 
 export type DataCubeComponentFilter = {
-  iri: Scalars['String'];
-  latest?: Maybe<Scalars['Boolean']>;
-  filters?: Maybe<Scalars['Filters']>;
-  componentIris?: Maybe<Array<Scalars['String']>>;
-  joinBy?: Maybe<Scalars['String']>;
-  loadValues?: Maybe<Scalars['Boolean']>;
+  iri: Scalars["String"];
+  latest?: Maybe<Scalars["Boolean"]>;
+  filters?: Maybe<Scalars["Filters"]>;
+  componentIris?: Maybe<Array<Scalars["String"]>>;
+  joinBy?: Maybe<Scalars["String"]>;
+  loadValues?: Maybe<Scalars["Boolean"]>;
 };
 
-
-
 export type DataCubeMetadataFilter = {
-  iri: Scalars['String'];
-  latest?: Maybe<Scalars['Boolean']>;
+  iri: Scalars["String"];
+  latest?: Maybe<Scalars["Boolean"]>;
 };
 
 export type DataCubeObservationFilter = {
-  iri: Scalars['String'];
-  latest?: Maybe<Scalars['Boolean']>;
-  filters?: Maybe<Scalars['Filters']>;
-  componentIris?: Maybe<Array<Scalars['String']>>;
-  joinBy?: Maybe<Scalars['String']>;
+  iri: Scalars["String"];
+  latest?: Maybe<Scalars["Boolean"]>;
+  filters?: Maybe<Scalars["Filters"]>;
+  componentIris?: Maybe<Array<Scalars["String"]>>;
+  joinBy?: Maybe<Scalars["String"]>;
 };
-
 
 export type DataCubeOrganization = {
-  __typename: 'DataCubeOrganization';
-  iri: Scalars['String'];
-  label?: Maybe<Scalars['String']>;
+  __typename: "DataCubeOrganization";
+  iri: Scalars["String"];
+  label?: Maybe<Scalars["String"]>;
 };
 
-
 export type DataCubePreviewFilter = {
-  iri: Scalars['String'];
-  latest?: Maybe<Scalars['Boolean']>;
+  iri: Scalars["String"];
+  latest?: Maybe<Scalars["Boolean"]>;
 };
 
 export enum DataCubePublicationStatus {
-  Draft = 'DRAFT',
-  Published = 'PUBLISHED'
+  Draft = "DRAFT",
+  Published = "PUBLISHED",
 }
 
 export type DataCubeTheme = {
-  __typename: 'DataCubeTheme';
-  iri: Scalars['String'];
-  label?: Maybe<Scalars['String']>;
+  __typename: "DataCubeTheme";
+  iri: Scalars["String"];
+  label?: Maybe<Scalars["String"]>;
 };
 
 export type Dimension = {
-  iri: Scalars['String'];
-  label: Scalars['String'];
-  description?: Maybe<Scalars['String']>;
-  unit?: Maybe<Scalars['String']>;
+  iri: Scalars["String"];
+  label: Scalars["String"];
+  description?: Maybe<Scalars["String"]>;
+  unit?: Maybe<Scalars["String"]>;
   scaleType?: Maybe<ScaleType>;
-  dataType?: Maybe<Scalars['String']>;
-  order?: Maybe<Scalars['Int']>;
-  isNumerical: Scalars['Boolean'];
-  isKeyDimension: Scalars['Boolean'];
-  values: Array<Scalars['DimensionValue']>;
+  dataType?: Maybe<Scalars["String"]>;
+  order?: Maybe<Scalars["Int"]>;
+  isNumerical: Scalars["Boolean"];
+  isKeyDimension: Scalars["Boolean"];
+  values: Array<Scalars["DimensionValue"]>;
   related?: Maybe<Array<RelatedDimension>>;
-  hierarchy?: Maybe<Array<Scalars['HierarchyValue']>>;
+  hierarchy?: Maybe<Array<Scalars["HierarchyValue"]>>;
 };
-
 
 export type DimensionValuesArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  filters?: Maybe<Scalars['Filters']>;
-  disableLoad?: Maybe<Scalars['Boolean']>;
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  filters?: Maybe<Scalars["Filters"]>;
+  disableLoad?: Maybe<Scalars["Boolean"]>;
 };
-
 
 export type DimensionHierarchyArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
 };
 
-
-
-
 export type GeoCoordinates = {
-  __typename: 'GeoCoordinates';
-  iri: Scalars['String'];
-  label: Scalars['String'];
-  latitude: Scalars['Float'];
-  longitude: Scalars['Float'];
+  __typename: "GeoCoordinates";
+  iri: Scalars["String"];
+  label: Scalars["String"];
+  latitude: Scalars["Float"];
+  longitude: Scalars["Float"];
 };
 
 export type GeoCoordinatesDimension = Dimension & {
-  __typename: 'GeoCoordinatesDimension';
-  iri: Scalars['String'];
-  label: Scalars['String'];
-  description?: Maybe<Scalars['String']>;
-  unit?: Maybe<Scalars['String']>;
+  __typename: "GeoCoordinatesDimension";
+  iri: Scalars["String"];
+  label: Scalars["String"];
+  description?: Maybe<Scalars["String"]>;
+  unit?: Maybe<Scalars["String"]>;
   scaleType?: Maybe<ScaleType>;
-  dataType?: Maybe<Scalars['String']>;
-  order?: Maybe<Scalars['Int']>;
-  isNumerical: Scalars['Boolean'];
-  isKeyDimension: Scalars['Boolean'];
-  values: Array<Scalars['DimensionValue']>;
+  dataType?: Maybe<Scalars["String"]>;
+  order?: Maybe<Scalars["Int"]>;
+  isNumerical: Scalars["Boolean"];
+  isKeyDimension: Scalars["Boolean"];
+  values: Array<Scalars["DimensionValue"]>;
   geoCoordinates?: Maybe<Array<GeoCoordinates>>;
   related?: Maybe<Array<RelatedDimension>>;
-  hierarchy?: Maybe<Array<Scalars['HierarchyValue']>>;
+  hierarchy?: Maybe<Array<Scalars["HierarchyValue"]>>;
 };
-
 
 export type GeoCoordinatesDimensionValuesArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  filters?: Maybe<Scalars['Filters']>;
-  disableLoad?: Maybe<Scalars['Boolean']>;
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  filters?: Maybe<Scalars["Filters"]>;
+  disableLoad?: Maybe<Scalars["Boolean"]>;
 };
-
 
 export type GeoCoordinatesDimensionHierarchyArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
 };
-
 
 export type GeoShapesDimension = Dimension & {
-  __typename: 'GeoShapesDimension';
-  iri: Scalars['String'];
-  label: Scalars['String'];
-  description?: Maybe<Scalars['String']>;
-  unit?: Maybe<Scalars['String']>;
+  __typename: "GeoShapesDimension";
+  iri: Scalars["String"];
+  label: Scalars["String"];
+  description?: Maybe<Scalars["String"]>;
+  unit?: Maybe<Scalars["String"]>;
   scaleType?: Maybe<ScaleType>;
-  dataType?: Maybe<Scalars['String']>;
-  order?: Maybe<Scalars['Int']>;
-  isNumerical: Scalars['Boolean'];
-  isKeyDimension: Scalars['Boolean'];
-  values: Array<Scalars['DimensionValue']>;
-  geoShapes?: Maybe<Scalars['GeoShapes']>;
+  dataType?: Maybe<Scalars["String"]>;
+  order?: Maybe<Scalars["Int"]>;
+  isNumerical: Scalars["Boolean"];
+  isKeyDimension: Scalars["Boolean"];
+  values: Array<Scalars["DimensionValue"]>;
+  geoShapes?: Maybe<Scalars["GeoShapes"]>;
   related?: Maybe<Array<RelatedDimension>>;
-  hierarchy?: Maybe<Array<Scalars['HierarchyValue']>>;
+  hierarchy?: Maybe<Array<Scalars["HierarchyValue"]>>;
 };
-
 
 export type GeoShapesDimensionValuesArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  filters?: Maybe<Scalars['Filters']>;
-  disableLoad?: Maybe<Scalars['Boolean']>;
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  filters?: Maybe<Scalars["Filters"]>;
+  disableLoad?: Maybe<Scalars["Boolean"]>;
 };
-
 
 export type GeoShapesDimensionHierarchyArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
 };
-
 
 export type Measure = NumericalMeasure | OrdinalMeasure;
 
 export type NominalDimension = Dimension & {
-  __typename: 'NominalDimension';
-  iri: Scalars['String'];
-  label: Scalars['String'];
-  description?: Maybe<Scalars['String']>;
-  unit?: Maybe<Scalars['String']>;
+  __typename: "NominalDimension";
+  iri: Scalars["String"];
+  label: Scalars["String"];
+  description?: Maybe<Scalars["String"]>;
+  unit?: Maybe<Scalars["String"]>;
   scaleType?: Maybe<ScaleType>;
-  dataType?: Maybe<Scalars['String']>;
-  order?: Maybe<Scalars['Int']>;
-  isNumerical: Scalars['Boolean'];
-  isKeyDimension: Scalars['Boolean'];
-  values: Array<Scalars['DimensionValue']>;
+  dataType?: Maybe<Scalars["String"]>;
+  order?: Maybe<Scalars["Int"]>;
+  isNumerical: Scalars["Boolean"];
+  isKeyDimension: Scalars["Boolean"];
+  values: Array<Scalars["DimensionValue"]>;
   related?: Maybe<Array<RelatedDimension>>;
-  hierarchy?: Maybe<Array<Scalars['HierarchyValue']>>;
+  hierarchy?: Maybe<Array<Scalars["HierarchyValue"]>>;
 };
-
 
 export type NominalDimensionValuesArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  filters?: Maybe<Scalars['Filters']>;
-  disableLoad?: Maybe<Scalars['Boolean']>;
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  filters?: Maybe<Scalars["Filters"]>;
+  disableLoad?: Maybe<Scalars["Boolean"]>;
 };
 
-
 export type NominalDimensionHierarchyArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
 };
 
 export type NumericalMeasure = Dimension & {
-  __typename: 'NumericalMeasure';
-  iri: Scalars['String'];
-  label: Scalars['String'];
-  description?: Maybe<Scalars['String']>;
-  unit?: Maybe<Scalars['String']>;
+  __typename: "NumericalMeasure";
+  iri: Scalars["String"];
+  label: Scalars["String"];
+  description?: Maybe<Scalars["String"]>;
+  unit?: Maybe<Scalars["String"]>;
   scaleType?: Maybe<ScaleType>;
-  dataType?: Maybe<Scalars['String']>;
-  order?: Maybe<Scalars['Int']>;
-  isNumerical: Scalars['Boolean'];
-  isKeyDimension: Scalars['Boolean'];
-  isCurrency?: Maybe<Scalars['Boolean']>;
-  isDecimal?: Maybe<Scalars['Boolean']>;
-  currencyExponent?: Maybe<Scalars['Int']>;
-  resolution?: Maybe<Scalars['Int']>;
-  values: Array<Scalars['DimensionValue']>;
+  dataType?: Maybe<Scalars["String"]>;
+  order?: Maybe<Scalars["Int"]>;
+  isNumerical: Scalars["Boolean"];
+  isKeyDimension: Scalars["Boolean"];
+  isCurrency?: Maybe<Scalars["Boolean"]>;
+  isDecimal?: Maybe<Scalars["Boolean"]>;
+  currencyExponent?: Maybe<Scalars["Int"]>;
+  resolution?: Maybe<Scalars["Int"]>;
+  values: Array<Scalars["DimensionValue"]>;
   related?: Maybe<Array<RelatedDimension>>;
-  hierarchy?: Maybe<Array<Scalars['HierarchyValue']>>;
+  hierarchy?: Maybe<Array<Scalars["HierarchyValue"]>>;
 };
-
 
 export type NumericalMeasureValuesArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  filters?: Maybe<Scalars['Filters']>;
-  disableLoad?: Maybe<Scalars['Boolean']>;
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  filters?: Maybe<Scalars["Filters"]>;
+  disableLoad?: Maybe<Scalars["Boolean"]>;
 };
-
 
 export type NumericalMeasureHierarchyArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
 };
 
-
 export type ObservationFilter = {
-  __typename: 'ObservationFilter';
-  type: Scalars['String'];
-  value?: Maybe<Scalars['FilterValue']>;
-  iri: Scalars['String'];
+  __typename: "ObservationFilter";
+  type: Scalars["String"];
+  value?: Maybe<Scalars["FilterValue"]>;
+  iri: Scalars["String"];
 };
 
 export type ObservationsQuery = {
-  __typename: 'ObservationsQuery';
-  data: Array<Scalars['Observation']>;
-  sparqlEditorUrl?: Maybe<Scalars['String']>;
+  __typename: "ObservationsQuery";
+  data: Array<Scalars["Observation"]>;
+  sparqlEditorUrl?: Maybe<Scalars["String"]>;
 };
 
 export type OrdinalDimension = Dimension & {
-  __typename: 'OrdinalDimension';
-  iri: Scalars['String'];
-  label: Scalars['String'];
-  description?: Maybe<Scalars['String']>;
-  unit?: Maybe<Scalars['String']>;
+  __typename: "OrdinalDimension";
+  iri: Scalars["String"];
+  label: Scalars["String"];
+  description?: Maybe<Scalars["String"]>;
+  unit?: Maybe<Scalars["String"]>;
   scaleType?: Maybe<ScaleType>;
-  dataType?: Maybe<Scalars['String']>;
-  order?: Maybe<Scalars['Int']>;
-  isNumerical: Scalars['Boolean'];
-  isKeyDimension: Scalars['Boolean'];
-  values: Array<Scalars['DimensionValue']>;
+  dataType?: Maybe<Scalars["String"]>;
+  order?: Maybe<Scalars["Int"]>;
+  isNumerical: Scalars["Boolean"];
+  isKeyDimension: Scalars["Boolean"];
+  values: Array<Scalars["DimensionValue"]>;
   related?: Maybe<Array<RelatedDimension>>;
-  hierarchy?: Maybe<Array<Scalars['HierarchyValue']>>;
+  hierarchy?: Maybe<Array<Scalars["HierarchyValue"]>>;
 };
-
 
 export type OrdinalDimensionValuesArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  filters?: Maybe<Scalars['Filters']>;
-  disableLoad?: Maybe<Scalars['Boolean']>;
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  filters?: Maybe<Scalars["Filters"]>;
+  disableLoad?: Maybe<Scalars["Boolean"]>;
 };
 
-
 export type OrdinalDimensionHierarchyArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
 };
 
 export type OrdinalMeasure = Dimension & {
-  __typename: 'OrdinalMeasure';
-  iri: Scalars['String'];
-  label: Scalars['String'];
-  description?: Maybe<Scalars['String']>;
-  unit?: Maybe<Scalars['String']>;
+  __typename: "OrdinalMeasure";
+  iri: Scalars["String"];
+  label: Scalars["String"];
+  description?: Maybe<Scalars["String"]>;
+  unit?: Maybe<Scalars["String"]>;
   scaleType?: Maybe<ScaleType>;
-  dataType?: Maybe<Scalars['String']>;
-  order?: Maybe<Scalars['Int']>;
-  isNumerical: Scalars['Boolean'];
-  isKeyDimension: Scalars['Boolean'];
-  values: Array<Scalars['DimensionValue']>;
+  dataType?: Maybe<Scalars["String"]>;
+  order?: Maybe<Scalars["Int"]>;
+  isNumerical: Scalars["Boolean"];
+  isKeyDimension: Scalars["Boolean"];
+  values: Array<Scalars["DimensionValue"]>;
   related?: Maybe<Array<RelatedDimension>>;
-  hierarchy?: Maybe<Array<Scalars['HierarchyValue']>>;
+  hierarchy?: Maybe<Array<Scalars["HierarchyValue"]>>;
 };
-
 
 export type OrdinalMeasureValuesArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  filters?: Maybe<Scalars['Filters']>;
-  disableLoad?: Maybe<Scalars['Boolean']>;
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  filters?: Maybe<Scalars["Filters"]>;
+  disableLoad?: Maybe<Scalars["Boolean"]>;
 };
 
-
 export type OrdinalMeasureHierarchyArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
 };
 
 export type Query = {
-  __typename: 'Query';
-  dataCubeComponents: Scalars['DataCubeComponents'];
-  dataCubeMetadata: Scalars['DataCubeMetadata'];
-  dataCubeObservations: Scalars['DataCubeObservations'];
-  dataCubePreview: Scalars['DataCubePreview'];
+  __typename: "Query";
+  dataCubeComponents: Scalars["DataCubeComponents"];
+  dataCubeMetadata: Scalars["DataCubeMetadata"];
+  dataCubeObservations: Scalars["DataCubeObservations"];
+  dataCubePreview: Scalars["DataCubePreview"];
   dataCubeByIri?: Maybe<DataCube>;
   possibleFilters: Array<ObservationFilter>;
   searchCubes: Array<SearchCubeResult>;
 };
 
-
 export type QueryDataCubeComponentsArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  locale: Scalars['String'];
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  locale: Scalars["String"];
   cubeFilter: DataCubeComponentFilter;
 };
 
-
 export type QueryDataCubeMetadataArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  locale: Scalars['String'];
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  locale: Scalars["String"];
   cubeFilter: DataCubeMetadataFilter;
 };
 
-
 export type QueryDataCubeObservationsArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  locale: Scalars['String'];
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  locale: Scalars["String"];
   cubeFilter: DataCubeObservationFilter;
 };
 
-
 export type QueryDataCubePreviewArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  locale: Scalars['String'];
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  locale: Scalars["String"];
   cubeFilter: DataCubePreviewFilter;
 };
 
-
 export type QueryDataCubeByIriArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  locale?: Maybe<Scalars['String']>;
-  iri: Scalars['String'];
-  latest?: Maybe<Scalars['Boolean']>;
-  filters?: Maybe<Scalars['Filters']>;
-  componentIris?: Maybe<Array<Scalars['String']>>;
-  disableValuesLoad?: Maybe<Scalars['Boolean']>;
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  locale?: Maybe<Scalars["String"]>;
+  iri: Scalars["String"];
+  latest?: Maybe<Scalars["Boolean"]>;
+  filters?: Maybe<Scalars["Filters"]>;
+  componentIris?: Maybe<Array<Scalars["String"]>>;
+  disableValuesLoad?: Maybe<Scalars["Boolean"]>;
 };
-
 
 export type QueryPossibleFiltersArgs = {
-  iri: Scalars['String'];
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  filters: Scalars['Filters'];
+  iri: Scalars["String"];
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  filters: Scalars["Filters"];
 };
 
-
 export type QuerySearchCubesArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  locale?: Maybe<Scalars['String']>;
-  query?: Maybe<Scalars['String']>;
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  locale?: Maybe<Scalars["String"]>;
+  query?: Maybe<Scalars["String"]>;
   order?: Maybe<SearchCubeResultOrder>;
-  includeDrafts?: Maybe<Scalars['Boolean']>;
+  includeDrafts?: Maybe<Scalars["Boolean"]>;
   filters?: Maybe<Array<SearchCubeFilter>>;
 };
 
-
 export type RelatedDimension = {
-  __typename: 'RelatedDimension';
-  type: Scalars['String'];
-  iri: Scalars['String'];
+  __typename: "RelatedDimension";
+  type: Scalars["String"];
+  iri: Scalars["String"];
 };
 
 export enum ScaleType {
-  Ordinal = 'Ordinal',
-  Nominal = 'Nominal',
-  Interval = 'Interval',
-  Ratio = 'Ratio'
+  Ordinal = "Ordinal",
+  Nominal = "Nominal",
+  Interval = "Interval",
+  Ratio = "Ratio",
 }
 
-
 export type SearchCubeFilter = {
-  type: Scalars['String'];
-  label?: Maybe<Scalars['String']>;
-  value: Scalars['String'];
+  type: Scalars["String"];
+  label?: Maybe<Scalars["String"]>;
+  value: Scalars["String"];
 };
 
 export type SearchCubeResult = {
-  __typename: 'SearchCubeResult';
-  score?: Maybe<Scalars['Float']>;
-  cube: Scalars['SearchCube'];
-  highlightedTitle?: Maybe<Scalars['String']>;
-  highlightedDescription?: Maybe<Scalars['String']>;
+  __typename: "SearchCubeResult";
+  score?: Maybe<Scalars["Float"]>;
+  cube: Scalars["SearchCube"];
+  highlightedTitle?: Maybe<Scalars["String"]>;
+  highlightedDescription?: Maybe<Scalars["String"]>;
 };
 
 export enum SearchCubeResultOrder {
-  Score = 'SCORE',
-  TitleAsc = 'TITLE_ASC',
-  CreatedDesc = 'CREATED_DESC'
+  Score = "SCORE",
+  TitleAsc = "TITLE_ASC",
+  CreatedDesc = "CREATED_DESC",
 }
 
 export type StandardErrorDimension = Dimension & {
-  __typename: 'StandardErrorDimension';
-  iri: Scalars['String'];
-  label: Scalars['String'];
-  description?: Maybe<Scalars['String']>;
-  unit?: Maybe<Scalars['String']>;
+  __typename: "StandardErrorDimension";
+  iri: Scalars["String"];
+  label: Scalars["String"];
+  description?: Maybe<Scalars["String"]>;
+  unit?: Maybe<Scalars["String"]>;
   scaleType?: Maybe<ScaleType>;
-  dataType?: Maybe<Scalars['String']>;
-  order?: Maybe<Scalars['Int']>;
-  isNumerical: Scalars['Boolean'];
-  isKeyDimension: Scalars['Boolean'];
-  values: Array<Scalars['DimensionValue']>;
+  dataType?: Maybe<Scalars["String"]>;
+  order?: Maybe<Scalars["Int"]>;
+  isNumerical: Scalars["Boolean"];
+  isKeyDimension: Scalars["Boolean"];
+  values: Array<Scalars["DimensionValue"]>;
   related?: Maybe<Array<RelatedDimension>>;
-  hierarchy?: Maybe<Array<Scalars['HierarchyValue']>>;
+  hierarchy?: Maybe<Array<Scalars["HierarchyValue"]>>;
 };
-
 
 export type StandardErrorDimensionValuesArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  filters?: Maybe<Scalars['Filters']>;
-  disableLoad?: Maybe<Scalars['Boolean']>;
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  filters?: Maybe<Scalars["Filters"]>;
+  disableLoad?: Maybe<Scalars["Boolean"]>;
 };
 
-
 export type StandardErrorDimensionHierarchyArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
 };
 
 export type TemporalDimension = Dimension & {
-  __typename: 'TemporalDimension';
-  iri: Scalars['String'];
-  label: Scalars['String'];
-  description?: Maybe<Scalars['String']>;
+  __typename: "TemporalDimension";
+  iri: Scalars["String"];
+  label: Scalars["String"];
+  description?: Maybe<Scalars["String"]>;
   timeUnit: TimeUnit;
-  timeFormat: Scalars['String'];
-  unit?: Maybe<Scalars['String']>;
+  timeFormat: Scalars["String"];
+  unit?: Maybe<Scalars["String"]>;
   scaleType?: Maybe<ScaleType>;
-  dataType?: Maybe<Scalars['String']>;
-  order?: Maybe<Scalars['Int']>;
-  isNumerical: Scalars['Boolean'];
-  isKeyDimension: Scalars['Boolean'];
-  values: Array<Scalars['DimensionValue']>;
+  dataType?: Maybe<Scalars["String"]>;
+  order?: Maybe<Scalars["Int"]>;
+  isNumerical: Scalars["Boolean"];
+  isKeyDimension: Scalars["Boolean"];
+  values: Array<Scalars["DimensionValue"]>;
   related?: Maybe<Array<RelatedDimension>>;
-  hierarchy?: Maybe<Array<Scalars['HierarchyValue']>>;
+  hierarchy?: Maybe<Array<Scalars["HierarchyValue"]>>;
 };
-
 
 export type TemporalDimensionValuesArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  filters?: Maybe<Scalars['Filters']>;
-  disableLoad?: Maybe<Scalars['Boolean']>;
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  filters?: Maybe<Scalars["Filters"]>;
+  disableLoad?: Maybe<Scalars["Boolean"]>;
 };
 
-
 export type TemporalDimensionHierarchyArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
 };
 
 export type TemporalOrdinalDimension = Dimension & {
-  __typename: 'TemporalOrdinalDimension';
-  iri: Scalars['String'];
-  label: Scalars['String'];
-  description?: Maybe<Scalars['String']>;
-  unit?: Maybe<Scalars['String']>;
+  __typename: "TemporalOrdinalDimension";
+  iri: Scalars["String"];
+  label: Scalars["String"];
+  description?: Maybe<Scalars["String"]>;
+  unit?: Maybe<Scalars["String"]>;
   scaleType?: Maybe<ScaleType>;
-  dataType?: Maybe<Scalars['String']>;
-  order?: Maybe<Scalars['Int']>;
-  isNumerical: Scalars['Boolean'];
-  isKeyDimension: Scalars['Boolean'];
-  values: Array<Scalars['DimensionValue']>;
+  dataType?: Maybe<Scalars["String"]>;
+  order?: Maybe<Scalars["Int"]>;
+  isNumerical: Scalars["Boolean"];
+  isKeyDimension: Scalars["Boolean"];
+  values: Array<Scalars["DimensionValue"]>;
   related?: Maybe<Array<RelatedDimension>>;
-  hierarchy?: Maybe<Array<Scalars['HierarchyValue']>>;
+  hierarchy?: Maybe<Array<Scalars["HierarchyValue"]>>;
 };
-
 
 export type TemporalOrdinalDimensionValuesArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  filters?: Maybe<Scalars['Filters']>;
-  disableLoad?: Maybe<Scalars['Boolean']>;
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  filters?: Maybe<Scalars["Filters"]>;
+  disableLoad?: Maybe<Scalars["Boolean"]>;
 };
 
-
 export type TemporalOrdinalDimensionHierarchyArgs = {
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
 };
 
 export enum TimeUnit {
-  Year = 'Year',
-  Month = 'Month',
-  Week = 'Week',
-  Day = 'Day',
-  Hour = 'Hour',
-  Minute = 'Minute',
-  Second = 'Second'
+  Year = "Year",
+  Month = "Month",
+  Week = "Week",
+  Day = "Day",
+  Hour = "Hour",
+  Minute = "Minute",
+  Second = "Second",
 }
 
-
-
 export type DataCubeComponentsQueryVariables = Exact<{
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  locale: Scalars['String'];
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  locale: Scalars["String"];
   cubeFilter: DataCubeComponentFilter;
 }>;
 
-
-export type DataCubeComponentsQuery = { __typename: 'Query', dataCubeComponents: DataCubeComponents };
+export type DataCubeComponentsQuery = {
+  __typename: "Query";
+  dataCubeComponents: DataCubeComponents;
+};
 
 export type DataCubeMetadataQueryVariables = Exact<{
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  locale: Scalars['String'];
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  locale: Scalars["String"];
   cubeFilter: DataCubeMetadataFilter;
 }>;
 
-
-export type DataCubeMetadataQuery = { __typename: 'Query', dataCubeMetadata: DataCubeMetadata };
+export type DataCubeMetadataQuery = {
+  __typename: "Query";
+  dataCubeMetadata: DataCubeMetadata;
+};
 
 export type DataCubeObservationsQueryVariables = Exact<{
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  locale: Scalars['String'];
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  locale: Scalars["String"];
   cubeFilter: DataCubeObservationFilter;
 }>;
 
-
-export type DataCubeObservationsQuery = { __typename: 'Query', dataCubeObservations: DataCubeObservations };
+export type DataCubeObservationsQuery = {
+  __typename: "Query";
+  dataCubeObservations: DataCubeObservations;
+};
 
 export type DataCubePreviewQueryVariables = Exact<{
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  locale: Scalars['String'];
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  locale: Scalars["String"];
   cubeFilter: DataCubePreviewFilter;
 }>;
 
-
-export type DataCubePreviewQuery = { __typename: 'Query', dataCubePreview: DataCubePreview };
+export type DataCubePreviewQuery = {
+  __typename: "Query";
+  dataCubePreview: DataCubePreview;
+};
 
 export type SearchCubesQueryVariables = Exact<{
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  locale: Scalars['String'];
-  query?: Maybe<Scalars['String']>;
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  locale: Scalars["String"];
+  query?: Maybe<Scalars["String"]>;
   order?: Maybe<SearchCubeResultOrder>;
-  includeDrafts?: Maybe<Scalars['Boolean']>;
+  includeDrafts?: Maybe<Scalars["Boolean"]>;
   filters?: Maybe<Array<SearchCubeFilter> | SearchCubeFilter>;
 }>;
 
-
-export type SearchCubesQuery = { __typename: 'Query', searchCubes: Array<{ __typename: 'SearchCubeResult', highlightedTitle?: Maybe<string>, highlightedDescription?: Maybe<string>, cube: SearchCube }> };
+export type SearchCubesQuery = {
+  __typename: "Query";
+  searchCubes: Array<{
+    __typename: "SearchCubeResult";
+    highlightedTitle?: Maybe<string>;
+    highlightedDescription?: Maybe<string>;
+    cube: SearchCube;
+  }>;
+};
 
 export type GeoCoordinatesByDimensionIriQueryVariables = Exact<{
-  dataCubeIri: Scalars['String'];
-  dimensionIri: Scalars['String'];
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  locale: Scalars['String'];
-  latest?: Maybe<Scalars['Boolean']>;
+  dataCubeIri: Scalars["String"];
+  dimensionIri: Scalars["String"];
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  locale: Scalars["String"];
+  latest?: Maybe<Scalars["Boolean"]>;
 }>;
 
-
-export type GeoCoordinatesByDimensionIriQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', dimensionByIri?: Maybe<{ __typename: 'GeoCoordinatesDimension', geoCoordinates?: Maybe<Array<{ __typename: 'GeoCoordinates', iri: string, label: string, latitude: number, longitude: number }>> } | { __typename: 'GeoShapesDimension' } | { __typename: 'NominalDimension' } | { __typename: 'NumericalMeasure' } | { __typename: 'OrdinalDimension' } | { __typename: 'OrdinalMeasure' } | { __typename: 'StandardErrorDimension' } | { __typename: 'TemporalDimension' } | { __typename: 'TemporalOrdinalDimension' }> }> };
+export type GeoCoordinatesByDimensionIriQuery = {
+  __typename: "Query";
+  dataCubeByIri?: Maybe<{
+    __typename: "DataCube";
+    dimensionByIri?: Maybe<
+      | {
+          __typename: "GeoCoordinatesDimension";
+          geoCoordinates?: Maybe<
+            Array<{
+              __typename: "GeoCoordinates";
+              iri: string;
+              label: string;
+              latitude: number;
+              longitude: number;
+            }>
+          >;
+        }
+      | { __typename: "GeoShapesDimension" }
+      | { __typename: "NominalDimension" }
+      | { __typename: "NumericalMeasure" }
+      | { __typename: "OrdinalDimension" }
+      | { __typename: "OrdinalMeasure" }
+      | { __typename: "StandardErrorDimension" }
+      | { __typename: "TemporalDimension" }
+      | { __typename: "TemporalOrdinalDimension" }
+    >;
+  }>;
+};
 
 export type GeoShapesByDimensionIriQueryVariables = Exact<{
-  dataCubeIri: Scalars['String'];
-  dimensionIri: Scalars['String'];
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  locale: Scalars['String'];
-  latest?: Maybe<Scalars['Boolean']>;
+  dataCubeIri: Scalars["String"];
+  dimensionIri: Scalars["String"];
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  locale: Scalars["String"];
+  latest?: Maybe<Scalars["Boolean"]>;
 }>;
 
-
-export type GeoShapesByDimensionIriQuery = { __typename: 'Query', dataCubeByIri?: Maybe<{ __typename: 'DataCube', dimensionByIri?: Maybe<{ __typename: 'GeoCoordinatesDimension' } | { __typename: 'GeoShapesDimension', geoShapes?: Maybe<any> } | { __typename: 'NominalDimension' } | { __typename: 'NumericalMeasure' } | { __typename: 'OrdinalDimension' } | { __typename: 'OrdinalMeasure' } | { __typename: 'StandardErrorDimension' } | { __typename: 'TemporalDimension' } | { __typename: 'TemporalOrdinalDimension' }> }> };
+export type GeoShapesByDimensionIriQuery = {
+  __typename: "Query";
+  dataCubeByIri?: Maybe<{
+    __typename: "DataCube";
+    dimensionByIri?: Maybe<
+      | { __typename: "GeoCoordinatesDimension" }
+      | { __typename: "GeoShapesDimension"; geoShapes?: Maybe<any> }
+      | { __typename: "NominalDimension" }
+      | { __typename: "NumericalMeasure" }
+      | { __typename: "OrdinalDimension" }
+      | { __typename: "OrdinalMeasure" }
+      | { __typename: "StandardErrorDimension" }
+      | { __typename: "TemporalDimension" }
+      | { __typename: "TemporalOrdinalDimension" }
+    >;
+  }>;
+};
 
 export type PossibleFiltersQueryVariables = Exact<{
-  iri: Scalars['String'];
-  sourceType: Scalars['String'];
-  sourceUrl: Scalars['String'];
-  filters: Scalars['Filters'];
+  iri: Scalars["String"];
+  sourceType: Scalars["String"];
+  sourceUrl: Scalars["String"];
+  filters: Scalars["Filters"];
 }>;
 
-
-export type PossibleFiltersQuery = { __typename: 'Query', possibleFilters: Array<{ __typename: 'ObservationFilter', iri: string, type: string, value?: Maybe<any> }> };
-
+export type PossibleFiltersQuery = {
+  __typename: "Query";
+  possibleFilters: Array<{
+    __typename: "ObservationFilter";
+    iri: string;
+    type: string;
+    value?: Maybe<any>;
+  }>;
+};
 
 export const DataCubeComponentsDocument = gql`
-    query DataCubeComponents($sourceType: String!, $sourceUrl: String!, $locale: String!, $cubeFilter: DataCubeComponentFilter!) {
-  dataCubeComponents(
-    sourceType: $sourceType
-    sourceUrl: $sourceUrl
-    locale: $locale
-    cubeFilter: $cubeFilter
-  )
-}
-    `;
-
-export function useDataCubeComponentsQuery(options: Omit<Urql.UseQueryArgs<DataCubeComponentsQueryVariables>, 'query'> = {}) {
-  return Urql.useQuery<DataCubeComponentsQuery>({ query: DataCubeComponentsDocument, ...options });
-};
-export const DataCubeMetadataDocument = gql`
-    query DataCubeMetadata($sourceType: String!, $sourceUrl: String!, $locale: String!, $cubeFilter: DataCubeMetadataFilter!) {
-  dataCubeMetadata(
-    sourceType: $sourceType
-    sourceUrl: $sourceUrl
-    locale: $locale
-    cubeFilter: $cubeFilter
-  )
-}
-    `;
-
-export function useDataCubeMetadataQuery(options: Omit<Urql.UseQueryArgs<DataCubeMetadataQueryVariables>, 'query'> = {}) {
-  return Urql.useQuery<DataCubeMetadataQuery>({ query: DataCubeMetadataDocument, ...options });
-};
-export const DataCubeObservationsDocument = gql`
-    query DataCubeObservations($sourceType: String!, $sourceUrl: String!, $locale: String!, $cubeFilter: DataCubeObservationFilter!) {
-  dataCubeObservations(
-    sourceType: $sourceType
-    sourceUrl: $sourceUrl
-    locale: $locale
-    cubeFilter: $cubeFilter
-  )
-}
-    `;
-
-export function useDataCubeObservationsQuery(options: Omit<Urql.UseQueryArgs<DataCubeObservationsQueryVariables>, 'query'> = {}) {
-  return Urql.useQuery<DataCubeObservationsQuery>({ query: DataCubeObservationsDocument, ...options });
-};
-export const DataCubePreviewDocument = gql`
-    query DataCubePreview($sourceType: String!, $sourceUrl: String!, $locale: String!, $cubeFilter: DataCubePreviewFilter!) {
-  dataCubePreview(
-    sourceType: $sourceType
-    sourceUrl: $sourceUrl
-    locale: $locale
-    cubeFilter: $cubeFilter
-  )
-}
-    `;
-
-export function useDataCubePreviewQuery(options: Omit<Urql.UseQueryArgs<DataCubePreviewQueryVariables>, 'query'> = {}) {
-  return Urql.useQuery<DataCubePreviewQuery>({ query: DataCubePreviewDocument, ...options });
-};
-export const SearchCubesDocument = gql`
-    query SearchCubes($sourceType: String!, $sourceUrl: String!, $locale: String!, $query: String, $order: SearchCubeResultOrder, $includeDrafts: Boolean, $filters: [SearchCubeFilter!]) {
-  searchCubes(
-    sourceType: $sourceType
-    sourceUrl: $sourceUrl
-    locale: $locale
-    query: $query
-    order: $order
-    includeDrafts: $includeDrafts
-    filters: $filters
+  query DataCubeComponents(
+    $sourceType: String!
+    $sourceUrl: String!
+    $locale: String!
+    $cubeFilter: DataCubeComponentFilter!
   ) {
-    highlightedTitle
-    highlightedDescription
-    cube
-  }
-}
-    `;
-
-export function useSearchCubesQuery(options: Omit<Urql.UseQueryArgs<SearchCubesQueryVariables>, 'query'> = {}) {
-  return Urql.useQuery<SearchCubesQuery>({ query: SearchCubesDocument, ...options });
-};
-export const GeoCoordinatesByDimensionIriDocument = gql`
-    query GeoCoordinatesByDimensionIri($dataCubeIri: String!, $dimensionIri: String!, $sourceType: String!, $sourceUrl: String!, $locale: String!, $latest: Boolean) {
-  dataCubeByIri(
-    iri: $dataCubeIri
-    sourceType: $sourceType
-    sourceUrl: $sourceUrl
-    locale: $locale
-    latest: $latest
-  ) {
-    dimensionByIri(
-      iri: $dimensionIri
+    dataCubeComponents(
       sourceType: $sourceType
       sourceUrl: $sourceUrl
+      locale: $locale
+      cubeFilter: $cubeFilter
+    )
+  }
+`;
+
+export function useDataCubeComponentsQuery(
+  options: Omit<
+    Urql.UseQueryArgs<DataCubeComponentsQueryVariables>,
+    "query"
+  > = {}
+) {
+  return Urql.useQuery<DataCubeComponentsQuery>({
+    query: DataCubeComponentsDocument,
+    ...options,
+  });
+}
+export const DataCubeMetadataDocument = gql`
+  query DataCubeMetadata(
+    $sourceType: String!
+    $sourceUrl: String!
+    $locale: String!
+    $cubeFilter: DataCubeMetadataFilter!
+  ) {
+    dataCubeMetadata(
+      sourceType: $sourceType
+      sourceUrl: $sourceUrl
+      locale: $locale
+      cubeFilter: $cubeFilter
+    )
+  }
+`;
+
+export function useDataCubeMetadataQuery(
+  options: Omit<Urql.UseQueryArgs<DataCubeMetadataQueryVariables>, "query"> = {}
+) {
+  return Urql.useQuery<DataCubeMetadataQuery>({
+    query: DataCubeMetadataDocument,
+    ...options,
+  });
+}
+export const DataCubeObservationsDocument = gql`
+  query DataCubeObservations(
+    $sourceType: String!
+    $sourceUrl: String!
+    $locale: String!
+    $cubeFilter: DataCubeObservationFilter!
+  ) {
+    dataCubeObservations(
+      sourceType: $sourceType
+      sourceUrl: $sourceUrl
+      locale: $locale
+      cubeFilter: $cubeFilter
+    )
+  }
+`;
+
+export function useDataCubeObservationsQuery(
+  options: Omit<
+    Urql.UseQueryArgs<DataCubeObservationsQueryVariables>,
+    "query"
+  > = {}
+) {
+  return Urql.useQuery<DataCubeObservationsQuery>({
+    query: DataCubeObservationsDocument,
+    ...options,
+  });
+}
+export const DataCubePreviewDocument = gql`
+  query DataCubePreview(
+    $sourceType: String!
+    $sourceUrl: String!
+    $locale: String!
+    $cubeFilter: DataCubePreviewFilter!
+  ) {
+    dataCubePreview(
+      sourceType: $sourceType
+      sourceUrl: $sourceUrl
+      locale: $locale
+      cubeFilter: $cubeFilter
+    )
+  }
+`;
+
+export function useDataCubePreviewQuery(
+  options: Omit<Urql.UseQueryArgs<DataCubePreviewQueryVariables>, "query"> = {}
+) {
+  return Urql.useQuery<DataCubePreviewQuery>({
+    query: DataCubePreviewDocument,
+    ...options,
+  });
+}
+export const SearchCubesDocument = gql`
+  query SearchCubes(
+    $sourceType: String!
+    $sourceUrl: String!
+    $locale: String!
+    $query: String
+    $order: SearchCubeResultOrder
+    $includeDrafts: Boolean
+    $filters: [SearchCubeFilter!]
+  ) {
+    searchCubes(
+      sourceType: $sourceType
+      sourceUrl: $sourceUrl
+      locale: $locale
+      query: $query
+      order: $order
+      includeDrafts: $includeDrafts
+      filters: $filters
     ) {
-      ... on GeoCoordinatesDimension {
-        geoCoordinates {
-          iri
-          label
-          latitude
-          longitude
+      highlightedTitle
+      highlightedDescription
+      cube
+    }
+  }
+`;
+
+export function useSearchCubesQuery(
+  options: Omit<Urql.UseQueryArgs<SearchCubesQueryVariables>, "query"> = {}
+) {
+  return Urql.useQuery<SearchCubesQuery>({
+    query: SearchCubesDocument,
+    ...options,
+  });
+}
+export const GeoCoordinatesByDimensionIriDocument = gql`
+  query GeoCoordinatesByDimensionIri(
+    $dataCubeIri: String!
+    $dimensionIri: String!
+    $sourceType: String!
+    $sourceUrl: String!
+    $locale: String!
+    $latest: Boolean
+  ) {
+    dataCubeByIri(
+      iri: $dataCubeIri
+      sourceType: $sourceType
+      sourceUrl: $sourceUrl
+      locale: $locale
+      latest: $latest
+    ) {
+      dimensionByIri(
+        iri: $dimensionIri
+        sourceType: $sourceType
+        sourceUrl: $sourceUrl
+      ) {
+        ... on GeoCoordinatesDimension {
+          geoCoordinates {
+            iri
+            label
+            latitude
+            longitude
+          }
         }
       }
     }
   }
-}
-    `;
+`;
 
-export function useGeoCoordinatesByDimensionIriQuery(options: Omit<Urql.UseQueryArgs<GeoCoordinatesByDimensionIriQueryVariables>, 'query'> = {}) {
-  return Urql.useQuery<GeoCoordinatesByDimensionIriQuery>({ query: GeoCoordinatesByDimensionIriDocument, ...options });
-};
+export function useGeoCoordinatesByDimensionIriQuery(
+  options: Omit<
+    Urql.UseQueryArgs<GeoCoordinatesByDimensionIriQueryVariables>,
+    "query"
+  > = {}
+) {
+  return Urql.useQuery<GeoCoordinatesByDimensionIriQuery>({
+    query: GeoCoordinatesByDimensionIriDocument,
+    ...options,
+  });
+}
 export const GeoShapesByDimensionIriDocument = gql`
-    query GeoShapesByDimensionIri($dataCubeIri: String!, $dimensionIri: String!, $sourceType: String!, $sourceUrl: String!, $locale: String!, $latest: Boolean) {
-  dataCubeByIri(
-    iri: $dataCubeIri
-    sourceType: $sourceType
-    sourceUrl: $sourceUrl
-    locale: $locale
-    latest: $latest
+  query GeoShapesByDimensionIri(
+    $dataCubeIri: String!
+    $dimensionIri: String!
+    $sourceType: String!
+    $sourceUrl: String!
+    $locale: String!
+    $latest: Boolean
   ) {
-    dimensionByIri(
-      iri: $dimensionIri
+    dataCubeByIri(
+      iri: $dataCubeIri
       sourceType: $sourceType
       sourceUrl: $sourceUrl
+      locale: $locale
+      latest: $latest
     ) {
-      ... on GeoShapesDimension {
-        geoShapes
+      dimensionByIri(
+        iri: $dimensionIri
+        sourceType: $sourceType
+        sourceUrl: $sourceUrl
+      ) {
+        ... on GeoShapesDimension {
+          geoShapes
+        }
       }
     }
   }
-}
-    `;
+`;
 
-export function useGeoShapesByDimensionIriQuery(options: Omit<Urql.UseQueryArgs<GeoShapesByDimensionIriQueryVariables>, 'query'> = {}) {
-  return Urql.useQuery<GeoShapesByDimensionIriQuery>({ query: GeoShapesByDimensionIriDocument, ...options });
-};
+export function useGeoShapesByDimensionIriQuery(
+  options: Omit<
+    Urql.UseQueryArgs<GeoShapesByDimensionIriQueryVariables>,
+    "query"
+  > = {}
+) {
+  return Urql.useQuery<GeoShapesByDimensionIriQuery>({
+    query: GeoShapesByDimensionIriDocument,
+    ...options,
+  });
+}
 export const PossibleFiltersDocument = gql`
-    query PossibleFilters($iri: String!, $sourceType: String!, $sourceUrl: String!, $filters: Filters!) {
-  possibleFilters(
-    iri: $iri
-    sourceType: $sourceType
-    sourceUrl: $sourceUrl
-    filters: $filters
+  query PossibleFilters(
+    $iri: String!
+    $sourceType: String!
+    $sourceUrl: String!
+    $filters: Filters!
   ) {
-    iri
-    type
-    value
+    possibleFilters(
+      iri: $iri
+      sourceType: $sourceType
+      sourceUrl: $sourceUrl
+      filters: $filters
+    ) {
+      iri
+      type
+      value
+    }
   }
-}
-    `;
+`;
 
-export function usePossibleFiltersQuery(options: Omit<Urql.UseQueryArgs<PossibleFiltersQueryVariables>, 'query'> = {}) {
-  return Urql.useQuery<PossibleFiltersQuery>({ query: PossibleFiltersDocument, ...options });
-};
+export function usePossibleFiltersQuery(
+  options: Omit<Urql.UseQueryArgs<PossibleFiltersQueryVariables>, "query"> = {}
+) {
+  return Urql.useQuery<PossibleFiltersQuery>({
+    query: PossibleFiltersDocument,
+    ...options,
+  });
+}

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -41,8 +41,8 @@ msgstr "Kein Ergebnis"
 msgid "annotation.add.description"
 msgstr "[ Ohne Beschreibung ]"
 
+#: app/components/rename-dialog.tsx
 #: app/configurator/components/annotators.tsx
-#: app/login/components/profile-tables.tsx
 #: app/login/components/profile-tables.tsx
 msgid "annotation.add.title"
 msgstr "[ Ohne Titel ]"
@@ -147,6 +147,14 @@ msgstr "Diese Visualisierung aktualisieren"
 #: app/components/chart-selection-tabs.tsx
 msgid "button.update.warning"
 msgstr "Denken Sie daran, dass sich die Aktualisierung dieser Visualisierung auf alle Stellen auswirkt, an denen sie bereits eingebettet ist!"
+
+#: app/configurator/components/chart-configurator.tsx
+msgid "chart.datasets.add"
+msgstr "Hinzufügen"
+
+#: app/configurator/components/add-dataset-dialog.tsx
+msgid "chart.datasets.add-dataset-dialog.title"
+msgstr "Wählen Sie einen Datensatz mit gemeinsamen Dimensionen aus"
 
 #: app/configurator/components/field-i18n.ts
 msgid "chart.map.layers.area"
@@ -520,23 +528,23 @@ msgstr "-"
 msgid "controls.imputation.type.zeros"
 msgstr "Nullen"
 
+#: app/components/rename-dialog.tsx
 #: app/configurator/components/field-i18n.ts
-#: app/login/components/profile-tables.tsx
 msgid "controls.language.english"
 msgstr "Englisch"
 
+#: app/components/rename-dialog.tsx
 #: app/configurator/components/field-i18n.ts
-#: app/login/components/profile-tables.tsx
 msgid "controls.language.french"
 msgstr "Französisch"
 
+#: app/components/rename-dialog.tsx
 #: app/configurator/components/field-i18n.ts
-#: app/login/components/profile-tables.tsx
 msgid "controls.language.german"
 msgstr "Deutsch"
 
+#: app/components/rename-dialog.tsx
 #: app/configurator/components/field-i18n.ts
-#: app/login/components/profile-tables.tsx
 msgid "controls.language.italian"
 msgstr "Italienisch"
 
@@ -689,6 +697,7 @@ msgid "controls.section.columnstyle"
 msgstr "Spaltenstil"
 
 #: app/components/chart-filters-list.tsx
+#: app/components/chart-filters-list.tsx
 #: app/configurator/components/chart-configurator.tsx
 msgid "controls.section.data.filters"
 msgstr "Filter"
@@ -701,6 +710,10 @@ msgstr "Keine Filter"
 #: app/configurator/components/chart-configurator.tsx
 msgid "controls.section.data.filters.possible-filters-error"
 msgstr "Beim Abrufen möglicher Filter ist ein Fehler aufgetreten. Bitte versuchen Sie es später erneut oder laden Sie die Seite neu."
+
+#: app/configurator/components/chart-configurator.tsx
+msgid "controls.section.datasets.title"
+msgstr "Datenquellen"
 
 #: app/configurator/components/annotators.tsx
 #: app/configurator/components/annotators.tsx
@@ -1061,11 +1074,17 @@ msgstr "Achtung, dieser Datensatz ist abgelaufen.<0/><1>Diese Grafik nicht für 
 msgid "dataset.results"
 msgstr "{0, plural, zero {Keine Datensätze} one {# Datensatz} other {# Datensätze}}"
 
+#: app/configurator/components/add-dataset-dialog.tsx
+msgid "dataset.search.add-dataset"
+msgstr ""
+
 #: app/browser/dataset-browse.tsx
+#: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.label"
 msgstr "Suchen"
 
 #: app/browser/dataset-browse.tsx
+#: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.placeholder"
 msgstr "Name, Organisation, Stichwort..."
 
@@ -1143,6 +1162,7 @@ msgstr "Daten-Ladefehler"
 msgid "hint.how.to.share"
 msgstr "Sie können diese Visualisierung teilen oder sie einbetten. Zudem können Sie eine neue Visualisierung erstellen oder die gezeigte Visualisierung kopieren."
 
+#: app/components/chart-filters-list.tsx
 #: app/components/form.tsx
 #: app/components/hint.tsx
 msgid "hint.loading.data"
@@ -1298,12 +1318,12 @@ msgid "login.profile.my-visualizations.multiple-datasets"
 msgstr ""
 
 #: app/login/components/profile-tables.tsx
-msgid "login.rename-dialog.cancel"
-msgstr "Abbrechen"
+#~ msgid "login.rename-dialog.cancel"
+#~ msgstr "Abbrechen"
 
 #: app/login/components/profile-tables.tsx
-msgid "login.rename-dialog.save"
-msgstr "Speichern"
+#~ msgid "login.rename-dialog.save"
+#~ msgstr "Speichern"
 
 #: app/components/header.tsx
 #: app/components/header.tsx
@@ -1334,11 +1354,11 @@ msgstr "Zur Tabellenansicht wechseln"
 msgid "no"
 msgstr "Nein"
 
-#: app/login/components/profile-tables.tsx
+#: app/components/rename-dialog.tsx
 msgid "profile.chart.rename-dialog.description"
 msgstr "Verbessern Sie die Klarheit des Diagramms mit einem klaren Titel. Ein guter Titel hilft Diagramminhalte verstehen."
 
-#: app/login/components/profile-tables.tsx
+#: app/components/rename-dialog.tsx
 msgid "profile.chart.rename-dialog.title"
 msgstr "Benennen Sie die Visualisierung um"
 

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -41,8 +41,8 @@ msgstr "No results"
 msgid "annotation.add.description"
 msgstr "[ No Description ]"
 
+#: app/components/rename-dialog.tsx
 #: app/configurator/components/annotators.tsx
-#: app/login/components/profile-tables.tsx
 #: app/login/components/profile-tables.tsx
 msgid "annotation.add.title"
 msgstr "[ No Title ]"
@@ -147,6 +147,14 @@ msgstr "Update this visualization"
 #: app/components/chart-selection-tabs.tsx
 msgid "button.update.warning"
 msgstr "Keep in mind that updating this visualization will affect all the places where it might be already embedded!"
+
+#: app/configurator/components/chart-configurator.tsx
+msgid "chart.datasets.add"
+msgstr "Add dataset"
+
+#: app/configurator/components/add-dataset-dialog.tsx
+msgid "chart.datasets.add-dataset-dialog.title"
+msgstr "Select dataset with shared dimensions"
 
 #: app/configurator/components/field-i18n.ts
 msgid "chart.map.layers.area"
@@ -520,23 +528,23 @@ msgstr "-"
 msgid "controls.imputation.type.zeros"
 msgstr "Zeros"
 
+#: app/components/rename-dialog.tsx
 #: app/configurator/components/field-i18n.ts
-#: app/login/components/profile-tables.tsx
 msgid "controls.language.english"
 msgstr "English"
 
+#: app/components/rename-dialog.tsx
 #: app/configurator/components/field-i18n.ts
-#: app/login/components/profile-tables.tsx
 msgid "controls.language.french"
 msgstr "French"
 
+#: app/components/rename-dialog.tsx
 #: app/configurator/components/field-i18n.ts
-#: app/login/components/profile-tables.tsx
 msgid "controls.language.german"
 msgstr "German"
 
+#: app/components/rename-dialog.tsx
 #: app/configurator/components/field-i18n.ts
-#: app/login/components/profile-tables.tsx
 msgid "controls.language.italian"
 msgstr "Italian"
 
@@ -689,6 +697,7 @@ msgid "controls.section.columnstyle"
 msgstr "Column Style"
 
 #: app/components/chart-filters-list.tsx
+#: app/components/chart-filters-list.tsx
 #: app/configurator/components/chart-configurator.tsx
 msgid "controls.section.data.filters"
 msgstr "Filters"
@@ -701,6 +710,10 @@ msgstr "No filters"
 #: app/configurator/components/chart-configurator.tsx
 msgid "controls.section.data.filters.possible-filters-error"
 msgstr "An error happened while fetching possible filters, please retry later or reload the page."
+
+#: app/configurator/components/chart-configurator.tsx
+msgid "controls.section.datasets.title"
+msgstr "Data Sources"
 
 #: app/configurator/components/annotators.tsx
 #: app/configurator/components/annotators.tsx
@@ -1061,11 +1074,17 @@ msgstr "Careful, the data for this chart has expired.<0/><1>Don't use for report
 msgid "dataset.results"
 msgstr "{0, plural, zero {No datasets} one {# dataset} other {# datasets}}"
 
+#: app/configurator/components/add-dataset-dialog.tsx
+msgid "dataset.search.add-dataset"
+msgstr "Add dataset"
+
 #: app/browser/dataset-browse.tsx
+#: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.label"
 msgstr "Search datasets"
 
 #: app/browser/dataset-browse.tsx
+#: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.placeholder"
 msgstr "Name, organization, keyword..."
 
@@ -1143,6 +1162,7 @@ msgstr "Data loading error"
 msgid "hint.how.to.share"
 msgstr "You can share this visualization by copying the URL or by embedding it on your own website. You can also create a new visualization from scratch or start by copying the visualization above."
 
+#: app/components/chart-filters-list.tsx
 #: app/components/form.tsx
 #: app/components/hint.tsx
 msgid "hint.loading.data"
@@ -1302,12 +1322,12 @@ msgid "login.profile.my-visualizations.multiple-datasets"
 msgstr "Multiple datasets"
 
 #: app/login/components/profile-tables.tsx
-msgid "login.rename-dialog.cancel"
-msgstr "Cancel"
+#~ msgid "login.rename-dialog.cancel"
+#~ msgstr "Cancel"
 
 #: app/login/components/profile-tables.tsx
-msgid "login.rename-dialog.save"
-msgstr "Save"
+#~ msgid "login.rename-dialog.save"
+#~ msgstr "Save"
 
 #: app/components/header.tsx
 #: app/components/header.tsx
@@ -1338,11 +1358,11 @@ msgstr "Switch to table view"
 msgid "no"
 msgstr "No"
 
-#: app/login/components/profile-tables.tsx
+#: app/components/rename-dialog.tsx
 msgid "profile.chart.rename-dialog.description"
 msgstr "Enhance chart clarity with a clear title; a good title helps understanding chart content."
 
-#: app/login/components/profile-tables.tsx
+#: app/components/rename-dialog.tsx
 msgid "profile.chart.rename-dialog.title"
 msgstr "Rename the visualization"
 

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -41,8 +41,8 @@ msgstr "Aucun résultat"
 msgid "annotation.add.description"
 msgstr "[ Pas de description ]"
 
+#: app/components/rename-dialog.tsx
 #: app/configurator/components/annotators.tsx
-#: app/login/components/profile-tables.tsx
 #: app/login/components/profile-tables.tsx
 msgid "annotation.add.title"
 msgstr "[ Pas de titre ]"
@@ -147,6 +147,14 @@ msgstr "Actualiser cette visualisation"
 #: app/components/chart-selection-tabs.tsx
 msgid "button.update.warning"
 msgstr "Gardez à l'esprit que la mise à jour de cette visualisation affectera tous les endroits où elle est déjà intégrée !"
+
+#: app/configurator/components/chart-configurator.tsx
+msgid "chart.datasets.add"
+msgstr "Ajouter"
+
+#: app/configurator/components/add-dataset-dialog.tsx
+msgid "chart.datasets.add-dataset-dialog.title"
+msgstr "Sélectionner un ensemble de données avec des dimensions partagées"
 
 #: app/configurator/components/field-i18n.ts
 msgid "chart.map.layers.area"
@@ -520,23 +528,23 @@ msgstr "-"
 msgid "controls.imputation.type.zeros"
 msgstr "Zéros"
 
+#: app/components/rename-dialog.tsx
 #: app/configurator/components/field-i18n.ts
-#: app/login/components/profile-tables.tsx
 msgid "controls.language.english"
 msgstr "Anglais"
 
+#: app/components/rename-dialog.tsx
 #: app/configurator/components/field-i18n.ts
-#: app/login/components/profile-tables.tsx
 msgid "controls.language.french"
 msgstr "Français"
 
+#: app/components/rename-dialog.tsx
 #: app/configurator/components/field-i18n.ts
-#: app/login/components/profile-tables.tsx
 msgid "controls.language.german"
 msgstr "Allemand"
 
+#: app/components/rename-dialog.tsx
 #: app/configurator/components/field-i18n.ts
-#: app/login/components/profile-tables.tsx
 msgid "controls.language.italian"
 msgstr "Italien"
 
@@ -689,6 +697,7 @@ msgid "controls.section.columnstyle"
 msgstr "Style de la colonne"
 
 #: app/components/chart-filters-list.tsx
+#: app/components/chart-filters-list.tsx
 #: app/configurator/components/chart-configurator.tsx
 msgid "controls.section.data.filters"
 msgstr "Filtres"
@@ -701,6 +710,10 @@ msgstr "Aucun filtre"
 #: app/configurator/components/chart-configurator.tsx
 msgid "controls.section.data.filters.possible-filters-error"
 msgstr "Une erreur s'est produite lors de la récupération des filtres possibles. Merci de réessayer plus tard ou d'actualiser la page."
+
+#: app/configurator/components/chart-configurator.tsx
+msgid "controls.section.datasets.title"
+msgstr "Sources de données"
 
 #: app/configurator/components/annotators.tsx
 #: app/configurator/components/annotators.tsx
@@ -1061,11 +1074,17 @@ msgstr "Attention, ce jeu de données est expiré.<0/><1>Ne l'utilisez pas pour 
 msgid "dataset.results"
 msgstr "{0, plural, zero {Aucun jeu de données} one {# jeu de données} other {# jeux de données}}"
 
+#: app/configurator/components/add-dataset-dialog.tsx
+msgid "dataset.search.add-dataset"
+msgstr "Ajouter la source"
+
 #: app/browser/dataset-browse.tsx
+#: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.label"
 msgstr "Chercher"
 
 #: app/browser/dataset-browse.tsx
+#: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.placeholder"
 msgstr "Nom, organisation, mots clés..."
 
@@ -1143,6 +1162,7 @@ msgstr "Problème de téléchargement des données"
 msgid "hint.how.to.share"
 msgstr "Vous pouvez partager cette visualisation en copiant l'URL ou en l'intégrant sur votre site Web. Vous pouvez également créer une toute nouvelle visualisation, ou bien copier et modifier la visualisation ci-dessus."
 
+#: app/components/chart-filters-list.tsx
 #: app/components/form.tsx
 #: app/components/hint.tsx
 msgid "hint.loading.data"
@@ -1302,12 +1322,12 @@ msgid "login.profile.my-visualizations.multiple-datasets"
 msgstr ""
 
 #: app/login/components/profile-tables.tsx
-msgid "login.rename-dialog.cancel"
-msgstr "Annuler"
+#~ msgid "login.rename-dialog.cancel"
+#~ msgstr "Annuler"
 
 #: app/login/components/profile-tables.tsx
-msgid "login.rename-dialog.save"
-msgstr "Sauver"
+#~ msgid "login.rename-dialog.save"
+#~ msgstr "Sauver"
 
 #: app/components/header.tsx
 #: app/components/header.tsx
@@ -1338,11 +1358,11 @@ msgstr "Passer à la vue en tableau"
 msgid "no"
 msgstr "Non"
 
-#: app/login/components/profile-tables.tsx
+#: app/components/rename-dialog.tsx
 msgid "profile.chart.rename-dialog.description"
 msgstr "Améliorez la clarté de la visualisation avec un titre clair ; un bon titre aide à comprendre le contenu de la visualisation."
 
-#: app/login/components/profile-tables.tsx
+#: app/components/rename-dialog.tsx
 msgid "profile.chart.rename-dialog.title"
 msgstr "Renommer la visualisation"
 

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -41,8 +41,8 @@ msgstr "Nessun risultato"
 msgid "annotation.add.description"
 msgstr "[ Nessuna descrizione ]"
 
+#: app/components/rename-dialog.tsx
 #: app/configurator/components/annotators.tsx
-#: app/login/components/profile-tables.tsx
 #: app/login/components/profile-tables.tsx
 msgid "annotation.add.title"
 msgstr "[ Nessun titolo ]"
@@ -147,6 +147,14 @@ msgstr "Aggiornare questa visualizzazione"
 #: app/components/chart-selection-tabs.tsx
 msgid "button.update.warning"
 msgstr "Tenete presente che l'aggiornamento di questa visualizzazione avrà effetto su tutti i luoghi in cui potrebbe essere già incorporata!"
+
+#: app/configurator/components/chart-configurator.tsx
+msgid "chart.datasets.add"
+msgstr "Aggiungere"
+
+#: app/configurator/components/add-dataset-dialog.tsx
+msgid "chart.datasets.add-dataset-dialog.title"
+msgstr "Seleziona il set di dati con dimensioni condivise"
 
 #: app/configurator/components/field-i18n.ts
 msgid "chart.map.layers.area"
@@ -520,23 +528,23 @@ msgstr "-"
 msgid "controls.imputation.type.zeros"
 msgstr "Zeri"
 
+#: app/components/rename-dialog.tsx
 #: app/configurator/components/field-i18n.ts
-#: app/login/components/profile-tables.tsx
 msgid "controls.language.english"
 msgstr "Inglese"
 
+#: app/components/rename-dialog.tsx
 #: app/configurator/components/field-i18n.ts
-#: app/login/components/profile-tables.tsx
 msgid "controls.language.french"
 msgstr "Francese"
 
+#: app/components/rename-dialog.tsx
 #: app/configurator/components/field-i18n.ts
-#: app/login/components/profile-tables.tsx
 msgid "controls.language.german"
 msgstr "Tedesco"
 
+#: app/components/rename-dialog.tsx
 #: app/configurator/components/field-i18n.ts
-#: app/login/components/profile-tables.tsx
 msgid "controls.language.italian"
 msgstr "Italiano"
 
@@ -689,6 +697,7 @@ msgid "controls.section.columnstyle"
 msgstr "Stile della colonna"
 
 #: app/components/chart-filters-list.tsx
+#: app/components/chart-filters-list.tsx
 #: app/configurator/components/chart-configurator.tsx
 msgid "controls.section.data.filters"
 msgstr "Filtri"
@@ -701,6 +710,10 @@ msgstr "Nessun filtro"
 #: app/configurator/components/chart-configurator.tsx
 msgid "controls.section.data.filters.possible-filters-error"
 msgstr "Si è verificato un errore durante il recupero dei possibili filtri. Riprova più tardi o aggiorna la pagina."
+
+#: app/configurator/components/chart-configurator.tsx
+msgid "controls.section.datasets.title"
+msgstr "Fonti di dati"
 
 #: app/configurator/components/annotators.tsx
 #: app/configurator/components/annotators.tsx
@@ -1061,11 +1074,17 @@ msgstr "Attenzione, questo set di dati è scaduto.<0/><1>Non utilizzare questo g
 msgid "dataset.results"
 msgstr "{0, plural, zero {Nessun set di dati} one {# set di dati} other {# set di dati}}"
 
+#: app/configurator/components/add-dataset-dialog.tsx
+msgid "dataset.search.add-dataset"
+msgstr "Aggiungi set di dati"
+
 #: app/browser/dataset-browse.tsx
+#: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.label"
 msgstr "Cerca"
 
 #: app/browser/dataset-browse.tsx
+#: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.placeholder"
 msgstr "Nome, organizzazione, parola chiave..."
 
@@ -1143,6 +1162,7 @@ msgstr "Problema di caricamento dei dati"
 msgid "hint.how.to.share"
 msgstr "È possibile condividere questa visualizzazione copiando l'URL o incorporandola nel vostro sito Web. Puoi anche creare una nuova visualizzazione partendo da zero oppure copiando e modificando la visualizzazione sopra."
 
+#: app/components/chart-filters-list.tsx
 #: app/components/form.tsx
 #: app/components/hint.tsx
 msgid "hint.loading.data"
@@ -1302,12 +1322,12 @@ msgid "login.profile.my-visualizations.multiple-datasets"
 msgstr ""
 
 #: app/login/components/profile-tables.tsx
-msgid "login.rename-dialog.cancel"
-msgstr "Annulla"
+#~ msgid "login.rename-dialog.cancel"
+#~ msgstr "Annulla"
 
 #: app/login/components/profile-tables.tsx
-msgid "login.rename-dialog.save"
-msgstr "Salva"
+#~ msgid "login.rename-dialog.save"
+#~ msgstr "Salva"
 
 #: app/components/header.tsx
 #: app/components/header.tsx
@@ -1338,11 +1358,11 @@ msgstr "Passare alla vista tabella"
 msgid "no"
 msgstr "No"
 
-#: app/login/components/profile-tables.tsx
+#: app/components/rename-dialog.tsx
 msgid "profile.chart.rename-dialog.description"
 msgstr ""
 
-#: app/login/components/profile-tables.tsx
+#: app/components/rename-dialog.tsx
 msgid "profile.chart.rename-dialog.title"
 msgstr ""
 

--- a/app/login/components/profile-content-tabs.tsx
+++ b/app/login/components/profile-content-tabs.tsx
@@ -82,7 +82,7 @@ export const ProfileContentTabs = (props: ProfileContentTabsProps) => {
                 className={classes.tab}
                 label={t({
                   id: "login.profile.my-published-visualizations",
-                  message: "My Published Visualizations",
+                  message: "My published visualizations",
                 })}
                 value="published"
               />

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -1,13 +1,7 @@
 import { t, Trans } from "@lingui/macro";
-import { LoadingButton, TabContext } from "@mui/lab";
 import {
   Box,
   Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogProps,
-  DialogTitle,
   Link,
   Skeleton,
   styled,
@@ -19,28 +13,25 @@ import {
   tableHeadClasses,
   TableRow,
   tableRowClasses,
-  TextField,
   Typography,
-  useEventCallback,
 } from "@mui/material";
 import { PUBLISHED_STATE } from "@prisma/client";
 import sortBy from "lodash/sortBy";
 import NextLink from "next/link";
-import React, { FormEvent, useState } from "react";
+import React from "react";
 
-import { VisualizeTab, VisualizeTabList } from "@/components/tabs";
 import useDisclosure from "@/components/use-disclosure";
 import { ParsedConfig } from "@/db/config";
 import { sourceToLabel } from "@/domain/datasource";
 import { truthy } from "@/domain/types";
 import { useUserConfigs } from "@/domain/user-configs";
 import { useDataCubesMetadataQuery } from "@/graphql/hooks";
-import { Locale } from "@/locales/locales";
 import { useRootStyles } from "@/login/utils";
 import { useLocale } from "@/src";
 import { removeConfig, updateConfig } from "@/utils/chart-config/api";
 import { useMutate } from "@/utils/use-fetch-data";
 
+import { RenameDialog } from "../../components/rename-dialog";
 import { ActionProps, RowActions } from "../../components/row-actions";
 
 const PREVIEW_LIMIT = 3;
@@ -173,145 +164,6 @@ export const ProfileVisualizationsTable = (
 type ProfileVisualizationsRowProps = {
   userId: number;
   config: ParsedConfig;
-};
-
-const RenameDialog = ({
-  config,
-  locale,
-  onClose,
-  userId,
-  ...props
-}: {
-  config: ParsedConfig;
-  locale: Locale;
-  onClose: () => void;
-  userId: number;
-} & Omit<DialogProps, "onClose">) => {
-  const { invalidate: invalidateUserConfigs } = useUserConfigs();
-  const [renameIndex, setRenameIndex] = useState(0);
-
-  const updateConfigMut = useMutate(updateConfig);
-
-  const handleRename = useEventCallback(
-    async (ev: FormEvent<HTMLFormElement>) => {
-      const arrData = Array.from(new FormData(ev.currentTarget));
-      const formData = arrData.reduce((acc, [key, value]) => {
-        const [_field, indexS, lang] = key.split(".");
-        const index = Number(indexS);
-        acc[index] = acc[index] || ({} as Record<string, string>);
-        acc[index][lang as Locale] = `${value}`;
-        return acc;
-      }, [] as Record<Locale, string>[]);
-      ev.preventDefault();
-
-      await updateConfigMut.mutate({
-        key: config.key,
-        data: {
-          ...config.data,
-          chartConfigs: config.data.chartConfigs.map((x, i) => ({
-            ...x,
-            meta: {
-              ...x.meta,
-              title: formData[i],
-            },
-          })),
-        },
-      });
-
-      invalidateUserConfigs();
-      onClose?.();
-    }
-  );
-
-  return (
-    <Dialog {...props} onClose={onClose} fullWidth>
-      <form style={{ display: "contents" }} onSubmit={handleRename}>
-        <DialogTitle>
-          <Trans id="profile.chart.rename-dialog.title">
-            Rename the visualization
-          </Trans>
-        </DialogTitle>
-        <DialogContent>
-          <Typography variant="body2">
-            <Trans id="profile.chart.rename-dialog.description">
-              Enhance chart clarity with a clear title; a good title helps
-              understanding chart content.
-            </Trans>
-          </Typography>
-          <TabContext value={`${renameIndex}`}>
-            <VisualizeTabList
-              sx={{ my: "1rem" }}
-              onChange={(_ev, newTab) => setRenameIndex(newTab)}
-            >
-              {config.data.chartConfigs.map((x, i) => {
-                return (
-                  <VisualizeTab
-                    key={i}
-                    value={`${i}`}
-                    label={
-                      <span>
-                        {x.meta.title[locale] !== ""
-                          ? x.meta.title[locale]
-                          : t({ id: "annotation.add.title" })}
-                      </span>
-                    }
-                  />
-                );
-              })}
-            </VisualizeTabList>
-            {config.data.chartConfigs.map((x, i) => {
-              return (
-                <Box
-                  key={i}
-                  sx={{
-                    padding: 0,
-                    gap: "1rem",
-                    flexDirection: "column",
-                    display: `${renameIndex}` === `${i}` ? "flex" : "none",
-                  }}
-                >
-                  <TextField
-                    name={`title.${i}.de`}
-                    label={t({ id: "controls.language.german" })}
-                    defaultValue={x.meta.title.de}
-                  />
-                  <TextField
-                    name={`title.${i}.fr`}
-                    label={t({ id: "controls.language.french" })}
-                    defaultValue={x.meta.title.fr}
-                  />
-                  <TextField
-                    name={`title.${i}.it`}
-                    label={t({ id: "controls.language.italian" })}
-                    defaultValue={x.meta.title.it}
-                  />
-                  <TextField
-                    name={`title.${i}.en`}
-                    label={t({ id: "controls.language.english" })}
-                    defaultValue={x.meta.title.en}
-                  />
-                </Box>
-              );
-            })}
-          </TabContext>
-        </DialogContent>
-        <DialogActions sx={{ pb: 6, pr: 6 }}>
-          <Button variant="outlined" onClick={onClose}>
-            {t({ id: "login.rename-dialog.cancel" })}
-          </Button>
-          <LoadingButton
-            sx={{ minWidth: "auto" }}
-            loading={updateConfigMut.status === "fetching"}
-            variant="contained"
-            color="primary"
-            type="submit"
-          >
-            {t({ id: "login.rename-dialog.save" })}
-          </LoadingButton>
-        </DialogActions>
-      </form>
-    </Dialog>
-  );
 };
 
 const ProfileVisualizationsRow = (props: ProfileVisualizationsRowProps) => {

--- a/app/package.json
+++ b/app/package.json
@@ -45,6 +45,7 @@
     "@rdfjs/namespace": "^2.0.1",
     "@reach/auto-id": "^0.15.0",
     "@sentry/nextjs": "^7.7.0",
+    "@testing-library/react-hooks": "^8.0.1",
     "@tpluscode/rdf-ns-builders": "2.0.1",
     "@tpluscode/rdf-string": "^0.2.26",
     "@tpluscode/sparql-builder": "^0.3.24",

--- a/app/rdf/mappings.ts
+++ b/app/rdf/mappings.ts
@@ -1,0 +1,20 @@
+import { TimeUnit } from "../graphql/resolver-types";
+
+import * as ns from "./namespace";
+
+export const timeUnits = new Map<string, TimeUnit>([
+  [ns.time.unitYear.value, TimeUnit.Year],
+  [ns.time.unitMonth.value, TimeUnit.Month],
+  [ns.time.unitWeek.value, TimeUnit.Week],
+  [ns.time.unitDay.value, TimeUnit.Day],
+  [ns.time.unitHour.value, TimeUnit.Hour],
+  [ns.time.unitMinute.value, TimeUnit.Minute],
+  [ns.time.unitSecond.value, TimeUnit.Second],
+]);
+
+export const timeFormats = new Map<string, string>([
+  [ns.xsd.gYear.value, "%Y"],
+  [ns.xsd.gYearMonth.value, "%Y-%m"],
+  [ns.xsd.date.value, "%Y-%m-%d"],
+  [ns.xsd.dateTime.value, "%Y-%m-%dT%H:%M:%S"],
+]);

--- a/app/rdf/mappings.ts
+++ b/app/rdf/mappings.ts
@@ -12,6 +12,10 @@ export const timeUnits = new Map<string, TimeUnit>([
   [ns.time.unitSecond.value, TimeUnit.Second],
 ]);
 
+export const unitsToNode = new Map(
+  Array.from(timeUnits.entries()).map(([k, v]) => [v, k])
+);
+
 export const timeFormats = new Map<string, string>([
   [ns.xsd.gYear.value, "%Y"],
   [ns.xsd.gYearMonth.value, "%Y-%m"],

--- a/app/rdf/parse.ts
+++ b/app/rdf/parse.ts
@@ -17,10 +17,11 @@ import { truthy } from "@/domain/types";
 import { ScaleType } from "@/graphql/query-hooks";
 import { ExtendedCube } from "@/rdf/extended-cube";
 
-import { DataCubePublicationStatus, TimeUnit } from "../graphql/resolver-types";
+import { DataCubePublicationStatus } from "../graphql/resolver-types";
 import { ResolvedDataCube, ResolvedDimension } from "../graphql/shared-types";
 import { locales } from "../locales/locales";
 
+import { timeFormats, timeUnits } from "./mappings";
 import * as ns from "./namespace";
 import { hasHierarchy } from "./queries";
 
@@ -94,23 +95,6 @@ export const parseCube = ({
     },
   };
 };
-
-const timeUnits = new Map<string, TimeUnit>([
-  [ns.time.unitYear.value, TimeUnit.Year],
-  [ns.time.unitMonth.value, TimeUnit.Month],
-  [ns.time.unitWeek.value, TimeUnit.Week],
-  [ns.time.unitDay.value, TimeUnit.Day],
-  [ns.time.unitHour.value, TimeUnit.Hour],
-  [ns.time.unitMinute.value, TimeUnit.Minute],
-  [ns.time.unitSecond.value, TimeUnit.Second],
-]);
-
-const timeFormats = new Map<string, string>([
-  [ns.xsd.gYear.value, "%Y"],
-  [ns.xsd.gYearMonth.value, "%Y-%m"],
-  [ns.xsd.date.value, "%Y-%m-%d"],
-  [ns.xsd.dateTime.value, "%Y-%m-%dT%H:%M:%S"],
-]);
 
 export const getScaleType = (
   scaleTypeTerm: Term | undefined

--- a/app/rdf/query-search.ts
+++ b/app/rdf/query-search.ts
@@ -243,7 +243,6 @@ export const searchCubes = async ({
     .THEN.BY`?description`.THEN.BY`?publisher`.THEN.BY`?creatorIri`.THEN
     .BY`?creatorLabel`.prologue`${pragmas}`.prologue`#pragma join.bind off`; // HOTFIX WRT Stardog v9.2.1 bug see https://control.vshn.net/tickets/sbar-1066
 
-  console.log(scoresQuery.build());
   const scoreResults = await scoresQuery.execute(sparqlClient.query, {
     operation: "postUrlencoded",
   });

--- a/app/test/utils.ts
+++ b/app/test/utils.ts
@@ -51,3 +51,47 @@ export const findFixtureConfig = async ({
   );
   return testConfig;
 };
+
+/** Used to mock fetch */
+export class Response {
+  body: ReadableStream<Uint8Array>;
+  ok: boolean;
+  status: number;
+  redirected: false;
+  statusText: string;
+  type: ResponseType;
+  url: string;
+  bodyUsed: boolean;
+  headers: Headers;
+  constructor(body: string) {
+    // @ts-ignore
+    this.body = body;
+    this.ok = true;
+    this.redirected = false;
+    this.status = 200;
+    this.statusText = "OK";
+    this.type = "basic";
+    this.url = "";
+    this.bodyUsed = false;
+    this.headers = new Headers();
+  }
+  async json() {
+    // @ts-ignore
+    return JSON.parse(this.body);
+  }
+  async text() {
+    return this.body.toString();
+  }
+  async arrayBuffer() {
+    return new ArrayBuffer(0);
+  }
+  clone() {
+    return this;
+  }
+  async blob() {
+    return new Blob();
+  }
+  async formData() {
+    return new FormData();
+  }
+}

--- a/app/urql-cache.mock.ts
+++ b/app/urql-cache.mock.ts
@@ -1,0 +1,404 @@
+import { ScaleType } from "@/graphql/query-hooks";
+import { getCachedComponents } from "@/urql-cache";
+
+export const getCachedComponentsMock: Record<
+  string,
+  ReturnType<typeof getCachedComponents>
+> = {
+  electricyPricePerCantonDimensions: {
+    dimensions: [
+      {
+        __typename: "GeoShapesDimension",
+        cubeIri: "https://energy.ld.admin.ch/elcom/electricityprice-canton",
+        iri: "https://energy.ld.admin.ch/elcom/electricityprice/dimension/canton",
+        label: "Kanton",
+        scaleType: "Nominal" as ScaleType,
+        isNumerical: false,
+        isKeyDimension: true,
+        values: [
+          {
+            value: "https://ld.admin.ch/canton/1",
+            label: "Zürich",
+            identifier: 1,
+            alternateName: "ZH",
+          },
+          {
+            value: "https://ld.admin.ch/canton/10",
+            label: "Freiburg",
+            identifier: 10,
+            alternateName: "FR",
+          },
+          {
+            value: "https://ld.admin.ch/canton/11",
+            label: "Solothurn",
+            identifier: 11,
+            alternateName: "SO",
+          },
+          {
+            value: "https://ld.admin.ch/canton/12",
+            label: "Basel-Stadt",
+            identifier: 12,
+            alternateName: "BS",
+          },
+          {
+            value: "https://ld.admin.ch/canton/13",
+            label: "Basel-Landschaft",
+            identifier: 13,
+            alternateName: "BL",
+          },
+          {
+            value: "https://ld.admin.ch/canton/14",
+            label: "Schaffhausen",
+            identifier: 14,
+            alternateName: "SH",
+          },
+          {
+            value: "https://ld.admin.ch/canton/15",
+            label: "Appenzell Ausserrhoden",
+            identifier: 15,
+            alternateName: "AR",
+          },
+          {
+            value: "https://ld.admin.ch/canton/16",
+            label: "Appenzell Innerrhoden",
+            identifier: 16,
+            alternateName: "AI",
+          },
+          {
+            value: "https://ld.admin.ch/canton/17",
+            label: "St. Gallen",
+            identifier: 17,
+            alternateName: "SG",
+          },
+          {
+            value: "https://ld.admin.ch/canton/18",
+            label: "Graubünden",
+            identifier: 18,
+            alternateName: "GR",
+          },
+          {
+            value: "https://ld.admin.ch/canton/19",
+            label: "Aargau",
+            identifier: 19,
+            alternateName: "AG",
+          },
+          {
+            value: "https://ld.admin.ch/canton/2",
+            label: "Bern",
+            identifier: 2,
+            alternateName: "BE",
+          },
+          {
+            value: "https://ld.admin.ch/canton/20",
+            label: "Thurgau",
+            identifier: 20,
+            alternateName: "TG",
+          },
+          {
+            value: "https://ld.admin.ch/canton/21",
+            label: "Tessin",
+            identifier: 21,
+            alternateName: "TI",
+          },
+          {
+            value: "https://ld.admin.ch/canton/22",
+            label: "Waadt",
+            identifier: 22,
+            alternateName: "VD",
+          },
+          {
+            value: "https://ld.admin.ch/canton/23",
+            label: "Wallis",
+            identifier: 23,
+            alternateName: "VS",
+          },
+          {
+            value: "https://ld.admin.ch/canton/24",
+            label: "Neuenburg",
+            identifier: 24,
+            alternateName: "NE",
+          },
+          {
+            value: "https://ld.admin.ch/canton/25",
+            label: "Genf",
+            identifier: 25,
+            alternateName: "GE",
+          },
+          {
+            value: "https://ld.admin.ch/canton/26",
+            label: "Jura",
+            identifier: 26,
+            alternateName: "JU",
+          },
+          {
+            value: "https://ld.admin.ch/canton/3",
+            label: "Luzern",
+            identifier: 3,
+            alternateName: "LU",
+          },
+          {
+            value: "https://ld.admin.ch/canton/4",
+            label: "Uri",
+            identifier: 4,
+            alternateName: "UR",
+          },
+          {
+            value: "https://ld.admin.ch/canton/5",
+            label: "Schwyz",
+            identifier: 5,
+            alternateName: "SZ",
+          },
+          {
+            value: "https://ld.admin.ch/canton/6",
+            label: "Obwalden",
+            identifier: 6,
+            alternateName: "OW",
+          },
+          {
+            value: "https://ld.admin.ch/canton/7",
+            label: "Nidwalden",
+            identifier: 7,
+            alternateName: "NW",
+          },
+          {
+            value: "https://ld.admin.ch/canton/8",
+            label: "Glarus",
+            identifier: 8,
+            alternateName: "GL",
+          },
+          {
+            value: "https://ld.admin.ch/canton/9",
+            label: "Zug",
+            identifier: 9,
+            alternateName: "ZG",
+          },
+        ],
+        related: [],
+        hierarchy: null,
+      },
+      {
+        __typename: "NominalDimension",
+        cubeIri: "https://energy.ld.admin.ch/elcom/electricityprice-canton",
+        iri: "https://energy.ld.admin.ch/elcom/electricityprice/dimension/category",
+        label: "Verbrauchsprofile typischer Haushalte",
+        scaleType: "Nominal" as ScaleType,
+        isNumerical: false,
+        isKeyDimension: true,
+        values: [
+          {
+            value:
+              "https://energy.ld.admin.ch/elcom/electricityprice/category/C1",
+            label: "C1",
+            description:
+              "8'000 kWh/Jahr: Kleinstbetrieb' max. beanspruchte Leistung: 8 kW",
+          },
+          {
+            value:
+              "https://energy.ld.admin.ch/elcom/electricityprice/category/C2",
+            label: "C2",
+            description:
+              "30'000 kWh/Jahr: Kleinbetrieb' max. beanspruchte Leistung: 15 kW",
+          },
+          {
+            value:
+              "https://energy.ld.admin.ch/elcom/electricityprice/category/C3",
+            label: "C3",
+            description:
+              "150'000 kWh/Jahr: Mittlerer Betrieb' max. beanspruchte Leistung: 50 kW",
+          },
+          {
+            value:
+              "https://energy.ld.admin.ch/elcom/electricityprice/category/C4",
+            label: "C4",
+            description:
+              "500'000 kWh/Jahr: Grosser Betrieb ' max. beanspruchte Leistung: 150 kW' Niederspannung",
+          },
+          {
+            value:
+              "https://energy.ld.admin.ch/elcom/electricityprice/category/C5",
+            label: "C5",
+            description:
+              "500'000 kWh/Jahr: Grosser Betrieb' max. beanspruchte Leistung: 150 kW' Mittelspannung' eigene Transformatorenstation",
+          },
+          {
+            value:
+              "https://energy.ld.admin.ch/elcom/electricityprice/category/C6",
+            label: "C6",
+            description:
+              "1'500'000 kWh/Jahr: Grosser Betrieb' max. beanspruchte Leistung: 400 kW' Mittelspannung' eigene Transformatorenstation",
+          },
+          {
+            value:
+              "https://energy.ld.admin.ch/elcom/electricityprice/category/C7",
+            label: "C7",
+            description:
+              "7'500'000 kWh/Jahr: Grosser Betrieb' max. beanspruchte Leistung: 1'630 kW' Mittelspannung' eigene Transformatorenstation",
+          },
+          {
+            value:
+              "https://energy.ld.admin.ch/elcom/electricityprice/category/H1",
+            label: "H1",
+            description: "1'600 kWh/Jahr: 2-Zimmerwohnung mit Elektroherd",
+          },
+          {
+            value:
+              "https://energy.ld.admin.ch/elcom/electricityprice/category/H2",
+            label: "H2",
+            description: "2'500 kWh/Jahr: 4-Zimmerwohnung mit Elektroherd",
+          },
+          {
+            value:
+              "https://energy.ld.admin.ch/elcom/electricityprice/category/H3",
+            label: "H3",
+            description:
+              "4'500 kWh/Jahr: 4-Zimmerwohnung mit Elektroherd und Elektroboiler",
+          },
+          {
+            value:
+              "https://energy.ld.admin.ch/elcom/electricityprice/category/H4",
+            label: "H4",
+            description:
+              "4'500 kWh/Jahr: 5-Zimmerwohnung mit Elektroherd und Tumbler (ohne Elektroboiler)",
+          },
+          {
+            value:
+              "https://energy.ld.admin.ch/elcom/electricityprice/category/H5",
+            label: "H5",
+            description:
+              "7'500 kWh/Jahr: 5-Zimmer-Einfamilienhaus mit Elektroherd' Elektroboiler und Tumbler",
+          },
+          {
+            value:
+              "https://energy.ld.admin.ch/elcom/electricityprice/category/H6",
+            label: "H6",
+            description:
+              "25'000 kWh/Jahr: 5-Zimmer-Einfamilienhaus mit Elektroherd' Elektroboiler' Tumbler und mit elektrischer Widerstandsheizung",
+          },
+          {
+            value:
+              "https://energy.ld.admin.ch/elcom/electricityprice/category/H7",
+            label: "H7",
+            description:
+              "13'000 kWh/Jahr: 5-Zimmer-Einfamilienhaus mit Elektroherd' Elektroboiler' Tumbler' Wärmepumpe 5 kW zur Beheizung",
+          },
+          {
+            value:
+              "https://energy.ld.admin.ch/elcom/electricityprice/category/H8",
+            label: "H8",
+            description:
+              "7'500 kWh/Jahr: Grosse' hoch elektrifizierte Eigentumswohnung",
+          },
+        ],
+        related: [],
+        hierarchy: null,
+      },
+      {
+        __typename: "NominalDimension",
+        cubeIri: "https://energy.ld.admin.ch/elcom/electricityprice-canton",
+        iri: "https://energy.ld.admin.ch/elcom/electricityprice/dimension/product",
+        label: "Produkt",
+        scaleType: "Nominal" as ScaleType,
+        isNumerical: false,
+        isKeyDimension: true,
+        values: [
+          {
+            value:
+              "https://energy.ld.admin.ch/elcom/electricityprice/product/cheapest",
+            label: "Günstigstes Produkt",
+          },
+          {
+            value:
+              "https://energy.ld.admin.ch/elcom/electricityprice/product/standard",
+            label: "Standardprodukt",
+          },
+        ],
+        related: [],
+        hierarchy: null,
+      },
+    ],
+    measures: [
+      {
+        __typename: "NumericalMeasure",
+        isCurrency: false,
+        isDecimal: false,
+        cubeIri: "https://energy.ld.admin.ch/elcom/electricityprice-canton",
+        iri: "https://energy.ld.admin.ch/elcom/electricityprice/dimension/total",
+        label: "Total exkl. MWST",
+        description:
+          "Total electricity costs in rappen per kWH. Includes all variable costs, but not fix costs",
+        scaleType: "Ratio" as ScaleType,
+        isNumerical: false,
+        isKeyDimension: false,
+        values: [
+          { value: 6.9948115, label: "6.9948115" },
+          { value: 41.933666, label: "41.933666" },
+        ],
+        related: [],
+      },
+      {
+        __typename: "NumericalMeasure",
+        isCurrency: false,
+        isDecimal: false,
+        cubeIri: "https://energy.ld.admin.ch/elcom/electricityprice-canton",
+        iri: "https://energy.ld.admin.ch/elcom/electricityprice/dimension/gridusage",
+        label: "Netznutzung",
+        scaleType: "Ratio" as ScaleType,
+        isNumerical: false,
+        isKeyDimension: false,
+        values: [
+          { value: 2.0865285, label: "2.0865285" },
+          { value: 21.119532, label: "21.119532" },
+        ],
+        related: [],
+      },
+      {
+        __typename: "NumericalMeasure",
+        isCurrency: false,
+        isDecimal: false,
+        cubeIri: "https://energy.ld.admin.ch/elcom/electricityprice-canton",
+        iri: "https://energy.ld.admin.ch/elcom/electricityprice/dimension/energy",
+        label: "Energielieferungkosten",
+        scaleType: "Ratio" as ScaleType,
+        isNumerical: false,
+        isKeyDimension: false,
+        values: [
+          { value: 1.11324, label: "1.11324" },
+          { value: 23.652, label: "23.652" },
+        ],
+        related: [],
+      },
+      {
+        __typename: "NumericalMeasure",
+        isCurrency: false,
+        isDecimal: false,
+        cubeIri: "https://energy.ld.admin.ch/elcom/electricityprice-canton",
+        iri: "https://energy.ld.admin.ch/elcom/electricityprice/dimension/charge",
+        label: "Abgaben an das Gemeinwesen",
+        scaleType: "Ratio" as ScaleType,
+        isNumerical: false,
+        isKeyDimension: false,
+        values: [
+          { value: 0, label: "0" },
+          { value: 7.584526, label: "7.584526" },
+        ],
+        related: [],
+      },
+      {
+        __typename: "NumericalMeasure",
+        isCurrency: false,
+        isDecimal: false,
+        cubeIri: "https://energy.ld.admin.ch/elcom/electricityprice-canton",
+        iri: "https://energy.ld.admin.ch/elcom/electricityprice/dimension/aidfee",
+        label: "Förderabgaben (KEV)",
+        scaleType: "Ratio" as ScaleType,
+        isNumerical: false,
+        isKeyDimension: false,
+        values: [
+          { value: 0.45, label: "0.45" },
+          { value: 2.3, label: "2.3" },
+        ],
+        related: [],
+      },
+    ],
+  },
+};

--- a/app/urql-cache.mock.ts
+++ b/app/urql-cache.mock.ts
@@ -1,10 +1,7 @@
 import { ScaleType } from "@/graphql/query-hooks";
 import { getCachedComponents } from "@/urql-cache";
 
-export const getCachedComponentsMock: Record<
-  string,
-  ReturnType<typeof getCachedComponents>
-> = {
+export const getCachedComponentsMock = {
   electricyPricePerCantonDimensions: {
     dimensions: [
       {
@@ -401,4 +398,46 @@ export const getCachedComponentsMock: Record<
       },
     ],
   },
-};
+  geoAndNumerical: {
+    dimensions: [
+      {
+        __typename: "GeoShapesDimension",
+        cubeIri: "mapDataset",
+        iri: "newAreaLayerColorIri",
+        label: "Geo shapes dimension",
+        isNumerical: false,
+        isKeyDimension: false,
+        values: [
+          {
+            value: "orange",
+            label: "orange",
+            color: "rgb(255, 153, 0)",
+          },
+        ],
+      },
+      {
+        __typename: "GeoCoordinatesDimension",
+        iri: "symbolLayerIri",
+        cubeIri: "mapDataset",
+        label: "Geo coordinates dimension",
+        isNumerical: false,
+        isKeyDimension: false,
+        values: [{ value: "x", label: "y" }],
+      },
+    ],
+    measures: [
+      {
+        __typename: "NumericalMeasure",
+        iri: "measure",
+        cubeIri: "mapDataset",
+        label: "Numerical dimension",
+        isNumerical: true,
+        isKeyDimension: false,
+        values: [],
+      },
+    ],
+  },
+} satisfies Record<
+string,
+ReturnType<typeof getCachedComponents>
+>;

--- a/app/urql-cache.tsx
+++ b/app/urql-cache.tsx
@@ -1,0 +1,46 @@
+import { ConfiguratorStateConfiguringChart } from "@/config-types";
+import { DataCubeComponents } from "@/domain/data";
+import { truthy } from "@/domain/types";
+import { client } from "@/graphql/client";
+import { joinDimensions } from "@/graphql/hook-utils";
+import {
+  DataCubeComponentFilter,
+  DataCubeComponentsDocument,
+  DataCubeComponentsQuery,
+  DataCubeComponentsQueryVariables,
+} from "@/graphql/query-hooks";
+import { Locale } from "@/locales/locales";
+
+/**
+ * Reads components from client cache, reading cube by cube.
+ * Components are not joined in cache, but transformed here.
+ */
+export const getCachedComponents = (
+  draft: ConfiguratorStateConfiguringChart,
+  cubeFilters: DataCubeComponentFilter[],
+  locale: Locale
+): DataCubeComponents | undefined => {
+  const queries = cubeFilters
+    .map((cubeFilter) => {
+      return client.readQuery<
+        DataCubeComponentsQuery,
+        DataCubeComponentsQueryVariables
+      >(DataCubeComponentsDocument, {
+        sourceType: draft.dataSource.type,
+        sourceUrl: draft.dataSource.url,
+        locale,
+        cubeFilter: {
+          iri: cubeFilter.iri,
+          componentIris: undefined,
+          joinBy: cubeFilter.joinBy,
+          loadValues: true,
+        },
+      })!;
+    })
+    .filter(truthy);
+
+  return {
+    dimensions: joinDimensions(queries),
+    measures: queries.flatMap((q) => q.data?.dataCubeComponents.measures!),
+  };
+};

--- a/app/urql-cache.tsx
+++ b/app/urql-cache.tsx
@@ -1,4 +1,4 @@
-import { ConfiguratorStateConfiguringChart } from "@/config-types";
+import { DataSource } from "@/config-types";
 import { DataCubeComponents } from "@/domain/data";
 import { truthy } from "@/domain/types";
 import { client } from "@/graphql/client";
@@ -16,7 +16,7 @@ import { Locale } from "@/locales/locales";
  * Components are not joined in cache, but transformed here.
  */
 export const getCachedComponents = (
-  draft: ConfiguratorStateConfiguringChart,
+  dataSource: DataSource,
   cubeFilters: DataCubeComponentFilter[],
   locale: Locale
 ): DataCubeComponents | undefined => {
@@ -26,8 +26,8 @@ export const getCachedComponents = (
         DataCubeComponentsQuery,
         DataCubeComponentsQueryVariables
       >(DataCubeComponentsDocument, {
-        sourceType: draft.dataSource.type,
-        sourceUrl: draft.dataSource.url,
+        sourceType: dataSource.type,
+        sourceUrl: dataSource.url,
         locale,
         cubeFilter: {
           iri: cubeFilter.iri,

--- a/app/urql-cache.tsx
+++ b/app/urql-cache.tsx
@@ -38,9 +38,15 @@ export const getCachedComponents = (
       })!;
     })
     .filter(truthy);
-
   return {
-    dimensions: joinDimensions(queries),
+    dimensions: joinDimensions(
+      queries
+        .filter((x) => x.data)
+        .map((x) => ({
+          dataCubeComponents: x.data?.dataCubeComponents!,
+          joinBy: x.operation.variables?.cubeFilter.joinBy,
+        }))
+    ),
     measures: queries.flatMap((q) => q.data?.dataCubeComponents.measures!),
   };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -191,43 +191,21 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.23.5.tgz#ffb878728bb6bdcb6f4510aa51b1be9afb8cfd98"
   integrity sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==
 
-"@babel/core@7.12.9":
-  version "7.12.9"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.9.tgz#fd450c4ec10cdbb980e2928b7aa7a28484593fc8"
-  integrity sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/generator" "^7.12.5"
-    "@babel/helper-module-transforms" "^7.12.1"
-    "@babel/helpers" "^7.12.5"
-    "@babel/parser" "^7.12.7"
-    "@babel/template" "^7.12.7"
-    "@babel/traverse" "^7.12.9"
-    "@babel/types" "^7.12.7"
-    convert-source-map "^1.7.0"
-    debug "^4.1.0"
-    gensync "^1.0.0-beta.1"
-    json5 "^2.1.2"
-    lodash "^4.17.19"
-    resolve "^1.3.2"
-    semver "^5.4.1"
-    source-map "^0.5.0"
-
-"@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.10.5", "@babel/core@^7.12.3", "@babel/core@^7.12.9", "@babel/core@^7.7.2", "@babel/core@^7.7.5", "@babel/core@^7.7.7":
-  version "7.23.9"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.23.9.tgz#b028820718000f267870822fec434820e9b1e4d1"
-  integrity sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==
+"@babel/core@7.12.9", "@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.10.5", "@babel/core@^7.12.3", "@babel/core@^7.12.9", "@babel/core@^7.14.6", "@babel/core@^7.7.2", "@babel/core@^7.7.5", "@babel/core@^7.7.7":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.24.0.tgz#56cbda6b185ae9d9bed369816a8f4423c5f2ff1b"
+  integrity sha512-fQfkg0Gjkza3nf0c7/w6Xf34BW4YvzNfACRLmmb7XRLa6XHdR+K9AlJlxneFfWYf6uhOzuzZVTjF/8KfndZANw==
   dependencies:
     "@ampproject/remapping" "^2.2.0"
     "@babel/code-frame" "^7.23.5"
     "@babel/generator" "^7.23.6"
     "@babel/helper-compilation-targets" "^7.23.6"
     "@babel/helper-module-transforms" "^7.23.3"
-    "@babel/helpers" "^7.23.9"
-    "@babel/parser" "^7.23.9"
-    "@babel/template" "^7.23.9"
-    "@babel/traverse" "^7.23.9"
-    "@babel/types" "^7.23.9"
+    "@babel/helpers" "^7.24.0"
+    "@babel/parser" "^7.24.0"
+    "@babel/template" "^7.24.0"
+    "@babel/traverse" "^7.24.0"
+    "@babel/types" "^7.24.0"
     convert-source-map "^2.0.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
@@ -243,22 +221,22 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.12.5", "@babel/generator@^7.23.6":
-  version "7.23.6"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.23.6.tgz#9e1fca4811c77a10580d17d26b57b036133f3c2e"
-  integrity sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==
-  dependencies:
-    "@babel/types" "^7.23.6"
-    "@jridgewell/gen-mapping" "^0.3.2"
-    "@jridgewell/trace-mapping" "^0.3.17"
-    jsesc "^2.5.1"
-
 "@babel/generator@^7.20.14":
   version "7.23.0"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.23.0.tgz#df5c386e2218be505b34837acbcb874d7a983420"
   integrity sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==
   dependencies:
     "@babel/types" "^7.23.0"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    "@jridgewell/trace-mapping" "^0.3.17"
+    jsesc "^2.5.1"
+
+"@babel/generator@^7.23.6":
+  version "7.23.6"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.23.6.tgz#9e1fca4811c77a10580d17d26b57b036133f3c2e"
+  integrity sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==
+  dependencies:
+    "@babel/types" "^7.23.6"
     "@jridgewell/gen-mapping" "^0.3.2"
     "@jridgewell/trace-mapping" "^0.3.17"
     jsesc "^2.5.1"
@@ -374,17 +352,6 @@
   dependencies:
     "@babel/types" "^7.22.15"
 
-"@babel/helper-module-transforms@^7.12.1", "@babel/helper-module-transforms@^7.23.3":
-  version "7.23.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz#d7d12c3c5d30af5b3c0fcab2a6d5217773e2d0f1"
-  integrity sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==
-  dependencies:
-    "@babel/helper-environment-visitor" "^7.22.20"
-    "@babel/helper-module-imports" "^7.22.15"
-    "@babel/helper-simple-access" "^7.22.5"
-    "@babel/helper-split-export-declaration" "^7.22.6"
-    "@babel/helper-validator-identifier" "^7.22.20"
-
 "@babel/helper-module-transforms@^7.14.5":
   version "7.15.8"
   resolved "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.8.tgz"
@@ -398,6 +365,17 @@
     "@babel/template" "^7.15.4"
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
+
+"@babel/helper-module-transforms@^7.23.3":
+  version "7.23.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz#d7d12c3c5d30af5b3c0fcab2a6d5217773e2d0f1"
+  integrity sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.22.20"
+    "@babel/helper-module-imports" "^7.22.15"
+    "@babel/helper-simple-access" "^7.22.5"
+    "@babel/helper-split-export-declaration" "^7.22.6"
+    "@babel/helper-validator-identifier" "^7.22.20"
 
 "@babel/helper-optimise-call-expression@^7.14.5", "@babel/helper-optimise-call-expression@^7.15.4":
   version "7.15.4"
@@ -521,15 +499,6 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz#907a3fbd4523426285365d1206c423c4c5520307"
   integrity sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==
 
-"@babel/helpers@^7.12.5":
-  version "7.24.0"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.24.0.tgz#a3dd462b41769c95db8091e49cfe019389a9409b"
-  integrity sha512-ulDZdc0Aj5uLc5nETsa7EPx2L7rM0YJM8r7ck7U73AXi7qOV44IHHRAYZHY6iU1rr3C5N4NtTmMRUJP6kwCWeA==
-  dependencies:
-    "@babel/template" "^7.24.0"
-    "@babel/traverse" "^7.24.0"
-    "@babel/types" "^7.24.0"
-
 "@babel/helpers@^7.23.9":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.23.9.tgz#c3e20bbe7f7a7e10cb9b178384b4affdf5995c7d"
@@ -538,6 +507,15 @@
     "@babel/template" "^7.23.9"
     "@babel/traverse" "^7.23.9"
     "@babel/types" "^7.23.9"
+
+"@babel/helpers@^7.24.0":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.24.0.tgz#a3dd462b41769c95db8091e49cfe019389a9409b"
+  integrity sha512-ulDZdc0Aj5uLc5nETsa7EPx2L7rM0YJM8r7ck7U73AXi7qOV44IHHRAYZHY6iU1rr3C5N4NtTmMRUJP6kwCWeA==
+  dependencies:
+    "@babel/template" "^7.24.0"
+    "@babel/traverse" "^7.24.0"
+    "@babel/types" "^7.24.0"
 
 "@babel/highlight@^7.10.4":
   version "7.18.6"
@@ -575,17 +553,7 @@
     chalk "^2.4.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@7.12.16":
-  version "7.12.16"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.16.tgz#cc31257419d2c3189d394081635703f549fc1ed4"
-  integrity sha512-c/+u9cqV6F0+4Hpq01jnJO+GLp2DdT63ppz9Xa+6cHaajM9VFzK/iDXiKK65YtpeVwu+ctfS6iqlMqRgQRzeCw==
-
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.12.13", "@babel/parser@^7.14.7", "@babel/parser@^7.15.4", "@babel/parser@^7.20.15", "@babel/parser@^7.21.4", "@babel/parser@^7.22.15", "@babel/parser@^7.23.9", "@babel/parser@^7.7.2":
-  version "7.23.9"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.9.tgz#7b903b6149b0f8fa7ad564af646c4c38a77fc44b"
-  integrity sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==
-
-"@babel/parser@^7.12.7", "@babel/parser@^7.24.0":
+"@babel/parser@7.12.16", "@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.12.13", "@babel/parser@^7.14.6", "@babel/parser@^7.14.7", "@babel/parser@^7.15.4", "@babel/parser@^7.20.15", "@babel/parser@^7.21.4", "@babel/parser@^7.22.15", "@babel/parser@^7.23.9", "@babel/parser@^7.24.0", "@babel/parser@^7.7.2":
   version "7.24.0"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.24.0.tgz#26a3d1ff49031c53a97d03b604375f028746a9ac"
   integrity sha512-QuP/FxEAzMSjXygs8v4N9dvdXzEHN4W1oF3PxuWAtPo08UdM17u89RDMgjLn/mlc56iM0HlLmVkO/wgR+rDgHg==
@@ -949,15 +917,6 @@
   resolved "https://registry.npmjs.org/@babel/standalone/-/standalone-7.14.6.tgz"
   integrity sha512-oAoSp82jhJFnXKybKTOj5QF04XxiDRyiiqrFToiU1udlBXuZoADlPmmnOcuqBrZxSNNUjzJIVK8vt838Qoqjxg==
 
-"@babel/template@^7.12.7", "@babel/template@^7.24.0":
-  version "7.24.0"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.24.0.tgz#c6a524aa93a4a05d66aaf31654258fae69d87d50"
-  integrity sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==
-  dependencies:
-    "@babel/code-frame" "^7.23.5"
-    "@babel/parser" "^7.24.0"
-    "@babel/types" "^7.24.0"
-
 "@babel/template@^7.15.4", "@babel/template@^7.3.3":
   version "7.15.4"
   resolved "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz"
@@ -984,6 +943,15 @@
     "@babel/code-frame" "^7.23.5"
     "@babel/parser" "^7.23.9"
     "@babel/types" "^7.23.9"
+
+"@babel/template@^7.24.0":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.24.0.tgz#c6a524aa93a4a05d66aaf31654258fae69d87d50"
+  integrity sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==
+  dependencies:
+    "@babel/code-frame" "^7.23.5"
+    "@babel/parser" "^7.24.0"
+    "@babel/types" "^7.24.0"
 
 "@babel/traverse@7.12.13":
   version "7.12.13"
@@ -1015,22 +983,6 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/traverse@^7.12.9", "@babel/traverse@^7.24.0":
-  version "7.24.0"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.24.0.tgz#4a408fbf364ff73135c714a2ab46a5eab2831b1e"
-  integrity sha512-HfuJlI8qq3dEDmNU5ChzzpZRWq+oxCZQyMzIMEqLho+AQnhMnKQUzH6ydo3RBl/YjPCuk68Y6s0Gx0AeyULiWw==
-  dependencies:
-    "@babel/code-frame" "^7.23.5"
-    "@babel/generator" "^7.23.6"
-    "@babel/helper-environment-visitor" "^7.22.20"
-    "@babel/helper-function-name" "^7.23.0"
-    "@babel/helper-hoist-variables" "^7.22.5"
-    "@babel/helper-split-export-declaration" "^7.22.6"
-    "@babel/parser" "^7.24.0"
-    "@babel/types" "^7.24.0"
-    debug "^4.3.1"
-    globals "^11.1.0"
-
 "@babel/traverse@^7.23.9":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.9.tgz#2f9d6aead6b564669394c5ce0f9302bb65b9d950"
@@ -1044,6 +996,22 @@
     "@babel/helper-split-export-declaration" "^7.22.6"
     "@babel/parser" "^7.23.9"
     "@babel/types" "^7.23.9"
+    debug "^4.3.1"
+    globals "^11.1.0"
+
+"@babel/traverse@^7.24.0":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.24.0.tgz#4a408fbf364ff73135c714a2ab46a5eab2831b1e"
+  integrity sha512-HfuJlI8qq3dEDmNU5ChzzpZRWq+oxCZQyMzIMEqLho+AQnhMnKQUzH6ydo3RBl/YjPCuk68Y6s0Gx0AeyULiWw==
+  dependencies:
+    "@babel/code-frame" "^7.23.5"
+    "@babel/generator" "^7.23.6"
+    "@babel/helper-environment-visitor" "^7.22.20"
+    "@babel/helper-function-name" "^7.23.0"
+    "@babel/helper-hoist-variables" "^7.22.5"
+    "@babel/helper-split-export-declaration" "^7.22.6"
+    "@babel/parser" "^7.24.0"
+    "@babel/types" "^7.24.0"
     debug "^4.3.1"
     globals "^11.1.0"
 
@@ -1062,15 +1030,6 @@
   integrity sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.9"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.12.7", "@babel/types@^7.24.0":
-  version "7.24.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.24.0.tgz#3b951f435a92e7333eba05b7566fd297960ea1bf"
-  integrity sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==
-  dependencies:
-    "@babel/helper-string-parser" "^7.23.4"
-    "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.16.7":
@@ -1112,6 +1071,15 @@
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.23.9.tgz#1dd7b59a9a2b5c87f8b41e52770b5ecbf492e002"
   integrity sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==
+  dependencies:
+    "@babel/helper-string-parser" "^7.23.4"
+    "@babel/helper-validator-identifier" "^7.22.20"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.24.0":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.24.0.tgz#3b951f435a92e7333eba05b7566fd297960ea1bf"
+  integrity sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==
   dependencies:
     "@babel/helper-string-parser" "^7.23.4"
     "@babel/helper-validator-identifier" "^7.22.20"
@@ -7205,11 +7173,6 @@ convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.6.0:
   dependencies:
     safe-buffer "~5.1.1"
 
-convert-source-map@^1.7.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
-  integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
-
 convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
@@ -9420,7 +9383,7 @@ fwd-stream@^1.0.4:
   dependencies:
     readable-stream "~1.0.26-4"
 
-gensync@^1.0.0-beta.1, gensync@^1.0.0-beta.2:
+gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
@@ -14668,7 +14631,7 @@ resolve.exports@^1.1.0:
   resolved "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz"
   integrity sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==
 
-resolve@1.22.8, resolve@^1.3.2:
+resolve@1.22.8:
   version "1.22.8"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
   integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
@@ -14959,11 +14922,6 @@ semver@7.x, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
-
-semver@^5.4.1:
-  version "5.7.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
-  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
 semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -191,7 +191,29 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.23.5.tgz#ffb878728bb6bdcb6f4510aa51b1be9afb8cfd98"
   integrity sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==
 
-"@babel/core@7.12.9", "@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.10.5", "@babel/core@^7.12.3", "@babel/core@^7.12.9", "@babel/core@^7.14.6", "@babel/core@^7.7.2", "@babel/core@^7.7.5", "@babel/core@^7.7.7":
+"@babel/core@7.12.9":
+  version "7.12.9"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.9.tgz#fd450c4ec10cdbb980e2928b7aa7a28484593fc8"
+  integrity sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.12.5"
+    "@babel/helper-module-transforms" "^7.12.1"
+    "@babel/helpers" "^7.12.5"
+    "@babel/parser" "^7.12.7"
+    "@babel/template" "^7.12.7"
+    "@babel/traverse" "^7.12.9"
+    "@babel/types" "^7.12.7"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.1"
+    json5 "^2.1.2"
+    lodash "^4.17.19"
+    resolve "^1.3.2"
+    semver "^5.4.1"
+    source-map "^0.5.0"
+
+"@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.10.5", "@babel/core@^7.12.3", "@babel/core@^7.12.9", "@babel/core@^7.7.2", "@babel/core@^7.7.5", "@babel/core@^7.7.7":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.23.9.tgz#b028820718000f267870822fec434820e9b1e4d1"
   integrity sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==
@@ -221,22 +243,22 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
+"@babel/generator@^7.12.5", "@babel/generator@^7.23.6":
+  version "7.23.6"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.23.6.tgz#9e1fca4811c77a10580d17d26b57b036133f3c2e"
+  integrity sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==
+  dependencies:
+    "@babel/types" "^7.23.6"
+    "@jridgewell/gen-mapping" "^0.3.2"
+    "@jridgewell/trace-mapping" "^0.3.17"
+    jsesc "^2.5.1"
+
 "@babel/generator@^7.20.14":
   version "7.23.0"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.23.0.tgz#df5c386e2218be505b34837acbcb874d7a983420"
   integrity sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==
   dependencies:
     "@babel/types" "^7.23.0"
-    "@jridgewell/gen-mapping" "^0.3.2"
-    "@jridgewell/trace-mapping" "^0.3.17"
-    jsesc "^2.5.1"
-
-"@babel/generator@^7.23.6":
-  version "7.23.6"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.23.6.tgz#9e1fca4811c77a10580d17d26b57b036133f3c2e"
-  integrity sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==
-  dependencies:
-    "@babel/types" "^7.23.6"
     "@jridgewell/gen-mapping" "^0.3.2"
     "@jridgewell/trace-mapping" "^0.3.17"
     jsesc "^2.5.1"
@@ -352,6 +374,17 @@
   dependencies:
     "@babel/types" "^7.22.15"
 
+"@babel/helper-module-transforms@^7.12.1", "@babel/helper-module-transforms@^7.23.3":
+  version "7.23.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz#d7d12c3c5d30af5b3c0fcab2a6d5217773e2d0f1"
+  integrity sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.22.20"
+    "@babel/helper-module-imports" "^7.22.15"
+    "@babel/helper-simple-access" "^7.22.5"
+    "@babel/helper-split-export-declaration" "^7.22.6"
+    "@babel/helper-validator-identifier" "^7.22.20"
+
 "@babel/helper-module-transforms@^7.14.5":
   version "7.15.8"
   resolved "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.8.tgz"
@@ -365,17 +398,6 @@
     "@babel/template" "^7.15.4"
     "@babel/traverse" "^7.15.4"
     "@babel/types" "^7.15.6"
-
-"@babel/helper-module-transforms@^7.23.3":
-  version "7.23.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz#d7d12c3c5d30af5b3c0fcab2a6d5217773e2d0f1"
-  integrity sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==
-  dependencies:
-    "@babel/helper-environment-visitor" "^7.22.20"
-    "@babel/helper-module-imports" "^7.22.15"
-    "@babel/helper-simple-access" "^7.22.5"
-    "@babel/helper-split-export-declaration" "^7.22.6"
-    "@babel/helper-validator-identifier" "^7.22.20"
 
 "@babel/helper-optimise-call-expression@^7.14.5", "@babel/helper-optimise-call-expression@^7.15.4":
   version "7.15.4"
@@ -499,6 +521,15 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz#907a3fbd4523426285365d1206c423c4c5520307"
   integrity sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==
 
+"@babel/helpers@^7.12.5":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.24.0.tgz#a3dd462b41769c95db8091e49cfe019389a9409b"
+  integrity sha512-ulDZdc0Aj5uLc5nETsa7EPx2L7rM0YJM8r7ck7U73AXi7qOV44IHHRAYZHY6iU1rr3C5N4NtTmMRUJP6kwCWeA==
+  dependencies:
+    "@babel/template" "^7.24.0"
+    "@babel/traverse" "^7.24.0"
+    "@babel/types" "^7.24.0"
+
 "@babel/helpers@^7.23.9":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.23.9.tgz#c3e20bbe7f7a7e10cb9b178384b4affdf5995c7d"
@@ -544,10 +575,20 @@
     chalk "^2.4.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@7.12.16", "@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.12.13", "@babel/parser@^7.14.6", "@babel/parser@^7.14.7", "@babel/parser@^7.15.4", "@babel/parser@^7.20.15", "@babel/parser@^7.21.4", "@babel/parser@^7.22.15", "@babel/parser@^7.23.9", "@babel/parser@^7.7.2":
+"@babel/parser@7.12.16":
+  version "7.12.16"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.16.tgz#cc31257419d2c3189d394081635703f549fc1ed4"
+  integrity sha512-c/+u9cqV6F0+4Hpq01jnJO+GLp2DdT63ppz9Xa+6cHaajM9VFzK/iDXiKK65YtpeVwu+ctfS6iqlMqRgQRzeCw==
+
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.12.13", "@babel/parser@^7.14.7", "@babel/parser@^7.15.4", "@babel/parser@^7.20.15", "@babel/parser@^7.21.4", "@babel/parser@^7.22.15", "@babel/parser@^7.23.9", "@babel/parser@^7.7.2":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.23.9.tgz#7b903b6149b0f8fa7ad564af646c4c38a77fc44b"
   integrity sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==
+
+"@babel/parser@^7.12.7", "@babel/parser@^7.24.0":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.24.0.tgz#26a3d1ff49031c53a97d03b604375f028746a9ac"
+  integrity sha512-QuP/FxEAzMSjXygs8v4N9dvdXzEHN4W1oF3PxuWAtPo08UdM17u89RDMgjLn/mlc56iM0HlLmVkO/wgR+rDgHg==
 
 "@babel/plugin-proposal-class-properties@^7.0.0":
   version "7.14.5"
@@ -908,6 +949,15 @@
   resolved "https://registry.npmjs.org/@babel/standalone/-/standalone-7.14.6.tgz"
   integrity sha512-oAoSp82jhJFnXKybKTOj5QF04XxiDRyiiqrFToiU1udlBXuZoADlPmmnOcuqBrZxSNNUjzJIVK8vt838Qoqjxg==
 
+"@babel/template@^7.12.7", "@babel/template@^7.24.0":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.24.0.tgz#c6a524aa93a4a05d66aaf31654258fae69d87d50"
+  integrity sha512-Bkf2q8lMB0AFpX0NFEqSbx1OkTHf0f+0j82mkw+ZpzBnkk7e9Ql0891vlfgi+kHwOk8tQjiQHpqh4LaSa0fKEA==
+  dependencies:
+    "@babel/code-frame" "^7.23.5"
+    "@babel/parser" "^7.24.0"
+    "@babel/types" "^7.24.0"
+
 "@babel/template@^7.15.4", "@babel/template@^7.3.3":
   version "7.15.4"
   resolved "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz"
@@ -965,6 +1015,22 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.12.9", "@babel/traverse@^7.24.0":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.24.0.tgz#4a408fbf364ff73135c714a2ab46a5eab2831b1e"
+  integrity sha512-HfuJlI8qq3dEDmNU5ChzzpZRWq+oxCZQyMzIMEqLho+AQnhMnKQUzH6ydo3RBl/YjPCuk68Y6s0Gx0AeyULiWw==
+  dependencies:
+    "@babel/code-frame" "^7.23.5"
+    "@babel/generator" "^7.23.6"
+    "@babel/helper-environment-visitor" "^7.22.20"
+    "@babel/helper-function-name" "^7.23.0"
+    "@babel/helper-hoist-variables" "^7.22.5"
+    "@babel/helper-split-export-declaration" "^7.22.6"
+    "@babel/parser" "^7.24.0"
+    "@babel/types" "^7.24.0"
+    debug "^4.3.1"
+    globals "^11.1.0"
+
 "@babel/traverse@^7.23.9":
   version "7.23.9"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.9.tgz#2f9d6aead6b564669394c5ce0f9302bb65b9d950"
@@ -996,6 +1062,15 @@
   integrity sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.9"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.12.7", "@babel/types@^7.24.0":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.24.0.tgz#3b951f435a92e7333eba05b7566fd297960ea1bf"
+  integrity sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==
+  dependencies:
+    "@babel/helper-string-parser" "^7.23.4"
+    "@babel/helper-validator-identifier" "^7.22.20"
     to-fast-properties "^2.0.0"
 
 "@babel/types@^7.16.7":
@@ -4167,6 +4242,14 @@
     lz-string "^1.5.0"
     pretty-format "^27.0.2"
 
+"@testing-library/react-hooks@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@^14.1.2":
   version "14.1.2"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-14.1.2.tgz#a2b9e9ee87721ec9ed2d7cfc51cc04e474537c32"
@@ -7122,6 +7205,11 @@ convert-source-map@^1.4.0, convert-source-map@^1.5.0, convert-source-map@^1.6.0:
   dependencies:
     safe-buffer "~5.1.1"
 
+convert-source-map@^1.7.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
+  integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
+
 convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
@@ -9332,7 +9420,7 @@ fwd-stream@^1.0.4:
   dependencies:
     readable-stream "~1.0.26-4"
 
-gensync@^1.0.0-beta.2:
+gensync@^1.0.0-beta.1, gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
@@ -14073,6 +14161,13 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-error-boundary@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-3.1.3.tgz"
@@ -14573,7 +14668,7 @@ resolve.exports@^1.1.0:
   resolved "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz"
   integrity sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==
 
-resolve@1.22.8:
+resolve@1.22.8, resolve@^1.3.2:
   version "1.22.8"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
   integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
@@ -14864,6 +14959,11 @@ semver@7.x, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^5.4.1:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
+  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
 semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"


### PR DESCRIPTION
- [x] Behind the flag "add-dataset" (add flag__add-dataset=true, with ? if not already there, to URL to activate flag)
  - [x] Add section in control showing current cubes
  - [x] Add dialog to search and add cubes based on shared dimension
- [x] Ability to add/remove dataset inside chart config
- [x] When removing dataset, the chart config is re-initialized since the current chart could use a joinBy dimension

## Behind the scenes

- [x] The ChartLoadingWrapper now is responsible for loading the data and values
  - [ ] Extra check the values loaded across chart to see if everything working correctly
- [x] useQuery hooks created with makeUseQuery will no longer return the previous loaded data if the query key changes

