### PR TITLE
fix: Cached endpoint variables

### DIFF
--- a/app/.env.development
+++ b/app/.env.development
@@ -1,5 +1,5 @@
 DATABASE_URL=postgres://postgres:password@localhost:5432/visualization_tool
-ENDPOINT=sparql+https://lindas.admin.ch/query
+ENDPOINT=sparql+https://lindas-cached.cluster.ldbar.ch/query
 SPARQL_GEO_ENDPOINT=https://geo.ld.admin.ch/query
 GRAPHQL_ENDPOINT=/api/graphql
 WHITELISTED_DATA_SOURCES=["Prod", "Int", "Test"]

--- a/app/domain/datasource/index.ts
+++ b/app/domain/datasource/index.ts
@@ -16,7 +16,7 @@ import {
 export const parseDataSource = (stringifiedSource: string): DataSource => {
   const [type, url] = stringifiedSource.split("+") as [
     DataSource["type"],
-    string
+    string,
   ];
 
   return { type, url };

--- a/app/domain/env.ts
+++ b/app/domain/env.ts
@@ -24,7 +24,7 @@ export const PUBLIC_URL = (
 export const ENDPOINT =
   clientEnv?.ENDPOINT ??
   process.env.ENDPOINT ??
-  "sparql+https://lindas.admin.ch/query";
+  "sparql+https://lindas-cached.cluster.ldbar.ch/query";
 
 export const WHITELISTED_DATA_SOURCES = clientEnv?.WHITELISTED_DATA_SOURCES ??
   (process.env.WHITELISTED_DATA_SOURCES !== undefined

--- a/app/stores/data-source.ts
+++ b/app/stores/data-source.ts
@@ -101,7 +101,7 @@ export const dataSourceStoreMiddleware =
     };
 
     // No need to unsubscribe, as store is created once and needs to update
-    // URL continously.
+    // URL continuously.
     router.events.on("routeChangeComplete", callback);
 
     // Initialize with correct url.


### PR DESCRIPTION
This PR fixes `ENDPOINT` variable to correctly reference cached LINDAS endpoint, which should fix missing data source selection in preview deployments.

### Next steps
- [ ] Reach out to Abraxas once we have a new PROD deployment to update the ENDPOINT env variable on their side