### PR TITLE
fix: Removing of optional filters

### DIFF
--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -429,8 +429,7 @@ const useFilterReorder = ({
     dispatch({
       type: "CHART_CONFIG_FILTER_REMOVE_SINGLE",
       value: {
-        cubeIri: dimension.cubeIri,
-        dimensionIri: dimension.iri,
+        filters: dimensionToFieldProps(dimension),
       },
     });
   });

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -457,15 +457,24 @@ export const useSingleFilterSelect = (
     ) => void
   >(
     (e) => {
-      dispatch({
-        type: "CHART_CONFIG_FILTER_SET_SINGLE",
-        value: {
-          filters,
-          value: (e.target.value === ""
-            ? FIELD_VALUE_NONE
-            : e.target.value) as string,
-        },
-      });
+      const value = e.target.value as string;
+
+      if (value === FIELD_VALUE_NONE) {
+        dispatch({
+          type: "CHART_CONFIG_FILTER_REMOVE_SINGLE",
+          value: {
+            filters,
+          },
+        });
+      } else {
+        dispatch({
+          type: "CHART_CONFIG_FILTER_SET_SINGLE",
+          value: {
+            filters,
+            value: value === "" ? FIELD_VALUE_NONE : value,
+          },
+        });
+      }
     },
     [dispatch, filters]
   );

--- a/app/configurator/configurator-state.tsx
+++ b/app/configurator/configurator-state.tsx
@@ -246,8 +246,10 @@ export type ConfiguratorStateAction =
   | {
       type: "CHART_CONFIG_FILTER_REMOVE_SINGLE";
       value: {
-        cubeIri: string;
-        dimensionIri: string;
+        filters: {
+          cubeIri: string;
+          dimensionIri: string;
+        }[];
       };
     }
   | {
@@ -1303,18 +1305,22 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
 
     case "CHART_CONFIG_FILTER_REMOVE_SINGLE":
       if (isConfiguring(draft)) {
-        const { cubeIri, dimensionIri } = action.value;
+        const { filters } = action.value;
         const chartConfig = getChartConfig(draft);
-        const cube = chartConfig.cubes.find((cube) => cube.iri === cubeIri);
 
-        if (cube) {
-          delete cube.filters[dimensionIri];
-          const newIFConfig = toggleInteractiveFilterDataDimension(
-            chartConfig.interactiveFiltersConfig,
-            dimensionIri,
-            false
-          );
-          chartConfig.interactiveFiltersConfig = newIFConfig;
+        for (const filter of filters) {
+          const { cubeIri, dimensionIri } = filter;
+          const cube = chartConfig.cubes.find((cube) => cube.iri === cubeIri);
+
+          if (cube) {
+            delete cube.filters[dimensionIri];
+            const newIFConfig = toggleInteractiveFilterDataDimension(
+              chartConfig.interactiveFiltersConfig,
+              dimensionIri,
+              false
+            );
+            chartConfig.interactiveFiltersConfig = newIFConfig;
+          }
         }
       }
 


### PR DESCRIPTION
This PR fixes removing of optional data filters by choosing `No filter` option.

## How to test
### PR
1. Go to [this link](https://visualization-tool-git-fix-removing-optional-dimensions-ixt1.vercel.app/en/create/new?cube=https://environment.ld.admin.ch/foen/gefahren-waldbrand-warnung/1&dataSource=Prod).
2. Add `Active since` filter.
3. Change filter value to `No filter`.
4. ✅ See that the filter was correctly removed.

### TEST
1. Go to [this link](https://test.visualize.admin.ch/en/create/new?cube=https://environment.ld.admin.ch/foen/gefahren-waldbrand-warnung/1&dataSource=Prod).
2. Add `Active since` filter.
3. Change filter value to `No filter`.
4. ❌ See that the filter was not removed and that there's a PossibleFilters error.