### PR TITLE
perf: Load PossibleFilters upfront

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 
 - Fixes
   - Full data download now correctly includes all cube dimensions again
+- Performance
+  - The application now fires the `PossibleFilters` query as soon as a chart is initialized to always load filters that make sense, without initial reloading
 
 # [3.27.2] - 2024-03-19
 

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -314,6 +314,7 @@ export const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
   const { dataSource, chartKey, actionElementSlot, disableMetadataPanel } =
     props;
   const [state, dispatch] = useConfiguratorState();
+  const configuring = isConfiguring(state);
   const chartConfig = getChartConfig(state, chartKey);
   const locale = useLocale();
   const commonQueryVariables = {
@@ -418,21 +419,19 @@ export const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
                       <Flex
                         sx={{
                           justifyContent:
-                            state.state === "CONFIGURING_CHART" ||
-                            chartConfig.meta.title[locale]
+                            configuring || chartConfig.meta.title[locale]
                               ? "space-between"
                               : "flex-end",
                           alignItems: "flex-start",
                           gap: 2,
                         }}
                       >
-                        {(state.state === "CONFIGURING_CHART" ||
-                          chartConfig.meta.title[locale]) && (
+                        {(configuring || chartConfig.meta.title[locale]) && (
                           <Title
                             text={chartConfig.meta.title[locale]}
                             lighterColor
                             onClick={
-                              state.state === "CONFIGURING_CHART"
+                              configuring
                                 ? () =>
                                     dispatch({
                                       type: "CHART_ACTIVE_FIELD_CHANGED",
@@ -454,13 +453,13 @@ export const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
                           {actionElementSlot}
                         </Flex>
                       </Flex>
-                      {(state.state === "CONFIGURING_CHART" ||
+                      {(configuring ||
                         chartConfig.meta.description[locale]) && (
                         <Description
                           text={chartConfig.meta.description[locale]}
                           lighterColor
                           onClick={
-                            state.state === "CONFIGURING_CHART"
+                            configuring
                               ? () => {
                                   dispatch({
                                     type: "CHART_ACTIVE_FIELD_CHANGED",

--- a/app/configurator/components/chart-controls/color-palette.tsx
+++ b/app/configurator/components/chart-controls/color-palette.tsx
@@ -73,8 +73,8 @@ export const ColorPalette = ({
   const palettes = isNumericalMeasure(component)
     ? divergingSteppedPalettes
     : defaultPalette
-    ? [defaultPalette, ...categoricalPalettes]
-    : categoricalPalettes;
+      ? [defaultPalette, ...categoricalPalettes]
+      : categoricalPalettes;
 
   const currentPaletteName = get(
     chartConfig,
@@ -145,7 +145,7 @@ export const ColorPalette = ({
           </MenuItem>
         ))}
       </Select>
-      {component && state.state === "CONFIGURING_CHART" && (
+      {component && (
         <ColorPaletteControls
           field={field}
           component={component}

--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -1,6 +1,5 @@
 import { Trans } from "@lingui/macro";
-import { SxProps, Typography } from "@mui/material";
-import { Box } from "@mui/material";
+import { Box, SxProps, Typography } from "@mui/material";
 import Button, { ButtonProps } from "@mui/material/Button";
 import { useRouter } from "next/router";
 import React from "react";
@@ -17,6 +16,7 @@ import { Loading } from "@/components/hint";
 import {
   ConfiguratorState,
   getChartConfig,
+  isConfiguring,
   useConfiguratorState,
 } from "@/configurator";
 import {
@@ -136,13 +136,14 @@ const BackToMainButton = (props: BackToMainButtonProps) => {
 
 const ConfigureChartStep = () => {
   const [state, dispatch] = useConfiguratorState();
+  const configuring = isConfiguring(state);
   const chartConfig = getChartConfig(state);
   const router = useRouter();
   const handleClosePanel = useEvent(() => {
     dispatch({ type: "CHART_ACTIVE_FIELD_CHANGED", value: undefined });
   });
   const handlePrevious = useEvent(() => {
-    if (state.state !== "CONFIGURING_CHART") {
+    if (!configuring) {
       return;
     }
 
@@ -160,7 +161,7 @@ const ConfigureChartStep = () => {
 
   useAssureCorrectDataSource("CONFIGURING_CHART");
 
-  if (state.state !== "CONFIGURING_CHART") {
+  if (!configuring) {
     return null;
   }
 

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -143,7 +143,8 @@ export const useChartFieldField = ({
   });
 
   let value: string | undefined;
-  if (state.state === "CONFIGURING_CHART") {
+
+  if (isConfiguring(state)) {
     const chartConfig = getChartConfig(state);
     value = getFieldComponentIri(chartConfig.fields, field) ?? FIELD_VALUE_NONE;
   }
@@ -185,7 +186,8 @@ export const useChartOptionSelectField = <V extends {} = string>(
   );
 
   let value: V | undefined;
-  if (state.state === "CONFIGURING_CHART") {
+
+  if (isConfiguring(state)) {
     value = get(
       getChartConfig(state),
       `fields["${field}"].${path}`,
@@ -233,10 +235,9 @@ export const useChartOptionSliderField = ({
     }
   });
 
-  const value =
-    state.state === "CONFIGURING_CHART"
-      ? +getChartOptionField(state, field, path)
-      : defaultValue;
+  const value = isConfiguring(state)
+    ? +getChartOptionField(state, field, path)
+    : defaultValue;
 
   return {
     name: path,
@@ -268,10 +269,7 @@ export const useChartOptionRadioField = <V extends string | number>(
       },
     });
   }, [dispatch, locale, field, path, value]);
-  const stateValue =
-    state.state === "CONFIGURING_CHART"
-      ? getChartOptionField(state, field, path)
-      : "";
+  const stateValue = getChartOptionField(state, field, path);
   const checked = stateValue ? stateValue === value : undefined;
 
   return {
@@ -308,10 +306,9 @@ export const useChartOptionBooleanField = ({
     },
     [locale, dispatch, path, field]
   );
-  const stateValue =
-    state.state === "CONFIGURING_CHART"
-      ? getChartOptionField(state, field, path, defaultValue)
-      : defaultValue;
+  const stateValue = isConfiguring(state)
+    ? getChartOptionField(state, field, path, defaultValue)
+    : defaultValue;
   const checked = stateValue ? stateValue : false;
 
   return {
@@ -401,7 +398,7 @@ export const useChartType = (
           chartConfig: getInitialConfig({
             chartType,
             iris: [
-              state.state === "CONFIGURING_CHART"
+              isConfiguring(state)
                 ? getChartConfig(state, state.activeChartKey).cubes[0].iri
                 : chartConfig.cubes[0].iri,
             ],
@@ -455,7 +452,7 @@ export const useSingleFilterSelect = ({
 
   let value = FIELD_VALUE_NONE;
 
-  if (state.state === "CONFIGURING_CHART") {
+  if (isConfiguring(state)) {
     const chartConfig = getChartConfig(state);
     const cube = chartConfig.cubes.find((cube) => cube.iri === cubeIri);
 
@@ -495,11 +492,9 @@ export const useSingleFilterField = ({
     [dispatch, cubeIri, dimensionIri]
   );
 
-  const stateValue =
-    state.state === "CONFIGURING_CHART"
-      ? get(getChartConfig(state), ["filters", dimensionIri, "value"], "")
-      : "";
-
+  const stateValue = isConfiguring(state)
+    ? get(getChartConfig(state), ["filters", dimensionIri, "value"], "")
+    : "";
   const checked = stateValue === value;
 
   return {
@@ -556,8 +551,8 @@ export const MultiFilterContextProvider = ({
       ? activeFilter.type === "single"
         ? [String(activeFilter.value)]
         : activeFilter.type === "multi"
-        ? Object.keys(activeFilter.values)
-        : []
+          ? Object.keys(activeFilter.values)
+          : []
       : allValues;
     return new Set(activeKeys);
   }, [activeFilter, allValues]);

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -34,7 +34,7 @@ import {
   updateColorMapping,
 } from "@/configurator/configurator-state";
 import { configStateMock } from "@/configurator/configurator-state.mock";
-import { Component, Dimension, Measure, NominalDimension } from "@/domain/data";
+import { Dimension, Measure, NominalDimension } from "@/domain/data";
 import covid19ColumnChartConfig from "@/test/__fixtures/config/dev/chartConfig-column-covid19.json";
 import covid19TableChartConfig from "@/test/__fixtures/config/dev/chartConfig-table-covid19.json";
 import { data as fakeVizFixture } from "@/test/__fixtures/config/prod/line-1.json";
@@ -559,8 +559,7 @@ describe("retainChartConfigWhenSwitchingChartType", () => {
     );
     deriveFiltersFromFields(newConfig, [
       ...dataSetMetadata.dimensions,
-      ...dataSetMetadata.measures,
-    ] as any as Component[]);
+    ] as any as Dimension[]);
 
     return current(newConfig);
   };

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/configurator/configurator-state";
 import { configStateMock } from "@/configurator/configurator-state.mock";
 import { Dimension, Measure, NominalDimension } from "@/domain/data";
+import { ObservationFilter } from "@/graphql/query-hooks";
 import covid19ColumnChartConfig from "@/test/__fixtures/config/dev/chartConfig-column-covid19.json";
 import covid19TableChartConfig from "@/test/__fixtures/config/dev/chartConfig-table-covid19.json";
 import { data as fakeVizFixture } from "@/test/__fixtures/config/prod/line-1.json";
@@ -69,9 +70,25 @@ jest.mock("@/utils/chart-config/api", () => ({
   fetchChartConfig: jest.fn(),
 }));
 
+const possibleFilters: ObservationFilter[] = [
+  {
+    __typename: "ObservationFilter",
+    iri: "symbolLayerIri",
+    type: "single",
+    value: "xPossible",
+  },
+];
+
 jest.mock("@/graphql/client", () => {
   return {
     client: {
+      query: jest.fn().mockImplementation(() => ({
+        toPromise: jest.fn().mockResolvedValue({
+          data: {
+            possibleFilters,
+          },
+        }),
+      })),
       readQuery: jest.fn().mockImplementation(() => ({
         data: {
           dataCubeComponents: getCachedComponentsMock.geoAndNumerical,
@@ -169,11 +186,12 @@ describe("initChartFromLocalStorage", () => {
 });
 
 describe("initChartStateFromCube", () => {
+  const dataSource: DataSource = {
+    url: "https://example.com/api",
+    type: "sparql",
+  };
+
   it("should work init fields with existing dataset and go directly to 2nd step", async () => {
-    const dataSource: DataSource = {
-      url: "https://example.com/api",
-      type: "sparql",
-    };
     const res = await initChartStateFromCube(
       "https://environment.ld.admin.ch/foen/ubd0104/3/",
       dataSource,
@@ -184,6 +202,20 @@ describe("initChartStateFromCube", () => {
         state: "CONFIGURING_CHART",
       })
     );
+  });
+
+  it("should prefer possible filters if provided", async () => {
+    const res = (await initChartStateFromCube(
+      "mapDataset",
+      dataSource,
+      "en"
+    )) as ConfiguratorStateConfiguringChart;
+    expect(res.chartConfigs[0].cubes[0].filters).toEqual({
+      symbolLayerIri: {
+        type: "single",
+        value: "xPossible",
+      },
+    });
   });
 });
 
@@ -557,9 +589,9 @@ describe("retainChartConfigWhenSwitchingChartType", () => {
         measures: dataSetMetadata.measures as any as Measure[],
       })
     );
-    deriveFiltersFromFields(newConfig, [
-      ...dataSetMetadata.dimensions,
-    ] as any as Dimension[]);
+    deriveFiltersFromFields(newConfig, {
+      dimensions: dataSetMetadata.dimensions as any as Dimension[],
+    });
 
     return current(newConfig);
   };

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -350,7 +350,7 @@ const INITIAL_STATE: ConfiguratorState = {
   dataSource: DEFAULT_DATA_SOURCE,
 };
 
-const EMPTY_STATE: ConfiguratorStateSelectingDataSet = {
+const SELECTING_DATASET_STATE: ConfiguratorStateSelectingDataSet = {
   ...INITIAL_STATE,
   version: CONFIGURATOR_STATE_VERSION,
   state: "SELECTING_DATASET",
@@ -1072,7 +1072,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
     case "INITIALIZED":
       // Never restore from an UNINITIALIZED state
       return action.value.state === "INITIAL"
-        ? getStateWithCurrentDataSource(EMPTY_STATE)
+        ? getStateWithCurrentDataSource(SELECTING_DATASET_STATE)
         : action.value;
     case "DATASOURCE_CHANGED":
       draft.dataSource = action.value;
@@ -1580,10 +1580,13 @@ export const initChartStateFromCube = async (
   });
 
   if (components?.dataCubesComponents) {
-    return transitionStepNext(getStateWithCurrentDataSource(EMPTY_STATE), {
+    return transitionStepNext(
+      getStateWithCurrentDataSource(SELECTING_DATASET_STATE),
+      {
       dataCubesComponents: components.dataCubesComponents,
       cubeIris: [cubeIri],
-    });
+      }
+    );
   }
 
   console.warn(`Could not fetch cube with iri ${cubeIri}!`);

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -855,7 +855,7 @@ export const handleChartFieldChanged = (
   draft: ConfiguratorState,
   action: Extract<ConfiguratorStateAction, { type: "CHART_FIELD_CHANGED" }>
 ) => {
-  if (draft.state !== "CONFIGURING_CHART") {
+  if (!isConfiguring(draft)) {
     return draft;
   }
 
@@ -920,7 +920,7 @@ export const handleChartOptionChanged = (
   draft: ConfiguratorState,
   action: Extract<ConfiguratorStateAction, { type: "CHART_OPTION_CHANGED" }>
 ) => {
-  if (draft.state === "CONFIGURING_CHART") {
+  if (isConfiguring(draft)) {
     const { locale, path, field, value } = action.value;
     const chartConfig = getChartConfig(draft);
     const updatePath = field === null ? path : `fields["${field}"].${path}`;
@@ -962,7 +962,7 @@ export const updateColorMapping = (
     { type: "CHART_CONFIG_UPDATE_COLOR_MAPPING" }
   >
 ) => {
-  if (draft.state === "CONFIGURING_CHART") {
+  if (isConfiguring(draft)) {
     const { field, colorConfigPath, dimensionIri, values, random } =
       action.value;
     const chartConfig = getChartConfig(draft);
@@ -1014,7 +1014,7 @@ const handleInteractiveFilterChanged = (
     { type: "INTERACTIVE_FILTER_CHANGED" }
   >
 ) => {
-  if (draft.state === "CONFIGURING_CHART") {
+  if (isConfiguring(draft)) {
     const chartConfig = getChartConfig(draft);
     setWith(chartConfig, "interactiveFiltersConfig", action.value, Object);
   }
@@ -1080,7 +1080,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       return draft;
 
     case "CHART_TYPE_CHANGED":
-      if (draft.state === "CONFIGURING_CHART") {
+      if (isConfiguring(draft)) {
         const { locale, chartKey, chartType } = action.value;
         const chartConfig = getChartConfig(draft, chartKey);
         const dataCubesComponents = getCachedComponents(
@@ -1115,7 +1115,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       return draft;
 
     case "CHART_ACTIVE_FIELD_CHANGED":
-      if (draft.state === "CONFIGURING_CHART") {
+      if (isConfiguring(draft)) {
         const chartConfig = getChartConfig(draft);
         chartConfig.activeField = action.value;
       }
@@ -1126,7 +1126,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       return handleChartFieldChanged(draft, action);
 
     case "CHART_FIELD_DELETED":
-      if (draft.state === "CONFIGURING_CHART") {
+      if (isConfiguring(draft)) {
         const chartConfig = getChartConfig(draft);
         delete (chartConfig.fields as GenericFields)[action.value.field];
         const dataCubesComponents = getCachedComponents(
@@ -1159,7 +1159,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       return handleChartOptionChanged(draft, action);
 
     case "CHART_PALETTE_CHANGED":
-      if (draft.state === "CONFIGURING_CHART") {
+      if (isConfiguring(draft)) {
         const chartConfig = getChartConfig(draft);
         setWith(
           chartConfig,
@@ -1186,7 +1186,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       return draft;
 
     case "CHART_PALETTE_RESET":
-      if (draft.state === "CONFIGURING_CHART") {
+      if (isConfiguring(draft)) {
         const chartConfig = getChartConfig(draft);
         setWith(
           chartConfig,
@@ -1203,7 +1203,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       return draft;
 
     case "CHART_COLOR_CHANGED":
-      if (draft.state === "CONFIGURING_CHART") {
+      if (isConfiguring(draft)) {
         const chartConfig = getChartConfig(draft);
         setWith(
           chartConfig,
@@ -1219,7 +1219,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       return draft;
 
     case "CHART_ANNOTATION_CHANGED":
-      if (draft.state === "CONFIGURING_CHART") {
+      if (isConfiguring(draft)) {
         const chartConfig = getChartConfig(draft);
         setWith(
           chartConfig,
@@ -1235,7 +1235,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       return handleInteractiveFilterChanged(draft, action);
 
     case "CHART_CONFIG_REPLACED":
-      if (draft.state === "CONFIGURING_CHART") {
+      if (isConfiguring(draft)) {
         const chartConfig = getChartConfig(draft);
         const index = draft.chartConfigs.findIndex(
           (d) => d.key === chartConfig.key
@@ -1249,7 +1249,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       return draft;
 
     case "CHART_CONFIG_FILTER_SET_SINGLE":
-      if (draft.state === "CONFIGURING_CHART") {
+      if (isConfiguring(draft)) {
         const { cubeIri, dimensionIri, value } = action.value;
         const chartConfig = getChartConfig(draft);
         const cube = chartConfig.cubes.find((cube) => cube.iri === cubeIri);
@@ -1265,7 +1265,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       return draft;
 
     case "CHART_CONFIG_FILTER_REMOVE_SINGLE":
-      if (draft.state === "CONFIGURING_CHART") {
+      if (isConfiguring(draft)) {
         const { cubeIri, dimensionIri } = action.value;
         const chartConfig = getChartConfig(draft);
         const cube = chartConfig.cubes.find((cube) => cube.iri === cubeIri);
@@ -1287,7 +1287,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       return updateColorMapping(draft, action);
 
     case "CHART_CONFIG_FILTER_SET_MULTI":
-      if (draft.state === "CONFIGURING_CHART") {
+      if (isConfiguring(draft)) {
         const { cubeIri, dimensionIri, values } = action.value;
         const chartConfig = getChartConfig(draft);
         const cube = chartConfig.cubes.find((cube) => cube.iri === cubeIri);
@@ -1300,7 +1300,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       return draft;
 
     case "CHART_CONFIG_FILTER_RESET_RANGE":
-      if (draft.state === "CONFIGURING_CHART") {
+      if (isConfiguring(draft)) {
         const { cubeIri, dimensionIri } = action.value;
         const chartConfig = getChartConfig(draft);
         const cube = chartConfig.cubes.find((cube) => cube.iri === cubeIri);
@@ -1313,14 +1313,14 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       return draft;
 
     case "CHART_CONFIG_FILTER_SET_RANGE":
-      if (draft.state === "CONFIGURING_CHART") {
+      if (isConfiguring(draft)) {
         setRangeFilter(draft, action);
       }
 
       return draft;
 
     case "CHART_CONFIG_FILTERS_UPDATE":
-      if (draft.state === "CONFIGURING_CHART") {
+      if (isConfiguring(draft)) {
         const { cubeIri, filters } = action.value;
         const chartConfig = getChartConfig(draft);
         const cube = chartConfig.cubes.find((cube) => cube.iri === cubeIri);
@@ -1333,7 +1333,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       return draft;
 
     case "IMPUTATION_TYPE_CHANGED":
-      if (draft.state === "CONFIGURING_CHART") {
+      if (isConfiguring(draft)) {
         const chartConfig = getChartConfig(draft);
         if (isAreaConfig(chartConfig)) {
           chartConfig.fields.y.imputationType = action.value.type;
@@ -1362,7 +1362,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       return draft;
 
     case "CHART_CONFIG_ADD":
-      if (draft.state === "CONFIGURING_CHART") {
+      if (isConfiguring(draft)) {
         const chartConfig = getChartConfig(draft);
         const dataCubesComponents = getCachedComponents(
           draft.dataSource,
@@ -1391,14 +1391,14 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       return draft;
 
     case "DATASET_ADD":
-      if (draft.state === "CONFIGURING_CHART") {
+      if (isConfiguring(draft)) {
         addDatasetInConfig(draft, action.value);
         return draft;
       }
       break;
 
     case "DATASET_REMOVE":
-      if (draft.state === "CONFIGURING_CHART") {
+      if (isConfiguring(draft)) {
         const chartConfig = getChartConfig(draft);
 
         const { locale } = action.value;
@@ -1447,7 +1447,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       }
       break;
     case "CHART_CONFIG_REMOVE":
-      if (draft.state === "CONFIGURING_CHART") {
+      if (isConfiguring(draft)) {
         const index = draft.chartConfigs.findIndex(
           (d) => d.key === action.value.chartKey
         );
@@ -1462,7 +1462,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       return draft;
 
     case "CHART_CONFIG_REORDER":
-      if (draft.state === "CONFIGURING_CHART" || draft.state === "LAYOUTING") {
+      if (isConfiguring(draft) || draft.state === "LAYOUTING") {
         const { oldIndex, newIndex } = action.value;
         const [removed] = draft.chartConfigs.splice(oldIndex, 1);
         draft.chartConfigs.splice(newIndex, 0, removed);
@@ -1471,7 +1471,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       return draft;
 
     case "CHART_CONFIG_SWAP":
-      if (draft.state === "CONFIGURING_CHART" || draft.state === "LAYOUTING") {
+      if (isConfiguring(draft) || draft.state === "LAYOUTING") {
         const { oldIndex, newIndex } = action.value;
         const oldChartConfig = draft.chartConfigs[oldIndex];
         const newChartConfig = draft.chartConfigs[newIndex];
@@ -1483,7 +1483,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
 
     case "SWITCH_ACTIVE_CHART":
       if (
-        draft.state === "CONFIGURING_CHART" ||
+        isConfiguring(draft) ||
         draft.state === "LAYOUTING" ||
         draft.state === "PUBLISHED"
       ) {

--- a/app/urql-cache.mock.ts
+++ b/app/urql-cache.mock.ts
@@ -406,7 +406,7 @@ export const getCachedComponentsMock = {
         iri: "newAreaLayerColorIri",
         label: "Geo shapes dimension",
         isNumerical: false,
-        isKeyDimension: false,
+        isKeyDimension: true,
         values: [
           {
             value: "orange",
@@ -421,8 +421,11 @@ export const getCachedComponentsMock = {
         cubeIri: "mapDataset",
         label: "Geo coordinates dimension",
         isNumerical: false,
-        isKeyDimension: false,
-        values: [{ value: "x", label: "y" }],
+        isKeyDimension: true,
+        values: [
+          { value: "x", label: "y" },
+          { value: "xPossible", label: "yPossible" },
+        ],
       },
     ],
     measures: [
@@ -437,7 +440,4 @@ export const getCachedComponentsMock = {
       },
     ],
   },
-} satisfies Record<
-string,
-ReturnType<typeof getCachedComponents>
->;
+} satisfies Record<string, ReturnType<typeof getCachedComponents>>;


### PR DESCRIPTION
This PR tackles the first point of #1423 to initialize chart config with filters that make sense (only applicable when starting a chart from scratch).

While in some cases it will improve performance, in other cases it might decrease it (depending on the scale of a cube / number of dimensions, etc) – but generally it should increase UX to never show a chart w/o observations.

### How to test
**PR**
1. Go to [this link](https://visualization-tool-git-perf-load-possible-filters-upfront-ixt1.vercel.app/en/create/new?cube=https://environment.ld.admin.ch/foen/fab_ahst_exp_imp_pipeline/1&dataSource=Test).
2. Watch closely that the first chart that loads is not empty.

**TEST**
1. Go to [this link](https://test.visualize.admin.ch/en/create/new?cube=https://environment.ld.admin.ch/foen/fab_ahst_exp_imp_pipeline/1&dataSource=Test).
2. Watch closely that the first chart that loads is empty, and is reloaded automatically afterwards.