### PR TITLE
fix: PossibleFilters firing when doesn't make sense

### DIFF
--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -7,7 +7,10 @@ import { useClient } from "urql";
 
 import { useQueryFilters } from "@/charts/shared/chart-helpers";
 import { useLoadingState } from "@/charts/shared/chart-loading-state";
-import { getPossibleFiltersQueryVariables } from "@/charts/shared/ensure-possible-filters";
+import {
+  getPossibleFiltersQueryVariables,
+  skipPossibleFiltersQuery,
+} from "@/charts/shared/ensure-possible-filters";
 import Flex from "@/components/flex";
 import { Select } from "@/components/form";
 import { Loading } from "@/components/hint";
@@ -51,7 +54,6 @@ import {
   useInteractiveFiltersRaw,
 } from "@/stores/interactive-filters";
 import { hierarchyToOptions } from "@/utils/hierarchy";
-import { orderedIsEqual } from "@/utils/ordered-is-equal";
 import useEvent from "@/utils/use-event";
 
 type PreparedFilter = {
@@ -583,9 +585,10 @@ const useEnsurePossibleInteractiveFilters = (
           filtersByCubeIri[cube.iri];
 
         if (
-          (lastFilters.current[cube.iri] &&
-            orderedIsEqual(lastFilters.current[cube.iri], unmappedFilters)) ||
-          isEmpty(unmappedFilters)
+          skipPossibleFiltersQuery(
+            lastFilters.current[cube.iri],
+            unmappedFilters
+          )
         ) {
           return;
         }

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -7,6 +7,7 @@ import { useClient } from "urql";
 
 import { useQueryFilters } from "@/charts/shared/chart-helpers";
 import { useLoadingState } from "@/charts/shared/chart-loading-state";
+import { getPossibleFiltersQueryKey } from "@/charts/shared/ensure-possible-filters";
 import Flex from "@/components/flex";
 import { Select } from "@/components/form";
 import { Loading } from "@/components/hint";
@@ -591,6 +592,8 @@ const useEnsurePossibleInteractiveFilters = (
 
         lastFilters.current[cube.iri] = unmappedFilters;
         loadingState.set("possible-interactive-filters", true);
+
+        const filterKey = getPossibleFiltersQueryKey(unmappedFilters);
         const { data, error } = await client
           .query<PossibleFiltersQuery, PossibleFiltersQueryVariables>(
             PossibleFiltersDocument,
@@ -599,8 +602,8 @@ const useEnsurePossibleInteractiveFilters = (
               sourceType: dataSource.type,
               sourceUrl: dataSource.url,
               filters: unmappedFilters,
-              // @ts-ignore This is to make urql requery
-              filterKeys: Object.keys(unmappedFilters).join(", "),
+              // @ts-ignore
+              filterKey,
             }
           )
           .toPromise();

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -7,7 +7,7 @@ import { useClient } from "urql";
 
 import { useQueryFilters } from "@/charts/shared/chart-helpers";
 import { useLoadingState } from "@/charts/shared/chart-loading-state";
-import { getPossibleFiltersQueryKey } from "@/charts/shared/ensure-possible-filters";
+import { getPossibleFiltersQueryVariables } from "@/charts/shared/ensure-possible-filters";
 import Flex from "@/components/flex";
 import { Select } from "@/components/form";
 import { Loading } from "@/components/hint";
@@ -592,20 +592,16 @@ const useEnsurePossibleInteractiveFilters = (
 
         lastFilters.current[cube.iri] = unmappedFilters;
         loadingState.set("possible-interactive-filters", true);
-
-        const filterKey = getPossibleFiltersQueryKey(unmappedFilters);
+        const variables = getPossibleFiltersQueryVariables({
+          cubeIri: cube.iri,
+          dataSource,
+          unmappedFilters,
+        });
         const { data, error } = await client
-          .query<PossibleFiltersQuery, PossibleFiltersQueryVariables>(
-            PossibleFiltersDocument,
-            {
-              iri: cube.iri,
-              sourceType: dataSource.type,
-              sourceUrl: dataSource.url,
-              filters: unmappedFilters,
-              // @ts-ignore
-              filterKey,
-            }
-          )
+          .query<
+            PossibleFiltersQuery,
+            PossibleFiltersQueryVariables
+          >(PossibleFiltersDocument, variables)
           .toPromise();
 
         if (error || !data) {
@@ -670,8 +666,7 @@ const useEnsurePossibleInteractiveFilters = (
     dispatch,
     chartConfig.fields,
     chartConfig.cubes,
-    dataSource.type,
-    dataSource.url,
+    dataSource,
     setDataFilters,
     loadingState,
     IFRaw,

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -22,7 +22,6 @@ import {
   useChartConfigFilters,
   useConfiguratorState,
 } from "@/configurator";
-import { orderedIsEqual } from "@/configurator/components/chart-configurator";
 import { FieldLabel, LoadingIndicator } from "@/configurator/components/field";
 import {
   canRenderDatePickerField,
@@ -52,6 +51,7 @@ import {
   useInteractiveFiltersRaw,
 } from "@/stores/interactive-filters";
 import { hierarchyToOptions } from "@/utils/hierarchy";
+import { orderedIsEqual } from "@/utils/ordered-is-equal";
 import useEvent from "@/utils/use-event";
 
 type PreparedFilter = {

--- a/app/charts/shared/ensure-possible-filters.ts
+++ b/app/charts/shared/ensure-possible-filters.ts
@@ -1,6 +1,24 @@
-import { SingleFilters } from "@/config-types";
+import { DataSource, SingleFilters } from "@/config-types";
+import { PossibleFiltersQueryVariables } from "@/graphql/query-hooks";
 
 /** Used to make urql re-query when order of filters changes. */
-export const getPossibleFiltersQueryKey = (unmappedFilters: SingleFilters) => {
+const getPossibleFiltersQueryKey = (unmappedFilters: SingleFilters) => {
   return Object.keys(unmappedFilters).join(", ");
+};
+
+export const getPossibleFiltersQueryVariables = (props: {
+  cubeIri: string;
+  dataSource: DataSource;
+  unmappedFilters: SingleFilters;
+}): PossibleFiltersQueryVariables => {
+  const { cubeIri, dataSource, unmappedFilters } = props;
+  const filterKey = getPossibleFiltersQueryKey(unmappedFilters);
+  return {
+    iri: cubeIri,
+    sourceType: dataSource.type,
+    sourceUrl: dataSource.url,
+    filters: unmappedFilters,
+    // @ts-ignore
+    filterKey,
+  };
 };

--- a/app/charts/shared/ensure-possible-filters.ts
+++ b/app/charts/shared/ensure-possible-filters.ts
@@ -1,5 +1,8 @@
-import { DataSource, SingleFilters } from "@/config-types";
+import isEmpty from "lodash/isEmpty";
+
+import { DataSource, Filters, SingleFilters } from "@/config-types";
 import { PossibleFiltersQueryVariables } from "@/graphql/query-hooks";
+import { orderedIsEqual } from "@/utils/ordered-is-equal";
 
 /** Used to make urql re-query when order of filters changes. */
 const getPossibleFiltersQueryKey = (unmappedFilters: SingleFilters) => {
@@ -21,4 +24,14 @@ export const getPossibleFiltersQueryVariables = (props: {
     // @ts-ignore
     filterKey,
   };
+};
+
+export const skipPossibleFiltersQuery = (
+  oldFilters: Filters | undefined,
+  newFilters: SingleFilters
+) => {
+  return (
+    (oldFilters && orderedIsEqual(oldFilters, newFilters)) ||
+    isEmpty(newFilters)
+  );
 };

--- a/app/charts/shared/ensure-possible-filters.ts
+++ b/app/charts/shared/ensure-possible-filters.ts
@@ -1,0 +1,6 @@
+import { SingleFilters } from "@/config-types";
+
+/** Used to make urql re-query when order of filters changes. */
+export const getPossibleFiltersQueryKey = (unmappedFilters: SingleFilters) => {
+  return Object.keys(unmappedFilters).join(", ");
+};

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -29,6 +29,7 @@ import { useClient } from "urql";
 
 import { getChartSpec } from "@/charts/chart-config-ui-options";
 import { useQueryFilters } from "@/charts/shared/chart-helpers";
+import { getPossibleFiltersQueryKey } from "@/charts/shared/ensure-possible-filters";
 import { OpenMetadataPanelWrapper } from "@/components/metadata-panel";
 import MoveDragButtons from "@/components/move-drag-buttons";
 import useDisclosure from "@/components/use-disclosure";
@@ -216,6 +217,7 @@ const useEnsurePossibleFilters = ({
         lastFilters.current[cube.iri] = unmappedFilters;
         setFetching(true);
 
+        const filterKey = getPossibleFiltersQueryKey(unmappedFilters);
         const { data, error } = await client
           .query<PossibleFiltersQuery, PossibleFiltersQueryVariables>(
             PossibleFiltersDocument,
@@ -224,8 +226,8 @@ const useEnsurePossibleFilters = ({
               sourceType: state.dataSource.type,
               sourceUrl: state.dataSource.url,
               filters: unmappedFilters,
-              // @ts-ignore This is to make urql requery
-              filterKey: Object.keys(unmappedFilters).join(", "),
+              // @ts-ignore
+              filterKey,
             }
           )
           .toPromise();

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -29,7 +29,7 @@ import { useClient } from "urql";
 
 import { getChartSpec } from "@/charts/chart-config-ui-options";
 import { useQueryFilters } from "@/charts/shared/chart-helpers";
-import { getPossibleFiltersQueryKey } from "@/charts/shared/ensure-possible-filters";
+import { getPossibleFiltersQueryVariables } from "@/charts/shared/ensure-possible-filters";
 import { OpenMetadataPanelWrapper } from "@/components/metadata-panel";
 import MoveDragButtons from "@/components/move-drag-buttons";
 import useDisclosure from "@/components/use-disclosure";
@@ -216,20 +216,16 @@ const useEnsurePossibleFilters = ({
 
         lastFilters.current[cube.iri] = unmappedFilters;
         setFetching(true);
-
-        const filterKey = getPossibleFiltersQueryKey(unmappedFilters);
+        const variables = getPossibleFiltersQueryVariables({
+          cubeIri: cube.iri,
+          dataSource: state.dataSource,
+          unmappedFilters,
+        });
         const { data, error } = await client
-          .query<PossibleFiltersQuery, PossibleFiltersQueryVariables>(
-            PossibleFiltersDocument,
-            {
-              iri: cube.iri,
-              sourceType: state.dataSource.type,
-              sourceUrl: state.dataSource.url,
-              filters: unmappedFilters,
-              // @ts-ignore
-              filterKey,
-            }
-          )
+          .query<
+            PossibleFiltersQuery,
+            PossibleFiltersQueryVariables
+          >(PossibleFiltersDocument, variables)
           .toPromise();
 
         if (error || !data) {
@@ -288,8 +284,7 @@ const useEnsurePossibleFilters = ({
     dispatch,
     chartConfig,
     chartConfig.cubes,
-    state.dataSource.type,
-    state.dataSource.url,
+    state.dataSource,
     joinByIris,
   ]);
 

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -206,8 +206,9 @@ const useEnsurePossibleFilters = ({
         );
 
         if (
-          lastFilters.current[cube.iri] &&
-          orderedIsEqual(lastFilters.current[cube.iri], unmappedFilters)
+          (lastFilters.current[cube.iri] &&
+            orderedIsEqual(lastFilters.current[cube.iri], unmappedFilters)) ||
+          isEmpty(unmappedFilters)
         ) {
           return;
         }

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -29,7 +29,10 @@ import { useClient } from "urql";
 
 import { getChartSpec } from "@/charts/chart-config-ui-options";
 import { useQueryFilters } from "@/charts/shared/chart-helpers";
-import { getPossibleFiltersQueryVariables } from "@/charts/shared/ensure-possible-filters";
+import {
+  getPossibleFiltersQueryVariables,
+  skipPossibleFiltersQuery,
+} from "@/charts/shared/ensure-possible-filters";
 import { OpenMetadataPanelWrapper } from "@/components/metadata-panel";
 import MoveDragButtons from "@/components/move-drag-buttons";
 import useDisclosure from "@/components/use-disclosure";
@@ -86,7 +89,6 @@ import {
 } from "@/graphql/query-hooks";
 import { Icon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
-import { orderedIsEqual } from "@/utils/ordered-is-equal";
 import useEvent from "@/utils/use-event";
 
 import { DatasetsControlSection } from "./dataset-control-section";
@@ -201,9 +203,10 @@ const useEnsurePossibleFilters = ({
         );
 
         if (
-          (lastFilters.current[cube.iri] &&
-            orderedIsEqual(lastFilters.current[cube.iri], unmappedFilters)) ||
-          isEmpty(unmappedFilters)
+          skipPossibleFiltersQuery(
+            lastFilters.current[cube.iri],
+            unmappedFilters
+          )
         ) {
           return;
         }

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -86,6 +86,7 @@ import {
 } from "@/graphql/query-hooks";
 import { Icon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
+import { orderedIsEqual } from "@/utils/ordered-is-equal";
 import useEvent from "@/utils/use-event";
 
 import { DatasetsControlSection } from "./dataset-control-section";
@@ -170,13 +171,6 @@ const DataFilterSelectGeneric = (props: DataFilterSelectGenericProps) => {
       <DataFilterSelect {...sharedProps} hierarchy={dimension.hierarchy} />
     );
   }
-};
-
-export const orderedIsEqual = (
-  obj1: Record<string, unknown>,
-  obj2: Record<string, unknown>
-) => {
-  return isEqual(Object.keys(obj1), Object.keys(obj2)) && isEqual(obj1, obj2);
 };
 
 /**

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -24,6 +24,7 @@ import {
   getChartFieldOptionChangeSideEffect,
   getChartSpec,
 } from "@/charts/chart-config-ui-options";
+import { getPossibleFiltersQueryKey } from "@/charts/shared/ensure-possible-filters";
 import {
   ChartConfig,
   ChartType,
@@ -1591,6 +1592,7 @@ export const initChartStateFromCube = async (
     cubeIri,
   });
   const shouldFetchPossibleFilters = Object.keys(unmappedFilters).length > 0;
+  const filterKey = getPossibleFiltersQueryKey(unmappedFilters);
   const { data: possibleFilters } = await client
     .query<PossibleFiltersQuery, PossibleFiltersQueryVariables>(
       PossibleFiltersDocument,
@@ -1599,10 +1601,12 @@ export const initChartStateFromCube = async (
         sourceType: dataSource.type,
         sourceUrl: dataSource.url,
         filters: unmappedFilters,
-        // @ts-ignore This is to make urql requery
-        filterKey: Object.keys(unmappedFilters).join(", "),
+        // @ts-ignore
+        filterKey,
       },
-      { pause: !shouldFetchPossibleFilters }
+      {
+        pause: !shouldFetchPossibleFilters,
+      }
     )
     .toPromise();
 

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -24,7 +24,7 @@ import {
   getChartFieldOptionChangeSideEffect,
   getChartSpec,
 } from "@/charts/chart-config-ui-options";
-import { getPossibleFiltersQueryKey } from "@/charts/shared/ensure-possible-filters";
+import { getPossibleFiltersQueryVariables } from "@/charts/shared/ensure-possible-filters";
 import {
   ChartConfig,
   ChartType,
@@ -1592,22 +1592,16 @@ export const initChartStateFromCube = async (
     cubeIri,
   });
   const shouldFetchPossibleFilters = Object.keys(unmappedFilters).length > 0;
-  const filterKey = getPossibleFiltersQueryKey(unmappedFilters);
+  const variables = getPossibleFiltersQueryVariables({
+    cubeIri,
+    dataSource,
+    unmappedFilters,
+  });
   const { data: possibleFilters } = await client
-    .query<PossibleFiltersQuery, PossibleFiltersQueryVariables>(
-      PossibleFiltersDocument,
-      {
-        iri: cubeIri,
-        sourceType: dataSource.type,
-        sourceUrl: dataSource.url,
-        filters: unmappedFilters,
-        // @ts-ignore
-        filterKey,
-      },
-      {
-        pause: !shouldFetchPossibleFilters,
-      }
-    )
+    .query<
+      PossibleFiltersQuery,
+      PossibleFiltersQueryVariables
+    >(PossibleFiltersDocument, variables, { pause: !shouldFetchPossibleFilters })
     .toPromise();
 
   if (!possibleFilters?.possibleFilters && shouldFetchPossibleFilters) {

--- a/app/rdf/query-possible-filters.ts
+++ b/app/rdf/query-possible-filters.ts
@@ -20,6 +20,12 @@ export const getPossibleFilters = async (
 ) => {
   const { filters, sparqlClient, cache } = options;
   const dimensionIris = Object.keys(filters);
+
+  if (dimensionIris.length === 0) {
+    console.warn("No filters provided, returning empty possible filters.");
+    return [];
+  }
+
   const dimensionsMetadata = await getDimensionsMetadata(
     cubeIri,
     dimensionIris,

--- a/app/utils/ordered-is-equal.ts
+++ b/app/utils/ordered-is-equal.ts
@@ -1,0 +1,7 @@
+import isEqual from "lodash/isEqual";
+
+type Value = Record<string, unknown>;
+
+export const orderedIsEqual = (obj1: Value, obj2: Value) => {
+  return isEqual(Object.keys(obj1), Object.keys(obj2)) && isEqual(obj1, obj2);
+};


### PR DESCRIPTION
Fixes #1430

This PR prevents the `PossibleFilters` query from being fired when it doesn't make sense (no filters are present). It also shares some logic related to `PossibleFilters` query across different parts of the application.

### How to test
**PR**
1. Go to [this link](https://visualization-tool-git-fix-possible-filters-error-ixt1.vercel.app/en/create/new?cube=https://communication.ld.admin.ch/ofcom/map_tv_konz/8&dataSource=Int).
2. ✅ See that there's no error in the `Filters` section.

**TEST**
1. Go to [this link](https://test.visualize.admin.ch/en/create/new?cube=https://communication.ld.admin.ch/ofcom/map_tv_konz/8&dataSource=Int).
2. ❌ See that there's an error in the `Filters` section.