### PR TITLE
Label docker image

### DIFF
--- a/scripts/docker-build-push.sh
+++ b/scripts/docker-build-push.sh
@@ -16,6 +16,8 @@ set -x
 
 # Build docker image, passing arguments defined in the CI 
 docker build \
+    --label "COMMIT=$CI_COMMIT_SHA" \
+    --label "TAGS=$DOCKER_IMAGE_TAGS" \
     --build-arg COMMIT=$CI_COMMIT_SHA \
     --build-arg MAPTILER_STYLE_KEY=$MAPTILER_STYLE_KEY \
     --build-arg VECTOR_TILE_URL=$VECTOR_TILE_URL \


### PR DESCRIPTION
Right now, it is difficult given an image retrieved via docker pull registry.ldbar.ch/visualize-admin/visualization-tool:release
to know which is the version. Using labels, we should be able to know exactly the version by doing docker inspect on the image.
