### PR TITLE
fix: Temporal joinBy dimension X axis filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 
 - Features
   - Added support for using dynamic most recent date in temporal X axis
-- Maintenance
-  - Vastly reduced Docker image size (9.78GB -> 520MB (-95%)), which should make CI pipelines faster
+- Fixes
+  - Temporal dimension X axis filtering in case of being a join by dimension
 
 # [4.1.0] - 2024-04-10
 

--- a/app/components/chart-panel.tsx
+++ b/app/components/chart-panel.tsx
@@ -14,9 +14,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   chartWrapper: {
     display: "contents",
-    backgroundColor: theme.palette.grey[100],
-    border: "1px solid",
-    borderColor: theme.palette.divider,
     overflow: "hidden",
     width: "auto",
     height: "100%",

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -7,7 +7,8 @@ import {
   useDroppable,
 } from "@dnd-kit/core";
 import { Trans } from "@lingui/macro";
-import { Box } from "@mui/material";
+import { Box, Theme } from "@mui/material";
+import { makeStyles } from "@mui/styles";
 import Head from "next/head";
 import React from "react";
 
@@ -300,6 +301,19 @@ const SingleURLsPreview = (props: SingleURLsPreviewProps) => {
   );
 };
 
+const useStyles = makeStyles<Theme>((theme) => ({
+  root: {
+    display: "grid",
+    gridTemplateRows: "subgrid",
+    gridRow: shouldShowDebugPanel() ? "span 5" : "span 4",
+    backgroundColor: theme.palette.background.paper,
+    color: theme.palette.grey[800],
+    padding: theme.spacing(6),
+    border: "1px solid",
+    borderColor: theme.palette.divider,
+  },
+}));
+
 type ChartPreviewInnerProps = ChartPreviewProps & {
   chartKey?: string | null;
   actionElementSlot?: React.ReactNode;
@@ -313,6 +327,7 @@ export const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
   const configuring = isConfiguring(state);
   const chartConfig = getChartConfig(state, chartKey);
   const locale = useLocale();
+  const classes = useStyles();
   const commonQueryVariables = {
     sourceType: dataSource.type,
     sourceUrl: dataSource.url,
@@ -357,16 +372,7 @@ export const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
   }, [components?.dataCubesComponents]);
 
   return (
-    <Box
-      sx={{
-        display: "grid",
-        gridTemplateRows: "subgrid",
-        gridRow: shouldShowDebugPanel() ? "span 5" : "span 4",
-        backgroundColor: "background.paper",
-        color: "grey.800",
-        p: 6,
-      }}
-    >
+    <Box className={classes.root}>
       <ChartErrorBoundary resetKeys={[state]}>
         {/* FIXME: adapt to design */}
         {metadata?.dataCubesMetadata.some(

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -148,6 +148,8 @@ const useStyles = makeStyles<Theme, { shrink: boolean }>((theme) => ({
     gridTemplateRows: "subgrid",
     gridRow: shouldShowDebugPanel() ? "span 6" : "span 5",
     backgroundColor: theme.palette.background.paper,
+    border: "1px solid",
+    borderColor: theme.palette.divider,
     padding: theme.spacing(6),
     paddingLeft: ({ shrink }) =>
       `calc(${theme.spacing(5)} + ${shrink ? DRAWER_WIDTH : 0}px)`,

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -348,7 +348,6 @@ const EncodingOptionsPanel = (props: EncodingOptionsPanelProps) => {
                 components={allComponents}
               />
             )}
-
             {encoding.options?.useAbbreviations && (
               <Box mt={3}>
                 <ChartFieldAbbreviations
@@ -444,7 +443,6 @@ const EncodingOptionsPanel = (props: EncodingOptionsPanelProps) => {
         dimensions={dimensions}
         measures={measures}
       />
-
       {fieldDimension &&
         field === "animation" &&
         isAnimationInConfig(chartConfig) &&
@@ -1165,21 +1163,18 @@ const ChartFieldAnimation = ({ field }: { field: AnimationField }) => {
   );
 };
 
-const ChartFieldMultiFilter = ({
-  chartConfig,
-  component,
-  encoding,
-  field,
-  dimensions,
-  measures,
-}: {
+type ChartFieldMultiFilterProps = {
   chartConfig: ChartConfig;
   component: Component | undefined;
   encoding: EncodingSpec;
-  field: string;
+  field: EncodingFieldType;
   dimensions: Dimension[];
   measures: Measure[];
-}) => {
+};
+
+const ChartFieldMultiFilter = (props: ChartFieldMultiFilterProps) => {
+  const { chartConfig, component, encoding, field, dimensions, measures } =
+    props;
   const colorComponentIri = get(
     chartConfig,
     `fields["${field}"].color.componentIri`

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -923,7 +923,7 @@ export const TimeFilter = (props: TimeFilterProps) => {
     [dispatch, dimension]
   );
 
-  const activeFilter = getFilterValue(state, dimension.iri);
+  const activeFilter = getFilterValue(state, dimension);
   const rangeActiveFilter =
     activeFilter?.type === "range" ? activeFilter : null;
   const usesMostRecentValue = rangeActiveFilter

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -543,7 +543,7 @@ export const MultiFilterContextProvider = ({
   getValueColor: (value: string) => string;
 }) => {
   const [state] = useConfiguratorState();
-  const activeFilter = getFilterValue(state, dimension.iri);
+  const activeFilter = getFilterValue(state, dimension);
   const allValues = useMemo(() => {
     return dimension.values.map((d) => `${d.value}`) ?? [];
   }, [dimension.values]);

--- a/app/configurator/configurator-state.spec.tsx
+++ b/app/configurator/configurator-state.spec.tsx
@@ -21,6 +21,7 @@ import {
   ConfiguratorStateAction,
   deriveFiltersFromFields,
   getFiltersByMappingStatus,
+  getFilterValue,
   getLocalStorageKey,
   handleChartFieldChanged,
   handleChartOptionChanged,
@@ -1249,5 +1250,42 @@ describe("add dataset", () => {
     const config = newState2.chartConfigs[0] as MapConfig;
     expect(config.cubes.length).toBe(1);
     expect(config.chartType).toEqual("column");
+  });
+});
+
+describe("getFilterValue", () => {
+  const f = {
+    type: "range",
+    from: "2010",
+    to: "2014",
+  };
+  const state = {
+    state: "CONFIGURING_CHART",
+    chartConfigs: [
+      {
+        cubes: [
+          {
+            iri: "foo",
+            filters: {
+              first: f,
+            },
+          },
+          {
+            iri: "bar",
+            filters: {
+              second: f,
+            },
+          },
+        ],
+      },
+    ],
+  } as any as ConfiguratorState;
+  const dimension = {
+    isJoinByDimension: true,
+    originalIris: [{ dimensionIri: "first" }, { dimensionIri: "second" }],
+  } as any as Dimension;
+
+  it("should correctly retrieve filters for joinBy dimension", () => {
+    expect(getFilterValue(state, dimension)).toEqual(f);
   });
 });

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -64,6 +64,7 @@ import {
   Dimension,
   DimensionValue,
   isGeoDimension,
+  isJoinByComponent,
   ObservationValue,
 } from "@/domain/data";
 import { DEFAULT_DATA_SOURCE } from "@/domain/datasource";
@@ -368,7 +369,7 @@ const SELECTING_DATASET_STATE: ConfiguratorStateSelectingDataSet = {
 
 export const getFilterValue = (
   state: ConfiguratorState,
-  dimensionIri: string
+  dimension: Dimension
 ): FilterValue | undefined => {
   if (state.state === "INITIAL" || state.state === "SELECTING_DATASET") {
     return;
@@ -377,7 +378,10 @@ export const getFilterValue = (
   const chartConfig = getChartConfig(state);
   const filters = getChartConfigFilters(chartConfig.cubes);
 
-  return filters[dimensionIri];
+  return isJoinByComponent(dimension)
+    ? // As filters are mirrored between the cubes, we can just pick the first one.
+      filters[dimension.originalIris[0].dimensionIri]
+    : filters[dimension.iri];
 };
 
 export const moveFilterField = produce(


### PR DESCRIPTION
This PR fixes a bug discovered by @sosiology that made the temporal X axis filtering not working with cubes merged by a temporal dimension. It also fixes an error of not displaying date pickers for joinBy dimensions.

## How to test
### PR
1. Go to [this link](https://visualization-tool-git-fix-year-filtering-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9&dataSource=Prod&flag__add-dataset=true).
2. Add a new cube – Heavy Metal Soil Contamination.
3. Go to horizontal axis.
4. ✅ See that the date pickers are displayed.
5. ✅ See that date filtering works.

### TEST
1. Go to [this link](https://test.visualize.admin.ch/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9&dataSource=Prod&flag__add-dataset=true).
2. Add a new cube – Heavy Metal Soil Contamination.
3. Go to horizontal axis.
4. ❌ See that the date pickers are not displayed.
5. ❌ See that date filtering doesn't work (jumps back to original selection).