### PR TITLE
fix: Do not unmount sidebar content when data is being re-fetched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
   - Added support for using dynamic most recent date in temporal X axis
 - Fixes
   - Temporal dimension X axis filtering in case of being a join by dimension
+  - Sidebar content no longer gets unmounted when data is being re-fetched (e.g. when interacting with time slider in temporal X axes)
 
 # [4.1.0] - 2024-04-10
 

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -46,7 +46,7 @@ import {
 } from "@/charts/shared/stacked-helpers";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
-import { Observer, useWidth } from "@/charts/shared/use-width";
+import { useWidth } from "@/charts/shared/use-width";
 import { AreaConfig } from "@/configurator";
 import { Observation } from "@/domain/data";
 import { useFormatNumber, useTimeFormatUnit } from "@/formatters";
@@ -454,10 +454,8 @@ export const AreaChart = (
   >
 ) => {
   return (
-    <Observer>
-      <InteractionProvider>
-        <AreaChartProvider {...props} />
-      </InteractionProvider>
-    </Observer>
+    <InteractionProvider>
+      <AreaChartProvider {...props} />
+    </InteractionProvider>
   );
 };

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -36,7 +36,7 @@ import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
 import { getCenteredTooltipPlacement } from "@/charts/shared/interaction/tooltip-box";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
-import { Observer, useWidth } from "@/charts/shared/use-width";
+import { useWidth } from "@/charts/shared/use-width";
 import { ColumnConfig } from "@/configurator";
 import { Observation } from "@/domain/data";
 import { formatNumberWithUnit, useFormatNumber } from "@/formatters";
@@ -454,10 +454,8 @@ export const GroupedColumnChart = (
   >
 ) => {
   return (
-    <Observer>
-      <InteractionProvider>
-        <GroupedColumnChartProvider {...props} />
-      </InteractionProvider>
-    </Observer>
+    <InteractionProvider>
+      <GroupedColumnChartProvider {...props} />
+    </InteractionProvider>
   );
 };

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -48,7 +48,7 @@ import {
 } from "@/charts/shared/stacked-helpers";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
-import { Observer, useWidth } from "@/charts/shared/use-width";
+import { useWidth } from "@/charts/shared/use-width";
 import { ColumnConfig } from "@/configurator";
 import { Observation } from "@/domain/data";
 import { useFormatNumber } from "@/formatters";
@@ -514,10 +514,8 @@ export const StackedColumnsChart = (
   >
 ) => {
   return (
-    <Observer>
-      <InteractionProvider>
-        <StackedColumnsChartProvider {...props} />
-      </InteractionProvider>
-    </Observer>
+    <InteractionProvider>
+      <StackedColumnsChartProvider {...props} />
+    </InteractionProvider>
   );
 };

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -29,7 +29,7 @@ import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
 import { getCenteredTooltipPlacement } from "@/charts/shared/interaction/tooltip-box";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
