### PR TITLE
fix: Can't add an optional filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
   - Temporal segment is no longer carried over when switching from scatterplot to column chart if it was already used as X axis
   - Dimension data type is now parsed in case of two data types defined directly in dimension metadata
   - Currently selected locale is now persisted when using actions in user profile page (view chart, edit, open, share)
+  - Optional filters can be added again
 
 # [3.26.3] - 2024-03-05
 

--- a/app/configurator/components/chart-configurator.spec.ts
+++ b/app/configurator/components/chart-configurator.spec.ts
@@ -1,0 +1,16 @@
+// eslint-disable-next-line import/order
+import { RDFCubeViewQueryMock } from "@/test/cube-view-query-mock";
+RDFCubeViewQueryMock;
+
+import { ChartConfig } from "@/config-types";
+import { getFilterReorderCubeFilters } from "@/configurator/components/chart-configurator";
+
+describe("getFilterReorderCubeFilters", () => {
+  it("should load dimension values", () => {
+    const cubeFilters = getFilterReorderCubeFilters(
+      { cubes: [{ filters: {} }], fields: {} } as any as ChartConfig,
+      { joinByIris: [] }
+    );
+    expect(cubeFilters[0].loadValues).toBe(true);
+  });
+});

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -302,6 +302,26 @@ const useEnsurePossibleFilters = ({
   return { error, fetching };
 };
 
+export const getFilterReorderCubeFilters = (
+  chartConfig: ChartConfig,
+  { joinByIris }: { joinByIris: string[] }
+) => {
+  return chartConfig.cubes.map(({ iri, joinBy }) => {
+    const { unmappedFilters } = getFiltersByMappingStatus(chartConfig, {
+      cubeIri: iri,
+      joinByIris,
+    });
+
+    return {
+      iri,
+      filters:
+        Object.keys(unmappedFilters).length > 0 ? unmappedFilters : undefined,
+      joinBy,
+      loadValues: true,
+    };
+  });
+};
+
 const useFilterReorder = ({
   onAddDimensionFilter,
 }: {
@@ -319,24 +339,8 @@ const useFilterReorder = ({
   }, [chartConfig, joinByIris]);
 
   const variables = useMemo(() => {
-    const cubeFilters = chartConfig.cubes.map((cube) => {
-      const { unmappedFilters } = getFiltersByMappingStatus(chartConfig, {
-        cubeIri: cube.iri,
-        joinByIris,
-      });
-
-      return Object.keys(unmappedFilters).length > 0
-        ? {
-            iri: cube.iri,
-            filters: unmappedFilters,
-            joinBy: cube.joinBy,
-          }
-        : {
-            iri: cube.iri,
-            filters: undefined,
-            joinBy: cube.joinBy,
-            loadValues: true,
-          };
+    const cubeFilters = getFilterReorderCubeFilters(chartConfig, {
+      joinByIris,
     });
 
     // This is important for urql not to think that filters


### PR DESCRIPTION
Fixes #1402.

## How to test
1. Go to [this link](https://visualization-tool-git-fix-adding-filter-ixt1.vercel.app/en/create/new?cube=https://environment.ld.admin.ch/foen/ubd0066/12&dataSource=Prod).
2. Add a new, optional filter (e.g. Year).
3. See that the filter is correctly added.