### PR TITLE
fix: Initial map zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 
 ## Unreleased
 
+- Features
+  - Slightly increased initial map zoom level
 - Fixes
   - SingleURLs layout mode now correctly publishes charts
   - Redirecting to latest cube now works correctly for cases of trying to access old cube that didn't look like a versioned cube, but in fact was a versioned cube
@@ -17,6 +19,7 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
   - Temporal segment is no longer carried over when switching from scatterplot to column chart if it was already used as X axis
   - Dimension data type is now parsed in case of two data types defined directly in dimension metadata
   - Currently selected locale is now persisted when using actions in user profile page (view chart, edit, open, share)
+  - Initial zoom map is now correctly (and consistently) applied again
 
 # [3.26.3] - 2024-03-05
 

--- a/app/charts/chart-data-wrapper.spec.tsx
+++ b/app/charts/chart-data-wrapper.spec.tsx
@@ -1,0 +1,82 @@
+// eslint-disable-next-line import/order
+import { RDFCubeViewQueryMock } from "@/test/cube-view-query-mock";
+RDFCubeViewQueryMock;
+
+// eslint-disable-next-line import/order
+import { render } from "@testing-library/react";
+
+import { ChartDataWrapper } from "@/charts/chart-data-wrapper";
+import { LoadingStateProvider } from "@/charts/shared/chart-loading-state";
+import { ChartConfig } from "@/config-types";
+
+jest.mock("@mui/styles", () => ({
+  makeStyles: () => () => ({}),
+}));
+
+jest.mock("@lingui/macro", () => ({
+  defineMessage: (str: string) => str,
+}));
+
+jest.mock("@/graphql/hooks", () => ({
+  useDataCubesComponentsQuery: jest.fn().mockReturnValue([
+    {
+      data: {
+        dataCubesComponents: {
+          dimensions: [],
+          measures: [],
+        },
+      },
+      error: undefined,
+      fetching: false,
+    },
+  ]),
+  useDataCubesMetadataQuery: jest.fn().mockReturnValue([
+    {
+      data: {
+        dataCubesMetadata: [
+          {
+            iri: "abc",
+            label: "ABC",
+            dimensions: [],
+            measures: [],
+          },
+        ],
+      },
+      error: undefined,
+      fetching: false,
+    },
+  ]),
+  useDataCubesObservationsQuery: jest.fn().mockReturnValue([
+    {
+      data: {
+        dataCubesObservations: {
+          data: [],
+        },
+      },
+      error: undefined,
+      fetching: false,
+    },
+  ]),
+}));
+
+jest.mock("@/components/hint", () => ({
+  Loading: jest.fn(() => null),
+}));
+
+describe("ChartDataWrapper", () => {
+  it("should not render the component if prop is still being loaded", () => {
+    const Chart = jest.fn();
+    render(
+      <LoadingStateProvider>
+        <ChartDataWrapper
+          chartConfig={{ cubes: [] } as any as ChartConfig}
+          Component={Chart}
+          dataSource={{ type: "sparql", url: "url" }}
+          observationQueryFilters={[]}
+          fetching
+        />
+      </LoadingStateProvider>
+    );
+    expect(Chart).not.toHaveBeenCalled();
+  });
+});

--- a/app/charts/chart-data-wrapper.tsx
+++ b/app/charts/chart-data-wrapper.tsx
@@ -121,6 +121,8 @@ export const ChartDataWrapper = <
     fetchingMetadata ||
     fetchingComponents ||
     fetchingObservations;
+  const error =
+    errorProp || metadataError || componentsError || observationsError;
 
   React.useEffect(() => {
     chartLoadingState.set("data", fetching);
@@ -133,7 +135,14 @@ export const ChartDataWrapper = <
     };
   }, [dimensions, measures]);
 
-  if (metadata && dimensions && measures && observations) {
+  if (
+    metadata &&
+    dimensions &&
+    measures &&
+    observations &&
+    !fetching &&
+    !error
+  ) {
     // FIXME: adapt to design
     const title = metadata.map((d) => d.title).join(", ");
 
@@ -168,12 +177,7 @@ export const ChartDataWrapper = <
         ) : null}
       </Box>
     );
-  } else if (
-    errorProp ||
-    metadataError ||
-    componentsError ||
-    observationsError
-  ) {
+  } else if (error) {
     return (
       <Flex sx={{ flexDirection: "column", gap: 3 }}>
         {metadataError && <Error message={metadataError.message} />}

--- a/app/charts/chart-data-wrapper.tsx
+++ b/app/charts/chart-data-wrapper.tsx
@@ -41,7 +41,7 @@ export const ChartDataWrapper = <
   observationQueryFilters,
 
   fetching: fetchingProp = false,
-  error: errorProp,
+  error: propError,
 }: {
   chartConfig: TChartConfig;
   Component: TChartComponent;
@@ -122,7 +122,7 @@ export const ChartDataWrapper = <
     fetchingComponents ||
     fetchingObservations;
   const error =
-    errorProp || metadataError || componentsError || observationsError;
+    propError || metadataError || componentsError || observationsError;
 
   React.useEffect(() => {
     chartLoadingState.set("data", fetching);
@@ -183,7 +183,7 @@ export const ChartDataWrapper = <
         {metadataError && <Error message={metadataError.message} />}
         {componentsError && <Error message={componentsError.message} />}
         {observationsError && <Error message={observationsError.message} />}
-        {errorProp && <Error message={errorProp.message} />}
+        {propError && <Error message={propError.message} />}
       </Flex>
     );
   } else {

--- a/app/charts/chart-data-wrapper.tsx
+++ b/app/charts/chart-data-wrapper.tsx
@@ -135,14 +135,22 @@ export const ChartDataWrapper = <
     };
   }, [dimensions, measures]);
 
