### PR TITLE
feat: Do not unmount the chart when data is being loaded

### DIFF
--- a/app/charts/chart-data-wrapper.spec.tsx
+++ b/app/charts/chart-data-wrapper.spec.tsx
@@ -61,9 +61,9 @@ jest.mock("@/components/hint", () => ({
 
 describe("ChartDataWrapper", () => {
   it("should render the LoadingOverlay if prop is still being loaded", () => {
-    const Chart = jest.fn();
-    const LoadingOverlay = jest.fn();
-    render(
+    const Chart = () => <div>My chart</div>;
+    const LoadingOverlay = () => <div>Loading overlay</div>;
+    const root = render(
       <LoadingStateProvider>
         <ChartDataWrapper
           chartConfig={{ cubes: [] } as any as ChartConfig}
@@ -75,7 +75,11 @@ describe("ChartDataWrapper", () => {
         />
       </LoadingStateProvider>
     );
-    expect(Chart).toHaveBeenCalled();
-    expect(LoadingOverlay).toHaveBeenCalled();
+    expect(
+      root.getByText("My chart").innerHTML.includes("My chart")
+    ).toBeTruthy();
+    expect(
+      root.getByText("Loading overlay").innerHTML.includes("Loading overlay")
+    ).toBeTruthy();
   });
 });

--- a/app/charts/chart-data-wrapper.spec.tsx
+++ b/app/charts/chart-data-wrapper.spec.tsx
@@ -56,15 +56,18 @@ jest.mock("@/graphql/hooks", () => ({
 
 jest.mock("@/components/hint", () => ({
   Loading: jest.fn(() => null),
+  NoDataHint: jest.fn(() => null),
 }));
 
 describe("ChartDataWrapper", () => {
-  it("should not render the component if prop is still being loaded", () => {
+  it("should render the LoadingOverlay if prop is still being loaded", () => {
     const Chart = jest.fn();
+    const LoadingOverlay = jest.fn();
     render(
       <LoadingStateProvider>
         <ChartDataWrapper
           chartConfig={{ cubes: [] } as any as ChartConfig}
+          LoadingOverlayComponent={LoadingOverlay}
           Component={Chart}
           dataSource={{ type: "sparql", url: "url" }}
           observationQueryFilters={[]}
@@ -72,6 +75,7 @@ describe("ChartDataWrapper", () => {
         />
       </LoadingStateProvider>
     );
-    expect(Chart).not.toHaveBeenCalled();
+    expect(Chart).toHaveBeenCalled();
+    expect(LoadingOverlay).toHaveBeenCalled();
   });
 });

--- a/app/components/hint.tsx
+++ b/app/components/hint.tsx
@@ -15,6 +15,7 @@ import { makeStyles } from "@mui/styles";
 import React, { ReactNode } from "react";
 
 import Flex from "@/components/flex";
+import { MotionBox } from "@/components/presence";
 import { Icon, IconName } from "@/icons";
 
 export const Error = ({ children }: { children: ReactNode }) => (
@@ -139,11 +140,16 @@ export const Loading = ({ delayMs = 1000 }: { delayMs?: number }) => {
 
 export const LoadingOverlay = () => {
   const classes = useLoadingStyles();
-
   return (
-    <Box className={classes.overlay}>
+    <MotionBox
+      className={classes.overlay}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 0.5 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.2 }}
+    >
       <Loading delayMs={0} />
-    </Box>
+    </MotionBox>
   );
 };
 

--- a/app/components/hint.tsx
+++ b/app/components/hint.tsx
@@ -5,10 +5,11 @@ import {
   AlertTitle,
   Box,
   BoxProps,
-  keyframes,
   Link,
   Theme,
   Typography,
+  alpha,
+  keyframes,
   useTheme,
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
@@ -85,11 +86,9 @@ const useLoadingStyles = makeStyles((theme: Theme) => ({
     flexGrow: 1,
     padding: theme.spacing(2),
     opacity: 0,
-    color: theme.palette.secondary.main,
   },
   overlay: {
     position: "absolute",
-    backgroundColor: theme.palette.grey[100],
     top: 0,
     left: 0,
     width: "100%",
@@ -140,12 +139,22 @@ export const Loading = ({ delayMs = 1000 }: { delayMs?: number }) => {
 
 export const LoadingOverlay = () => {
   const classes = useLoadingStyles();
+  const theme = useTheme();
   return (
     <MotionBox
       className={classes.overlay}
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 0.5 }}
-      exit={{ opacity: 0 }}
+      initial={{
+        backgroundColor: alpha(theme.palette.grey[100], 0),
+        color: alpha(theme.palette.secondary.active!, 0),
+      }}
+      animate={{
+        backgroundColor: alpha(theme.palette.grey[100], 0.7),
+        color: theme.palette.text.primary,
+      }}
+      exit={{
+        backgroundColor: alpha(theme.palette.grey[100], 0),
+        color: alpha(theme.palette.secondary.active!, 0),
+      }}
       transition={{ duration: 0.2 }}
     >
       <Loading delayMs={0} />


### PR DESCRIPTION
Closes #1126

Currently we unmount the whole chart component and use `<Loading />` when data is being fetched via the `ChartDataWrapper` component.

In my opinion, this is suboptimal user experience, as we lose track of the old chart state when the data is being loaded, and immediately are presented with new state, losing the sense of the difference between prior and current charts.

As we take advantage of smooth transitions between chart states in several chart types, it should result in less obtrusive behavior of the chart component, especially when manipulating chart filters.

For an initial implementation I applied a semi-transparent `LoadingOverlay` component, this might be changed after @KerstinFaye's review 😁

I also discovered a bug in the hook for data loading we use, that results in missing loading indication of any kind for the charts – this is also fixed by this PR.

## How to test
### PR
1. Go to [this link](https://visualization-tool-git-feat-do-not-unmount-chart-wh-2a4991-ixt1.vercel.app/en/create/new?cube=https://environment.ld.admin.ch/foen/nfi/nfi_C-20/cube/2023-3&dataSource=Prod).
2. Play around with the filters.
3. ✅ See that there is a semi-transparent loading overlay and that the chart is not unmounted.

### PROD
1. Go to [this link](https://visualize.admin.ch/en/create/new?cube=https://environment.ld.admin.ch/foen/nfi/nfi_C-20/cube/2023-3&dataSource=Prod).
2. Play around with the filters.
3. ❌ See that there's no indication of the data being fetched (bug in the data fetching hooks, previously the whole chart was being unmounted).