### PR TITLE
feat: Improve resizing behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
   - Sidebar content no longer gets unmounted when data is being re-fetched (e.g. when interacting with time slider in temporal X axes)
   - Reduced content layout shift when changing chart type
   - Filters are now correctly applied when adding a new chart
+  - Charts now resize immediately to remove a "laggy" feeling caused by calling transitions multiple times
 - Style
   - Introduced smaller UI improvements in the options panel
 - Performance

--- a/app/charts/shared/containers.tsx
+++ b/app/charts/shared/containers.tsx
@@ -22,10 +22,15 @@ export const ChartContainer = ({ children }: { children: ReactNode }) => {
       }
 
       const sel = select(ref.current);
-      (enableTransition
-        ? sel.transition().duration(transitionDuration)
-        : sel
-      ).style("height", `${height}px`);
+
+      if (enableTransition) {
+        sel
+          .transition()
+          .duration(transitionDuration)
+          .style("height", `${height}px`);
+      } else {
+        sel.style("height", `${height}px`);
+      }
     }
   }, [height, enableTransition, transitionDuration]);
 

--- a/app/charts/shared/use-width.tsx
+++ b/app/charts/shared/use-width.tsx
@@ -1,45 +1,60 @@
-import { createContext, ReactNode, useContext } from "react";
+import React, { createContext, ReactNode, useContext } from "react";
 
+import { useTransitionStore } from "@/stores/transition";
 import { useResizeObserver } from "@/utils/use-resize-observer";
 
-export interface Margins {
+export type Margins = {
   top: number;
   right: number;
   bottom: number;
   left: number;
-}
-export type Width = number;
-export interface Bounds {
+};
+
+export type Bounds = {
   width: number;
   height: number;
   margins: Margins;
   chartWidth: number;
   chartHeight: number;
-}
+};
 
-const INITIAL_WIDTH: Width = 1;
+const INITIAL_WIDTH = 1;
 
 export const Observer = ({ children }: { children: ReactNode }) => {
-  const [resizeRef, width] = useResizeObserver<HTMLDivElement>();
+  const [ref, width] = useResizeObserver<HTMLDivElement>();
+  const setEnableTransition = useTransitionStore((state) => state.setEnable);
+
+  // Disable transitions during resize, so we don't have a "laggy" feeling
+  React.useEffect(() => {
+    setEnableTransition(false);
+    const timeout = setTimeout(() => {
+      setEnableTransition(true);
+    }, 500);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [width, setEnableTransition]);
 
   return (
     <div ref={ref} style={{ display: "flex", minHeight: "100%" }}>
-        <ChartObserverContext.Provider value={width}>
-          {children}
-        </ChartObserverContext.Provider>
-      ) : null}
+      <ChartObserverContext.Provider value={width}>
+        {children}
+      </ChartObserverContext.Provider>
     </div>
   );
 };
 
-const ChartObserverContext = createContext<Width>(INITIAL_WIDTH);
+const ChartObserverContext = createContext(INITIAL_WIDTH);
 
 export const useWidth = () => {
   const ctx = useContext(ChartObserverContext);
+
   if (ctx === undefined) {
     throw Error(
       "You need to wrap your component in <ChartObserverContextProvider /> to useWidth()"
     );
   }
+
   return ctx;
 };

--- a/app/charts/shared/use-width.tsx
+++ b/app/charts/shared/use-width.tsx
@@ -23,8 +23,7 @@ export const Observer = ({ children }: { children: ReactNode }) => {
   const [resizeRef, width] = useResizeObserver<HTMLDivElement>();
 
   return (
-    <div ref={resizeRef}>
-      {width > 1 ? (
+    <div ref={ref} style={{ display: "flex", minHeight: "100%" }}>
         <ChartObserverContext.Provider value={width}>
           {children}
         </ChartObserverContext.Provider>

--- a/app/charts/shared/use-width.tsx
+++ b/app/charts/shared/use-width.tsx
@@ -2,6 +2,7 @@ import React, { createContext, ReactNode, useContext } from "react";
 
 import { useTransitionStore } from "@/stores/transition";
 import { useResizeObserver } from "@/utils/use-resize-observer";
+import { useTimedPrevious } from "@/utils/use-timed-previous";
 
 export type Margins = {
   top: number;
@@ -22,19 +23,14 @@ const INITIAL_WIDTH = 1;
 
 export const Observer = ({ children }: { children: ReactNode }) => {
   const [ref, width] = useResizeObserver<HTMLDivElement>();
+  const prev = useTimedPrevious(width, 500);
+  const isResizing = prev !== width;
   const setEnableTransition = useTransitionStore((state) => state.setEnable);
 
-  // Disable transitions during resize, so we don't have a "laggy" feeling
-  React.useEffect(() => {
-    setEnableTransition(false);
-    const timeout = setTimeout(() => {
-      setEnableTransition(true);
-    }, 500);
-
-    return () => {
-      clearTimeout(timeout);
-    };
-  }, [width, setEnableTransition]);
+  React.useEffect(
+    () => setEnableTransition(!isResizing),
+    [isResizing, setEnableTransition]
+  );
 
   return (
     <div ref={ref} style={{ display: "flex", minHeight: "100%" }}>

--- a/app/utils/use-timed-previous.ts
+++ b/app/utils/use-timed-previous.ts
@@ -1,0 +1,16 @@
+import React from "react";
+
+export const useTimedPrevious = <T>(value: T, duration: number): T => {
+  const [previousValue, setPreviousValue] = React.useState<T>(value);
+  React.useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      setPreviousValue(value);
+    }, duration);
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [value, duration]);
+
+  return previousValue;
+};


### PR DESCRIPTION
This PR improves resize behavior by disabling transitions during resizing. It also makes the Observer container a flex one, so the `Loading` indicator is centered when the chart is being loaded.

## How to test
### PR
1. Go to [this link](https://visualization-tool-git-feat-improve-resizing-behavior-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/14&dataSource=Int).
2. Disable browser fullscreen mode if applicable.
3. Grab the edge of the browser window and resize it.
4. ✅ See that the chart resizes immediately.

### TEST
1. Go to [this link](https://test.visualize.admin.ch/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/14&dataSource=Int).
2. Disable browser fullscreen mode if applicable.
3. Grab the edge of the browser window and resize it.
4. ❌ See that the chart resizing is laggy.