-  if (
-    metadata &&
-    dimensions &&
-    measures &&
-    observations &&
-    !fetching &&
-    !error
-  ) {
+  if (error) {
+    return (
+      <Flex sx={{ flexDirection: "column", gap: 3 }}>
+        {metadataError && <Error message={metadataError.message} />}
+        {componentsError && <Error message={componentsError.message} />}
+        {observationsError && <Error message={observationsError.message} />}
+        {propError && <Error message={propError.message} />}
+      </Flex>
+    );
+  } else if (fetching) {
+    return (
+      <Flex flexGrow={1} justifyContent="center" minHeight={300}>
+        <Loading />
+      </Flex>
+    );
+  } else if (metadata && dimensions && measures && observations) {
     // FIXME: adapt to design
     const title = metadata.map((d) => d.title).join(", ");
 
@@ -177,21 +185,8 @@ export const ChartDataWrapper = <
         ) : null}
       </Box>
     );
-  } else if (error) {
-    return (
-      <Flex sx={{ flexDirection: "column", gap: 3 }}>
-        {metadataError && <Error message={metadataError.message} />}
-        {componentsError && <Error message={componentsError.message} />}
-        {observationsError && <Error message={observationsError.message} />}
-        {propError && <Error message={propError.message} />}
-      </Flex>
-    );
   } else {
-    return (
-      <Flex flexGrow={1} justifyContent="center" minHeight={300}>
-        <Loading />
-      </Flex>
-    );
+    return null;
   }
 };
 

--- a/app/charts/map/helpers.ts
+++ b/app/charts/map/helpers.ts
@@ -105,7 +105,7 @@ export const useViewState = (props: ViewStateInitializationProps) => {
       getViewStateFromBounds({
         width,
         height,
-        padding: 1 / 3,
+        padding: 1 / 4,
         bbox: featuresBBox,
       }) ?? BASE_VIEW_STATE
     );

--- a/app/charts/map/map.tsx
+++ b/app/charts/map/map.tsx
@@ -102,8 +102,6 @@ export const MapComponent = () => {
     featuresBBox,
   });
 
-  const currentBBox = React.useRef<BBox>();
-
   const lockedRef = React.useRef(locked);
   React.useEffect(() => {
     lockedRef.current = locked;
@@ -362,9 +360,8 @@ export const MapComponent = () => {
       return;
     }
 
-    const bbox = map.getBounds().toArray() as BBox;
-    currentBBox.current = bbox;
-    resizeAndFit(map, lockedBBox || bbox);
+    const bbox = lockedBBox ?? (map.getBounds().toArray() as BBox);
+    resizeAndFit(map, bbox);
   });
 
   const handleResize = useEvent((e: MapboxEvent) => {
@@ -402,8 +399,8 @@ export const MapComponent = () => {
           doubleClickZoom={!locked}
           dragRotate={false}
           touchZoomRotate={!locked}
-          onData={(ev) => {
-            if (ev.dataType === "source" && !ev.isSourceLoaded) {
+          onData={(e) => {
+            if (e.dataType === "source" && !e.isSourceLoaded) {
               setLoaded(false);
             }
           }}
@@ -416,7 +413,6 @@ export const MapComponent = () => {
           }}
           onLoad={(e) => {
             setMap(e.target as mapboxgl.Map);
-            currentBBox.current = e.target.getBounds().toArray() as BBox;
 
             /**
              * Redraw the map on load, when style data has been downloaded
@@ -426,16 +422,7 @@ export const MapComponent = () => {
              */
             redrawMap();
           }}
-          onMove={(e) => {
-            const userTriggered =
-              e.originalEvent && e.originalEvent.type !== "resize";
-
-            if (userTriggered) {
-              currentBBox.current = e.target.getBounds().toArray() as BBox;
-            }
-
-            onViewStateChange(e);
-          }}
+          onMove={onViewStateChange}
           onResize={handleResize}
           {...viewState}
         >


### PR DESCRIPTION
Fixes #1394.

## How to test
1. Go to any map chart from the deployment preview, e.g. [here](https://visualization-tool-git-fix-initial-map-zoom-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9&dataSource=Prod).
2. Switch to a map chart.
3. Refresh the page several times.
4. See that the initial zoom level is correctly applied.