### PR TITLE
refactor: Combined query to fetch dimension values

### DIFF
--- a/app/rdf/query-dimension-values.ts
+++ b/app/rdf/query-dimension-values.ts
@@ -137,10 +137,10 @@ export async function loadDimensionsValuesWithMetadata(
             SELECT ?observation WHERE {
               ${
                 queryFilters
-                  ? `<${cubeIri}> cube:observationConstraint/sh:property ?dimension .
+                  ? `VALUES ?dimensionIri { <${dimensionIri}> }
+                  <${cubeIri}> cube:observationConstraint/sh:property ?dimension .
                   ?dimension sh:path ?dimensionIri .
-                  ?dimension schema:version ?version .
-                  FILTER(?dimensionIri NOT IN (rdf:type, cube:observedBy))`
+                  ?dimension schema:version ?version .`
                   : `VALUES ?dimensionIri { <${dimensionIri}> }
                   <${cubeIri}> cube:observationConstraint/sh:property ?dimension .
                   ?dimension sh:path ?dimensionIri .
@@ -153,9 +153,9 @@ export async function loadDimensionsValuesWithMetadata(
           }
           ${
             queryFilters
-              ? `<${cubeIri}> cube:observationConstraint/sh:property ?dimension .
-              ?dimension sh:path ?dimensionIri .
-              FILTER(?dimensionIri NOT IN (rdf:type, cube:observedBy))`
+              ? `VALUES ?dimensionIri { <${dimensionIri}> }
+              <${cubeIri}> cube:observationConstraint/sh:property ?dimension .
+              ?dimension sh:path ?dimensionIri .`
               : `VALUES ?dimensionIri { <${dimensionIri}> }`
           }
           ?observation ?dimensionIri ?versionedValue .
@@ -169,10 +169,10 @@ export async function loadDimensionsValuesWithMetadata(
             SELECT ?observation WHERE {
               ${
                 queryFilters
-                  ? `<${cubeIri}> cube:observationConstraint/sh:property ?dimension .
+                  ? `VALUES ?dimensionIri { <${dimensionIri}> }
+                  <${cubeIri}> cube:observationConstraint/sh:property ?dimension .
                   ?dimension sh:path ?dimensionIri .
-                  FILTER NOT EXISTS { ?dimension schema:version ?version . }
-                  FILTER(?dimensionIri NOT IN (rdf:type, cube:observedBy))`
+                  FILTER NOT EXISTS { ?dimension schema:version ?version . }`
                   : `VALUES ?dimensionIri { <${dimensionIri}> }
                   <${cubeIri}> cube:observationConstraint/sh:property ?dimension .
                   ?dimension sh:path ?dimensionIri .
@@ -185,9 +185,9 @@ export async function loadDimensionsValuesWithMetadata(
           }
           ${
             queryFilters
-              ? `<${cubeIri}> cube:observationConstraint/sh:property ?dimension .
-              ?dimension sh:path ?dimensionIri .
-              FILTER(?dimensionIri NOT IN (rdf:type, cube:observedBy))`
+              ? `VALUES ?dimensionIri { <${dimensionIri}> }
+              <${cubeIri}> cube:observationConstraint/sh:property ?dimension .
+              ?dimension sh:path ?dimensionIri .`
               : `VALUES ?dimensionIri { <${dimensionIri}> }`
           }
           ?observation ?dimensionIri ?versionedValue .

--- a/app/rdf/query-dimension-values.ts
+++ b/app/rdf/query-dimension-values.ts
@@ -131,46 +131,67 @@ export async function loadDimensionsValuesWithMetadata(
       }
     } UNION`
     } {
-      { #pragma evaluate on
+      {
         SELECT DISTINCT ?dimensionIri ?versionedValue ?unversionedValue WHERE {
+          { #pragma evaluate on
+            SELECT ?observation WHERE {
+              ${
+                queryFilters
+                  ? `<${cubeIri}> cube:observationConstraint/sh:property ?dimension .
+                  ?dimension sh:path ?dimensionIri .
+                  ?dimension schema:version ?version .
+                  FILTER(?dimensionIri NOT IN (rdf:type, cube:observedBy))`
+                  : `VALUES ?dimensionIri { <${dimensionIri}> }
+                  <${cubeIri}> cube:observationConstraint/sh:property ?dimension .
+                  ?dimension sh:path ?dimensionIri .
+                  ?dimension schema:version ?version .
+                  FILTER NOT EXISTS { ?dimension sh:in ?in . }`
+              }
+              <${cubeIri}> cube:observationSet/cube:observation ?observation .
+              ${queryFilters}
+            }
+          }
           ${
             queryFilters
               ? `<${cubeIri}> cube:observationConstraint/sh:property ?dimension .
               ?dimension sh:path ?dimensionIri .
-              ?dimension schema:version ?version .
               FILTER(?dimensionIri NOT IN (rdf:type, cube:observedBy))`
-              : `
-          VALUES ?dimensionIri { <${dimensionIri}> }
-          <${cubeIri}> cube:observationConstraint/sh:property ?dimension .
-          ?dimension sh:path ?dimensionIri .
-          ?dimension schema:version ?version .
-          FILTER(NOT EXISTS{ ?dimension sh:in ?in . })`
+              : `VALUES ?dimensionIri { <${dimensionIri}> }`
           }
-          <${cubeIri}> cube:observationSet/cube:observation ?observation .
           ?observation ?dimensionIri ?versionedValue .
           ?versionedValue schema:sameAs ?unversionedValue .
-          ${queryFilters}
         }
       }
     } UNION {
-      { #pragma evaluate on
+      {
         SELECT DISTINCT ?dimensionIri ?versionedValue ?unversionedValue WHERE {
+          { #pragma evaluate on
+            SELECT ?observation WHERE {
+              ${
+                queryFilters
+                  ? `<${cubeIri}> cube:observationConstraint/sh:property ?dimension .
+                  ?dimension sh:path ?dimensionIri .
+                  FILTER NOT EXISTS { ?dimension schema:version ?version . }
+                  FILTER(?dimensionIri NOT IN (rdf:type, cube:observedBy))`
+                  : `VALUES ?dimensionIri { <${dimensionIri}> }
+                  <${cubeIri}> cube:observationConstraint/sh:property ?dimension .
+                  ?dimension sh:path ?dimensionIri .
+                  FILTER NOT EXISTS { ?dimension schema:version ?version . }
+                  FILTER NOT EXISTS { ?dimension sh:in ?in . }`
+              }
+              <${cubeIri}> cube:observationSet/cube:observation ?observation .
+              ${queryFilters}
+            }
+          }
           ${
             queryFilters
               ? `<${cubeIri}> cube:observationConstraint/sh:property ?dimension .
               ?dimension sh:path ?dimensionIri .
               FILTER(?dimensionIri NOT IN (rdf:type, cube:observedBy))`
-              : `
-          VALUES ?dimensionIri { <${dimensionIri}> }
-          <${cubeIri}> cube:observationConstraint/sh:property ?dimension .
-          ?dimension sh:path ?dimensionIri .
-          FILTER(NOT EXISTS{ ?dimension sh:in ?in . })`
+              : `VALUES ?dimensionIri { <${dimensionIri}> }`
           }
-          <${cubeIri}> cube:observationSet/cube:observation ?observation .
           ?observation ?dimensionIri ?versionedValue .
-          FILTER NOT EXISTS { ?dimension schema:version ?version . }
           BIND(?versionedValue as ?unversionedValue)
-          ${queryFilters}
         }
       }
     }`;


### PR DESCRIPTION
Closes #1470

This PR is an exploration of the feasibility to fetch values for multiple dimensions in a single SPARQL query.

### Constrains

- We need to be able to filter each dimension individually, due to cascading filters behavior. Could be achieved with ```FILTER(IF(?dimensionIri = <A>, ?dimensionIri = <a> && ?dimensionIri = <a>, ?dimensionIri))```
- We need to be able to unversion dimension values per individual dimension (can't unversion values outside of individual SELECT queries, as sometimes `schema:sameAs` is not used to indicate unversioned values, this is only the case when a dimension is versioned).

we need to combine individual queries into a big one (at least that's my current assumption).