-import { Observer, useWidth } from "@/charts/shared/use-width";
+import { useWidth } from "@/charts/shared/use-width";
 import { ColumnConfig } from "@/configurator";
 import { Observation } from "@/domain/data";
 import {
@@ -287,10 +287,8 @@ export const ColumnChart = (
   >
 ) => {
   return (
-    <Observer>
-      <InteractionProvider>
-        <ColumnChartProvider {...props} />
-      </InteractionProvider>
-    </Observer>
+    <InteractionProvider>
+      <ColumnChartProvider {...props} />
+    </InteractionProvider>
   );
 };

--- a/app/charts/combo/combo-line-column-state.tsx
+++ b/app/charts/combo/combo-line-column-state.tsx
@@ -31,7 +31,6 @@ import { getCenteredTooltipPlacement } from "@/charts/shared/interaction/tooltip
 import { getTickNumber } from "@/charts/shared/ticks";
 import { TICK_FONT_SIZE } from "@/charts/shared/use-chart-theme";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
-import { Observer } from "@/charts/shared/use-width";
 import { ComboLineColumnConfig } from "@/configurator";
 import { Observation } from "@/domain/data";
 import { truthy } from "@/domain/types";
@@ -231,10 +230,8 @@ export const ComboLineColumnChart = (
   >
 ) => {
   return (
-    <Observer>
-      <InteractionProvider>
-        <ComboLineColumnChartProvider {...props} />
-      </InteractionProvider>
-    </Observer>
+    <InteractionProvider>
+      <ComboLineColumnChartProvider {...props} />
+    </InteractionProvider>
   );
 };

--- a/app/charts/combo/combo-line-dual-state.tsx
+++ b/app/charts/combo/combo-line-dual-state.tsx
@@ -30,7 +30,6 @@ import { getCenteredTooltipPlacement } from "@/charts/shared/interaction/tooltip
 import { getTickNumber } from "@/charts/shared/ticks";
 import { TICK_FONT_SIZE } from "@/charts/shared/use-chart-theme";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
-import { Observer } from "@/charts/shared/use-width";
 import { ComboLineDualConfig } from "@/configurator";
 import { Observation } from "@/domain/data";
 import { truthy } from "@/domain/types";
@@ -213,10 +212,8 @@ export const ComboLineDualChart = (
   >
 ) => {
   return (
-    <Observer>
-      <InteractionProvider>
-        <ComboLineDualChartProvider {...props} />
-      </InteractionProvider>
-    </Observer>
+    <InteractionProvider>
+      <ComboLineDualChartProvider {...props} />
+    </InteractionProvider>
   );
 };

--- a/app/charts/combo/combo-line-single-state.tsx
+++ b/app/charts/combo/combo-line-single-state.tsx
@@ -26,7 +26,6 @@ import {
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
 import { getCenteredTooltipPlacement } from "@/charts/shared/interaction/tooltip-box";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
-import { Observer } from "@/charts/shared/use-width";
 import { ComboLineSingleConfig } from "@/configurator";
 import { Observation } from "@/domain/data";
 import { truthy } from "@/domain/types";
@@ -190,10 +189,8 @@ export const ComboLineSingleChart = (
   >
 ) => {
   return (
-    <Observer>
-      <InteractionProvider>
-        <ComboLineSingleChartProvider {...props} />
-      </InteractionProvider>
-    </Observer>
+    <InteractionProvider>
+      <ComboLineSingleChartProvider {...props} />
+    </InteractionProvider>
   );
 };

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -31,7 +31,7 @@ import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
 import { getCenteredTooltipPlacement } from "@/charts/shared/interaction/tooltip-box";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
-import { Observer, useWidth } from "@/charts/shared/use-width";
+import { useWidth } from "@/charts/shared/use-width";
 import { LineConfig } from "@/configurator";
 import { Observation } from "@/domain/data";
 import {
@@ -311,10 +311,8 @@ export const LineChart = (
   >
 ) => {
   return (
-    <Observer>
-      <InteractionProvider>
-        <LineChartProvider {...props} />
-      </InteractionProvider>
-    </Observer>
+    <InteractionProvider>
+      <LineChartProvider {...props} />
+    </InteractionProvider>
   );
 };

--- a/app/charts/map/helpers.ts
+++ b/app/charts/map/helpers.ts
@@ -2,7 +2,7 @@ import { WebMercatorViewport } from "@deck.gl/core/typed";
 import { MapboxOverlay, MapboxOverlayProps } from "@deck.gl/mapbox/typed";
 import { extent } from "d3-array";
 import { geoBounds } from "d3-geo";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ViewState, useControl } from "react-map-gl";
 import { feature } from "topojson-client";
 
@@ -120,6 +120,11 @@ export const useViewState = (props: ViewStateInitializationProps) => {
       setViewState((oldViewState) => ({ ...oldViewState, ...viewState }));
     }
   );
+
+  // Update view state when locked or default view state changes.
+  useEffect(() => {
+    setViewState(lockedViewState ?? defaultViewState);
+  }, [lockedViewState, defaultViewState]);
 
   return { defaultViewState, viewState, onViewStateChange };
 };

