### PR TITLE
fix: Redirects to latest cube

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 
 - Fixes
   - SingleURLs layout mode now correctly publishes charts
+  - Redirecting to latest cube now works correctly for cases of trying to access old cube that didn't look like a versioned cube, but in fact was a versioned cube
 
 # [3.26.3] - 2024-03-05
 

--- a/app/browser/select-dataset-step.tsx
+++ b/app/browser/select-dataset-step.tsx
@@ -29,6 +29,7 @@ import {
   navPresenceProps,
   smoothPresenceProps,
 } from "@/components/presence";
+import { useRedirectToLatestCube } from "@/components/use-redirect-to-latest-cube";
 import {
   PanelBodyWrapper,
   PanelLayout,
@@ -41,8 +42,6 @@ import {
 } from "@/graphql/query-hooks";
 import { Icon } from "@/icons";
 import { useConfiguratorState, useLocale } from "@/src";
-
-import { useRedirectToVersionedCube } from "../components/use-redirect-to-versioned-cube";
 
 import {
   BrowseStateProvider,
@@ -178,7 +177,7 @@ const SelectDatasetStepContent = () => {
     pause: !!dataset,
   });
 
-  useRedirectToVersionedCube({
+  useRedirectToLatestCube({
     dataSource: configState.dataSource,
     datasetIri: dataset,
   });

--- a/app/rdf/light-cube.ts
+++ b/app/rdf/light-cube.ts
@@ -8,6 +8,7 @@ import {
 import { getCubeComponentsMetadata } from "@/rdf/query-cube-components";
 import { getCubeMetadata } from "@/rdf/query-cube-metadata";
 import { getCubePreview } from "@/rdf/query-cube-preview";
+import { getLatestCubeIriQuery } from "@/rdf/query-latest-cube-iri";
 
 type LightCubeOptions = {
   iri: string;
@@ -39,21 +40,7 @@ export class LightCube {
       return this;
     }
 
-    const query = `PREFIX schema: <http://schema.org/>
-
-SELECT ?iri WHERE {
-  VALUES ?oldIri { <${this.iri}> }
-
-  ?versionHistory schema:hasPart ?oldIri .
-  ?versionHistory schema:hasPart ?iri .
-  ?iri schema:version ?version .
-  ?iri schema:creativeWorkStatus ?status .
-  ?oldIri schema:creativeWorkStatus ?oldStatus .
-  FILTER(NOT EXISTS { ?iri schema:expires ?expires . } && ?status IN (?oldStatus, <https://ld.admin.ch/vocabulary/CreativeWorkStatus/Published>))
-}
-ORDER BY DESC(?version)
-LIMIT 1`;
-
+    const query = getLatestCubeIriQuery(this.iri);
     const result = await this.sparqlClient.query.select(query);
     const latestIri = result[0]?.iri?.value;
 

--- a/app/rdf/query-latest-cube-iri.ts
+++ b/app/rdf/query-latest-cube-iri.ts
@@ -7,6 +7,7 @@ PREFIX schema: <http://schema.org/>
 
 SELECT ?iri WHERE {
   {
+    # Versioned cube.
     SELECT ?iri WHERE {
       VALUES ?oldIri { <${cubeIri}> }
       ?versionHistory schema:hasPart ?oldIri .
@@ -17,11 +18,24 @@ SELECT ?iri WHERE {
       FILTER(NOT EXISTS { ?iri schema:expires ?expires . } && ?status IN (?oldStatus, <https://ld.admin.ch/vocabulary/CreativeWorkStatus/Published>))
     }
   } UNION {
-    SELECT ?iri WHERE {
-      VALUES ?iri { <${cubeIri}> }
-      ?iri cube:observationConstraint ?shape .
+    {
+      # Non-versioned cube.
+      SELECT ?iri WHERE {
+        VALUES ?iri { <${cubeIri}> }
+        ?iri cube:observationConstraint ?shape .
+        ?iri schema:creativeWorkStatus ?status .
+        FILTER(NOT EXISTS { ?iri schema:expires ?expires . } && ?status = <https://ld.admin.ch/vocabulary/CreativeWorkStatus/Published>)      
+      }
+    }
+  } UNION {
+    {
+      # Version history of a cube.
+      VALUES ?versionHistory { <${cubeIri}> }
+      ?versionHistory schema:hasPart ?iri .
+      ?iri schema:version ?version .
       ?iri schema:creativeWorkStatus ?status .
-      FILTER(NOT EXISTS { ?iri schema:expires ?expires . } && ?status = <https://ld.admin.ch/vocabulary/CreativeWorkStatus/Published>)      
+      ?oldIri schema:creativeWorkStatus ?oldStatus .
+      FILTER(NOT EXISTS { ?iri schema:expires ?expires . } && ?status IN (?oldStatus, <https://ld.admin.ch/vocabulary/CreativeWorkStatus/Published>))
     }
   }
 }

--- a/app/rdf/query-latest-cube-iri.ts
+++ b/app/rdf/query-latest-cube-iri.ts
@@ -34,8 +34,7 @@ SELECT ?iri WHERE {
       ?versionHistory schema:hasPart ?iri .
       ?iri schema:version ?version .
       ?iri schema:creativeWorkStatus ?status .
-      ?oldIri schema:creativeWorkStatus ?oldStatus .
-      FILTER(NOT EXISTS { ?iri schema:expires ?expires . } && ?status IN (?oldStatus, <https://ld.admin.ch/vocabulary/CreativeWorkStatus/Published>))
+      FILTER(NOT EXISTS { ?iri schema:expires ?expires . } && ?status = <https://ld.admin.ch/vocabulary/CreativeWorkStatus/Published>)
     }
   }
 }

--- a/app/rdf/query-latest-cube-iri.ts
+++ b/app/rdf/query-latest-cube-iri.ts
@@ -1,0 +1,30 @@
+/** Creates SPARQL query to fetch latest cube iri.
+ * Works for both versioned and unversioned cubes.
+ */
+export const getLatestCubeIriQuery = (cubeIri: string) => {
+  return `PREFIX cube: <https://cube.link/>
+PREFIX schema: <http://schema.org/>
+
+SELECT ?iri WHERE {
+  {
+    SELECT ?iri WHERE {
+      VALUES ?oldIri { <${cubeIri}> }
+      ?versionHistory schema:hasPart ?oldIri .
+      ?versionHistory schema:hasPart ?iri .
+      ?iri schema:version ?version .
+      ?iri schema:creativeWorkStatus ?status .
+      ?oldIri schema:creativeWorkStatus ?oldStatus .
+      FILTER(NOT EXISTS { ?iri schema:expires ?expires . } && ?status IN (?oldStatus, <https://ld.admin.ch/vocabulary/CreativeWorkStatus/Published>))
+    }
+  } UNION {
+    SELECT ?iri WHERE {
+      VALUES ?iri { <${cubeIri}> }
+      ?iri cube:observationConstraint ?shape .
+      ?iri schema:creativeWorkStatus ?status .
+      FILTER(NOT EXISTS { ?iri schema:expires ?expires . } && ?status = <https://ld.admin.ch/vocabulary/CreativeWorkStatus/Published>)      
+    }
+  }
+}
+ORDER BY DESC(?version)
+LIMIT 1`;
+};


### PR DESCRIPTION
Fixes #1390.

I think the problem was that we didn't treat the cube with version "2023-2" as versioned cube and failed to fetch latest iri. This PR solves this on a SPARQL query level (and removes relying on checking if a cube is versioned by a heuristic).

With this change, we try to look for newest version of the cube if an older version was passed in the URL (respecting published status).

## How to test
**PR**
1. Go to [this link](https://visualization-tool-git-fix-redirects-to-latest-cube-ixt1.vercel.app/en/browse?previous=%7B%22order%22%3A%22SCORE%22%2C%22search%22%3A%22nfi%22%7D&dataset=https%3A%2F%2Fenvironment.ld.admin.ch%2Ffoen%2Fnfi%2Fnfi_C-20%2Fcube%2F2023-2&dataSource=Prod) (NFI/2023-02).
2. ✅ See that the latest version of the cube has been loaded.

**TEST**
1. Go to [this link](https://test.visualize.admin.ch/en/browse?dataset=https://environment.ld.admin.ch/foen/nfi/nfi_C-20/cube/2023-2&dataSource=Prod) (NFI/2023-02).
2. ❌ See that there's a _cube not found_ error.