### PR TITLE
perf: Fire DataCubesObservations query as soon as possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
   - Filters are now correctly applied when adding a new chart
 - Style
   - Introduced smaller UI improvements in the options panel
+- Performance
+  - DataCubesObservations query no longer waits for DataCubesComponents query to finish in order to start executing
 
 # [4.1.0] - 2024-04-10
 

--- a/app/browse/datatable.tsx
+++ b/app/browse/datatable.tsx
@@ -269,17 +269,13 @@ export const DataSetTable = ({
       ...componentsData.dataCubesComponents.measures,
     ]);
   }, [componentsData?.dataCubesComponents]);
-  const queryFilters = useQueryFilters({
-    chartConfig,
-    dimensions: componentsData?.dataCubesComponents?.dimensions,
-    componentIris,
-  });
+  const queryFilters = useQueryFilters({ chartConfig, componentIris });
   const [{ data: observationsData }] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      cubeFilters: queryFilters ?? [],
+      cubeFilters: queryFilters,
     },
-    pause: fetchingComponents || !queryFilters,
+    pause: fetchingComponents,
   });
 
   return metadataData?.dataCubesMetadata &&

--- a/app/browse/datatable.tsx
+++ b/app/browse/datatable.tsx
@@ -272,7 +272,6 @@ export const DataSetTable = ({
   const queryFilters = useQueryFilters({
     chartConfig,
     dimensions: componentsData?.dataCubesComponents?.dimensions,
-    measures: componentsData?.dataCubesComponents?.measures,
     componentIris,
   });
   const [{ data: observationsData }] = useDataCubesObservationsQuery({

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -28,7 +28,7 @@ export const ChartAreasVisualization = ({
 }: {
   dataSource: DataSource;
   chartConfig: AreaConfig;
-  queryFilters?: DataCubeObservationFilter[];
+  queryFilters: DataCubeObservationFilter[];
   componentIris: string[] | undefined;
 }) => {
   return (

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -15,31 +15,14 @@ import { Ruler } from "@/charts/shared/interaction/ruler";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
-import { AreaConfig, DataSource } from "@/config-types";
-import { DataCubeObservationFilter } from "@/graphql/query-hooks";
+import { AreaConfig } from "@/config-types";
 
-import { ChartProps } from "../shared/ChartProps";
+import { ChartProps, VisualizationProps } from "../shared/ChartProps";
 
-export const ChartAreasVisualization = ({
-  dataSource,
-  chartConfig,
-  queryFilters,
-  componentIris,
-}: {
-  dataSource: DataSource;
-  chartConfig: AreaConfig;
-  queryFilters: DataCubeObservationFilter[];
-  componentIris: string[] | undefined;
-}) => {
-  return (
-    <ChartDataWrapper
-      dataSource={dataSource}
-      componentIris={componentIris}
-      observationQueryFilters={queryFilters}
-      chartConfig={chartConfig}
-      Component={ChartAreas}
-    />
-  );
+export const ChartAreasVisualization = (
+  props: VisualizationProps<AreaConfig>
+) => {
+  return <ChartDataWrapper {...props} Component={ChartAreas} />;
 };
 
 export const ChartAreas = memo((props: ChartProps<AreaConfig>) => {

--- a/app/charts/chart-data-wrapper.tsx
+++ b/app/charts/chart-data-wrapper.tsx
@@ -53,7 +53,7 @@ export const ChartDataWrapper = <
   >;
   componentIris?: string[];
   dataSource: DataSource;
-  observationQueryFilters: DataCubeObservationFilter[] | undefined;
+  observationQueryFilters: DataCubeObservationFilter[];
   fetching?: boolean;
   /* Use this if extra data is loaded and the possible error must be shown by ChartDataWrapper*/
   error?: Error;
@@ -88,9 +88,8 @@ export const ChartDataWrapper = <
   const [observationsQuery] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      cubeFilters: observationQueryFilters ?? [],
+      cubeFilters: observationQueryFilters,
     },
-    pause: !observationQueryFilters,
     keepPreviousData: true,
   });
 

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -24,36 +24,15 @@ import {
 } from "@/charts/shared/containers";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
-import {
-  ColumnConfig,
-  DataSource,
-  useChartConfigFilters,
-} from "@/config-types";
+import { ColumnConfig, useChartConfigFilters } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
-import { DataCubeObservationFilter } from "@/graphql/query-hooks";
 
-import { ChartProps } from "../shared/ChartProps";
+import { ChartProps, VisualizationProps } from "../shared/ChartProps";
 
-export const ChartColumnsVisualization = ({
-  dataSource,
-  componentIris,
-  chartConfig,
-  queryFilters,
-}: {
-  dataSource: DataSource;
-  componentIris: string[] | undefined;
-  chartConfig: ColumnConfig;
-  queryFilters: DataCubeObservationFilter[];
-}) => {
-  return (
-    <ChartDataWrapper
-      dataSource={dataSource}
-      componentIris={componentIris}
-      observationQueryFilters={queryFilters}
-      chartConfig={chartConfig}
-      Component={ChartColumns}
-    />
-  );
+export const ChartColumnsVisualization = (
+  props: VisualizationProps<ColumnConfig>
+) => {
+  return <ChartDataWrapper {...props} Component={ChartColumns} />;
 };
 
 export const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -43,7 +43,7 @@ export const ChartColumnsVisualization = ({
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: ColumnConfig;
-  queryFilters?: DataCubeObservationFilter[];
+  queryFilters: DataCubeObservationFilter[];
 }) => {
   return (
     <ChartDataWrapper

--- a/app/charts/combo/chart-combo-line-column.tsx
+++ b/app/charts/combo/chart-combo-line-column.tsx
@@ -20,7 +20,7 @@ type ChartComboLineColumnVisualizationProps = {
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: ComboLineColumnConfig;
-  queryFilters?: DataCubeObservationFilter[];
+  queryFilters: DataCubeObservationFilter[];
 };
 
 export const ChartComboLineColumnVisualization = (

--- a/app/charts/combo/chart-combo-line-column.tsx
+++ b/app/charts/combo/chart-combo-line-column.tsx
@@ -11,31 +11,14 @@ import { ChartContainer, ChartSvg } from "@/charts/shared/containers";
 import { HoverDotMultiple } from "@/charts/shared/interaction/hover-dots-multiple";
 import { Ruler } from "@/charts/shared/interaction/ruler";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
-import { ComboLineColumnConfig, DataSource } from "@/config-types";
-import { DataCubeObservationFilter } from "@/graphql/query-hooks";
+import { ComboLineColumnConfig } from "@/config-types";
 
-import { ChartProps } from "../shared/ChartProps";
-
-type ChartComboLineColumnVisualizationProps = {
-  dataSource: DataSource;
-  componentIris: string[] | undefined;
-  chartConfig: ComboLineColumnConfig;
-  queryFilters: DataCubeObservationFilter[];
-};
+import { ChartProps, VisualizationProps } from "../shared/ChartProps";
 
 export const ChartComboLineColumnVisualization = (
-  props: ChartComboLineColumnVisualizationProps
+  props: VisualizationProps<ComboLineColumnConfig>
 ) => {
-  const { dataSource, componentIris, chartConfig, queryFilters } = props;
-  return (
-    <ChartDataWrapper
-      dataSource={dataSource}
-      componentIris={componentIris}
-      observationQueryFilters={queryFilters}
-      chartConfig={chartConfig}
-      Component={ChartComboLineColumn}
-    />
-  );
+  return <ChartDataWrapper {...props} Component={ChartComboLineColumn} />;
 };
 
 export const ChartComboLineColumn = React.memo(

--- a/app/charts/combo/chart-combo-line-dual.tsx
+++ b/app/charts/combo/chart-combo-line-dual.tsx
@@ -20,7 +20,7 @@ type ChartComboLineDualVisualizationProps = {
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: ComboLineDualConfig;
-  queryFilters?: DataCubeObservationFilter[];
+  queryFilters: DataCubeObservationFilter[];
 };
 
 export const ChartComboLineDualVisualization = (

--- a/app/charts/combo/chart-combo-line-dual.tsx
+++ b/app/charts/combo/chart-combo-line-dual.tsx
@@ -11,31 +11,14 @@ import { HoverDotMultiple } from "@/charts/shared/interaction/hover-dots-multipl
 import { Ruler } from "@/charts/shared/interaction/ruler";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
-import { ComboLineDualConfig, DataSource } from "@/config-types";
-import { DataCubeObservationFilter } from "@/graphql/query-hooks";
+import { ComboLineDualConfig } from "@/config-types";
 
-import { ChartProps } from "../shared/ChartProps";
-
-type ChartComboLineDualVisualizationProps = {
-  dataSource: DataSource;
-  componentIris: string[] | undefined;
-  chartConfig: ComboLineDualConfig;
-  queryFilters: DataCubeObservationFilter[];
-};
+import { ChartProps, VisualizationProps } from "../shared/ChartProps";
 
 export const ChartComboLineDualVisualization = (
-  props: ChartComboLineDualVisualizationProps
+  props: VisualizationProps<ComboLineDualConfig>
 ) => {
-  const { dataSource, componentIris, chartConfig, queryFilters } = props;
-  return (
-    <ChartDataWrapper
-      dataSource={dataSource}
-      componentIris={componentIris}
-      observationQueryFilters={queryFilters}
-      chartConfig={chartConfig}
-      Component={ChartComboLineDual}
-    />
-  );
+  return <ChartDataWrapper {...props} Component={ChartComboLineDual} />;
 };
 
 export const ChartComboLineDual = React.memo(

--- a/app/charts/combo/chart-combo-line-single.tsx
+++ b/app/charts/combo/chart-combo-line-single.tsx
@@ -16,31 +16,14 @@ import { Ruler } from "@/charts/shared/interaction/ruler";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
-import { ComboLineSingleConfig, DataSource } from "@/config-types";
-import { DataCubeObservationFilter } from "@/graphql/query-hooks";
+import { ComboLineSingleConfig } from "@/config-types";
 
-import { ChartProps } from "../shared/ChartProps";
-
-type ChartComboLineSingleVisualizationProps = {
-  dataSource: DataSource;
-  componentIris: string[] | undefined;
-  chartConfig: ComboLineSingleConfig;
-  queryFilters: DataCubeObservationFilter[];
-};
+import { ChartProps, VisualizationProps } from "../shared/ChartProps";
 
 export const ChartComboLineSingleVisualization = (
-  props: ChartComboLineSingleVisualizationProps
+  props: VisualizationProps<ComboLineSingleConfig>
 ) => {
-  const { dataSource, componentIris, chartConfig, queryFilters } = props;
-  return (
-    <ChartDataWrapper
-      dataSource={dataSource}
-      componentIris={componentIris}
-      observationQueryFilters={queryFilters}
-      chartConfig={chartConfig}
-      Component={ChartComboLineSingle}
-    />
-  );
+  return <ChartDataWrapper {...props} Component={ChartComboLineSingle} />;
 };
 
 export const ChartComboLineSingle = React.memo(

--- a/app/charts/combo/chart-combo-line-single.tsx
+++ b/app/charts/combo/chart-combo-line-single.tsx
@@ -25,14 +25,13 @@ type ChartComboLineSingleVisualizationProps = {
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: ComboLineSingleConfig;
-  queryFilters?: DataCubeObservationFilter[];
+  queryFilters: DataCubeObservationFilter[];
 };
 
 export const ChartComboLineSingleVisualization = (
   props: ChartComboLineSingleVisualizationProps
 ) => {
   const { dataSource, componentIris, chartConfig, queryFilters } = props;
-
   return (
     <ChartDataWrapper
       dataSource={dataSource}
@@ -48,7 +47,6 @@ export const ChartComboLineSingle = React.memo(
   (props: ChartProps<ComboLineSingleConfig>) => {
     const { chartConfig, measures } = props;
     const { interactiveFiltersConfig } = chartConfig;
-
     const getLegendItemDimension = React.useCallback(
       (label: string) => {
         return measures.find((measure) => measure.label === label);

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -16,31 +16,14 @@ import { Ruler } from "@/charts/shared/interaction/ruler";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
-import { DataSource, LineConfig } from "@/config-types";
-import { DataCubeObservationFilter } from "@/graphql/query-hooks";
+import { LineConfig } from "@/config-types";
 
-import { ChartProps } from "../shared/ChartProps";
+import { ChartProps, VisualizationProps } from "../shared/ChartProps";
 
-export const ChartLinesVisualization = ({
-  dataSource,
-  componentIris,
-  chartConfig,
-  queryFilters,
-}: {
-  dataSource: DataSource;
-  componentIris: string[] | undefined;
-  chartConfig: LineConfig;
-  queryFilters: DataCubeObservationFilter[];
-}) => {
-  return (
-    <ChartDataWrapper
-      dataSource={dataSource}
-      componentIris={componentIris}
-      observationQueryFilters={queryFilters}
-      chartConfig={chartConfig}
-      Component={ChartLines}
-    />
-  );
+export const ChartLinesVisualization = (
+  props: VisualizationProps<LineConfig>
+) => {
+  return <ChartDataWrapper {...props} Component={ChartLines} />;
 };
 
 export const ChartLines = memo((props: ChartProps<LineConfig>) => {

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -30,7 +30,7 @@ export const ChartLinesVisualization = ({
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: LineConfig;
-  queryFilters?: DataCubeObservationFilter[];
+  queryFilters: DataCubeObservationFilter[];
 }) => {
   return (
     <ChartDataWrapper

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -36,12 +36,11 @@ export const ChartMapVisualization = ({
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: MapConfig;
-  queryFilters?: DataCubeObservationFilter[];
+  queryFilters: DataCubeObservationFilter[];
 }) => {
   const locale = useLocale();
   const areaDimensionIri = chartConfig.fields.areaLayer?.componentIri || "";
   const symbolDimensionIri = chartConfig.fields.symbolLayer?.componentIri || "";
-
   const [
     {
       data: geoCoordinatesDimension,
@@ -140,7 +139,6 @@ export const ChartMap = memo((props: ChartMapProps) => {
   const { chartConfig, dimensions } = props;
   const { fields } = chartConfig;
   const filters = useChartConfigFilters(chartConfig);
-
   return (
     <MapChart {...props}>
       <ChartContainer>

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -11,7 +11,7 @@ import {
   ChartControlsContainer,
 } from "@/charts/shared/containers";
 import { NoGeometriesHint } from "@/components/hint";
-import { DataSource, MapConfig, useChartConfigFilters } from "@/config-types";
+import { MapConfig, useChartConfigFilters } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import {
   GeoCoordinates,
@@ -19,25 +19,13 @@ import {
   dimensionValuesToGeoCoordinates,
 } from "@/domain/data";
 import { useDataCubesComponentsQuery } from "@/graphql/hooks";
-import {
-  DataCubeObservationFilter,
-  useDataCubeDimensionGeoShapesQuery,
-} from "@/graphql/query-hooks";
+import { useDataCubeDimensionGeoShapesQuery } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
 
-import { ChartProps } from "../shared/ChartProps";
+import { ChartProps, VisualizationProps } from "../shared/ChartProps";
 
-export const ChartMapVisualization = ({
-  dataSource,
-  componentIris,
-  chartConfig,
-  queryFilters,
-}: {
-  dataSource: DataSource;
-  componentIris: string[] | undefined;
-  chartConfig: MapConfig;
-  queryFilters: DataCubeObservationFilter[];
-}) => {
+export const ChartMapVisualization = (props: VisualizationProps<MapConfig>) => {
+  const { dataSource, chartConfig } = props;
   const locale = useLocale();
   const areaDimensionIri = chartConfig.fields.areaLayer?.componentIri || "";
   const symbolDimensionIri = chartConfig.fields.symbolLayer?.componentIri || "";
@@ -118,14 +106,11 @@ export const ChartMapVisualization = ({
     <NoGeometriesHint />
   ) : (
     <ChartDataWrapper
-      dataSource={dataSource}
+      {...props}
       error={error}
       fetching={fetching}
-      componentIris={componentIris}
-      observationQueryFilters={queryFilters}
       Component={ChartMap}
       ComponentProps={{ shapes, coordinates }}
-      chartConfig={chartConfig}
     />
   );
 };

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -26,7 +26,7 @@ export const ChartPieVisualization = ({
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: PieConfig;
-  queryFilters?: DataCubeObservationFilter[];
+  queryFilters: DataCubeObservationFilter[];
 }) => {
   return (
     <ChartDataWrapper

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -11,32 +11,13 @@ import {
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { OnlyNegativeDataHint } from "@/components/hint";
-import { DataSource, PieConfig, useChartConfigFilters } from "@/config-types";
+import { PieConfig, useChartConfigFilters } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
-import { DataCubeObservationFilter } from "@/graphql/query-hooks";
 
-import { ChartProps } from "../shared/ChartProps";
+import { ChartProps, VisualizationProps } from "../shared/ChartProps";
 
-export const ChartPieVisualization = ({
-  dataSource,
-  componentIris,
-  chartConfig,
-  queryFilters,
-}: {
-  dataSource: DataSource;
-  componentIris: string[] | undefined;
-  chartConfig: PieConfig;
-  queryFilters: DataCubeObservationFilter[];
-}) => {
-  return (
-    <ChartDataWrapper
-      dataSource={dataSource}
-      componentIris={componentIris}
-      observationQueryFilters={queryFilters}
-      chartConfig={chartConfig}
-      Component={ChartPie}
-    />
-  );
+export const ChartPieVisualization = (props: VisualizationProps<PieConfig>) => {
+  return <ChartDataWrapper {...props} Component={ChartPie} />;
 };
 
 export const ChartPie = memo((props: ChartProps<PieConfig>) => {

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -19,36 +19,15 @@ import {
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionVoronoi } from "@/charts/shared/overlay-voronoi";
-import {
-  DataSource,
-  ScatterPlotConfig,
-  useChartConfigFilters,
-} from "@/config-types";
+import { ScatterPlotConfig, useChartConfigFilters } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
-import { DataCubeObservationFilter } from "@/graphql/query-hooks";
 
-import { ChartProps } from "../shared/ChartProps";
+import { ChartProps, VisualizationProps } from "../shared/ChartProps";
 
-export const ChartScatterplotVisualization = ({
-  dataSource,
-  componentIris,
-  chartConfig,
-  queryFilters,
-}: {
-  dataSource: DataSource;
-  componentIris: string[] | undefined;
-  chartConfig: ScatterPlotConfig;
-  queryFilters: DataCubeObservationFilter[];
-}) => {
-  return (
-    <ChartDataWrapper
-      dataSource={dataSource}
-      componentIris={componentIris}
-      observationQueryFilters={queryFilters}
-      Component={ChartScatterplot}
-      chartConfig={chartConfig}
-    />
-  );
+export const ChartScatterplotVisualization = (
+  props: VisualizationProps<ScatterPlotConfig>
+) => {
+  return <ChartDataWrapper {...props} Component={ChartScatterplot} />;
 };
 
 export const ChartScatterplot = memo((props: ChartProps<ScatterPlotConfig>) => {

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -38,7 +38,7 @@ export const ChartScatterplotVisualization = ({
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: ScatterPlotConfig;
-  queryFilters?: DataCubeObservationFilter[];
+  queryFilters: DataCubeObservationFilter[];
 }) => {
   return (
     <ChartDataWrapper
@@ -55,7 +55,6 @@ export const ChartScatterplot = memo((props: ChartProps<ScatterPlotConfig>) => {
   const { chartConfig, dimensions } = props;
   const { fields, interactiveFiltersConfig } = chartConfig;
   const filters = useChartConfigFilters(chartConfig);
-
   return (
     <ScatterplotChart aspectRatio={0.4} {...props}>
       <ChartContainer>

--- a/app/charts/shared/ChartProps.tsx
+++ b/app/charts/shared/ChartProps.tsx
@@ -1,5 +1,6 @@
-import { ChartConfig } from "@/configurator";
+import { ChartConfig, DataSource } from "@/config-types";
 import { Dimension, Measure, Observation } from "@/domain/data";
+import { DataCubeObservationFilter } from "@/graphql/query-hooks";
 
 export type ComponentsByIri = Record<string, Dimension | Measure>;
 
@@ -17,4 +18,11 @@ export type BaseChartProps = {
 
 export type ChartProps<TChartConfig extends ChartConfig> = BaseChartProps & {
   chartConfig: TChartConfig;
+};
+
+export type VisualizationProps<TChartConfig extends ChartConfig> = {
+  dataSource: DataSource;
+  componentIris: string[] | undefined;
+  chartConfig: TChartConfig;
+  observationQueryFilters: DataCubeObservationFilter[];
 };

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -65,18 +65,16 @@ type PreparedFilter = {
 type ChartDataFiltersProps = {
   dataSource: DataSource;
   chartConfig: ChartConfig;
-  dimensions?: Dimension[];
 };
 
 export const ChartDataFilters = (props: ChartDataFiltersProps) => {
-  const { dataSource, chartConfig, dimensions } = props;
+  const { dataSource, chartConfig } = props;
   const { loading } = useLoadingState();
   const dataFilters = useInteractiveFilters((d) => d.dataFilters);
   const componentIris = chartConfig.interactiveFiltersConfig?.dataFilters
     .componentIris as string[];
   const queryFilters = useQueryFilters({
     chartConfig,
-    dimensions,
     allowNoneValues: true,
     componentIris,
   });
@@ -89,10 +87,6 @@ export const ChartDataFilters = (props: ChartDataFiltersProps) => {
   }, [componentIris.length]);
 
   const preparedFilters: PreparedFilter[] | undefined = React.useMemo(() => {
-    if (!queryFilters) {
-      return;
-    }
-
     return chartConfig.cubes.map((cube) => {
       const cubeQueryFilters = queryFilters.find(
         (d) => d.iri === cube.iri

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -35,7 +35,6 @@ import {
   Dimension,
   HierarchyValue,
   isTemporalDimension,
-  Measure,
   TemporalDimension,
 } from "@/domain/data";
 import { useTimeFormatLocale } from "@/formatters";
@@ -67,11 +66,10 @@ type ChartDataFiltersProps = {
   dataSource: DataSource;
   chartConfig: ChartConfig;
   dimensions?: Dimension[];
-  measures?: Measure[];
 };
 
 export const ChartDataFilters = (props: ChartDataFiltersProps) => {
-  const { dataSource, chartConfig, dimensions, measures } = props;
+  const { dataSource, chartConfig, dimensions } = props;
   const { loading } = useLoadingState();
   const dataFilters = useInteractiveFilters((d) => d.dataFilters);
   const componentIris = chartConfig.interactiveFiltersConfig?.dataFilters
@@ -79,7 +77,6 @@ export const ChartDataFilters = (props: ChartDataFiltersProps) => {
   const queryFilters = useQueryFilters({
     chartConfig,
     dimensions,
-    measures,
     allowNoneValues: true,
     componentIris,
   });

--- a/app/charts/shared/chart-helpers.spec.tsx
+++ b/app/charts/shared/chart-helpers.spec.tsx
@@ -123,6 +123,29 @@ describe("useQueryFilters", () => {
 
     expect(queryFilters[col("3")]).toBeUndefined();
   });
+
+  it("should scope interactive filters to cube filters", () => {
+    const allDataFilters = {
+      A_1: { type: "single", value: "A_1_1" },
+      A_2: { type: "single", value: "A_2_1" },
+      B_1: { type: "single", value: "B_1_1" },
+    } as InteractiveFiltersState["dataFilters"];
+    const queryFilters = prepareQueryFilters(
+      "area",
+      {
+        A_1: { type: "single", value: "A_1_3" },
+        A_2: { type: "single", value: "A_2_5" },
+      },
+      {
+        dataFilters: { active: true, componentIris: ["A_1", "A_2", "B_1"] },
+      } as InteractiveFiltersConfig,
+      allDataFilters
+    );
+    expect(queryFilters).toEqual({
+      A_1: { type: "single", value: "A_1_1" },
+      A_2: { type: "single", value: "A_2_1" },
+    });
+  });
 });
 
 describe("getChartConfigComponentIris", () => {

--- a/app/charts/shared/chart-helpers.spec.tsx
+++ b/app/charts/shared/chart-helpers.spec.tsx
@@ -1,10 +1,17 @@
+import { renderHook } from "@testing-library/react";
 import merge from "lodash/merge";
 
 import {
   extractChartConfigComponentIris,
-  prepareQueryFilters,
+  prepareCubeQueryFilters,
+  useQueryFilters,
 } from "@/charts/shared/chart-helpers";
-import { ChartType, Filters, InteractiveFiltersConfig } from "@/configurator";
+import {
+  ChartConfig,
+  ChartType,
+  Filters,
+  InteractiveFiltersConfig,
+} from "@/configurator";
 import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import { InteractiveFiltersState } from "@/stores/interactive-filters";
 import map1Fixture from "@/test/__fixtures/config/int/map-nfi.json";
@@ -13,6 +20,14 @@ import { migrateChartConfig } from "@/utils/chart-config/versioning";
 
 jest.mock("../../rdf/extended-cube", () => ({
   ExtendedCube: jest.fn(),
+}));
+
+jest.mock("@/stores/interactive-filters", () => ({
+  useInteractiveFilters: jest.fn(() => ({
+    A_1: { type: "single", value: "A_1_1" },
+    A_2: { type: "single", value: "A_2_1" },
+    B_1: { type: "single", value: "B_1_1" },
+  })),
 }));
 
 const makeCubeNsGetters = (cubeIri: string) => ({
@@ -72,7 +87,7 @@ const commonInteractiveFiltersState: InteractiveFiltersState = {
 
 describe("useQueryFilters", () => {
   it("should not merge interactive filters state if interactive filters are disabled at publish time", () => {
-    const queryFilters = prepareQueryFilters(
+    const queryFilters = prepareCubeQueryFilters(
       line1Fixture.data.chartConfig.chartType as ChartType,
       line1Fixture.data.chartConfig.filters as Filters,
       commonInteractiveFiltersConfig,
@@ -85,7 +100,7 @@ describe("useQueryFilters", () => {
   });
 
   it("should merge interactive filters state if interactive filters are active at publish time", () => {
-    const queryFilters = prepareQueryFilters(
+    const queryFilters = prepareCubeQueryFilters(
       line1Fixture.data.chartConfig.chartType as ChartType,
       line1Fixture.data.chartConfig.filters as Filters,
       merge({}, commonInteractiveFiltersConfig, {
@@ -103,7 +118,7 @@ describe("useQueryFilters", () => {
   });
 
   it("should omit none values since they should not be passed to graphql layer", () => {
-    const queryFilters = prepareQueryFilters(
+    const queryFilters = prepareCubeQueryFilters(
       line1Fixture.data.chartConfig.chartType as ChartType,
       line1Fixture.data.chartConfig.filters as Filters,
       merge({}, commonInteractiveFiltersConfig, {
@@ -125,26 +140,56 @@ describe("useQueryFilters", () => {
   });
 
   it("should scope interactive filters to cube filters", () => {
-    const allDataFilters = {
-      A_1: { type: "single", value: "A_1_1" },
-      A_2: { type: "single", value: "A_2_1" },
-      B_1: { type: "single", value: "B_1_1" },
-    } as InteractiveFiltersState["dataFilters"];
-    const queryFilters = prepareQueryFilters(
-      "area",
+    const chartConfig = {
+      chartType: "line",
+      interactiveFiltersConfig: {
+        dataFilters: {
+          active: true,
+        },
+      },
+      cubes: [
+        {
+          iri: "A",
+          filters: {
+            A_1: { type: "single", value: "A_1_5" },
+            A_2: { type: "single", value: "A_2_3" },
+          },
+        },
+        {
+          iri: "B",
+          filters: {
+            B_1: { type: "single", value: "B_1_1" },
+          },
+        },
+      ],
+    } as any as ChartConfig;
+    const { result: queryFilters } = renderHook<
+      ReturnType<typeof useQueryFilters>,
+      Parameters<typeof useQueryFilters>[0]
+    >(
+      (props: Parameters<typeof useQueryFilters>[0]) => useQueryFilters(props),
       {
-        A_1: { type: "single", value: "A_1_3" },
-        A_2: { type: "single", value: "A_2_5" },
+        initialProps: { chartConfig },
+      }
+    );
+
+    expect(queryFilters.current).toEqual([
+      {
+        iri: "A",
+        componentIris: undefined,
+        filters: {
+          A_1: { type: "single", value: "A_1_1" },
+          A_2: { type: "single", value: "A_2_1" },
+        },
+        joinBy: undefined,
       },
       {
-        dataFilters: { active: true, componentIris: ["A_1", "A_2", "B_1"] },
-      } as InteractiveFiltersConfig,
-      allDataFilters
-    );
-    expect(queryFilters).toEqual({
-      A_1: { type: "single", value: "A_1_1" },
-      A_2: { type: "single", value: "A_2_1" },
-    });
+        iri: "B",
+        componentIris: undefined,
+        filters: { B_1: { type: "single", value: "B_1_1" } },
+        joinBy: undefined,
+      },
+    ]);
   });
 });
 

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -75,30 +75,17 @@ export const prepareQueryFilters = (
 
 export const useQueryFilters = ({
   chartConfig,
-  dimensions,
   allowNoneValues,
   componentIris,
 }: {
   chartConfig: ChartConfig;
-  dimensions?: Dimension[];
   allowNoneValues?: boolean;
   componentIris?: string[];
-}): DataCubeObservationFilter[] | undefined => {
-  const allDataFilters = useInteractiveFilters((d) => d.dataFilters);
-
+}): DataCubeObservationFilter[] => {
+  const dataFilters = useInteractiveFilters((d) => d.dataFilters);
   return React.useMemo(() => {
-    if (!dimensions) {
-      return;
-    }
-
     return chartConfig.cubes.map((cube) => {
       const filters = getChartConfigFilters(chartConfig.cubes, cube.iri);
-      const dataFilters = Object.fromEntries(
-        Object.entries(allDataFilters).filter(([k]) =>
-          dimensions.find((d) => d.iri === k)
-        )
-      );
-
       return {
         iri: cube.iri,
         componentIris,
@@ -116,9 +103,8 @@ export const useQueryFilters = ({
     chartConfig.cubes,
     chartConfig.chartType,
     chartConfig.interactiveFiltersConfig,
-    allDataFilters,
+    dataFilters,
     allowNoneValues,
-    dimensions,
     componentIris,
   ]);
 };

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -34,7 +34,6 @@ import {
   Component,
   Dimension,
   DimensionValue,
-  Measure,
   Observation,
   ObservationValue,
   getTemporalEntityValue,
@@ -77,20 +76,18 @@ export const prepareQueryFilters = (
 export const useQueryFilters = ({
   chartConfig,
   dimensions,
-  measures,
   allowNoneValues,
   componentIris,
 }: {
   chartConfig: ChartConfig;
   dimensions?: Dimension[];
-  measures?: Measure[];
   allowNoneValues?: boolean;
   componentIris?: string[];
 }): DataCubeObservationFilter[] | undefined => {
   const allDataFilters = useInteractiveFilters((d) => d.dataFilters);
 
   return React.useMemo(() => {
-    if (!dimensions || !measures) {
+    if (!dimensions) {
       return;
     }
 
@@ -122,7 +119,6 @@ export const useQueryFilters = ({
     allDataFilters,
     allowNoneValues,
     dimensions,
-    measures,
     componentIris,
   ]);
 };

--- a/app/charts/table/chart-table.tsx
+++ b/app/charts/table/chart-table.tsx
@@ -3,30 +3,23 @@ import { memo } from "react";
 import { ChartDataWrapper } from "@/charts/chart-data-wrapper";
 import { Table } from "@/charts/table/table";
 import { TableChart } from "@/charts/table/table-state";
-import { DataSource, TableConfig } from "@/configurator";
+import { TableConfig } from "@/configurator";
 
-import { ChartProps } from "../shared/ChartProps";
+import { ChartProps, VisualizationProps } from "../shared/ChartProps";
 
-export const ChartTableVisualization = ({
-  dataSource,
-  componentIris,
-  chartConfig,
-}: {
-  dataSource: DataSource;
-  componentIris: string[] | undefined;
-  chartConfig: TableConfig;
-}) => {
+export const ChartTableVisualization = (
+  props: Omit<VisualizationProps<TableConfig>, "observationQueryFilters">
+) => {
+  const { chartConfig, componentIris } = props;
   return (
     <ChartDataWrapper
-      dataSource={dataSource}
-      componentIris={componentIris}
-      Component={ChartTable}
-      chartConfig={chartConfig}
+      {...props}
       observationQueryFilters={chartConfig.cubes.map((cube) => ({
         iri: cube.iri,
         componentIris,
         filters: cube.filters,
       }))}
+      Component={ChartTable}
     />
   );
 };

--- a/app/components/chart-filters-list.tsx
+++ b/app/components/chart-filters-list.tsx
@@ -36,9 +36,8 @@ export const ChartFiltersList = (props: ChartFiltersListProps) => {
   const timeFormatUnit = useTimeFormatUnit();
   const timeSlider = useInteractiveFilters((d) => d.timeSlider);
   const animationField = getAnimationField(chartConfig);
-  const filters = useQueryFilters({
+  const queryFilters = useQueryFilters({
     chartConfig,
-    dimensions,
     componentIris: extractChartConfigComponentIris(chartConfig),
   });
   // TODO: Refactor to somehow access current filter labels instead of fetching them again
@@ -47,23 +46,21 @@ export const ChartFiltersList = (props: ChartFiltersListProps) => {
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      cubeFilters:
-        filters?.map((filter) => ({
-          iri: filter.iri,
-          componentIris: filter.componentIris,
-          filters: filter.filters,
-          joinBy: filter.joinBy,
-          loadValues: true,
-        })) ?? [],
+      cubeFilters: queryFilters.map((filter) => ({
+        iri: filter.iri,
+        componentIris: filter.componentIris,
+        filters: filter.filters,
+        joinBy: filter.joinBy,
+        loadValues: true,
+      })),
     },
-    pause: !filters,
   });
   const allFilters = React.useMemo(() => {
-    if (!data?.dataCubesComponents || !filters || !dimensions) {
+    if (!data?.dataCubesComponents || !dimensions) {
       return [];
     }
 
-    return filters.flatMap((filter) => {
+    return queryFilters.flatMap((filter) => {
       const namedFilters = Object.entries<FilterValue>(
         filter.filters ?? {}
       ).flatMap(([iri, f]) => {
@@ -133,7 +130,7 @@ export const ChartFiltersList = (props: ChartFiltersListProps) => {
   }, [
     data?.dataCubesComponents,
     dimensions,
-    filters,
+    queryFilters,
     animationField,
     timeFormatUnit,
     timeSlider.value,

--- a/app/components/chart-filters-list.tsx
+++ b/app/components/chart-filters-list.tsx
@@ -15,7 +15,6 @@ import {
 } from "@/configurator";
 import {
   Dimension,
-  Measure,
   isTemporalDimension,
   isTemporalOrdinalDimension,
 } from "@/domain/data";
@@ -29,11 +28,10 @@ type ChartFiltersListProps = {
   dataSource: DataSource;
   chartConfig: ChartConfig;
   dimensions?: Dimension[];
-  measures?: Measure[];
 };
 
 export const ChartFiltersList = (props: ChartFiltersListProps) => {
-  const { dataSource, chartConfig, dimensions, measures } = props;
+  const { dataSource, chartConfig, dimensions } = props;
   const locale = useLocale();
   const timeFormatUnit = useTimeFormatUnit();
   const timeSlider = useInteractiveFilters((d) => d.timeSlider);
@@ -41,7 +39,6 @@ export const ChartFiltersList = (props: ChartFiltersListProps) => {
   const filters = useQueryFilters({
     chartConfig,
     dimensions,
-    measures,
     componentIris: extractChartConfigComponentIris(chartConfig),
   });
   // TODO: Refactor to somehow access current filter labels instead of fetching them again
@@ -62,7 +59,7 @@ export const ChartFiltersList = (props: ChartFiltersListProps) => {
     pause: !filters,
   });
   const allFilters = React.useMemo(() => {
-    if (!data?.dataCubesComponents || !filters || !dimensions || !measures) {
+    if (!data?.dataCubesComponents || !filters || !dimensions) {
       return [];
     }
 
@@ -136,7 +133,6 @@ export const ChartFiltersList = (props: ChartFiltersListProps) => {
   }, [
     data?.dataCubesComponents,
     dimensions,
-    measures,
     filters,
     animationField,
     timeFormatUnit,

--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -17,7 +17,6 @@ import {
   useDataCubesMetadataQuery,
   useDataCubesObservationsQuery,
 } from "@/graphql/hooks";
-import { DataCubeObservationFilter } from "@/graphql/query-hooks";
 import { Icon, getChartIcon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
 import { useEmbedOptions } from "@/utils/embed";
@@ -63,6 +62,7 @@ export const ChartFootnotes = ({
   const [shareUrl, setShareUrl] = useState("");
   const { state: isTablePreview, setStateRaw: setIsTablePreview } =
     useChartTablePreview();
+
   // Reset back to chart view when switching chart type.
   useEffect(() => {
     setIsTablePreview(false);
@@ -72,9 +72,8 @@ export const ChartFootnotes = ({
     setShareUrl(`${window.location.origin}/${locale}/v/${configKey}`);
   }, [configKey, locale]);
 
-  const filters = useQueryFilters({
+  const queryFilters = useQueryFilters({
     chartConfig,
-    dimensions,
     componentIris: extractChartConfigComponentIris(chartConfig),
   });
   const commonQueryVariables = {
@@ -91,9 +90,8 @@ export const ChartFootnotes = ({
   const [{ data: downloadData }] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,
-      cubeFilters: filters ?? [],
+      cubeFilters: queryFilters,
     },
-    pause: !filters,
   });
   const sparqlEditorUrls =
     downloadData?.dataCubesObservations?.sparqlEditorUrls;
@@ -208,7 +206,7 @@ export const ChartFootnotes = ({
                     <DataDownloadMenu
                       dataSource={dataSource}
                       title={dataCubeMetadata.title}
-                      filters={getDataDownloadFilters(chartConfig, filters)}
+                      filters={queryFilters}
                     />
                   ) : null}
                   {showTableSwitch !== false ? (
@@ -296,11 +294,4 @@ const LinkButton = (props: PropsWithChildren<{ href: string }>) => {
       {...props}
     />
   );
-};
-
-const getDataDownloadFilters = (
-  chartConfig: ChartConfig,
-  queryFilters?: DataCubeObservationFilter[]
-) => {
-  return queryFilters ?? chartConfig.cubes.map((cube) => ({ iri: cube.iri }));
 };

--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -11,7 +11,7 @@ import { ChartFiltersList } from "@/components/chart-filters-list";
 import { useChartTablePreview } from "@/components/chart-table-preview";
 import { DataDownloadMenu, RunSparqlQuery } from "@/components/data-download";
 import { ChartConfig, DataSource } from "@/configurator";
-import { Dimension, Measure } from "@/domain/data";
+import { Dimension } from "@/domain/data";
 import { useTimeFormatLocale } from "@/formatters";
 import {
   useDataCubesMetadataQuery,
@@ -47,7 +47,6 @@ export const ChartFootnotes = ({
   dataSource,
   chartConfig,
   dimensions,
-  measures,
   configKey,
   onToggleTableView,
   visualizeLinkText,
@@ -55,7 +54,6 @@ export const ChartFootnotes = ({
   dataSource: DataSource;
   chartConfig: ChartConfig;
   dimensions?: Dimension[];
-  measures?: Measure[];
   configKey?: string;
   onToggleTableView: () => void;
   visualizeLinkText?: JSX.Element;
@@ -77,7 +75,6 @@ export const ChartFootnotes = ({
   const filters = useQueryFilters({
     chartConfig,
     dimensions,
-    measures,
     componentIris: extractChartConfigComponentIris(chartConfig),
   });
   const commonQueryVariables = {
@@ -119,7 +116,6 @@ export const ChartFootnotes = ({
         dataSource={dataSource}
         chartConfig={chartConfig}
         dimensions={dimensions}
-        measures={measures}
       />
       {data?.dataCubesMetadata
         ? data.dataCubesMetadata.map((dataCubeMetadata) => {

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -467,7 +467,6 @@ export const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
                     dataSource={dataSource}
                     chartConfig={chartConfig}
                     dimensions={dimensions}
-                    measures={measures}
                   />
                 )}
                 <div
@@ -499,7 +498,6 @@ export const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
                   chartConfig={chartConfig}
                   onToggleTableView={handleToggleTableView}
                   dimensions={dimensions}
-                  measures={measures}
                 />
                 <DebugPanel configurator interactiveFilters />
               </InteractiveFiltersProvider>

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -361,15 +361,12 @@ export const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
   const dimensions = components?.dataCubesComponents.dimensions;
   const measures = components?.dataCubesComponents.measures;
   const allComponents = React.useMemo(() => {
-    if (!components?.dataCubesComponents) {
+    if (!dimensions || !measures) {
       return [];
     }
 
-    return [
-      ...components.dataCubesComponents.dimensions,
-      ...components.dataCubesComponents.measures,
-    ];
-  }, [components?.dataCubesComponents]);
+    return [...dimensions, ...measures];
+  }, [dimensions, measures]);
 
   return (
     <Box className={classes.root}>
@@ -466,7 +463,6 @@ export const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
                   <ChartDataFilters
                     dataSource={dataSource}
                     chartConfig={chartConfig}
-                    dimensions={dimensions}
                   />
                 )}
                 <div
@@ -488,8 +484,6 @@ export const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
                       dataSource={dataSource}
                       componentIris={componentIris}
                       chartConfig={chartConfig}
-                      dimensions={dimensions}
-                      measures={measures}
                     />
                   )}
                 </div>

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -174,7 +174,6 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
   } = props;
   const { meta } = chartConfig;
   const rootRef = useRef<HTMLDivElement>(null);
-
   const {
     state: isTablePreview,
     setState: setIsTablePreview,
@@ -182,6 +181,8 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
     containerHeight,
     computeContainerHeight,
   } = useChartTablePreview();
+  const handleToggleTableView = useEvent(() => setIsTablePreview((c) => !c));
+  const [{ showDownload }] = useEmbedOptions();
   const metadataPanelStore = useMemo(() => createMetadataPanelStore(), []);
   const metadataPanelOpen = useStore(metadataPanelStore, (state) => state.open);
   const shouldShrink = useMemo(() => {
@@ -212,7 +213,7 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
     sourceUrl: dataSource.url,
     locale,
   };
-  const [{ data: metadata }] = useDataCubesMetadataQuery({
+  const [{ data: metadataData }] = useDataCubesMetadataQuery({
     variables: {
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
@@ -220,8 +221,9 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
       cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
     },
   });
+  const metadata = metadataData?.dataCubesMetadata;
   const componentIris = extractChartConfigsComponentIris(state.chartConfigs);
-  const [{ data: components }] = useDataCubesComponentsQuery({
+  const [{ data: componentsData }] = useDataCubesComponentsQuery({
     variables: {
       ...commonQueryVariables,
       cubeFilters: chartConfig.cubes.map((cube) => ({
@@ -231,28 +233,22 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
       })),
     },
   });
-  const handleToggleTableView = useEvent(() => setIsTablePreview((c) => !c));
-
-  const dimensions = components?.dataCubesComponents.dimensions;
-  const measures = components?.dataCubesComponents.measures;
+  const components = componentsData?.dataCubesComponents;
+  const dimensions = components?.dimensions;
+  const measures = components?.measures;
   const allComponents = useMemo(() => {
-    if (!components?.dataCubesComponents) {
+    if (!dimensions || !measures) {
       return [];
     }
 
-    return [
-      ...components.dataCubesComponents.dimensions,
-      ...components.dataCubesComponents.measures,
-    ];
-  }, [components?.dataCubesComponents]);
-
-  const [{ showDownload }] = useEmbedOptions();
+    return [...dimensions, ...measures];
+  }, [dimensions, measures]);
 
   return (
     <MetadataPanelStoreContext.Provider value={metadataPanelStore}>
       <Box className={classes.root} ref={rootRef}>
         <ChartErrorBoundary resetKeys={[chartConfig]}>
-          {metadata?.dataCubesMetadata.some(
+          {metadata?.some(
             (d) => d.publicationStatus === DataCubePublicationStatus.Draft
           ) && (
             <Box sx={{ mb: 4 }}>
@@ -265,7 +261,7 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
               </HintRed>
             </Box>
           )}
-          {metadata?.dataCubesMetadata.some((d) => d.expires) && (
+          {metadata?.some((d) => d.expires) && (
             <Box sx={{ mb: 4 }}>
               <HintRed iconName="datasetError" iconSize={64}>
                 <Trans id="dataset.publicationStatus.expires.warning">

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -326,7 +326,6 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
                 <ChartDataFilters
                   dataSource={dataSource}
                   chartConfig={chartConfig}
-                  dimensions={dimensions}
                 />
               ) : (
                 // We need to have a span here to keep the space between the
@@ -352,8 +351,6 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
                     dataSource={dataSource}
                     componentIris={componentIris}
                     chartConfig={chartConfig}
-                    dimensions={dimensions}
-                    measures={measures}
                   />
                 )}
               </div>

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -327,7 +327,6 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
                   dataSource={dataSource}
                   chartConfig={chartConfig}
                   dimensions={dimensions}
-                  measures={measures}
                 />
               ) : (
                 // We need to have a span here to keep the space between the
@@ -362,7 +361,6 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
                 dataSource={dataSource}
                 chartConfig={chartConfig}
                 dimensions={dimensions}
-                measures={measures}
                 configKey={configKey}
                 onToggleTableView={handleToggleTableView}
                 visualizeLinkText={

--- a/app/components/chart-with-filters.tsx
+++ b/app/components/chart-with-filters.tsx
@@ -73,16 +73,13 @@ type GenericChartProps = {
   componentIris: string[] | undefined;
   chartConfig: ChartConfig;
   dimensions?: Dimension[];
-  measures?: Measure[];
 };
 
 const GenericChart = (props: GenericChartProps) => {
-  const { dataSource, componentIris, chartConfig, dimensions, measures } =
-    props;
+  const { dataSource, componentIris, chartConfig, dimensions } = props;
   const queryFilters = useQueryFilters({
     chartConfig,
     dimensions,
-    measures,
     componentIris,
   });
   const commonProps = {

--- a/app/components/chart-with-filters.tsx
+++ b/app/components/chart-with-filters.tsx
@@ -5,7 +5,6 @@ import { useQueryFilters } from "@/charts/shared/chart-helpers";
 import useSyncInteractiveFilters from "@/charts/shared/use-sync-interactive-filters";
 import { Observer } from "@/charts/shared/use-width";
 import { ChartConfig, DataSource } from "@/configurator";
-import { Dimension, Measure } from "@/domain/data";
 
 const ChartAreasVisualization = dynamic(
   import("@/charts/area/chart-area").then(
@@ -72,16 +71,11 @@ type GenericChartProps = {
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: ChartConfig;
-  dimensions?: Dimension[];
 };
 
 const GenericChart = (props: GenericChartProps) => {
-  const { dataSource, componentIris, chartConfig, dimensions } = props;
-  const queryFilters = useQueryFilters({
-    chartConfig,
-    dimensions,
-    componentIris,
-  });
+  const { dataSource, componentIris, chartConfig } = props;
+  const queryFilters = useQueryFilters({ chartConfig, componentIris });
   const commonProps = {
     dataSource,
     queryFilters,
@@ -152,8 +146,6 @@ type ChartWithFiltersProps = {
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: ChartConfig;
-  dimensions?: Dimension[];
-  measures?: Measure[];
 };
 
 export const ChartWithFilters = React.forwardRef<

--- a/app/components/chart-with-filters.tsx
+++ b/app/components/chart-with-filters.tsx
@@ -75,10 +75,13 @@ type GenericChartProps = {
 
 const GenericChart = (props: GenericChartProps) => {
   const { dataSource, componentIris, chartConfig } = props;
-  const queryFilters = useQueryFilters({ chartConfig, componentIris });
+  const observationQueryFilters = useQueryFilters({
+    chartConfig,
+    componentIris,
+  });
   const commonProps = {
     dataSource,
-    queryFilters,
+    observationQueryFilters,
     componentIris,
   };
 

--- a/app/components/copy-to-clipboard-text-input.tsx
+++ b/app/components/copy-to-clipboard-text-input.tsx
@@ -4,7 +4,7 @@ import { makeStyles } from "@mui/styles";
 import * as clipboard from "clipboard-polyfill/text";
 import { MouseEvent as ReactMouseEvent, ReactNode, useState } from "react";
 
-import Flex, { FlexProps } from "@/components/flex";
+import Flex from "@/components/flex";
 import { Icon } from "@/icons";
 
 const useActionTooltipStyles = makeStyles((theme: Theme) => ({
@@ -99,15 +99,11 @@ export const ActionTooltip = ({ children }: { children: ReactNode }) => {
   return <div className={classes.actionTooltip}>{children}</div>;
 };
 
-export const CopyToClipboardTextInput = ({
-  content,
-  ...flexProps
-}: { content: string } & FlexProps) => {
+export const CopyToClipboardTextInput = ({ content }: { content: string }) => {
   const [showTooltip, toggleTooltip] = useState(false);
   const [tooltipContent, updateTooltipContent] = useState(
     <Trans id="button.hint.click.to.copy">click to copy</Trans>
   );
-
   const handleMouseLeave = () => {
     toggleTooltip(false);
     updateTooltipContent(
@@ -122,15 +118,10 @@ export const CopyToClipboardTextInput = ({
     clipboard.writeText(content);
   };
   const classes = useCopyToClipboardTextInputStyles();
-  return (
-    <Flex sx={{ alignItems: "stretch", height: 48 }} {...flexProps}>
-      <Input
-        className={classes.input}
-        type="text"
-        value={content}
-        readOnly={true}
-      ></Input>
 
+  return (
+    <Flex sx={{ alignItems: "stretch", height: 48, mt: 1, mb: 2 }}>
+      <Input className={classes.input} type="text" value={content} readOnly />
       <Button
         variant="text"
         onMouseOver={() => toggleTooltip(true)}
@@ -142,7 +133,6 @@ export const CopyToClipboardTextInput = ({
         className={classes.button}
       >
         <Icon name="copy" size={16} />
-
         {showTooltip && <ActionTooltip>{tooltipContent}</ActionTooltip>}
       </Button>
     </Flex>

--- a/app/components/publish-actions.tsx
+++ b/app/components/publish-actions.tsx
@@ -1,7 +1,6 @@
 import { t, Trans } from "@lingui/macro";
 import {
   Box,
-  BoxProps,
   Button,
   Divider,
   FormControl,
@@ -12,50 +11,43 @@ import {
   Radio,
   RadioGroup,
   RadioGroupProps,
+  Stack,
   Typography,
 } from "@mui/material";
-import { Stack } from "@mui/material";
 import { ReactNode, useEffect, useState } from "react";
 
+import { CopyToClipboardTextInput } from "@/components/copy-to-clipboard-text-input";
 import Flex from "@/components/flex";
 import { IconLink } from "@/components/links";
 import { Icon } from "@/icons";
-import { useLocale } from "@/locales/use-locale";
 import { useEmbedOptions } from "@/utils/embed";
 import { useI18n } from "@/utils/use-i18n";
 
-import { CopyToClipboardTextInput } from "./copy-to-clipboard-text-input";
-
-export const PublishActions = ({
-  configKey,
-  sx,
-}: {
+type PublishActionProps = {
   configKey: string;
-  sx?: BoxProps["sx"];
-}) => {
-  const locale = useLocale();
+  locale: string;
+};
 
+export const PublishActions = (props: PublishActionProps) => {
   return (
-    <Stack direction="row" spacing={2} sx={sx}>
-      <Share configKey={configKey} locale={locale} />
-      <Embed configKey={configKey} locale={locale} />
+    <Stack direction="row" spacing={2}>
+      <Share {...props} />
+      <Embed {...props} />
     </Stack>
   );
 };
 
-const TriggeredPopover = ({
-  children,
-  renderTrigger,
-  popoverProps,
-}: {
+type TriggeredPopoverProps = {
   children: ReactNode;
   renderTrigger: (
     setAnchorEl: (el: HTMLElement | undefined) => void
   ) => React.ReactNode;
   popoverProps: Omit<PopoverProps, "open" | "anchorEl" | "onClose">;
-}) => {
-  const [anchorEl, setAnchorEl] = useState<Element | undefined>();
+};
 
+const TriggeredPopover = (props: TriggeredPopoverProps) => {
+  const { children, renderTrigger, popoverProps } = props;
+  const [anchorEl, setAnchorEl] = useState<Element | undefined>();
   return (
     <>
       {renderTrigger(setAnchorEl)}
@@ -71,123 +63,7 @@ const TriggeredPopover = ({
   );
 };
 
-export const Share = ({ configKey, locale }: EmbedShareProps) => {
-  const [shareUrl, setShareUrl] = useState("");
-  const i18n = useI18n();
-  useEffect(() => {
-    setShareUrl(`${window.location.origin}/${locale}/v/${configKey}`);
-  }, [configKey, locale]);
-  return (
-    <TriggeredPopover
-      popoverProps={{
-        anchorOrigin: {
-          vertical: "bottom",
-          horizontal: "right",
-        },
-        transformOrigin: {
-          vertical: -4,
-          horizontal: "right",
-        },
-      }}
-      renderTrigger={(setAnchorEl) => {
-        return (
-          <Button
-            onClick={(ev) => {
-              setAnchorEl(ev.target as HTMLElement);
-            }}
-            startIcon={<Icon name="linkExternal" size={16} />}
-          >
-            <Trans id="button.share">Share</Trans>
-          </Button>
-        );
-      }}
-    >
-      <Box m={4}>
-        <Flex
-          sx={{
-            justifyContent: "space-between",
-            alignItems: "center",
-
-            mb: 4,
-          }}
-        >
-          <Typography component="div" variant="body1" color="grey.700">
-            <Trans id="publication.popup.share">Share</Trans>:
-          </Typography>
-          <Flex color="primary">
-            <IconLink
-              iconName="facebook"
-              title={i18n._(
-                t({
-                  id: "publication.share.linktitle.facebook",
-                  message: `Share on Facebook`,
-                })
-              )}
-              href={`https://www.facebook.com/sharer/sharer.php?u=${shareUrl}`}
-            ></IconLink>
-            <IconLink
-              iconName="twitter"
-              title={i18n._(
-                t({
-                  id: "publication.share.linktitle.twitter",
-                  message: `Share on Twitter`,
-                })
-              )}
-              href={`https://twitter.com/intent/tweet?url=${shareUrl}&via=bafuCH`}
-            ></IconLink>
-            <IconLink
-              iconName="mail"
-              title={i18n._(
-                t({
-                  id: "publication.share.linktitle.mail",
-                  message: `Share via email`,
-                })
-              )}
-              href={`mailto:?subject=${i18n._(
-                t({
-                  id: "publication.share.mail.subject",
-                  message: `visualize.admin.ch`,
-                })
-              )}&body=${i18n._(
-                t({
-                  id: "publication.share.mail.body",
-                  message: `Here is a link to a visualization I created on visualize.admin.ch`,
-                })
-              )}: ${shareUrl}`}
-            ></IconLink>
-          </Flex>
-        </Flex>
-        <Divider />
-        <Box mt={2}>
-          <Typography component="div" variant="body1" color="grey.700">
-            <Trans id="publication.share.chart.url">Chart URL: </Trans>
-          </Typography>
-          <Box my={1} sx={{ color: "primary" }}>
-            <Link
-              href={shareUrl}
-              sx={{
-                color: "primary",
-                textDecoration: "underline",
-                cursor: "pointer",
-                mr: 4,
-              }}
-            >
-              {shareUrl}
-            </Link>
-            {/* <Icon name="share"></Icon> */}
-          </Box>
-        </Box>
-      </Box>
-    </TriggeredPopover>
-  );
-};
-
-type EmbedShareProps = {
-  configKey: string;
-  locale: string;
-};
-
-export const Embed = ({ configKey, locale }: EmbedShareProps) => {
+export const Embed = ({ configKey, locale }: PublishActionProps) => {
   const [embedIframeUrl, setEmbedIframeUrl] = useState("");
   const [embedAEMUrl, setEmbedAEMUrl] = useState("");
   const [embedOptions, setEmbedOptions] = useEmbedOptions();
@@ -320,10 +196,7 @@ export const Embed = ({ configKey, locale }: EmbedShareProps) => {
               Use this link to embed the chart into other webpages.
             </Trans>
           </Typography>
-
           <CopyToClipboardTextInput
-            mt={1}
-            mb={2}
             content={`<iframe src="${embedIframeUrl}" style="border:0px #ffffff none; max-width: 100%" name="visualize.admin.ch" scrolling="no" frameborder="1" marginheight="0px" marginwidth="0px" height="${iFrameHeight}" width="600px" allowfullscreen></iframe>`}
           />
         </div>
@@ -340,9 +213,119 @@ export const Embed = ({ configKey, locale }: EmbedShareProps) => {
               assets.
             </Trans>
           </Typography>
-
-          <CopyToClipboardTextInput mt={1} mb={2} content={embedAEMUrl} />
+          <CopyToClipboardTextInput content={embedAEMUrl} />
         </div>
+      </Box>
+    </TriggeredPopover>
+  );
+};
+
+export const Share = ({ configKey, locale }: PublishActionProps) => {
+  const [shareUrl, setShareUrl] = useState("");
+  const i18n = useI18n();
+
+  useEffect(() => {
+    setShareUrl(`${window.location.origin}/${locale}/v/${configKey}`);
+  }, [configKey, locale]);
+
+  return (
+    <TriggeredPopover
+      popoverProps={{
+        anchorOrigin: {
+          vertical: "bottom",
+          horizontal: "right",
+        },
+        transformOrigin: {
+          vertical: -4,
+          horizontal: "right",
+        },
+      }}
+      renderTrigger={(setAnchorEl) => {
+        return (
+          <Button
+            onClick={(ev) => {
+              setAnchorEl(ev.target as HTMLElement);
+            }}
+            startIcon={<Icon name="linkExternal" size={16} />}
+          >
+            <Trans id="button.share">Share</Trans>
+          </Button>
+        );
+      }}
+    >
+      <Box m={4}>
+        <Flex
+          sx={{
+            justifyContent: "space-between",
+            alignItems: "center",
+            mb: 4,
+          }}
+        >
+          <Typography component="div" variant="body1" color="grey.700">
+            <Trans id="publication.popup.share">Share</Trans>:
+          </Typography>
+          <Flex color="primary">
+            <IconLink
+              iconName="facebook"
+              title={i18n._(
+                t({
+                  id: "publication.share.linktitle.facebook",
+                  message: `Share on Facebook`,
+                })
+              )}
+              href={`https://www.facebook.com/sharer/sharer.php?u=${shareUrl}`}
+            ></IconLink>
+            <IconLink
+              iconName="twitter"
+              title={i18n._(
+                t({
+                  id: "publication.share.linktitle.twitter",
+                  message: `Share on Twitter`,
+                })
+              )}
+              href={`https://twitter.com/intent/tweet?url=${shareUrl}&via=bafuCH`}
+            ></IconLink>
+            <IconLink
+              iconName="mail"
+              title={i18n._(
+                t({
+                  id: "publication.share.linktitle.mail",
+                  message: `Share via email`,
+                })
+              )}
+              href={`mailto:?subject=${i18n._(
+                t({
+                  id: "publication.share.mail.subject",
+                  message: `visualize.admin.ch`,
+                })
+              )}&body=${i18n._(
+                t({
+                  id: "publication.share.mail.body",
+                  message: `Here is a link to a visualization I created on visualize.admin.ch`,
+                })
+              )}: ${shareUrl}`}
+            ></IconLink>
+          </Flex>
+        </Flex>
+        <Divider />
+        <Box mt={2}>
+          <Typography component="div" variant="body1" color="grey.700">
+            <Trans id="publication.share.chart.url">Chart URL: </Trans>
+          </Typography>
+          <Box my={1} sx={{ color: "primary" }}>
+            <Link
+              href={shareUrl}
+              sx={{
+                color: "primary",
+                textDecoration: "underline",
+                cursor: "pointer",
+                mr: 4,
+              }}
+            >
+              {shareUrl}
+            </Link>
+          </Box>
+        </Box>
       </Box>
     </TriggeredPopover>
   );

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -747,7 +747,6 @@ const ChartFields = (props: ChartFieldsProps) => {
   const queryFilters = useQueryFilters({
     chartConfig,
     dimensions,
-    measures,
   });
   const locale = useLocale();
   const [{ data: observationsData }] = useDataCubesObservationsQuery({
@@ -767,7 +766,6 @@ const ChartFields = (props: ChartFieldsProps) => {
         .encodings.filter((d) => !d.hide)
         .map((encoding) => {
           const { field, getDisabledState, iriAttributes } = encoding;
-
           const componentIris = iriAttributes
             .map((x) => (chartConfig.fields as any)[field]?.[x])
             .filter(truthy) as string[];

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -744,19 +744,15 @@ type ChartFieldsProps = {
 const ChartFields = (props: ChartFieldsProps) => {
   const { dataSource, chartConfig, dimensions, measures } = props;
   const components = [...(dimensions ?? []), ...(measures ?? [])];
-  const queryFilters = useQueryFilters({
-    chartConfig,
-    dimensions,
-  });
+  const queryFilters = useQueryFilters({ chartConfig });
   const locale = useLocale();
   const [{ data: observationsData }] = useDataCubesObservationsQuery({
     variables: {
       locale,
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
-      cubeFilters: queryFilters ?? [],
+      cubeFilters: queryFilters,
     },
-    pause: !queryFilters,
   });
   const observations = observationsData?.dataCubesObservations?.data ?? [];
 

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -124,7 +124,6 @@ export const ChartOptionsSelector = ({
   const queryFilters = useQueryFilters({
     chartConfig,
     dimensions,
-    measures,
   });
   const [{ data: observationsData, fetching: fetchingObservations }] =
     useDataCubesObservationsQuery({

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -121,19 +121,16 @@ export const ChartOptionsSelector = ({
     });
   const dimensions = componentsData?.dataCubesComponents.dimensions;
   const measures = componentsData?.dataCubesComponents.measures;
-  const queryFilters = useQueryFilters({
-    chartConfig,
-    dimensions,
-  });
+  const queryFilters = useQueryFilters({ chartConfig });
   const [{ data: observationsData, fetching: fetchingObservations }] =
     useDataCubesObservationsQuery({
       variables: {
         sourceType: dataSource.type,
         sourceUrl: dataSource.url,
         locale,
-        cubeFilters: queryFilters ?? [],
+        cubeFilters: queryFilters,
       },
-      pause: fetchingComponents || !queryFilters,
+      pause: fetchingComponents,
       keepPreviousData: true,
     });
   const observations = observationsData?.dataCubesObservations?.data;

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -1863,17 +1863,12 @@ type ConfiguratorStateProviderProps = React.PropsWithChildren<{
 export const ConfiguratorStateProvider = (
   props: ConfiguratorStateProviderProps
 ) => {
-  const { chartId, initialState, allowDefaultRedirect, children } = props;
-  // Ensure that the state is reset by using the `chartId` as `key`
   return (
     <ConfiguratorStateProviderInternal
-      key={chartId}
-      chartId={chartId}
-      initialState={initialState}
-      allowDefaultRedirect={allowDefaultRedirect}
-    >
-      {children}
-    </ConfiguratorStateProviderInternal>
+      // Ensure that the state is reset by using the `chartId` as `key`
+      key={props.chartId}
+      {...props}
+    />
   );
 };
 

--- a/app/docs/publish-actions.stories.tsx
+++ b/app/docs/publish-actions.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta = {
 export default meta;
 
 const PublishActionsStory = () => {
-  return <PublishActions configKey="123456789" />;
+  return <PublishActions configKey="123456789" locale="en" />;
 };
 
 export { PublishActionsStory as PublishActions };

--- a/app/pages/v/[chartId].tsx
+++ b/app/pages/v/[chartId].tsx
@@ -16,7 +16,7 @@ import ErrorPage from "next/error";
 import Head from "next/head";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
-import React, { useEffect, useState } from "react";
+import React from "react";
 
 import { ChartPublished } from "@/components/chart-published";
 import { PublishSuccess } from "@/components/hint";
@@ -83,7 +83,7 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
   const classes = useStyles();
 
   // Keep initial value of publishSuccess
-  const [publishSuccess] = useState(() => !!query.publishSuccess);
+  const [publishSuccess] = React.useState(() => !!query.publishSuccess);
   const { status, config } = deserializeProps(props);
 
   const session = useSession();
@@ -110,8 +110,7 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
   }, [props]);
   const chartConfig = state ? getChartConfig(state) : undefined;
 
-  const { dataSource, setDataSource } = useDataSourceStore();
-  useEffect(
+  React.useEffect(
     function removePublishSuccessFromURL() {
       // Remove publishSuccess from URL so that when reloading of sharing the link
       // to someone, there is no publishSuccess mention
@@ -122,7 +121,8 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
     [query.publishSuccess, replace]
   );
 
-  useEffect(
+  const { dataSource, setDataSource } = useDataSourceStore();
+  React.useEffect(
     function setCorrectDataSource() {
       if (
         props.status === "found" &&
@@ -130,7 +130,6 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
       ) {
         setDataSource(props.config.data.dataSource);
       }
-      // eslint-disable-next-line react-hooks/exhaustive-deps
     },
     [dataSource.url, setDataSource, props]
   );
@@ -154,11 +153,10 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
           property="og:description"
           content={state.layout.meta.description[locale]}
         />
-        {/* og:url is set in _app.tsx */}
       </Head>
       <ContentLayout>
         <Box className={classes.actionBar}>
-          <PublishActions configKey={key} sx={{ m: 0 }} />
+          <PublishActions configKey={key} locale={locale} />
         </Box>
         <Box
           px={[2, 4]}


### PR DESCRIPTION
Closes #1423

This PR removes a need to pass dimensions to get query filters, as it looks like this behavior is not needed. It was used to filter out interactive data filters that are a part of dimensions, which should always be true (except when a dimension was completely removed from a cube, which would most probably break the chart anyway).

With this change we fire `DataCubesObservations` query in parallel to `DataCubesComponents` fetching, not waiting for it to finish first.

## How to test
### PR
1. Go to [this link](https://visualization-tool-git-perf-fire-observations-query-asap-ixt1.vercel.app/en/v/ENrCApdv5Cbo?dataSource=Prod).
2. Open Developer Tools (e.g. [see how to do so on Chrome](https://developer.chrome.com/docs/devtools/open)).
3. Switch to the Network tab.
4. Reload the page.
5. ✅ See that the `graphql` queries were fired (almost) at the same time.

<img width="878" alt="Screenshot 2024-04-19 at 13 30 54" src="https://github.com/visualize-admin/visualization-tool/assets/52032047/dbf85c0c-3554-48fc-b925-e219fb81263a">

### TEST
1. Go to [this link](https://test.visualize.admin.ch/en/v/Zq6ql3-tONlE?dataSource=Prod).
2. Open Developer Tools (e.g. [see how to do so on Chrome](https://developer.chrome.com/docs/devtools/open)).
3. Switch to the Network tab.
4. Reload the page.
5. ❌ See that some graphql queries were fired sequentially (waited for other queries to finish first).

<img width="878" alt="Screenshot 2024-04-19 at 13 31 11" src="https://github.com/visualize-admin/visualization-tool/assets/52032047/a8038b71-8fbc-471a-8944-92aa49c74bb3">