--- a/app/charts/map/map-state.tsx
+++ b/app/charts/map/map-state.tsx
@@ -39,7 +39,7 @@ import {
 import { ChartContext, CommonChartState } from "@/charts/shared/chart-state";
 import { colorToRgbArray } from "@/charts/shared/colors";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
-import { Observer, useWidth } from "@/charts/shared/use-width";
+import { useWidth } from "@/charts/shared/use-width";
 import {
   BBox,
   CategoricalColorField,
@@ -603,12 +603,10 @@ export const MapChart = (props: React.PropsWithChildren<ChartMapProps>) => {
   const { children, ...rest } = props;
 
   return (
-    <Observer>
-      <InteractionProvider>
-        <MapChartProvider {...rest}>
-          <MapTooltipProvider>{children}</MapTooltipProvider>
-        </MapChartProvider>
-      </InteractionProvider>
-    </Observer>
+    <InteractionProvider>
+      <MapChartProvider {...rest}>
+        <MapTooltipProvider>{children}</MapTooltipProvider>
+      </MapChartProvider>
+    </InteractionProvider>
   );
 };

--- a/app/charts/map/map.tsx
+++ b/app/charts/map/map.tsx
@@ -17,7 +17,11 @@ import {
   RESET_DURATION,
 } from "@/charts/map/constants";
 import { useMapStyle } from "@/charts/map/get-base-layer-style";
-import { DeckGLOverlay, useViewState } from "@/charts/map/helpers";
+import {
+  BASE_VIEW_STATE,
+  DeckGLOverlay,
+  useViewState,
+} from "@/charts/map/helpers";
 import { MapState } from "@/charts/map/map-state";
 import { HoverObjectType, useMapTooltip } from "@/charts/map/map-tooltip";
 import { getMap, setMap } from "@/charts/map/ref";
@@ -134,7 +138,7 @@ export const MapComponent = () => {
   const zoomIn = useEvent(() => {
     const newViewState = {
       center: [viewState.longitude, viewState.latitude] as LngLatLike,
-      zoom: Math.min(viewState.zoom + 1, viewState.maxZoom),
+      zoom: Math.min(viewState.zoom + 1, BASE_VIEW_STATE.maxZoom),
       duration: FLY_TO_DURATION,
       essential: true,
     };
@@ -144,7 +148,7 @@ export const MapComponent = () => {
   const zoomOut = useEvent(() => {
     const newViewState = {
       center: [viewState.longitude, viewState.latitude] as LngLatLike,
-      zoom: Math.max(viewState.zoom - 1, viewState.minZoom),
+      zoom: Math.max(viewState.zoom - 1, BASE_VIEW_STATE.minZoom),
       duration: FLY_TO_DURATION,
       essential: true,
     };
@@ -425,7 +429,6 @@ export const MapComponent = () => {
           }}
           onLoad={(e) => {
             setMap(e.target as mapboxgl.Map);
-
             /**
              * Redraw the map on load, when style data has been downloaded
              * to solve an offset problem between the viz layer and the base layer

--- a/app/charts/pie/pie-state.tsx
+++ b/app/charts/pie/pie-state.tsx
@@ -19,7 +19,7 @@ import {
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
-import { Observer, useWidth } from "@/charts/shared/use-width";
+import { useWidth } from "@/charts/shared/use-width";
 import { PieConfig } from "@/configurator";
 import { Dimension, Observation } from "@/domain/data";
 import { formatNumberWithUnit, useFormatNumber } from "@/formatters";
@@ -282,10 +282,8 @@ export const PieChart = (
   >
 ) => {
   return (
-    <Observer>
-      <InteractionProvider>
-        <PieChartProvider {...props} />
-      </InteractionProvider>
-    </Observer>
+    <InteractionProvider>
+      <PieChartProvider {...props} />
+    </InteractionProvider>
   );
 };

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -21,7 +21,7 @@ import {
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
 import { TooltipScatterplot } from "@/charts/shared/interaction/tooltip-content";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
-import { Observer, useWidth } from "@/charts/shared/use-width";
+import { useWidth } from "@/charts/shared/use-width";
 import { ScatterPlotConfig, SortingField } from "@/configurator";
 import { Observation } from "@/domain/data";
 import { useFormatNumber } from "@/formatters";
@@ -240,10 +240,8 @@ export const ScatterplotChart = (
   >
 ) => {
   return (
-    <Observer>
-      <InteractionProvider>
-        <ScatterplotChartProvider {...props} />
-      </InteractionProvider>
-    </Observer>
+    <InteractionProvider>
+      <ScatterplotChartProvider {...props} />
+    </InteractionProvider>
   );
 };

--- a/app/charts/table/table-state.tsx
+++ b/app/charts/table/table-state.tsx
@@ -23,7 +23,7 @@ import {
   ChartStateData,
   CommonChartState,
 } from "@/charts/shared/chart-state";
-import { Observer, useWidth } from "@/charts/shared/use-width";
+import { useWidth } from "@/charts/shared/use-width";
 import { BAR_CELL_PADDING, TABLE_HEIGHT } from "@/charts/table/constants";
 import {
   TableStateVariables,
@@ -417,9 +417,5 @@ const TableChartProvider = (
 export const TableChart = (
   props: React.PropsWithChildren<ChartProps<TableConfig>>
 ) => {
-  return (
-    <Observer>
-      <TableChartProvider {...props} />
-    </Observer>
-  );
+  return <TableChartProvider {...props} />;
 };

--- a/app/components/chart-with-filters.tsx
+++ b/app/components/chart-with-filters.tsx
@@ -3,6 +3,7 @@ import React from "react";
 
 import { useQueryFilters } from "@/charts/shared/chart-helpers";
 import useSyncInteractiveFilters from "@/charts/shared/use-sync-interactive-filters";
+import { Observer } from "@/charts/shared/use-width";
 import { ChartConfig, DataSource } from "@/configurator";
 import { Dimension, Measure } from "@/domain/data";
 
@@ -167,7 +168,9 @@ export const ChartWithFilters = React.forwardRef<
   return (
     // Minimum aspect ratio for any chart (0.4)
     <div ref={ref} style={{ width: "100%", aspectRatio: "5 / 2" }}>
-      <GenericChart {...props} />
+      <Observer>
+        <GenericChart {...props} />
+      </Observer>
     </div>
   );
 });

--- a/app/components/chart-with-filters.tsx
+++ b/app/components/chart-with-filters.tsx
@@ -165,7 +165,8 @@ export const ChartWithFilters = React.forwardRef<
   useSyncInteractiveFilters(props.chartConfig);
 
   return (
-    <div ref={ref}>
+    // Minimum aspect ratio for any chart (0.4)
+    <div ref={ref} style={{ width: "100%", aspectRatio: "5 / 2" }}>
       <GenericChart {...props} />
     </div>
   );

--- a/app/components/hint.tsx
+++ b/app/components/hint.tsx
@@ -148,7 +148,7 @@ export const LoadingOverlay = () => {
         color: alpha(theme.palette.secondary.active!, 0),
       }}
       animate={{
-        backgroundColor: alpha(theme.palette.grey[100], 0.7),
+        backgroundColor: alpha(theme.palette.grey[100], 0.3),
         color: theme.palette.text.primary,
       }}
       exit={{
@@ -157,7 +157,7 @@ export const LoadingOverlay = () => {
       }}
       transition={{ duration: 0.2 }}
     >
-      <Loading delayMs={0} />
+      <Loading delayMs={500} />
     </MotionBox>
   );
 };

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -117,6 +117,7 @@ export const ChartOptionsSelector = ({
           loadValues: true,
         })),
       },
+      keepPreviousData: true,
     });
   const dimensions = componentsData?.dataCubesComponents.dimensions;
   const measures = componentsData?.dataCubesComponents.measures;
@@ -125,16 +126,19 @@ export const ChartOptionsSelector = ({
     dimensions,
     measures,
   });
-  const [{ data: observationsData }] = useDataCubesObservationsQuery({
-    variables: {
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-      cubeFilters: queryFilters ?? [],
-    },
-    pause: fetchingComponents || !queryFilters,
-  });
+  const [{ data: observationsData, fetching: fetchingObservations }] =
+    useDataCubesObservationsQuery({
+      variables: {
+        sourceType: dataSource.type,
+        sourceUrl: dataSource.url,
+        locale,
+        cubeFilters: queryFilters ?? [],
+      },
+      pause: fetchingComponents || !queryFilters,
+      keepPreviousData: true,
+    });
   const observations = observationsData?.dataCubesObservations?.data;
+  const fetching = fetchingComponents || fetchingObservations;
 
   return dimensions && measures && observations ? (
     <Box
@@ -142,6 +146,9 @@ export const ChartOptionsSelector = ({
         // we need these overflow parameters to allow iOS scrolling
         overflowX: "hidden",
         overflowY: "auto",
+        pointerEvents: fetching ? "none" : "auto",
+        opacity: fetching ? 0.7 : 1,
+        transition: "opacity 0.2s",
       }}
     >
       {activeField ? (


### PR DESCRIPTION
Closes #1459

This PR makes use of `keepPreviousData` property in data fetching hooks to not unmount sidebar contents on option change. It also improves the situation around content jumps when changing chart type.

## How to test
### PR
1. Go to [this link](https://visualization-tool-git-fix-do-not-unmount-sidebar-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9&dataSource=Prod).
2. ✅ Change chart type from column to line back and forth several times and see that there is only a small blink when doing so.
3. Open Horizontal Axis.
4. Change year filter either by using a slider or time picker.
5. ✅ See that the sidebar is slightly dimmed when data is being loaded, mirroring the chart's behavior.

### TEST
1. Go to [this link](https://test.visualize.admin.ch/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9&dataSource=Prod).
2. ❌ Change chart type from column to line back and forth several times and see that it's noticeable that chart footnotes jump to the top for a brief moment when doing so.
3. Open Horizontal Axis.
4. Change year filter either by using a slider or time picker.
5. ❌ See that the sidebar content is completely unmounted when the data is being loaded.