### PR TITLE
feat: Add Save button to annotations panel

### DIFF
--- a/app/configurator/components/annotation-options.tsx
+++ b/app/configurator/components/annotation-options.tsx
@@ -1,4 +1,3 @@
-import { Trans } from "@lingui/macro";
 import { Box, Button, Typography } from "@mui/material";
 import { useEffect, useRef } from "react";
 
@@ -108,9 +107,7 @@ const AnnotationOptions = (props: AnnotationOptionsProps) => {
             onClick={handleClosePanel}
             sx={{ alignSelf: "flex-end", mt: 3, px: 5 }}
           >
-            <Typography component="span">
-              <Trans id="save">Save</Trans>
-            </Typography>
+            <Typography component="span">Ok</Typography>
           </Button>
         </ControlSectionContent>
       </ControlSection>

--- a/app/configurator/components/annotation-options.tsx
+++ b/app/configurator/components/annotation-options.tsx
@@ -1,4 +1,5 @@
-import { Box } from "@mui/material";
+import { Trans } from "@lingui/macro";
+import { Box, Button, Typography } from "@mui/material";
 import { useEffect, useRef } from "react";
 
 import { Meta, getChartConfig } from "@/config-types";
@@ -17,11 +18,11 @@ import { MetaInputField } from "@/configurator/components/field";
 import { getFieldLabel } from "@/configurator/components/field-i18n";
 import { locales } from "@/locales/locales";
 import { useLocale } from "@/locales/use-locale";
+import useEvent from "@/utils/use-event";
 
 export const ChartAnnotationsSelector = () => {
   const [state] = useConfiguratorState(isConfiguring);
   const chartConfig = getChartConfig(state);
-
   return (
     <AnnotationOptions
       type="chart"
@@ -50,11 +51,21 @@ type AnnotationOptionsProps = {
 
 const AnnotationOptions = (props: AnnotationOptionsProps) => {
   const { type, activeField, meta } = props;
+  const [_, dispatch] = useConfiguratorState();
   const locale = useLocale();
   // Reorder locales so the input field for
   // the current locale is on top
   const orderedLocales = [locale, ...locales.filter((l) => l !== locale)];
   const panelRef = useRef<HTMLDivElement>(null);
+  const handleClosePanel = useEvent(() => {
+    dispatch({
+      type:
+        type === "chart"
+          ? "CHART_ACTIVE_FIELD_CHANGED"
+          : "LAYOUT_ACTIVE_FIELD_CHANGED",
+      value: undefined,
+    });
+  });
 
   useEffect(() => {
     if (panelRef?.current) {
@@ -92,6 +103,14 @@ const AnnotationOptions = (props: AnnotationOptionsProps) => {
               />
             </Box>
           ))}
+          <Button
+            onClick={handleClosePanel}
+            sx={{ alignSelf: "flex-end", minHeight: 32, mt: 3, px: 5 }}
+          >
+            <Typography component="span">
+              <Trans id="save"> Save</Trans>
+            </Typography>
+          </Button>
         </ControlSectionContent>
       </ControlSection>
     </Box>

--- a/app/configurator/components/annotation-options.tsx
+++ b/app/configurator/components/annotation-options.tsx
@@ -104,11 +104,12 @@ const AnnotationOptions = (props: AnnotationOptionsProps) => {
             </Box>
           ))}
           <Button
+            size="small"
             onClick={handleClosePanel}
-            sx={{ alignSelf: "flex-end", minHeight: 32, mt: 3, px: 5 }}
+            sx={{ alignSelf: "flex-end", mt: 3, px: 5 }}
           >
             <Typography component="span">
-              <Trans id="save"> Save</Trans>
+              <Trans id="save">Save</Trans>
             </Typography>
           </Button>
         </ControlSectionContent>


### PR DESCRIPTION
Closes #1427

This PR adds a "Save" button to the annotations panel. As we save the changes dynamically anyway, it acts as a "close panel" button.