### PR TITLE
fix: Keep locale in user actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
   - Scatterplot is now correctly initialized with non-empty segment
   - Changes of segment dimension now correctly update chart config which prevents errors with copying published charts
   - Temporal segment is no longer carried over when switching from scatterplot to column chart if it was already used as X axis
+  - Currently selected locale is now persisted when using actions in user profile page (view chart, edit, open, share)
 
 # [3.26.3] - 2024-03-05
 

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -199,7 +199,7 @@ const ProfileVisualizationsRow = (props: ProfileVisualizationsRowProps) => {
     const actions: (ActionProps | null)[] = [
       {
         type: "link",
-        href: `/v/${config.key}`,
+        href: `/${locale}/v/${config.key}`,
         label: t({ id: "login.chart.view", message: "View" }),
         iconName: "eye",
         priority:
@@ -207,13 +207,13 @@ const ProfileVisualizationsRow = (props: ProfileVisualizationsRowProps) => {
       },
       {
         type: "link",
-        href: `/create/new?copy=${config.key}`,
+        href: `/${locale}/create/new?copy=${config.key}`,
         label: t({ id: "login.chart.copy", message: "Copy" }),
         iconName: "copy",
       },
       {
         type: "link",
-        href: `/create/new?edit=${config.key}`,
+        href: `/${locale}/create/new?edit=${config.key}`,
         label: t({ id: "login.chart.edit", message: "Edit" }),
         iconName: "edit",
         priority:
@@ -221,7 +221,7 @@ const ProfileVisualizationsRow = (props: ProfileVisualizationsRowProps) => {
       },
       {
         type: "link",
-        href: `/v/${config.key}`,
+        href: `/${locale}/v/${config.key}`,
         label: t({ id: "login.chart.share", message: "Share" }),
         iconName: "linkExternal",
       },
@@ -286,6 +286,7 @@ const ProfileVisualizationsRow = (props: ProfileVisualizationsRowProps) => {
 
     return sortBy(actions.filter(truthy), (x) => x.priority);
   }, [
+    locale,
     config.data,
     config.key,
     config.published_state,

--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -84,7 +84,7 @@ export const createSelectors = ({ screen, page, within }: Ctx) => {
         screen
           .getByTestId("panel-drawer")
           .within()
-          .findByText("Use abbreviations"),
+          .findByText("Use abbreviations", {}, { timeout: 10_000 }),
     },
     published: {
       interactiveFilters: () =>


### PR DESCRIPTION
This PR keeps the currently selected locale when using profile actions (view, edit, copy, share) from the user profile.

## How to test
1. Go to [this link](https://visualization-tool-git-fix-keep-locale-in-user-actions-ixt1.vercel.app/en?dataSource=Prod).
2. Log in (e.g. as `ixt` test user).
3. Navigate to user profile.
4. Edit an example chart.
5. See that the page opened in English (on TEST it opens in German).