### PR TITLE
Termset search filter

### DIFF
--- a/app/browser/dataset-browse.tsx
+++ b/app/browser/dataset-browse.tsx
@@ -211,7 +211,16 @@ export const SearchDatasetControls = ({
   );
 };
 
-const defaultNavItemTheme = {
+type NavItemTheme = {
+  activeBg: string;
+  activeTextColor: string;
+  textColor: string;
+  countColor: string;
+  countBg: string;
+  closeColor?: string;
+};
+
+const defaultNavItemTheme: NavItemTheme = {
   activeTextColor: "white",
   activeBg: "primary.main",
   textColor: "text.primary",
@@ -219,7 +228,7 @@ const defaultNavItemTheme = {
   countBg: "grey.300",
 };
 
-const themeNavItemTheme = {
+const themeNavItemTheme: NavItemTheme = {
   activeBg: "category.main",
   activeTextColor: "white",
   textColor: "text.primary",
@@ -227,7 +236,7 @@ const themeNavItemTheme = {
   countBg: "category.light",
 };
 
-const organizationNavItemTheme = {
+const organizationNavItemTheme: NavItemTheme = {
   activeBg: "organization.main",
   activeTextColor: "white",
   textColor: "text.primary",
@@ -235,12 +244,13 @@ const organizationNavItemTheme = {
   countBg: "organization.light",
 };
 
-const termsetNavItemTheme = {
+const termsetNavItemTheme: NavItemTheme = {
   activeBg: "warning.light",
   activeTextColor: "text.primary",
   textColor: "text.primary",
   countColor: "warning.main",
   countBg: "warning.light",
+  closeColor: "warning.main",
 };
 
 const useStyles = makeStyles(() => ({
@@ -391,7 +401,10 @@ const NavItem = ({
         className={classes.removeFilterButton}
         sx={{
           backgroundColor: level === 1 ? theme.activeBg : "transparent",
-          color: level === 1 ? theme.activeTextColor : theme.activeBg,
+          color:
+            level === 1
+              ? theme.closeColor ?? theme.activeTextColor
+              : theme.activeBg,
         }}
       >
         <SvgIcClose width={24} height={24} />
@@ -532,7 +545,7 @@ const NavSection = ({
   icon: React.ReactNode;
   items: (DataCubeTheme | DataCubeOrganization | Termset)[];
   theme: { backgroundColor: string; borderColor: string };
-  navItemTheme: typeof themeNavItemTheme;
+  navItemTheme: NavItemTheme;
   currentFilter?: DataCubeTheme | DataCubeOrganization | Termset;
   filters: BrowseFilter[];
   counts: Record<string, number>;

--- a/app/browser/dataset-browse.tsx
+++ b/app/browser/dataset-browse.tsx
@@ -617,23 +617,12 @@ const NavSection = ({
 
 const TermsetNavSection = ({
   currentFilter,
+  termsetCounts,
 }: {
   currentFilter: Termset | undefined;
+  termsetCounts: { termset: Termset; count: number }[];
 }) => {
-  const locale = useLocale();
-  const [configState] = useConfiguratorState();
-  const { dataSource } = configState;
-
-  const [searchPageQuery] = useSearchPageQuery({
-    variables: {
-      sourceType: dataSource.type,
-      sourceUrl: dataSource.url,
-      locale,
-    },
-  });
-
   const { counts, termsets } = useMemo(() => {
-    const termsetCounts = searchPageQuery.data?.allTermsets ?? [];
     const termsets = termsetCounts.map((x) => x.termset) ?? [];
     const counts = Object.fromEntries(
       termsetCounts.map((x) => [x.termset.iri, x.count])
@@ -642,11 +631,7 @@ const TermsetNavSection = ({
       counts,
       termsets,
     };
-  }, [searchPageQuery.data?.allTermsets]);
-
-  if (searchPageQuery.fetching) {
-    return null;
-  }
+  }, [termsetCounts]);
 
   return (
     <NavSection
@@ -679,10 +664,12 @@ export const SearchFilters = ({
   cubes,
   themes,
   orgs,
+  termsets: termsetCounts,
 }: {
   cubes: SearchCubeResult[];
   themes: DataCubeTheme[];
   orgs: DataCubeOrganization[];
+  termsets: TermsetCount[];
 }) => {
   const { filters } = useBrowseContext();
   const counts = useMemo(() => {
@@ -805,8 +792,13 @@ export const SearchFilters = ({
       />
     ) : null;
 
-  const termsetNav = <TermsetNavSection currentFilter={termsetFilter} />;
-
+  const termsetNav =
+    termsetCounts.length === 0 ? null : (
+      <TermsetNavSection
+        termsetCounts={termsetCounts ?? []}
+        currentFilter={termsetFilter}
+      />
+    );
   const navs = sortBy(
     [
       { element: themeNav, __typename: "DataCubeTheme" },

--- a/app/browser/dataset-browse.tsx
+++ b/app/browser/dataset-browse.tsx
@@ -644,7 +644,6 @@ const TermsetNavSection = ({
       currentFilter={currentFilter}
       icon={<SvgIcOrganisations width={20} height={20} />}
       label={<Trans id="browse-panel.termsets">Concepts</Trans>}
-      extra={null}
       filters={[]}
       counts={counts}
     />

--- a/app/browser/dataset-browse.tsx
+++ b/app/browser/dataset-browse.tsx
@@ -311,7 +311,6 @@ const encodeFilter = (filter: BrowseFilter) => {
       case "Termset":
         return "termset";
       default:
-        // eslint-disable-next-line
         const check: never = __typename;
         throw new Error('Unknown filter type "' + check + '"');
     }

--- a/app/browser/dataset-browse.tsx
+++ b/app/browser/dataset-browse.tsx
@@ -40,7 +40,7 @@ import {
   DataCubeOrganization,
   DataCubeTheme,
   SearchCubeResultOrder,
-  useSearchPageQuery,
+  TermsetCount,
 } from "@/graphql/query-hooks";
 import {
   DataCubePublicationStatus,
@@ -49,7 +49,6 @@ import {
 import SvgIcCategories from "@/icons/components/IcCategories";
 import SvgIcClose from "@/icons/components/IcClose";
 import SvgIcOrganisations from "@/icons/components/IcOrganisations";
-import { useConfiguratorState, useLocale } from "@/src";
 import { MaybeTooltip } from "@/utils/maybe-tooltip";
 import useEvent from "@/utils/use-event";
 
@@ -237,8 +236,8 @@ const organizationNavItemTheme = {
 };
 
 const termsetNavItemTheme = {
-  activeBg: "warning.main",
-  activeTextColor: "white",
+  activeBg: "warning.light",
+  activeTextColor: "text.primary",
   textColor: "text.primary",
   countColor: "warning.main",
   countBg: "warning.light",
@@ -644,7 +643,7 @@ const TermsetNavSection = ({
       navItemTheme={termsetNavItemTheme}
       currentFilter={currentFilter}
       icon={<SvgIcOrganisations width={20} height={20} />}
-      label={<Trans id="browse-panel.termsets">Termsets</Trans>}
+      label={<Trans id="browse-panel.termsets">Concepts</Trans>}
       extra={null}
       filters={[]}
       counts={counts}

--- a/app/browser/filters.tsx
+++ b/app/browser/filters.tsx
@@ -1,3 +1,4 @@
+import { Termset } from "@/domain/data";
 import {
   DataCubeOrganization,
   DataCubeTheme,
@@ -10,7 +11,12 @@ export type DataCubeAbout = {
   iri: string;
 };
 
-export type BrowseFilter = DataCubeTheme | DataCubeOrganization | DataCubeAbout;
+export type BrowseFilter =
+  | DataCubeTheme
+  | DataCubeOrganization
+  | DataCubeAbout
+  | (Omit<Termset, "label"> & { label?: string });
+
 /** Builds the state search filters from query params */
 
 export const getFiltersFromParams = (params: BrowseParams) => {
@@ -20,12 +26,19 @@ export const getFiltersFromParams = (params: BrowseParams) => {
     [type, iri],
     [subtype, subiri],
   ]) {
-    if (t && i && (t === "theme" || t === "organization")) {
+    if (t && i && (t === "theme" || t === "organization" || t === "termset")) {
+      const __typename = (() => {
+        switch (t) {
+          case "theme":
+            return SearchCubeFilterType.DataCubeTheme;
+          case "organization":
+            return SearchCubeFilterType.DataCubeOrganization;
+          case "termset":
+            return SearchCubeFilterType.Termset;
+        }
+      })();
       filters.push({
-        __typename:
-          t === "theme"
-            ? SearchCubeFilterType.DataCubeTheme
-            : SearchCubeFilterType.DataCubeOrganization,
+        __typename,
         iri: i,
       });
     }

--- a/app/browser/search-page-data.tsx
+++ b/app/browser/search-page-data.tsx
@@ -1,0 +1,16 @@
+import { useSearchPageQuery } from "@/graphql/query-hooks";
+import { useConfiguratorState, useLocale } from "@/src";
+
+export const useSearchPageData = () => {
+  const locale = useLocale();
+  const [configState] = useConfiguratorState();
+  const { dataSource } = configState;
+  const [searchPageQuery] = useSearchPageQuery({
+    variables: {
+      sourceType: dataSource.type,
+      sourceUrl: dataSource.url,
+      locale,
+    },
+  });
+  return searchPageQuery;
+};

--- a/app/browser/select-dataset-step.tsx
+++ b/app/browser/select-dataset-step.tsx
@@ -21,9 +21,9 @@ import { DatasetMetadata } from "@/components/dataset-metadata";
 import Flex from "@/components/flex";
 import { Footer } from "@/components/footer";
 import {
-  bannerPresenceProps,
   BANNER_HEIGHT,
   BANNER_MARGIN_TOP,
+  bannerPresenceProps,
   DURATION,
   MotionBox,
   navPresenceProps,
@@ -143,8 +143,15 @@ const prepareSearchQueryFilters = (filters: BrowseFilter[]) => {
           d.__typename !== SearchCubeFilterType.DataCubeAbout
       )
       .map((d) => {
-        const type = SearchCubeFilterType[d.__typename];
-        return { type, label: d.label, value: d.iri };
+        const type =
+          d.__typename === "Termset"
+            ? SearchCubeFilterType.Termset
+            : SearchCubeFilterType[d.__typename];
+        return {
+          type,
+          label: d.label,
+          value: d.iri,
+        };
       })
   );
 };

--- a/app/browser/select-dataset-step.tsx
+++ b/app/browser/select-dataset-step.tsx
@@ -143,10 +143,7 @@ const prepareSearchQueryFilters = (filters: BrowseFilter[]) => {
           d.__typename !== SearchCubeFilterType.DataCubeAbout
       )
       .map((d) => {
-        const type =
-          d.__typename === "Termset"
-            ? SearchCubeFilterType.Termset
-            : SearchCubeFilterType[d.__typename];
+        const type = SearchCubeFilterType[d.__typename];
         return {
           type,
           label: d.label,

--- a/app/components/graphql-search.stories.tsx
+++ b/app/components/graphql-search.stories.tsx
@@ -92,7 +92,7 @@ export const Search = () => {
       filters: [
         sharedComponents
           ? {
-              type: SearchCubeFilterType.SharedDimensions,
+              type: SearchCubeFilterType.Termset,
               value: sharedComponents
                 .map((x) => cubeSharedDimensionsByIri[x])
                 .filter(truthy)

--- a/app/configurator/components/add-dataset-dialog.tsx
+++ b/app/configurator/components/add-dataset-dialog.tsx
@@ -741,7 +741,7 @@ export const DatasetDialog = ({
           : null,
         selectedSharedDimensions && selectedSharedDimensions.length > 0
           ? {
-              type: SearchCubeFilterType.SharedDimensions,
+              type: SearchCubeFilterType.Termset,
               value: uniq(
                 selectedSharedDimensions.flatMap((x) =>
                   x.termsets.map((x) => x.iri)

--- a/app/domain/data.ts
+++ b/app/domain/data.ts
@@ -97,6 +97,7 @@ export type DataCubePreview = {
 export type Termset = {
   iri: string;
   label: string;
+  __typename: "Termset";
 };
 
 export type ComponentTermsets = {

--- a/app/graphql/queries/data-cubes.graphql
+++ b/app/graphql/queries/data-cubes.graphql
@@ -133,3 +133,10 @@ query DataCubeDimensionGeoShapes(
     locale: $locale
   )
 }
+
+query SearchPage($sourceType: String!, $sourceUrl: String!, $locale: String!) {
+  allTermsets(sourceType: $sourceType, sourceUrl: $sourceUrl, locale: $locale) {
+    count
+    termset
+  }
+}

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -118,6 +118,7 @@ export type Query = {
   possibleFilters: Array<ObservationFilter>;
   searchCubes: Array<SearchCubeResult>;
   dataCubeDimensionGeoShapes?: Maybe<Scalars['GeoShapes']>;
+  allTermsets: Array<TermsetCount>;
 };
 
 
@@ -196,6 +197,13 @@ export type QueryDataCubeDimensionGeoShapesArgs = {
 };
 
 
+export type QueryAllTermsetsArgs = {
+  sourceType: Scalars['String'];
+  sourceUrl: Scalars['String'];
+  locale: Scalars['String'];
+};
+
+
 export type RelatedDimension = {
   __typename: 'RelatedDimension';
   type: Scalars['String'];
@@ -239,6 +247,12 @@ export enum SearchCubeResultOrder {
 }
 
 
+
+export type TermsetCount = {
+  __typename: 'TermsetCount';
+  termset: Scalars['Termset'];
+  count: Scalars['Int'];
+};
 
 export enum TimeUnit {
   Year = 'Year',
@@ -344,6 +358,15 @@ export type DataCubeDimensionGeoShapesQueryVariables = Exact<{
 
 
 export type DataCubeDimensionGeoShapesQuery = { __typename: 'Query', dataCubeDimensionGeoShapes?: Maybe<GeoShapes> };
+
+export type SearchPageQueryVariables = Exact<{
+  sourceType: Scalars['String'];
+  sourceUrl: Scalars['String'];
+  locale: Scalars['String'];
+}>;
+
+
+export type SearchPageQuery = { __typename: 'Query', allTermsets: Array<{ __typename: 'TermsetCount', count: number, termset: Termset }> };
 
 
 export const DataCubeLatestIriDocument = gql`
@@ -478,4 +501,16 @@ export const DataCubeDimensionGeoShapesDocument = gql`
 
 export function useDataCubeDimensionGeoShapesQuery(options: Omit<Urql.UseQueryArgs<DataCubeDimensionGeoShapesQueryVariables>, 'query'> = {}) {
   return Urql.useQuery<DataCubeDimensionGeoShapesQuery>({ query: DataCubeDimensionGeoShapesDocument, ...options });
+};
+export const SearchPageDocument = gql`
+    query SearchPage($sourceType: String!, $sourceUrl: String!, $locale: String!) {
+  allTermsets(sourceType: $sourceType, sourceUrl: $sourceUrl, locale: $locale) {
+    count
+    termset
+  }
+}
+    `;
+
+export function useSearchPageQuery(options: Omit<Urql.UseQueryArgs<SearchPageQueryVariables>, 'query'> = {}) {
+  return Urql.useQuery<SearchPageQuery>({ query: SearchPageDocument, ...options });
 };

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -201,6 +201,7 @@ export type QueryAllTermsetsArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
+  includeDrafts?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -229,7 +230,7 @@ export enum SearchCubeFilterType {
   DataCubeTheme = 'DataCubeTheme',
   DataCubeOrganization = 'DataCubeOrganization',
   DataCubeAbout = 'DataCubeAbout',
-  SharedDimensions = 'SharedDimensions'
+  Termset = 'Termset'
 }
 
 export type SearchCubeResult = {

--- a/app/graphql/resolver-types.ts
+++ b/app/graphql/resolver-types.ts
@@ -118,6 +118,7 @@ export type Query = {
   possibleFilters: Array<ObservationFilter>;
   searchCubes: Array<SearchCubeResult>;
   dataCubeDimensionGeoShapes?: Maybe<Scalars['GeoShapes']>;
+  allTermsets: Array<TermsetCount>;
 };
 
 
@@ -196,6 +197,13 @@ export type QueryDataCubeDimensionGeoShapesArgs = {
 };
 
 
+export type QueryAllTermsetsArgs = {
+  sourceType: Scalars['String'];
+  sourceUrl: Scalars['String'];
+  locale: Scalars['String'];
+};
+
+
 export type RelatedDimension = {
   __typename?: 'RelatedDimension';
   type: Scalars['String'];
@@ -239,6 +247,12 @@ export enum SearchCubeResultOrder {
 }
 
 
+
+export type TermsetCount = {
+  __typename?: 'TermsetCount';
+  termset: Scalars['Termset'];
+  count: Scalars['Int'];
+};
 
 export enum TimeUnit {
   Year = 'Year',
@@ -352,6 +366,8 @@ export type ResolversTypes = ResolversObject<{
   SearchCubeResultOrder: SearchCubeResultOrder;
   SingleFilters: ResolverTypeWrapper<Scalars['SingleFilters']>;
   Termset: ResolverTypeWrapper<Scalars['Termset']>;
+  TermsetCount: ResolverTypeWrapper<TermsetCount>;
+  Int: ResolverTypeWrapper<Scalars['Int']>;
   TimeUnit: TimeUnit;
   ValueIdentifier: ResolverTypeWrapper<Scalars['ValueIdentifier']>;
   ValuePosition: ResolverTypeWrapper<Scalars['ValuePosition']>;
@@ -389,6 +405,8 @@ export type ResolversParentTypes = ResolversObject<{
   Float: Scalars['Float'];
   SingleFilters: Scalars['SingleFilters'];
   Termset: Scalars['Termset'];
+  TermsetCount: TermsetCount;
+  Int: Scalars['Int'];
   ValueIdentifier: Scalars['ValueIdentifier'];
   ValuePosition: Scalars['ValuePosition'];
 }>;
@@ -466,6 +484,7 @@ export type QueryResolvers<ContextType = VisualizeGraphQLContext, ParentType ext
   possibleFilters?: Resolver<Array<ResolversTypes['ObservationFilter']>, ParentType, ContextType, RequireFields<QueryPossibleFiltersArgs, 'iri' | 'sourceType' | 'sourceUrl' | 'filters'>>;
   searchCubes?: Resolver<Array<ResolversTypes['SearchCubeResult']>, ParentType, ContextType, RequireFields<QuerySearchCubesArgs, 'sourceType' | 'sourceUrl'>>;
   dataCubeDimensionGeoShapes?: Resolver<Maybe<ResolversTypes['GeoShapes']>, ParentType, ContextType, RequireFields<QueryDataCubeDimensionGeoShapesArgs, 'cubeIri' | 'dimensionIri' | 'sourceType' | 'sourceUrl' | 'locale'>>;
+  allTermsets?: Resolver<Array<ResolversTypes['TermsetCount']>, ParentType, ContextType, RequireFields<QueryAllTermsetsArgs, 'sourceType' | 'sourceUrl' | 'locale'>>;
 }>;
 
 export interface RawObservationScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['RawObservation'], any> {
@@ -498,6 +517,12 @@ export interface TermsetScalarConfig extends GraphQLScalarTypeConfig<ResolversTy
   name: 'Termset';
 }
 
+export type TermsetCountResolvers<ContextType = VisualizeGraphQLContext, ParentType extends ResolversParentTypes['TermsetCount'] = ResolversParentTypes['TermsetCount']> = ResolversObject<{
+  termset?: Resolver<ResolversTypes['Termset'], ParentType, ContextType>;
+  count?: Resolver<ResolversTypes['Int'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export interface ValueIdentifierScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes['ValueIdentifier'], any> {
   name: 'ValueIdentifier';
 }
@@ -528,6 +553,7 @@ export type Resolvers<ContextType = VisualizeGraphQLContext> = ResolversObject<{
   SearchCubeResult?: SearchCubeResultResolvers<ContextType>;
   SingleFilters?: GraphQLScalarType;
   Termset?: GraphQLScalarType;
+  TermsetCount?: TermsetCountResolvers<ContextType>;
   ValueIdentifier?: GraphQLScalarType;
   ValuePosition?: GraphQLScalarType;
 }>;

--- a/app/graphql/resolver-types.ts
+++ b/app/graphql/resolver-types.ts
@@ -201,6 +201,7 @@ export type QueryAllTermsetsArgs = {
   sourceType: Scalars['String'];
   sourceUrl: Scalars['String'];
   locale: Scalars['String'];
+  includeDrafts?: Maybe<Scalars['Boolean']>;
 };
 
 
@@ -229,7 +230,7 @@ export enum SearchCubeFilterType {
   DataCubeTheme = 'DataCubeTheme',
   DataCubeOrganization = 'DataCubeOrganization',
   DataCubeAbout = 'DataCubeAbout',
-  SharedDimensions = 'SharedDimensions'
+  Termset = 'Termset'
 }
 
 export type SearchCubeResult = {

--- a/app/graphql/resolvers/index.ts
+++ b/app/graphql/resolvers/index.ts
@@ -51,6 +51,10 @@ export const Query: QueryResolvers = {
     const source = getSource(args.sourceType);
     return await source.dataCubeDimensionGeoShapes(parent, args, context, info);
   },
+  allTermsets: async (parent, args, context, info) => {
+    const source = getSource(args.sourceType);
+    return await source.allTermsets(parent, args, context, info);
+  },
 };
 
 export const resolveDimensionType = (

--- a/app/graphql/resolvers/rdf.ts
+++ b/app/graphql/resolvers/rdf.ts
@@ -37,6 +37,7 @@ import { parseHierarchy, queryHierarchies } from "@/rdf/query-hierarchies";
 import { queryLatestCubeIri } from "@/rdf/query-latest-cube-iri";
 import { getPossibleFilters } from "@/rdf/query-possible-filters";
 import { SearchResult, searchCubes as _searchCubes } from "@/rdf/query-search";
+import { queryAllTermsets } from "@/rdf/query-termsets";
 import { getSparqlEditorUrl } from "@/rdf/sparql-utils";
 
 export const dataCubeLatestIri: NonNullable<
@@ -423,4 +424,14 @@ const getDimensionValuesLoader = (
   } else {
     return loaders.dimensionValues;
   }
+};
+
+export const allTermsets: NonNullable<QueryResolvers["allTermsets"]> = async (
+  _,
+  { locale },
+  { setup },
+  info
+) => {
+  const { sparqlClient } = await setup(info);
+  return await queryAllTermsets({ locale, sparqlClient });
 };

--- a/app/graphql/resolvers/sql.ts
+++ b/app/graphql/resolvers/sql.ts
@@ -218,3 +218,9 @@ export const dataCubePreview: NonNullable<
     observations: [],
   };
 };
+
+export const allTermsets: NonNullable<
+  QueryResolvers["allTermsets"]
+> = async () => {
+  return [];
+};

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -114,6 +114,11 @@ input DataCubePreviewFilter {
   iri: String!
 }
 
+type TermsetCount {
+  termset: Termset!
+  count: Int!
+}
+
 # The "Query" type is special: it lists all of the available queries that
 # clients can execute, along with the return type for each.
 type Query {
@@ -174,4 +179,9 @@ type Query {
     sourceUrl: String!
     locale: String!
   ): GeoShapes
+  allTermsets(
+    sourceType: String!
+    sourceUrl: String!
+    locale: String!
+  ): [TermsetCount!]!
 }

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -72,7 +72,7 @@ enum SearchCubeFilterType {
   DataCubeTheme
   DataCubeOrganization
   DataCubeAbout
-  SharedDimensions
+  Termset
 }
 
 input SearchCubeFilter {
@@ -183,5 +183,6 @@ type Query {
     sourceType: String!
     sourceUrl: String!
     locale: String!
+    includeDrafts: Boolean
   ): [TermsetCount!]!
 }

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -45,6 +45,10 @@ msgid "browse-panel.organizations"
 msgstr "Organisationen"
 
 #: app/browser/dataset-browse.tsx
+msgid "browse-panel.termsets"
+msgstr "Konzepte"
+
+#: app/browser/dataset-browse.tsx
 msgid "browse-panel.themes"
 msgstr "Kategorien"
 
@@ -1107,12 +1111,24 @@ msgid "dataset.search.placeholder"
 msgstr "Name, Organisation, Stichwort..."
 
 #: app/configurator/components/add-dataset-dialog.tsx
+msgid "dataset.search.preview.datasets"
+msgstr "Datensätze"
+
+#: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.preview.description"
 msgstr "Überprüfen Sie die Datenvorschau der neuen verfügbaren Dimensionen und bearbeiten Sie die Visualisierung weiter."
 
 #: app/configurator/components/add-dataset-dialog.tsx
+msgid "dataset.search.preview.dimensions"
+msgstr "Dimensionen"
+
+#: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.preview.dimensions-shown"
 msgstr "{0} dargestellt"
+
+#: app/configurator/components/add-dataset-dialog.tsx
+msgid "dataset.search.preview.new-dimension"
+msgstr "Neue"
 
 #: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.preview.title"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -45,6 +45,10 @@ msgid "browse-panel.organizations"
 msgstr "Organizations"
 
 #: app/browser/dataset-browse.tsx
+msgid "browse-panel.termsets"
+msgstr "Concepts"
+
+#: app/browser/dataset-browse.tsx
 msgid "browse-panel.themes"
 msgstr "Categories"
 
@@ -1107,12 +1111,24 @@ msgid "dataset.search.placeholder"
 msgstr "Name, organization, keyword..."
 
 #: app/configurator/components/add-dataset-dialog.tsx
+msgid "dataset.search.preview.datasets"
+msgstr "Datasets"
+
+#: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.preview.description"
 msgstr "Review data preview of new available dimensions and continue to edit visualization."
 
 #: app/configurator/components/add-dataset-dialog.tsx
+msgid "dataset.search.preview.dimensions"
+msgstr "Dimensions"
+
+#: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.preview.dimensions-shown"
 msgstr "{0} shown"
+
+#: app/configurator/components/add-dataset-dialog.tsx
+msgid "dataset.search.preview.new-dimension"
+msgstr "New"
 
 #: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.preview.title"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -45,6 +45,10 @@ msgid "browse-panel.organizations"
 msgstr "Organisations"
 
 #: app/browser/dataset-browse.tsx
+msgid "browse-panel.termsets"
+msgstr "Concepts"
+
+#: app/browser/dataset-browse.tsx
 msgid "browse-panel.themes"
 msgstr "Catégories"
 
@@ -1107,12 +1111,24 @@ msgid "dataset.search.placeholder"
 msgstr "Nom, organisation, mots clés..."
 
 #: app/configurator/components/add-dataset-dialog.tsx
+msgid "dataset.search.preview.datasets"
+msgstr "Ensemble de données"
+
+#: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.preview.description"
 msgstr "Examinez l’aperçu des données des nouvelles dimensions disponibles puis continuez à modifier la visualisation."
 
 #: app/configurator/components/add-dataset-dialog.tsx
+msgid "dataset.search.preview.dimensions"
+msgstr "Dimensions"
+
+#: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.preview.dimensions-shown"
 msgstr "{0} affichée(s) "
+
+#: app/configurator/components/add-dataset-dialog.tsx
+msgid "dataset.search.preview.new-dimension"
+msgstr "Nouveau"
 
 #: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.preview.title"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -45,6 +45,10 @@ msgid "browse-panel.organizations"
 msgstr "Organizzazioni"
 
 #: app/browser/dataset-browse.tsx
+msgid "browse-panel.termsets"
+msgstr "Concetti"
+
+#: app/browser/dataset-browse.tsx
 msgid "browse-panel.themes"
 msgstr "Categorie"
 
@@ -1107,12 +1111,24 @@ msgid "dataset.search.placeholder"
 msgstr "Nome, organizzazione, parola chiave..."
 
 #: app/configurator/components/add-dataset-dialog.tsx
+msgid "dataset.search.preview.datasets"
+msgstr "Set di dati"
+
+#: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.preview.description"
 msgstr "Examinez l’aperçu des données des nouvelles dimensions disponibles puis continuez à modifier la visualisation."
 
 #: app/configurator/components/add-dataset-dialog.tsx
+msgid "dataset.search.preview.dimensions"
+msgstr "Dimensioni"
+
+#: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.preview.dimensions-shown"
 msgstr "{0} mostrate"
+
+#: app/configurator/components/add-dataset-dialog.tsx
+msgid "dataset.search.preview.new-dimension"
+msgstr "Nuovo"
 
 #: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.preview.title"

--- a/app/rdf/query-cube-termsets.ts
+++ b/app/rdf/query-cube-termsets.ts
@@ -36,6 +36,7 @@ SELECT DISTINCT ?termsetIri ?termsetLabel WHERE {
   return qs.map((result) => ({
     iri: result.termsetIri.value,
     label: result.termsetLabel.value,
+    __typename: "Termset",
   }));
 };
 
@@ -81,6 +82,10 @@ SELECT DISTINCT ?dimensionIri ?dimensionLabel ?termsetIri ?termsetLabel WHERE {
   return grouped.map(([dimensionIri, termsets]) => ({
     iri: dimensionIri,
     label: termsets[0].dimensionLabel,
-    termsets: termsets.map(({ iri, label }) => ({ iri, label })),
+    termsets: termsets.map(({ iri, label }) => ({
+      iri,
+      label,
+      __typename: "Termset",
+    })),
   }));
 };

--- a/app/rdf/query-search.ts
+++ b/app/rdf/query-search.ts
@@ -38,7 +38,7 @@ const fanOutExclusiveFilters = (
   }
 
   const { exclusive = [], common = [] } = groupBy(filters, (f) => {
-    return f.type === SearchCubeFilterType.SharedDimensions ||
+    return f.type === SearchCubeFilterType.Termset ||
       f.type === SearchCubeFilterType.TemporalDimension
       ? "exclusive"
       : "common";
@@ -224,7 +224,7 @@ const mkScoresQuery = (
               }
             )}
           `;
-          } else if (df.type === SearchCubeFilterType.SharedDimensions) {
+          } else if (df.type === SearchCubeFilterType.Termset) {
             const sharedDimensions = df.value.split(";");
             return `
             VALUES (?termsetIri) {${sharedDimensions.map((sd) => `(<${sd}>)`).join(" ")}}

--- a/app/rdf/query-termsets.ts
+++ b/app/rdf/query-termsets.ts
@@ -1,7 +1,6 @@
-import groupBy from "lodash/groupBy";
 import ParsingClient from "sparql-http-client/ParsingClient";
 
-import { ComponentTermsets, Termset } from "@/domain/data";
+import { Termset } from "@/domain/data";
 import {
   buildLocalizedSubQuery,
   makeVisualizeDatasetFilter,
@@ -43,55 +42,5 @@ SELECT DISTINCT (COUNT(distinct ?iri) as ?count) ?termsetIri ?termsetLabel WHERE
       iri: result.termsetIri.value,
       label: result.termsetLabel.value,
     },
-  }));
-};
-
-export const getCubeComponentTermsets = async (
-  iri: string,
-  options: {
-    locale: string;
-    sparqlClient: ParsingClient;
-  }
-): Promise<ComponentTermsets[]> => {
-  const { sparqlClient, locale } = options;
-  const query = `PREFIX cube: <https://cube.link/>
-PREFIX meta: <https://cube.link/meta/>
-PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
-PREFIX schema: <http://schema.org/>
-PREFIX sh: <http://www.w3.org/ns/shacl#>
-
-SELECT DISTINCT ?dimensionIri ?dimensionLabel ?termsetIri ?termsetLabel WHERE {
-  VALUES (?iri) {(<${iri}>)}
-
-  ?iri cube:observationConstraint/sh:property ?dimension .
-  ?dimension sh:path ?dimensionIri .
-  ?dimension a cube:KeyDimension .
-  ?dimension sh:in/rdf:rest*/rdf:first ?value.
-  ?value schema:inDefinedTermSet ?termsetIri .
-  ?termsetIri a meta:SharedDimension .
-
-  ${buildLocalizedSubQuery("dimension", "schema:name", "dimensionLabel", { locale })}
-  ${buildLocalizedSubQuery("termsetIri", "schema:name", "termsetLabel", { locale })}
-  
-}`;
-  const qs = await sparqlClient.query.select(query);
-
-  const parsed = qs.map((result) => ({
-    dimensionIri: result.dimensionIri.value,
-    dimensionLabel: result.dimensionLabel.value,
-    iri: result.termsetIri.value,
-    label: result.termsetLabel.value,
-  }));
-
-  const grouped = Object.entries(groupBy(parsed, (r) => r.dimensionIri));
-
-  return grouped.map(([dimensionIri, termsets]) => ({
-    iri: dimensionIri,
-    label: termsets[0].dimensionLabel,
-    termsets: termsets.map(({ iri, label }) => ({
-      iri,
-      label,
-      __typename: "Termset",
-    })),
   }));
 };

--- a/app/rdf/query-termsets.ts
+++ b/app/rdf/query-termsets.ts
@@ -1,0 +1,82 @@
+import groupBy from "lodash/groupBy";
+import ParsingClient from "sparql-http-client/ParsingClient";
+
+import { ComponentTermsets, Termset } from "@/domain/data";
+import { buildLocalizedSubQuery } from "@/rdf/query-utils";
+
+export const queryAllTermsets = async (options: {
+  locale: string;
+  sparqlClient: ParsingClient;
+}): Promise<{ termset: Termset; count: number }[]> => {
+  const { sparqlClient, locale } = options;
+  const qs = await sparqlClient.query.select(
+    `PREFIX cube: <https://cube.link/>
+PREFIX meta: <https://cube.link/meta/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX schema: <http://schema.org/>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+
+SELECT DISTINCT (COUNT(distinct ?iri) as ?count) ?termsetIri ?termsetLabel WHERE {
+    ?iri cube:observationConstraint/sh:property ?dimension .
+    ?dimension a cube:KeyDimension .
+    ?dimension sh:in/rdf:rest*/rdf:first ?value.
+    ?value schema:inDefinedTermSet ?termsetIri .
+    ?termsetIri a meta:SharedDimension .
+    ${buildLocalizedSubQuery("termsetIri", "schema:name", "termsetLabel", { locale })}
+  }      GROUP BY ?termsetIri ?termsetLabel`
+  );
+
+  return qs.map((result) => ({
+    count: Number(result.count.value),
+    termset: {
+      iri: result.termsetIri.value,
+      label: result.termsetLabel.value,
+    },
+  }));
+};
+
+export const getCubeComponentTermsets = async (
+  iri: string,
+  options: {
+    locale: string;
+    sparqlClient: ParsingClient;
+  }
+): Promise<ComponentTermsets[]> => {
+  const { sparqlClient, locale } = options;
+  const query = `PREFIX cube: <https://cube.link/>
+PREFIX meta: <https://cube.link/meta/>
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX schema: <http://schema.org/>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+
+SELECT DISTINCT ?dimensionIri ?dimensionLabel ?termsetIri ?termsetLabel WHERE {
+  VALUES (?iri) {(<${iri}>)}
+
+  ?iri cube:observationConstraint/sh:property ?dimension .
+  ?dimension sh:path ?dimensionIri .
+  ?dimension a cube:KeyDimension .
+  ?dimension sh:in/rdf:rest*/rdf:first ?value.
+  ?value schema:inDefinedTermSet ?termsetIri .
+  ?termsetIri a meta:SharedDimension .
+
+  ${buildLocalizedSubQuery("dimension", "schema:name", "dimensionLabel", { locale })}
+  ${buildLocalizedSubQuery("termsetIri", "schema:name", "termsetLabel", { locale })}
+  
+}`;
+  const qs = await sparqlClient.query.select(query);
+
+  const parsed = qs.map((result) => ({
+    dimensionIri: result.dimensionIri.value,
+    dimensionLabel: result.dimensionLabel.value,
+    iri: result.termsetIri.value,
+    label: result.termsetLabel.value,
+  }));
+
+  const grouped = Object.entries(groupBy(parsed, (r) => r.dimensionIri));
+
+  return grouped.map(([dimensionIri, termsets]) => ({
+    iri: dimensionIri,
+    label: termsets[0].dimensionLabel,
+    termsets: termsets.map(({ iri, label }) => ({ iri, label })),
+  }));
+};


### PR DESCRIPTION
Adds a section in the search page to filter cubes per termsets.

<img width="545" alt="image" src="https://github.com/visualize-admin/visualization-tool/assets/465582/5b11df09-0f2e-4901-91df-696b387a399e">


- [ ] I could not find yet why the counts are not correct, it seems like my query is correct ?
   The visualize filter is there. I have added the `distinct` in the count clause when
   counting by cube, since multiple dimensions of the same cube might have the termset.

```
PREFIX cube: <https://cube.link/>
  PREFIX meta: <https://cube.link/meta/>
  PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
  PREFIX schema: <http://schema.org/>
  PREFIX sh: <http://www.w3.org/ns/shacl#>
  
  SELECT DISTINCT (COUNT(distinct ?iri) as ?count) ?termsetIri ?termsetLabel WHERE {
      ?iri cube:observationConstraint/sh:property ?dimension .
      ?dimension a cube:KeyDimension .
      ?dimension sh:in/rdf:rest*/rdf:first ?value.
      ?value schema:inDefinedTermSet ?termsetIri .
      ?termsetIri a meta:SharedDimension .
      OPTIONAL { ?termsetIri schema:name ?termsetLabel_en . FILTER(LANG(?termsetLabel_en) = "en") }
OPTIONAL { ?termsetIri schema:name ?termsetLabel_de . FILTER(LANG(?termsetLabel_de) = "de") }
OPTIONAL { ?termsetIri schema:name ?termsetLabel_fr . FILTER(LANG(?termsetLabel_fr) = "fr") }
OPTIONAL { ?termsetIri schema:name ?termsetLabel_it . FILTER(LANG(?termsetLabel_it) = "it") }
OPTIONAL { ?termsetIri schema:name ?termsetLabel_ . FILTER(LANG(?termsetLabel_) = "") }
BIND(COALESCE(?termsetLabel_en, ?termsetLabel_de, ?termsetLabel_fr, ?termsetLabel_it, ?termsetLabel_) AS ?termsetLabel)
  
      
    ?iri schema:workExample <https://ld.admin.ch/application/visualize> .
    ?iri schema:creativeWorkStatus <https://ld.admin.ch/vocabulary/CreativeWorkStatus/Published> .
    ?iri cube:observationConstraint ?shape .
    FILTER NOT EXISTS { ?iri schema:expires ?expiryDate }
  
    }      GROUP BY ?termsetIri ?termsetLabel
```

