### PR TITLE
Remove React member expressions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": "next",
-  "plugins": ["import", "visualize-admin", "jest"],
+  "plugins": ["import", "visualize-admin", "jest", "deprecate"],
   "rules": {
     "no-restricted-imports": [
       "error",
@@ -18,6 +18,16 @@
     "visualize-admin/no-large-sx": "error",
     "visualize-admin/make-styles": "error",
     "@next/next/no-html-link-for-pages": ["error", "app/pages/"],
+    "deprecate/member-expression": [
+      "error",
+      { "name": "React.useMemo", "use": "named import" },
+      { "name": "React.memo", "use": "named import" },
+      { "name": "React.useState", "use": "named import" },
+      { "name": "React.useEffect", "use": "named import" },
+      { "name": "React.useReducer", "use": "named import" },
+      { "name": "React.use", "use": "named import" },
+      { "name": "React.useMemo", "use": "named import" }
+    ],
     "import/order": [
       2,
       {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,13 +20,18 @@
     "@next/next/no-html-link-for-pages": ["error", "app/pages/"],
     "deprecate/member-expression": [
       "error",
-      { "name": "React.useMemo", "use": "named import" },
-      { "name": "React.memo", "use": "named import" },
-      { "name": "React.useState", "use": "named import" },
-      { "name": "React.useEffect", "use": "named import" },
-      { "name": "React.useReducer", "use": "named import" },
-      { "name": "React.use", "use": "named import" },
-      { "name": "React.useMemo", "use": "named import" }
+      { "name": "useMemo", "use": "named import" },
+      { "name": "useState", "use": "named import" },
+      { "name": "useContext", "use": "named import" },
+      { "name": "useEffect", "use": "named import" },
+      { "name": "createContext", "use": "named import" },
+      { "name": "useReducer", "use": "named import" },
+      { "name": "memo", "use": "named import" },
+      { "name": "forwardRef", "use": "named import" },
+      { "name": "useRef", "use": "named import" },
+      { "name": "useCallback", "use": "named import" },
+      { "name": "useImperativeHandle", "use": "named import" },
+      { "name": "createElement", "use": "named import" }
     ],
     "import/order": [
       2,

--- a/app/browser/context.tsx
+++ b/app/browser/context.tsx
@@ -5,7 +5,14 @@ import pick from "lodash/pick";
 import pickBy from "lodash/pickBy";
 import Link from "next/link";
 import { Router, useRouter } from "next/router";
-import React, { useContext, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  createContext,
+} from "react";
 
 import { SearchCubeResultOrder } from "@/graphql/query-hooks";
 import { BrowseParams } from "@/pages/browse";
@@ -195,7 +202,7 @@ export const useBrowseState = () => {
 };
 
 export type BrowseState = ReturnType<typeof useBrowseState>;
-const BrowseContext = React.createContext<BrowseState | undefined>(undefined);
+const BrowseContext = createContext<BrowseState | undefined>(undefined);
 /**
  * Provides browse context to children below
  * Responsible for connecting the router to the browsing state

--- a/app/browser/dataset-browse.tsx
+++ b/app/browser/dataset-browse.tsx
@@ -766,7 +766,7 @@ export const SearchFilters = ({
       />
     ) : null;
 
-  const subthemes = React.useMemo(() => {
+  const subthemes = useMemo(() => {
     return sortBy(
       uniqBy(
         cubes.flatMap((d) => d.cube.subthemes),

--- a/app/browser/dataset-preview.tsx
+++ b/app/browser/dataset-preview.tsx
@@ -3,7 +3,7 @@ import { Box, Button, Paper, Theme, Typography } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import Head from "next/head";
 import Link from "next/link";
-import * as React from "react";
+import { useEffect } from "react";
 
 import { DataSetPreviewTable } from "@/browse/datatable";
 import { useFootnotesStyles } from "@/components/chart-footnotes";
@@ -110,7 +110,7 @@ export const DataSetPreview = ({
     descriptionPresent: !!metadata?.dataCubeMetadata.description,
   });
 
-  React.useEffect(() => {
+  useEffect(() => {
     window.scrollTo({ top: 0 });
   }, []);
 

--- a/app/charts/area/areas-state-props.ts
+++ b/app/charts/area/areas-state-props.ts
@@ -1,5 +1,5 @@
 import { ascending } from "d3-array";
-import React from "react";
+import { useCallback, useMemo } from "react";
 
 import { ChartProps } from "@/charts/shared/ChartProps";
 import { usePlottableData } from "@/charts/shared/chart-helpers";
@@ -44,7 +44,7 @@ export const useAreasStateVariables = (
   });
 
   const { getX } = temporalXVariables;
-  const sortData: AreasStateVariables["sortData"] = React.useCallback(
+  const sortData: AreasStateVariables["sortData"] = useCallback(
     (data) => {
       return [...data].sort((a, b) => {
         return ascending(getX(a), getX(b));
@@ -72,7 +72,7 @@ export const useAreasStateData = (
     getX,
     getY,
   });
-  const sortedPlottableData = React.useMemo(() => {
+  const sortedPlottableData = useMemo(() => {
     return sortData(plottableData);
   }, [sortData, plottableData]);
   const data = useChartData(sortedPlottableData, {

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -198,7 +198,7 @@ const useAreasState = (
     return group(chartData, getXAsString);
   }, [chartData, getXAsString, sumsByX, getY, yMeasure.iri, normalize]);
 
-  const chartWideData = React.useMemo(() => {
+  const chartWideData = useMemo(() => {
     return getWideData({
       dataGroupedByX: chartDataGroupedByX,
       xKey,

--- a/app/charts/area/areas.tsx
+++ b/app/charts/area/areas.tsx
@@ -1,5 +1,5 @@
 import { area } from "d3-shape";
-import React from "react";
+import React, { useMemo, useEffect, useRef } from "react";
 
 import { AreasState } from "@/charts/area/areas-state";
 import { RenderAreaDatum, renderAreas } from "@/charts/area/rendering-utils";
@@ -11,7 +11,7 @@ export const Areas = () => {
   const { bounds, getX, xScale, yScale, colors, series } =
     useChartState() as AreasState;
   const { margins } = bounds;
-  const ref = React.useRef<SVGGElement>(null);
+  const ref = useRef<SVGGElement>(null);
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
   const areaGenerator = area<$FixMe>()
@@ -19,7 +19,7 @@ export const Areas = () => {
     .x((d) => xScale(getX(d.data)))
     .y0((d) => yScale(d[0]))
     .y1((d) => yScale(d[1]));
-  const renderData: RenderAreaDatum[] = React.useMemo(() => {
+  const renderData: RenderAreaDatum[] = useMemo(() => {
     return series.map((d) => {
       return {
         key: `${d.key}`,
@@ -37,7 +37,7 @@ export const Areas = () => {
     });
   }, [series, areaGenerator, colors]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (ref.current) {
       renderContainer(ref.current, {
         id: "areas",

--- a/app/charts/chart-data-wrapper.tsx
+++ b/app/charts/chart-data-wrapper.tsx
@@ -1,7 +1,7 @@
 import { Box } from "@mui/material";
 import { AnimatePresence } from "framer-motion";
 import keyBy from "lodash/keyBy";
-import React from "react";
+import React, { useMemo, useEffect, createElement } from "react";
 
 import { A11yTable } from "@/charts/shared/a11y-table";
 import { useLoadingState } from "@/charts/shared/chart-loading-state";
@@ -122,11 +122,11 @@ export const ChartDataWrapper = <
   const error =
     propError || metadataError || componentsError || observationsError;
 
-  React.useEffect(() => {
+  useEffect(() => {
     chartLoadingState.set("data", fetching);
   }, [chartLoadingState, fetching]);
 
-  const { dimensionsByIri, measuresByIri } = React.useMemo(() => {
+  const { dimensionsByIri, measuresByIri } = useMemo(() => {
     return {
       dimensionsByIri: keyBy(dimensions ?? [], (d) => d.iri),
       measuresByIri: keyBy(measures ?? [], (d) => d.iri),
@@ -165,7 +165,7 @@ export const ChartDataWrapper = <
           />
         )}
 
-        {React.createElement(Component, {
+        {createElement(Component, {
           observations,
           dimensions,
           dimensionsByIri,

--- a/app/charts/column/columns-grouped-state-props.ts
+++ b/app/charts/column/columns-grouped-state-props.ts
@@ -1,6 +1,6 @@
 import { ascending, rollup, sum } from "d3-array";
 import orderBy from "lodash/orderBy";
-import React from "react";
+import { useCallback, useMemo } from "react";
 
 import { usePlottableData } from "@/charts/shared/chart-helpers";
 import {
@@ -68,7 +68,7 @@ export const useColumnsGroupedStateVariables = (
 
   const { getX } = bandXVariables;
   const { getY } = numericalYVariables;
-  const sortData: ColumnsGroupedStateVariables["sortData"] = React.useCallback(
+  const sortData: ColumnsGroupedStateVariables["sortData"] = useCallback(
     (data) => {
       const { sortingOrder, sortingType } = x.sorting ?? {};
       const order = [
@@ -120,7 +120,7 @@ export const useColumnsGroupedStateData = (
   const plottableData = usePlottableData(observations, {
     getY,
   });
-  const sortedPlottableData = React.useMemo(() => {
+  const sortedPlottableData = useMemo(() => {
     return sortData(plottableData);
   }, [sortData, plottableData]);
   const data = useChartData(sortedPlottableData, {

--- a/app/charts/column/columns-grouped.tsx
+++ b/app/charts/column/columns-grouped.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo, useEffect, useRef } from "react";
 
 import { GroupedColumnsState } from "@/charts/column/columns-grouped-state";
 import {
@@ -25,10 +25,10 @@ export const ErrorWhiskers = () => {
     showYStandardError,
   } = useChartState() as GroupedColumnsState;
   const { margins } = bounds;
-  const ref = React.useRef<SVGGElement>(null);
+  const ref = useRef<SVGGElement>(null);
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
-  const renderData: RenderWhiskerDatum[] = React.useMemo(() => {
+  const renderData: RenderWhiskerDatum[] = useMemo(() => {
     if (!getYErrorRange || !showYStandardError) {
       return [];
     }
@@ -62,7 +62,7 @@ export const ErrorWhiskers = () => {
     yScale,
   ]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (ref.current) {
       renderContainer(ref.current, {
         id: "columns-grouped-error-whiskers",
@@ -94,13 +94,13 @@ export const ColumnsGrouped = () => {
     grouped,
     getRenderingKey,
   } = useChartState() as GroupedColumnsState;
-  const ref = React.useRef<SVGGElement>(null);
+  const ref = useRef<SVGGElement>(null);
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
   const { margins } = bounds;
   const bandwidth = xScaleIn.bandwidth();
   const y0 = yScale(0);
-  const renderData: RenderColumnDatum[] = React.useMemo(() => {
+  const renderData: RenderColumnDatum[] = useMemo(() => {
     return grouped.flatMap(([segment, observations]) => {
       return observations.map((d) => {
         const key = getRenderingKey(d, getSegment(d));
@@ -130,7 +130,7 @@ export const ColumnsGrouped = () => {
     getRenderingKey,
   ]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (ref.current) {
       renderContainer(ref.current, {
         id: "columns-grouped",

--- a/app/charts/column/columns-stacked-state-props.ts
+++ b/app/charts/column/columns-stacked-state-props.ts
@@ -1,5 +1,5 @@
 import { ascending, descending, group } from "d3-array";
-import React from "react";
+import { useCallback, useMemo } from "react";
 
 import { getWideData, usePlottableData } from "@/charts/shared/chart-helpers";
 import {
@@ -58,7 +58,7 @@ export const useColumnsStackedStateVariables = (
   });
 
   const { getX } = bandXVariables;
-  const sortData: ColumnsStackedStateVariables["sortData"] = React.useCallback(
+  const sortData: ColumnsStackedStateVariables["sortData"] = useCallback(
     (data, { plottableDataWide }) => {
       const { sortingOrder, sortingType } = x.sorting ?? {};
       const xOrder = plottableDataWide
@@ -122,7 +122,7 @@ export const useColumnsStackedStateData = (
   const plottableData = usePlottableData(observations, {
     getY,
   });
-  const { sortedPlottableData, plottableDataWide } = React.useMemo(() => {
+  const { sortedPlottableData, plottableDataWide } = useMemo(() => {
     const plottableDataByX = group(plottableData, getX);
     const plottableDataWide = getWideData({
       dataGroupedByX: plottableDataByX,

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -195,7 +195,7 @@ const useColumnsStackedState = (
     return group(chartData, getX);
   }, [chartData, getX, sumsByX, getY, yMeasure.iri, normalize]);
 
-  const chartWideData = React.useMemo(() => {
+  const chartWideData = useMemo(() => {
     return getWideData({
       dataGroupedByX: chartDataGroupedByX,
       xKey,
@@ -305,7 +305,7 @@ const useColumnsStackedState = (
   ]);
 
   const animationIri = fields.animation?.componentIri;
-  const getAnimation = React.useCallback(
+  const getAnimation = useCallback(
     (d: Observation) => {
       return animationIri ? (d[animationIri] as string) : "";
     },

--- a/app/charts/column/columns-stacked.tsx
+++ b/app/charts/column/columns-stacked.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo, useEffect, useRef } from "react";
 
 import { StackedColumnsState } from "@/charts/column/columns-stacked-state";
 import {
@@ -10,7 +10,7 @@ import { renderContainer } from "@/charts/shared/rendering-utils";
 import { useTransitionStore } from "@/stores/transition";
 
 export const ColumnsStacked = () => {
-  const ref = React.useRef<SVGGElement>(null);
+  const ref = useRef<SVGGElement>(null);
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
   const { bounds, getX, xScale, yScale, colors, series, getRenderingKey } =
@@ -18,7 +18,7 @@ export const ColumnsStacked = () => {
   const { margins } = bounds;
   const bandwidth = xScale.bandwidth();
   const y0 = yScale(0);
-  const renderData: RenderColumnDatum[] = React.useMemo(() => {
+  const renderData: RenderColumnDatum[] = useMemo(() => {
     return series.flatMap((d) => {
       const color = colors(d.key);
 
@@ -37,7 +37,7 @@ export const ColumnsStacked = () => {
     });
   }, [bandwidth, colors, getX, series, xScale, yScale, getRenderingKey]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (ref.current) {
       renderContainer(ref.current, {
         id: "columns-stacked",

--- a/app/charts/column/columns-state-props.ts
+++ b/app/charts/column/columns-state-props.ts
@@ -1,5 +1,5 @@
 import { ascending, descending } from "d3-array";
-import React from "react";
+import { useCallback, useMemo } from "react";
 
 import { usePlottableData } from "@/charts/shared/chart-helpers";
 import {
@@ -59,7 +59,7 @@ export const useColumnsStateVariables = (
 
   const { getX } = bandXVariables;
   const { getY } = numericalYVariables;
-  const sortData: ColumnsStateVariables["sortData"] = React.useCallback(
+  const sortData: ColumnsStateVariables["sortData"] = useCallback(
     (data) => {
       const { sortingOrder, sortingType } = x.sorting ?? {};
       if (sortingOrder === "desc" && sortingType === "byDimensionLabel") {
@@ -107,7 +107,7 @@ export const useColumnsStateData = (
   const plottableData = usePlottableData(observations, {
     getY,
   });
-  const sortedPlottableData = React.useMemo(() => {
+  const sortedPlottableData = useMemo(() => {
     return sortData(plottableData);
   }, [sortData, plottableData]);
   const data = useChartData(sortedPlottableData, {

--- a/app/charts/column/columns.tsx
+++ b/app/charts/column/columns.tsx
@@ -1,5 +1,5 @@
 import { schemeCategory10 } from "d3-scale-chromatic";
-import React from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 import { ColumnsState } from "@/charts/column/columns-state";
 import {
@@ -26,10 +26,10 @@ export const ErrorWhiskers = () => {
     bounds,
   } = useChartState() as ColumnsState;
   const { margins } = bounds;
-  const ref = React.useRef<SVGGElement>(null);
+  const ref = useRef<SVGGElement>(null);
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
-  const renderData: RenderWhiskerDatum[] = React.useMemo(() => {
+  const renderData: RenderWhiskerDatum[] = useMemo(() => {
     if (!getYErrorRange || !showYStandardError) {
       return [];
     }
@@ -58,7 +58,7 @@ export const ErrorWhiskers = () => {
     yScale,
   ]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (ref.current) {
       renderContainer(ref.current, {
         id: "columns-error-whiskers",
@@ -83,12 +83,12 @@ export const Columns = () => {
     useChartState() as ColumnsState;
   const theme = useTheme();
   const { margins } = bounds;
-  const ref = React.useRef<SVGGElement>(null);
+  const ref = useRef<SVGGElement>(null);
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
   const bandwidth = xScale.bandwidth();
   const y0 = yScale(0);
-  const renderData: RenderColumnDatum[] = React.useMemo(() => {
+  const renderData: RenderColumnDatum[] = useMemo(() => {
     const getColor = (d: number) => {
       return d <= 0 ? theme.palette.secondary.main : schemeCategory10[0];
     };
@@ -124,7 +124,7 @@ export const Columns = () => {
     getRenderingKey,
   ]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (ref.current) {
       renderContainer(ref.current, {
         id: "columns",

--- a/app/charts/combo/axis-height-linear-dual.tsx
+++ b/app/charts/combo/axis-height-linear-dual.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 
 import { ComboLineColumnState } from "@/charts/combo/combo-line-column-state";
 import { ComboLineDualState } from "@/charts/combo/combo-line-dual-state";
@@ -23,7 +23,7 @@ export const AxisHeightLinearDual = (props: AxisHeightLinearDualProps) => {
   const { orientation = "left" } = props;
   const leftAligned = orientation === "left";
   const { gridColor, labelColor, axisLabelFontSize } = useChartTheme();
-  const [ref, setRef] = React.useState<SVGGElement | null>(null);
+  const [ref, setRef] = useState<SVGGElement | null>(null);
   const { y, yOrientationScales, colors, bounds, maxRightTickWidth } =
     useChartState() as ComboLineDualState | ComboLineColumnState;
   const yScale = yOrientationScales[orientation];

--- a/app/charts/combo/chart-combo-line-column.tsx
+++ b/app/charts/combo/chart-combo-line-column.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo } from "react";
 
 import { ChartDataWrapper } from "@/charts/chart-data-wrapper";
 import { InteractionColumns } from "@/charts/column/overlay-columns";
@@ -21,7 +21,7 @@ export const ChartComboLineColumnVisualization = (
   return <ChartDataWrapper {...props} Component={ChartComboLineColumn} />;
 };
 
-export const ChartComboLineColumn = React.memo(
+export const ChartComboLineColumn = memo(
   (props: ChartProps<ComboLineColumnConfig>) => {
     const { chartConfig } = props;
     const { interactiveFiltersConfig } = chartConfig;

--- a/app/charts/combo/chart-combo-line-dual.tsx
+++ b/app/charts/combo/chart-combo-line-dual.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo } from "react";
 
 import { ChartDataWrapper } from "@/charts/chart-data-wrapper";
 import { AxisHeightLinearDual } from "@/charts/combo/axis-height-linear-dual";
@@ -21,7 +21,7 @@ export const ChartComboLineDualVisualization = (
   return <ChartDataWrapper {...props} Component={ChartComboLineDual} />;
 };
 
-export const ChartComboLineDual = React.memo(
+export const ChartComboLineDual = memo(
   (props: ChartProps<ComboLineDualConfig>) => {
     const { chartConfig } = props;
     const { interactiveFiltersConfig } = chartConfig;

--- a/app/charts/combo/chart-combo-line-single.tsx
+++ b/app/charts/combo/chart-combo-line-single.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { memo, useCallback } from "react";
 
 import { ChartDataWrapper } from "@/charts/chart-data-wrapper";
 import { ComboLineSingle } from "@/charts/combo/combo-line-single";
@@ -26,11 +26,11 @@ export const ChartComboLineSingleVisualization = (
   return <ChartDataWrapper {...props} Component={ChartComboLineSingle} />;
 };
 
-export const ChartComboLineSingle = React.memo(
+export const ChartComboLineSingle = memo(
   (props: ChartProps<ComboLineSingleConfig>) => {
     const { chartConfig, measures } = props;
     const { interactiveFiltersConfig } = chartConfig;
-    const getLegendItemDimension = React.useCallback(
+    const getLegendItemDimension = useCallback(
       (label: string) => {
         return measures.find((measure) => measure.label === label);
       },

--- a/app/charts/combo/combo-line-column-state-props.ts
+++ b/app/charts/combo/combo-line-column-state-props.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import { useCallback, useMemo } from "react";
 
 import { BaseYGetter, sortComboData } from "@/charts/combo/combo-state-props";
 import {
@@ -101,7 +101,7 @@ export const useComboLineColumnStateVariables = (
         };
 
   const { getXAsDate } = bandXVariables;
-  const sortData: ComboLineColumnStateVariables["sortData"] = React.useCallback(
+  const sortData: ComboLineColumnStateVariables["sortData"] = useCallback(
     (data) => {
       return sortComboData(data, {
         getX: getXAsDate,
@@ -144,7 +144,7 @@ export const useComboLineColumnStateData = (
       }
     },
   });
-  const sortedPlottableData = React.useMemo(() => {
+  const sortedPlottableData = useMemo(() => {
     return sortData(plottableData);
   }, [sortData, plottableData]);
   const data = useChartData(sortedPlottableData, {

--- a/app/charts/combo/combo-line-column.tsx
+++ b/app/charts/combo/combo-line-column.tsx
@@ -1,5 +1,5 @@
 import { line } from "d3-shape";
-import React from "react";
+import React, { useMemo, useEffect, memo, useRef } from "react";
 
 import {
   RenderColumnDatum,
@@ -23,7 +23,7 @@ const Columns = () => {
     getRenderingKey,
   } = useChartState() as ComboLineColumnState;
   const { margins } = bounds;
-  const ref = React.useRef<SVGGElement>(null);
+  const ref = useRef<SVGGElement>(null);
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
   const bandwidth = xScale.bandwidth();
@@ -33,7 +33,7 @@ const Columns = () => {
       ? yOrientationScales.left
       : yOrientationScales.right;
   const y0 = yScale(0);
-  const renderData: RenderColumnDatum[] = React.useMemo(() => {
+  const renderData: RenderColumnDatum[] = useMemo(() => {
     return chartData.map((d) => {
       const key = getRenderingKey(d);
       const xScaled = xScale(getX(d)) as number;
@@ -64,7 +64,7 @@ const Columns = () => {
     bandwidth,
   ]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (ref.current) {
       renderContainer(ref.current, {
         id: "columns",
@@ -118,7 +118,7 @@ type LineProps = {
   color: string;
 };
 
-const Line = React.memo(function Line(props: LineProps) {
+const Line = memo(function Line(props: LineProps) {
   const { path, color } = props;
 
   return <path d={path} stroke={color} strokeWidth={4} fill="none" />;

--- a/app/charts/combo/combo-line-dual-state-props.ts
+++ b/app/charts/combo/combo-line-dual-state-props.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import { useCallback, useMemo } from "react";
 
 import { BaseYGetter, sortComboData } from "@/charts/combo/combo-state-props";
 import {
@@ -70,7 +70,7 @@ export const useComboLineDualStateVariables = (
   };
 
   const { getX } = temporalXVariables;
-  const sortData: ComboLineDualStateVariables["sortData"] = React.useCallback(
+  const sortData: ComboLineDualStateVariables["sortData"] = useCallback(
     (data) => {
       return sortComboData(data, {
         getX,
@@ -105,7 +105,7 @@ export const useComboLineDualStateData = (
       }
     },
   });
-  const sortedPlottableData = React.useMemo(() => {
+  const sortedPlottableData = useMemo(() => {
     return sortData(plottableData);
   }, [sortData, plottableData]);
   const data = useChartData(sortedPlottableData, {

--- a/app/charts/combo/combo-line-dual.tsx
+++ b/app/charts/combo/combo-line-dual.tsx
@@ -1,5 +1,5 @@
 import { line } from "d3-shape";
-import React from "react";
+import React, { memo } from "react";
 
 import { ComboLineDualState } from "@/charts/combo/combo-line-dual-state";
 import { useChartState } from "@/charts/shared/chart-state";
@@ -37,7 +37,7 @@ type LineProps = {
   color: string;
 };
 
-const Line = React.memo(function Line(props: LineProps) {
+const Line = memo(function Line(props: LineProps) {
   const { path, color } = props;
 
   return <path d={path} stroke={color} fill="none" />;

--- a/app/charts/combo/combo-line-single-state-props.ts
+++ b/app/charts/combo/combo-line-single-state-props.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import { useCallback, useMemo } from "react";
 
 import { BaseYGetter, sortComboData } from "@/charts/combo/combo-state-props";
 import {
@@ -53,7 +53,7 @@ export const useComboLineSingleStateVariables = (
   };
 
   const { getX } = temporalXVariables;
-  const sortData: ComboLineSingleStateVariables["sortData"] = React.useCallback(
+  const sortData: ComboLineSingleStateVariables["sortData"] = useCallback(
     (data) => {
       return sortComboData(data, {
         getX,
@@ -88,7 +88,7 @@ export const useComboLineSingleStateData = (
       }
     },
   });
-  const sortedPlottableData = React.useMemo(() => {
+  const sortedPlottableData = useMemo(() => {
     return sortData(plottableData);
   }, [sortData, plottableData]);
   const data = useChartData(sortedPlottableData, {

--- a/app/charts/combo/combo-line-single.tsx
+++ b/app/charts/combo/combo-line-single.tsx
@@ -1,5 +1,5 @@
 import { line } from "d3-shape";
-import React from "react";
+import React, { memo } from "react";
 
 import { ComboLineSingleState } from "@/charts/combo/combo-line-single-state";
 import { useChartState } from "@/charts/shared/chart-state";
@@ -37,7 +37,7 @@ type LineProps = {
   color: string;
 };
 
-const Line = React.memo(function Line(props: LineProps) {
+const Line = memo(function Line(props: LineProps) {
   const { path, color } = props;
 
   return <path d={path} stroke={color} fill="none" />;

--- a/app/charts/combo/combo-state.ts
+++ b/app/charts/combo/combo-state.ts
@@ -1,6 +1,6 @@
 import { extent, groups, max, min, sum } from "d3-array";
 import { scaleLinear, scaleOrdinal, scaleTime } from "d3-scale";
-import React from "react";
+import { useMemo } from "react";
 
 import { useWidth } from "@/charts/shared/use-width";
 import { Observation } from "@/domain/data";
@@ -35,11 +35,11 @@ export const useCommonComboState = (options: UseCommonComboStateOptions) => {
   const formatNumber = useFormatNumber({ decimals: "auto" });
   const timeFormatUnit = useTimeFormatUnit();
 
-  const chartDataByX = React.useMemo(() => {
+  const chartDataByX = useMemo(() => {
     return groups(chartData, getXAsString).sort();
   }, [chartData, getXAsString]);
 
-  const chartWideData = React.useMemo(() => {
+  const chartWideData = useMemo(() => {
     const chartWideData: Observation[] = [];
 
     for (const [date, observations] of chartDataByX) {
@@ -63,17 +63,17 @@ export const useCommonComboState = (options: UseCommonComboStateOptions) => {
     return chartWideData;
   }, [computeTotal, chartDataByX, xKey, yGetters]);
 
-  const xScaleTime = React.useMemo(() => {
+  const xScaleTime = useMemo(() => {
     const domain = extent(chartData, getXAsDate) as [Date, Date];
     return scaleTime().domain(domain);
   }, [chartData, getXAsDate]);
 
-  const xScaleTimeRange = React.useMemo(() => {
+  const xScaleTimeRange = useMemo(() => {
     const domain = extent(timeRangeData, getXAsDate) as [Date, Date];
     return scaleTime().domain(domain);
   }, [getXAsDate, timeRangeData]);
 
-  const colors = React.useMemo(() => {
+  const colors = useMemo(() => {
     const domain = yGetters.map((d) => d.label);
     const range = yGetters.map((d) => d.color);
 

--- a/app/charts/line/lines-state-props.ts
+++ b/app/charts/line/lines-state-props.ts
@@ -1,5 +1,5 @@
 import { ascending } from "d3-array";
-import React from "react";
+import { useCallback, useMemo } from "react";
 
 import { usePlottableData } from "@/charts/shared/chart-helpers";
 import {
@@ -45,7 +45,7 @@ export const useLinesStateVariables = (
   });
 
   const { getX } = temporalXVariables;
-  const sortData: LinesStateVariables["sortData"] = React.useCallback(
+  const sortData: LinesStateVariables["sortData"] = useCallback(
     (data) => {
       return [...data].sort((a, b) => {
         return ascending(getX(a), getX(b));
@@ -74,7 +74,7 @@ export const useLinesStateData = (
   const plottableData = usePlottableData(observations, {
     getY,
   });
-  const sortedPlottableData = React.useMemo(() => {
+  const sortedPlottableData = useMemo(() => {
     return sortData(plottableData);
   }, [sortData, plottableData]);
   const data = useChartData(sortedPlottableData, {

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -56,7 +56,7 @@ export const ChartMapVisualization = (props: VisualizationProps<MapConfig>) => {
 
   const geoCoordinatesDimensionValues =
     geoCoordinatesDimension?.dataCubesComponents.dimensions[0].values;
-  const coordinates = React.useMemo(() => {
+  const coordinates = useMemo(() => {
     return geoCoordinatesDimensionValues
       ? dimensionValuesToGeoCoordinates(geoCoordinatesDimensionValues)
       : undefined;

--- a/app/charts/map/get-base-layer-style.ts
+++ b/app/charts/map/get-base-layer-style.ts
@@ -1,5 +1,5 @@
 import merge from "lodash/merge";
-import React from "react";
+import { useMemo } from "react";
 import { MapboxStyle } from "react-map-gl";
 
 import { BASE_VECTOR_TILE_URL, MAPTILER_STYLE_KEY } from "@/domain/env";
@@ -7,7 +7,7 @@ import { BASE_VECTOR_TILE_URL, MAPTILER_STYLE_KEY } from "@/domain/env";
 import { Locale } from "../../locales/locales";
 
 import greyStyleBase from "./grey.json";
-import { hasLayout, replaceStyleTokens, mapLayers } from "./style-helpers";
+import { hasLayout, mapLayers, replaceStyleTokens } from "./style-helpers";
 
 const tokens = {
   "{key}": MAPTILER_STYLE_KEY,
@@ -81,7 +81,7 @@ export const useMapStyle = ({
   showBaseLayer: boolean;
   showLabels: boolean;
 }): MapboxStyle => {
-  const style = React.useMemo(() => {
+  const style = useMemo(() => {
     if (showBaseLayer) {
       return getBaseLayerStyle({ locale, showLabels });
     } else {

--- a/app/charts/map/map-legend.tsx
+++ b/app/charts/map/map-legend.tsx
@@ -405,7 +405,7 @@ const useLegendWithRotatedAxisLabelsHeight = (
   }
 ) => {
   const { formatNumber, legendFontSize } = options;
-  const maxLabelHeight = React.useMemo(() => {
+  const maxLabelHeight = useMemo(() => {
     return getMaxRotatedAxisLabelHeight(values, {
       formatNumber,
       legendFontSize,

--- a/app/charts/map/map-state-props.ts
+++ b/app/charts/map/map-state-props.ts
@@ -1,6 +1,6 @@
 import { geoCentroid } from "d3-geo";
 import keyBy from "lodash/keyBy";
-import React from "react";
+import { useMemo } from "react";
 
 import { ChartMapProps } from "@/charts/map/chart-map";
 import { prepareFeatureCollection } from "@/charts/map/helpers";
@@ -98,7 +98,7 @@ export const useMapStateData = (
     chartConfig,
   });
 
-  const areaLayer = React.useMemo(() => {
+  const areaLayer = useMemo(() => {
     const iri = areaLayerDimension?.iri;
 
     if (!(iri && shapes)) {
@@ -118,7 +118,7 @@ export const useMapStateData = (
     };
   }, [areaLayerDimension?.iri, shapes, filters, data.chartData]);
 
-  const symbolLayer = React.useMemo(() => {
+  const symbolLayer = useMemo(() => {
     if (isGeoCoordinatesDimension(symbolLayerDimension) && coordinates) {
       const points: GeoPoint[] = [];
       const coordsByLabel = keyBy(coordinates, (d) => d.label);

--- a/app/charts/map/map.tsx
+++ b/app/charts/map/map.tsx
@@ -6,7 +6,7 @@ import { geoArea } from "d3-geo";
 import debounce from "lodash/debounce";
 import orderBy from "lodash/orderBy";
 import maplibreglraw from "maplibre-gl";
-import React, { useState } from "react";
+import React, { useState, useMemo, useEffect, useRef } from "react";
 import Map, { LngLatLike, MapboxEvent } from "react-map-gl";
 
 import "maplibre-gl/dist/maplibre-gl.css";
@@ -109,8 +109,8 @@ export const MapComponent = () => {
     featuresBBox,
   });
 
-  const lockedRef = React.useRef(locked);
-  React.useEffect(() => {
+  const lockedRef = useRef(locked);
+  useEffect(() => {
     lockedRef.current = locked;
   }, [locked]);
 
@@ -130,7 +130,7 @@ export const MapComponent = () => {
   });
 
   // Reset the view when default view changes (new features appeared on the map).
-  React.useEffect(() => {
+  useEffect(() => {
     reset();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [defaultViewState]);
@@ -191,7 +191,7 @@ export const MapComponent = () => {
     }
   );
 
-  const sortedShapes = React.useMemo(() => {
+  const sortedShapes = useMemo(() => {
     // Sort for smaller shapes to be over larger ones, to be able to use tooltip
     const sortedFeatures = orderBy(
       features.areaLayer?.shapes?.features,
@@ -205,7 +205,7 @@ export const MapComponent = () => {
     };
   }, [features.areaLayer?.shapes]);
 
-  const geoJsonLayer = React.useMemo(() => {
+  const geoJsonLayer = useMemo(() => {
     if (!areaLayer?.colors) {
       return;
     }
@@ -258,7 +258,7 @@ export const MapComponent = () => {
     });
   }, [areaLayer?.colors, sortedShapes, onHover, showBaseLayer]);
 
-  const hoverLayer = React.useMemo(() => {
+  const hoverLayer = useMemo(() => {
     if (!interaction.visible || !sortedShapes || !areaLayer) {
       return;
     }
@@ -295,7 +295,7 @@ export const MapComponent = () => {
     }
   }, [areaLayer, interaction.d, interaction.visible, sortedShapes]);
 
-  const scatterplotLayer = React.useMemo(() => {
+  const scatterplotLayer = useMemo(() => {
     if (!symbolLayer) {
       return;
     }

--- a/app/charts/pie/pie.tsx
+++ b/app/charts/pie/pie.tsx
@@ -1,5 +1,5 @@
 import { arc, PieArcDatum } from "d3-shape";
-import React from "react";
+import React, { useMemo, useEffect, useRef } from "react";
 
 import { PieState } from "@/charts/pie/pie-state";
 import { RenderDatum, renderPies } from "@/charts/pie/rendering-utils";
@@ -17,7 +17,7 @@ export const Pie = () => {
   const transitionDuration = useTransitionStore((state) => state.duration);
   const { width, height, chartWidth, chartHeight } = bounds;
   const [, dispatch] = useInteraction();
-  const ref = React.useRef<SVGGElement>(null);
+  const ref = useRef<SVGGElement>(null);
 
   const maxSide = Math.min(chartWidth, chartHeight) / 2;
 
@@ -28,7 +28,7 @@ export const Pie = () => {
   const yTranslate = height / 2;
 
   const arcs = getPieData(chartData);
-  const renderData: RenderDatum[] = React.useMemo(() => {
+  const renderData: RenderDatum[] = useMemo(() => {
     return arcs.map((arcDatum) => {
       return {
         key: getRenderingKey(arcDatum.data),
@@ -61,7 +61,7 @@ export const Pie = () => {
     });
   });
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (ref.current && renderData) {
       renderContainer(ref.current, {
         id: "pies",

--- a/app/charts/scatterplot/scatterplot.tsx
+++ b/app/charts/scatterplot/scatterplot.tsx
@@ -1,5 +1,5 @@
 import { schemeCategory10 } from "d3-scale-chromatic";
-import React from "react";
+import React, { useMemo, useEffect, useRef } from "react";
 
 import {
   RenderDatum,
@@ -24,10 +24,10 @@ export const Scatterplot = () => {
     getRenderingKey,
   } = useChartState() as ScatterplotState;
   const { margins } = bounds;
-  const ref = React.useRef<SVGGElement>(null);
+  const ref = useRef<SVGGElement>(null);
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
-  const renderData: RenderDatum[] = React.useMemo(() => {
+  const renderData: RenderDatum[] = useMemo(() => {
     return chartData.map((d) => {
       return {
         key: getRenderingKey(d),
@@ -48,7 +48,7 @@ export const Scatterplot = () => {
     getRenderingKey,
   ]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (ref.current && renderData) {
       renderContainer(ref.current, {
         id: "scatterplot",

--- a/app/charts/shared/abbreviations.ts
+++ b/app/charts/shared/abbreviations.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import { useCallback, useMemo } from "react";
 
 import { DimensionValue, Observation, ObservationValue } from "@/domain/data";
 
@@ -67,7 +67,7 @@ export const useMaybeAbbreviations = ({
   dimensionValues: DimensionValue[] | undefined;
 }) => {
   const { valueLookup, labelLookup, abbreviationOrLabelLookup } =
-    React.useMemo(() => {
+    useMemo(() => {
       const values = dimensionValues ?? [];
 
       const valueLookup = new Map<
@@ -95,7 +95,7 @@ export const useMaybeAbbreviations = ({
       };
     }, [dimensionValues, useAbbreviations]);
 
-  const getAbbreviationOrLabelByValue = React.useCallback(
+  const getAbbreviationOrLabelByValue = useCallback(
     (d: Observation) => {
       if (!dimensionIri) {
         return "";

--- a/app/charts/shared/axis-height-linear.tsx
+++ b/app/charts/shared/axis-height-linear.tsx
@@ -1,6 +1,6 @@
 import { axisLeft, axisRight } from "d3-axis";
 import { NumberValue, ScaleLinear } from "d3-scale";
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState, useCallback } from "react";
 
 import type { AreasState } from "@/charts/area/areas-state";
 import type { GroupedColumnsState } from "@/charts/column/columns-grouped-state";
@@ -26,7 +26,7 @@ export const TICK_PADDING = 6;
 
 export const AxisHeightLinear = () => {
   const { gridColor, labelColor, axisLabelFontSize } = useChartTheme();
-  const [ref, setRef] = React.useState<SVGGElement | null>(null);
+  const [ref, setRef] = useState<SVGGElement | null>(null);
   const state = useChartState() as
     | AreasState
     | ColumnsState
@@ -104,14 +104,14 @@ export const useRenderAxisHeightLinear = (
   const calculationType = useInteractiveFilters((d) => d.calculation.type);
   const normalized = calculationType === "percent";
   const ticks = getTickNumber(height);
-  const tickFormat = React.useCallback(
+  const tickFormat = useCallback(
     (d: NumberValue) => {
       return normalized ? `${formatNumber(d)}%` : formatNumber(d);
     },
     [formatNumber, normalized]
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (!container) {
       return;
     }

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -2,7 +2,7 @@ import { t, Trans } from "@lingui/macro";
 import { Box, Button, SelectChangeEvent, Typography } from "@mui/material";
 import isEmpty from "lodash/isEmpty";
 import isEqual from "lodash/isEqual";
-import * as React from "react";
+import React, { useMemo, useState, useEffect, useRef } from "react";
 import { useClient } from "urql";
 
 import { useQueryFilters } from "@/charts/shared/chart-helpers";
@@ -78,15 +78,15 @@ export const ChartDataFilters = (props: ChartDataFiltersProps) => {
     allowNoneValues: true,
     componentIris,
   });
-  const [filtersVisible, setFiltersVisible] = React.useState(false);
+  const [filtersVisible, setFiltersVisible] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (componentIris.length === 0) {
       setFiltersVisible(false);
     }
   }, [componentIris.length]);
 
-  const preparedFilters: PreparedFilter[] | undefined = React.useMemo(() => {
+  const preparedFilters: PreparedFilter[] | undefined = useMemo(() => {
     return chartConfig.cubes.map((cube) => {
       const cubeQueryFilters = queryFilters.find(
         (d) => d.iri === cube.iri
@@ -272,7 +272,7 @@ const DataFilter = (props: DataFilterProps) => {
   const dataFilterValue = dimension ? dataFilters[dimension.iri]?.value : null;
   const value = dataFilterValue ?? configFilterValue ?? FIELD_VALUE_NONE;
 
-  React.useEffect(() => {
+  useEffect(() => {
     const values = dimension?.values.map((d) => d.value) ?? [];
 
     // We only want to disable loading state when the filter is actually valid.
@@ -354,7 +354,7 @@ const DataFilterGenericDimension = (props: DataFilterGenericDimensionProps) => {
     message: "No Filter",
   });
   const options = propOptions ?? dimension.values;
-  const allOptions = React.useMemo(() => {
+  const allOptions = useMemo(() => {
     return isKeyDimension
       ? options
       : [
@@ -404,7 +404,7 @@ const DataFilterHierarchyDimension = (
     id: "controls.dimensionvalue.none",
     message: `No Filter`,
   });
-  const options = React.useMemo(() => {
+  const options = useMemo(() => {
     const opts = (
       hierarchy
         ? hierarchyToOptions(
@@ -472,7 +472,7 @@ const DataFilterTemporalDimension = ({
     id: "controls.dimensionvalue.none",
     message: "No Filter",
   });
-  const { minDate, maxDate, options, optionValues } = React.useMemo(() => {
+  const { minDate, maxDate, options, optionValues } = useMemo(() => {
     if (values.length) {
       const options = values.map((d) => {
         return {
@@ -554,19 +554,19 @@ const useEnsurePossibleInteractiveFilters = (
   const { dataSource, chartConfig, preparedFilters } = props;
   const [, dispatch] = useConfiguratorState();
   const loadingState = useLoadingState();
-  const [error, setError] = React.useState<Error>();
-  const lastFilters = React.useRef<Record<string, Filters>>({});
+  const [error, setError] = useState<Error>();
+  const lastFilters = useRef<Record<string, Filters>>({});
   const client = useClient();
   const IFRaw = useInteractiveFiltersRaw();
   const setDataFilters = useInteractiveFilters((d) => d.setDataFilters);
-  const filtersByCubeIri = React.useMemo(() => {
+  const filtersByCubeIri = useMemo(() => {
     return preparedFilters?.reduce<Record<string, PreparedFilter>>((acc, d) => {
       acc[d.cubeIri] = d;
       return acc;
     }, {});
   }, [preparedFilters]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const run = async () => {
       if (!filtersByCubeIri) {
         return;

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -1,7 +1,7 @@
 import { InternMap, sum } from "d3-array";
 import omitBy from "lodash/omitBy";
 import uniq from "lodash/uniq";
-import React, { useCallback, useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 import { useMaybeAbbreviations } from "@/charts/shared/abbreviations";
 import {
@@ -83,7 +83,7 @@ export const useQueryFilters = ({
   componentIris?: string[];
 }): DataCubeObservationFilter[] => {
   const allInteractiveDataFilters = useInteractiveFilters((d) => d.dataFilters);
-  return React.useMemo(() => {
+  return useMemo(() => {
     return chartConfig.cubes.map((cube) => {
       const cubeFilters = getChartConfigFilters(chartConfig.cubes, {
         cubeIri: cube.iri,
@@ -488,7 +488,7 @@ const getBaseWideData = ({
 
 const getIdentityIri = (iri: string) => `${iri}/__identity__`;
 export const useGetIdentityY = (iri: string) => {
-  return React.useCallback(
+  return useCallback(
     (d: Observation) => {
       return (d[getIdentityIri(iri)] as number | null) ?? null;
     },

--- a/app/charts/shared/chart-loading-state.tsx
+++ b/app/charts/shared/chart-loading-state.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { createContext, useContext, useMemo } from "react";
 import { useSyncExternalStore } from "use-sync-external-store/shim";
 
 import { Observable } from "@/utils/observables";
@@ -34,9 +34,7 @@ export class LoadingState extends Observable {
   }
 }
 
-const LoadingStateContext = React.createContext<LoadingState | undefined>(
-  undefined
-);
+const LoadingStateContext = createContext<LoadingState | undefined>(undefined);
 
 /** Used to consolidate loading state across different components.
  *
@@ -45,7 +43,7 @@ const LoadingStateContext = React.createContext<LoadingState | undefined>(
  * being fetched.
  */
 export const useLoadingState = () => {
-  const ctx = React.useContext(LoadingStateContext);
+  const ctx = useContext(LoadingStateContext);
 
   if (!ctx) {
     throw new Error(
@@ -59,6 +57,6 @@ export const useLoadingState = () => {
 };
 
 export const LoadingStateProvider = (props: React.PropsWithChildren<{}>) => {
-  const loadingState = React.useMemo(() => new LoadingState(), []);
+  const loadingState = useMemo(() => new LoadingState(), []);
   return <LoadingStateContext.Provider value={loadingState} {...props} />;
 };

--- a/app/charts/shared/chart-state.ts
+++ b/app/charts/shared/chart-state.ts
@@ -1,7 +1,7 @@
 import { ScaleTime } from "d3-scale";
 import get from "lodash/get";
 import overEvery from "lodash/overEvery";
-import React from "react";
+import { createContext, useContext, useMemo } from "react";
 
 import { AreasState } from "@/charts/area/areas-state";
 import { GroupedColumnsState } from "@/charts/column/columns-grouped-state";
@@ -82,10 +82,10 @@ export type CommonChartState = {
 };
 
 export type ColorsChartState = Has<ChartState, "colors">;
-export const ChartContext = React.createContext<ChartState>(undefined);
+export const ChartContext = createContext<ChartState>(undefined);
 
 export const useChartState = () => {
-  const ctx = React.useContext(ChartContext);
+  const ctx = useContext(ChartContext);
   if (ctx === undefined) {
     throw Error(
       "You need to wrap your component in <ChartContext.Provider /> to useChartState()"
@@ -415,7 +415,7 @@ export const useChartData = (
   const timeRangeToTime = interactiveTimeRange?.presets.to
     ? parseDate(interactiveTimeRange?.presets.to).getTime()
     : undefined;
-  const timeRangeFilters = React.useMemo(() => {
+  const timeRangeFilters = useMemo(() => {
     const timeRangeFilter: ValuePredicate | null =
       timeRangeFromTime && timeRangeToTime
         ? (d: Observation) => {
@@ -430,7 +430,7 @@ export const useChartData = (
   // interactive time range
   const interactiveFromTime = timeRange.from?.getTime();
   const interactiveToTime = timeRange.to?.getTime();
-  const interactiveTimeRangeFilters = React.useMemo(() => {
+  const interactiveTimeRangeFilters = useMemo(() => {
     const interactiveTimeRangeFilter: ValuePredicate | null =
       getXAsDate &&
       interactiveFromTime &&
@@ -456,7 +456,7 @@ export const useChartData = (
   const animationComponentIri = animationField?.componentIri ?? "";
   const getAnimationDate = useTemporalVariable(animationComponentIri);
   const getAnimationOrdinalDate = useStringVariable(animationComponentIri);
-  const interactiveTimeSliderFilters = React.useMemo(() => {
+  const interactiveTimeSliderFilters = useMemo(() => {
     const interactiveTimeSliderFilter: ValuePredicate | null =
       animationField?.componentIri && timeSlider.value
         ? (d: Observation) => {
@@ -481,7 +481,7 @@ export const useChartData = (
   ]);
 
   // interactive legend
-  const interactiveLegendFilters = React.useMemo(() => {
+  const interactiveLegendFilters = useMemo(() => {
     const legendItems = Object.keys(categories);
     const interactiveLegendFilter: ValuePredicate | null =
       interactiveFiltersConfig?.legend?.active && getSegmentAbbreviationOrLabel
@@ -497,7 +497,7 @@ export const useChartData = (
     interactiveFiltersConfig?.legend?.active,
   ]);
 
-  const chartData = React.useMemo(() => {
+  const chartData = useMemo(() => {
     return observations.filter(
       overEvery([
         ...interactiveLegendFilters,
@@ -512,7 +512,7 @@ export const useChartData = (
     interactiveTimeSliderFilters,
   ]);
 
-  const scalesData = React.useMemo(() => {
+  const scalesData = useMemo(() => {
     if (dynamicScales) {
       return chartData;
     } else {
@@ -528,15 +528,15 @@ export const useChartData = (
     interactiveTimeRangeFilters,
   ]);
 
-  const segmentData = React.useMemo(() => {
+  const segmentData = useMemo(() => {
     return observations.filter(overEvery(interactiveTimeRangeFilters));
   }, [observations, interactiveTimeRangeFilters]);
 
-  const timeRangeData = React.useMemo(() => {
+  const timeRangeData = useMemo(() => {
     return observations.filter(overEvery(timeRangeFilters));
   }, [observations, timeRangeFilters]);
 
-  const paddingData = React.useMemo(() => {
+  const paddingData = useMemo(() => {
     if (dynamicScales) {
       return chartData;
     } else {

--- a/app/charts/shared/containers.tsx
+++ b/app/charts/shared/containers.tsx
@@ -1,20 +1,20 @@
 import { Box, BoxProps } from "@mui/material";
 import { select } from "d3-selection";
-import React, { ReactNode } from "react";
+import React, { ReactNode, useEffect, useRef } from "react";
 
 import { useChartState } from "@/charts/shared/chart-state";
 import { CalculationToggle } from "@/charts/shared/interactive-filter-calculation-toggle";
 import { useTransitionStore } from "@/stores/transition";
 
 export const ChartContainer = ({ children }: { children: ReactNode }) => {
-  const ref = React.useRef<HTMLDivElement>(null);
+  const ref = useRef<HTMLDivElement>(null);
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
   const {
     bounds: { width, height },
   } = useChartState();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (ref.current) {
       // Initialize height on mount
       if (!ref.current.style.height) {
@@ -42,13 +42,13 @@ export const ChartContainer = ({ children }: { children: ReactNode }) => {
 };
 
 export const ChartSvg = ({ children }: { children: ReactNode }) => {
-  const ref = React.useRef<SVGSVGElement>(null);
+  const ref = useRef<SVGSVGElement>(null);
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
   const { bounds, interactiveFiltersConfig } = useChartState();
   const { width, height, margins } = bounds;
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (ref.current) {
       // Initialize height on mount.
       if (!ref.current.getAttribute("height")) {

--- a/app/charts/shared/interactive-filter-calculation-toggle.tsx
+++ b/app/charts/shared/interactive-filter-calculation-toggle.tsx
@@ -1,5 +1,5 @@
 import { t } from "@lingui/macro";
-import React from "react";
+import React, { useCallback } from "react";
 
 import { Switch } from "@/components/form";
 import { useInteractiveFilters } from "@/stores/interactive-filters";
@@ -8,7 +8,7 @@ export const CalculationToggle = () => {
   const calculation = useInteractiveFilters((d) => d.calculation);
   const setCalculationType = useInteractiveFilters((d) => d.setCalculationType);
 
-  const onChange = React.useCallback(() => {
+  const onChange = useCallback(() => {
     setCalculationType(calculation.type === "percent" ? "identity" : "percent");
   }, [calculation.type, setCalculationType]);
 

--- a/app/charts/shared/observation-labels.ts
+++ b/app/charts/shared/observation-labels.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import { useCallback, useMemo } from "react";
 
 import { Observation } from "@/domain/data";
 
@@ -45,7 +45,7 @@ export const useObservationLabels = (
   getLabel: (d: Observation) => string,
   componentIri?: string
 ) => {
-  const getIri = React.useCallback(
+  const getIri = useCallback(
     (d: Observation) => {
       const iri = d[`${componentIri}/__iri__`] as string | undefined;
       return iri;
@@ -53,7 +53,7 @@ export const useObservationLabels = (
     [componentIri]
   );
 
-  const lookup = React.useMemo(() => {
+  const lookup = useMemo(() => {
     const lookup = new Map<string, string>();
     data.forEach((d) => {
       const iri = getIri(d);
@@ -64,14 +64,14 @@ export const useObservationLabels = (
     return lookup;
   }, [data, getIri, getLabel]);
 
-  const getValue = React.useCallback(
+  const getValue = useCallback(
     (d: Observation) => {
       return getIri(d) ?? getLabel(d);
     },
     [getIri, getLabel]
   );
 
-  const getLookupLabel = React.useCallback(
+  const getLookupLabel = useCallback(
     (d: string) => {
       return lookup.get(d) ?? d;
     },

--- a/app/charts/shared/rendering-utils.ts
+++ b/app/charts/shared/rendering-utils.ts
@@ -1,6 +1,6 @@
 import { select, Selection } from "d3-selection";
 import { Transition } from "d3-transition";
-import React from "react";
+import { useCallback, useMemo } from "react";
 
 import {
   AnimationField,
@@ -23,7 +23,7 @@ export const useRenderingKeyVariable = (
   interactiveFiltersConfig: InteractiveFiltersConfig,
   animationField: AnimationField | undefined
 ) => {
-  const filterableDimensionKeys = React.useMemo(() => {
+  const filterableDimensionKeys = useMemo(() => {
     // Remove single filters from the rendering key, as we want to be able
     // to animate them.
     const keysToRemove = Object.entries(filters)
@@ -56,7 +56,7 @@ export const useRenderingKeyVariable = (
    * This is useful for stacked charts, where we can't easily
    * access the segment value from the data.
    */
-  const getRenderingKey = React.useCallback(
+  const getRenderingKey = useCallback(
     (d: Observation, segment: string = "") => {
       return filterableDimensionKeys
         .map((key) => d[key])

--- a/app/charts/shared/use-sync-interactive-filters.tsx
+++ b/app/charts/shared/use-sync-interactive-filters.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from "react";
+import { useEffect, useMemo } from "react";
 
 import {
   ChartConfig,
@@ -104,7 +104,7 @@ const useSyncInteractiveFilters = (chartConfig: ChartConfig) => {
   // Calculation
   const calculationActive = interactiveFiltersConfig?.calculation.active;
   const calculationType = interactiveFiltersConfig?.calculation.type;
-  React.useEffect(() => {
+  useEffect(() => {
     if (calculationType) {
       setCalculationType(calculationType);
     }

--- a/app/charts/shared/use-width.tsx
+++ b/app/charts/shared/use-width.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, ReactNode, useContext } from "react";
+import React, { createContext, ReactNode, useContext, useEffect } from "react";
 
 import { useTransitionStore } from "@/stores/transition";
 import { useResizeObserver } from "@/utils/use-resize-observer";
@@ -27,7 +27,7 @@ export const Observer = ({ children }: { children: ReactNode }) => {
   const isResizing = prev !== width;
   const setEnableTransition = useTransitionStore((state) => state.setEnable);
 
-  React.useEffect(
+  useEffect(
     () => setEnableTransition(!isResizing),
     [isResizing, setEnableTransition]
   );

--- a/app/charts/table/table-content.tsx
+++ b/app/charts/table/table-content.tsx
@@ -1,7 +1,7 @@
 import { Box, TableSortLabel, Theme } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import clsx from "clsx";
-import React, { useMemo, useContext } from "react";
+import React, { useMemo, useContext, createContext } from "react";
 import { HeaderGroup } from "react-table";
 
 import { OpenMetadataPanelWrapper } from "@/components/metadata-panel";
@@ -19,7 +19,7 @@ type TableContentProps = {
   customSortCount: number;
   totalColumnsWidth: number;
 };
-const TableContentContext = React.createContext<TableContentProps | undefined>(
+const TableContentContext = createContext<TableContentProps | undefined>(
   undefined
 );
 

--- a/app/components/chart-filters-list.tsx
+++ b/app/components/chart-filters-list.tsx
@@ -1,6 +1,6 @@
 import { Trans } from "@lingui/macro";
 import { Box, Typography } from "@mui/material";
-import React, { Fragment } from "react";
+import React, { Fragment, useMemo } from "react";
 
 import {
   extractChartConfigComponentIris,
@@ -55,7 +55,7 @@ export const ChartFiltersList = (props: ChartFiltersListProps) => {
       })),
     },
   });
-  const allFilters = React.useMemo(() => {
+  const allFilters = useMemo(() => {
     if (!data?.dataCubesComponents || !dimensions) {
       return [];
     }

--- a/app/components/chart-panel.tsx
+++ b/app/components/chart-panel.tsx
@@ -1,6 +1,6 @@
 import { Box, BoxProps, Theme, useMediaQuery } from "@mui/material";
 import { makeStyles } from "@mui/styles";
-import React from "react";
+import React, { useMemo, forwardRef } from "react";
 
 import { ChartSelectionTabs } from "@/components/chart-selection-tabs";
 import { ChartConfig, Layout } from "@/config-types";
@@ -25,7 +25,7 @@ export type ChartWrapperProps = BoxProps & {
   layoutType?: Layout["type"];
 };
 
-export const ChartWrapper = React.forwardRef<HTMLDivElement, ChartWrapperProps>(
+export const ChartWrapper = forwardRef<HTMLDivElement, ChartWrapperProps>(
   (props, ref) => {
     const { children, editing, layoutType, ...rest } = props;
     const classes = useStyles();
@@ -70,7 +70,7 @@ type ChartPanelLayoutTallProps = {
 
 export const ChartPanelLayoutTall = (props: ChartPanelLayoutTallProps) => {
   const { chartConfigs, renderChart } = props;
-  const rows = React.useMemo(() => {
+  const rows = useMemo(() => {
     return getChartPanelLayoutTallRows(chartConfigs, renderChart);
   }, [chartConfigs, renderChart]);
 

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -9,7 +9,7 @@ import {
 import { Trans } from "@lingui/macro";
 import { Box } from "@mui/material";
 import Head from "next/head";
-import React from "react";
+import React, { useState, useMemo, useCallback } from "react";
 
 import { DataSetTable } from "@/browse/datatable";
 import { ChartDataFilters } from "@/charts/shared/chart-data-filters";
@@ -95,12 +95,10 @@ const DashboardPreview = (props: DashboardPreviewProps) => {
   const [state, dispatch] = useConfiguratorState(hasChartConfigs);
   const theme = useTheme();
   const transition = useTransitionStore();
-  const [isDragging, setIsDragging] = React.useState(false);
-  const [activeChartKey, setActiveChartKey] = React.useState<string | null>(
-    null
-  );
-  const [over, setOver] = React.useState<Over | null>(null);
-  const renderChart = React.useCallback(
+  const [isDragging, setIsDragging] = useState(false);
+  const [activeChartKey, setActiveChartKey] = useState<string | null>(null);
+  const [over, setOver] = useState<Over | null>(null);
+  const renderChart = useCallback(
     (chartConfig: ChartConfig) => (
       <DndChartPreview
         chartKey={chartConfig.key}
@@ -207,7 +205,7 @@ const DndChartPreview = (props: DndChartPreviewProps) => {
     active,
   } = useDroppable({ id: chartKey });
 
-  const setRef = React.useCallback(
+  const setRef = useCallback(
     (node: HTMLElement | null) => {
       setDraggableNodeRef(node);
       setDroppableNodeRef(node);
@@ -253,7 +251,7 @@ type SingleURLsPreviewProps = ChartPreviewProps & {
 const SingleURLsPreview = (props: SingleURLsPreviewProps) => {
   const { dataSource, layout } = props;
   const [state, dispatch] = useConfiguratorState(hasChartConfigs);
-  const renderChart = React.useCallback(
+  const renderChart = useCallback(
     (chartConfig: ChartConfig) => {
       const checked = layout.publishableChartKeys.includes(chartConfig.key);
       const { publishableChartKeys: keys } = layout;
@@ -347,7 +345,7 @@ export const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
   const handleToggleTableView = useEvent(() => setIsTablePreview((c) => !c));
   const dimensions = components?.dataCubesComponents.dimensions;
   const measures = components?.dataCubesComponents.measures;
-  const allComponents = React.useMemo(() => {
+  const allComponents = useMemo(() => {
     if (!dimensions || !measures) {
       return [];
     }

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -2,7 +2,7 @@ import { Trans } from "@lingui/macro";
 import { Box, Theme } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import clsx from "clsx";
-import React, { useEffect, useMemo, useRef } from "react";
+import React, { useEffect, useMemo, useRef, useCallback } from "react";
 import { useStore } from "zustand";
 
 import { DataSetTable } from "@/browse/datatable";
@@ -63,7 +63,7 @@ export const ChartPublished = (props: ChartPublishedProps) => {
   const [state] = useConfiguratorState(isPublished);
   const { dataSource } = state;
   const locale = useLocale();
-  const renderChart = React.useCallback(
+  const renderChart = useCallback(
     (chartConfig: ChartConfig) => (
       <ChartTablePreviewProvider key={chartConfig.key}>
         <ChartWrapper key={chartConfig.key} layoutType={state.layout.type}>

--- a/app/components/chart-selection-tabs.tsx
+++ b/app/components/chart-selection-tabs.tsx
@@ -15,7 +15,13 @@ import { PUBLISHED_STATE } from "@prisma/client";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import React from "react";
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  forwardRef,
+} from "react";
 import { DragDropContext, Draggable, Droppable } from "react-beautiful-dnd";
 import { useClient } from "urql";
 import { useDebounce } from "use-debounce";
@@ -66,12 +72,12 @@ const TABS_STATE: TabsState = {
   activeChartKey: "",
 };
 
-const TabsStateContext = React.createContext<
+const TabsStateContext = createContext<
   [TabsState, React.Dispatch<TabsState>] | undefined
 >(undefined);
 
 export const useTabsState = () => {
-  const ctx = React.useContext(TabsStateContext);
+  const ctx = useContext(TabsStateContext);
 
   if (ctx === undefined) {
     throw Error(
@@ -84,7 +90,7 @@ export const useTabsState = () => {
 
 const TabsStateProvider = (props: React.PropsWithChildren<{}>) => {
   const { children } = props;
-  const [state, dispatch] = React.useState<TabsState>(TABS_STATE);
+  const [state, dispatch] = useState<TabsState>(TABS_STATE);
 
   return (
     <TabsStateContext.Provider value={[state, dispatch]}>
@@ -134,8 +140,9 @@ const TabsEditable = (props: TabsEditableProps) => {
   const isConfiguringChart = isConfiguring(state);
   const locale = useLocale();
   const [tabsState, setTabsState] = useTabsState();
-  const [popoverAnchorEl, setPopoverAnchorEl] =
-    React.useState<HTMLElement | null>(null);
+  const [popoverAnchorEl, setPopoverAnchorEl] = useState<HTMLElement | null>(
+    null
+  );
 
   const handleClose = useEvent(() => {
     setPopoverAnchorEl(null);
@@ -146,7 +153,7 @@ const TabsEditable = (props: TabsEditableProps) => {
     });
   });
 
-  React.useEffect(() => {
+  useEffect(() => {
     handleClose();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.activeChartKey]);
@@ -752,7 +759,7 @@ type DragHandleProps = BoxProps & {
   dragging?: boolean;
 };
 
-export const DragHandle = React.forwardRef<HTMLDivElement, DragHandleProps>(
+export const DragHandle = forwardRef<HTMLDivElement, DragHandleProps>(
   (props, ref) => {
     const { dragging, ...rest } = props;
     const classes = useIconStyles({ active: false, dragging });

--- a/app/components/chart-table-preview.tsx
+++ b/app/components/chart-table-preview.tsx
@@ -1,4 +1,16 @@
-import React, { Dispatch, ReactNode, RefObject, SetStateAction } from "react";
+import React, {
+  Dispatch,
+  ReactNode,
+  RefObject,
+  SetStateAction,
+  createContext,
+  useContext,
+  useState,
+  useMemo,
+  useEffect,
+  useRef,
+  useCallback,
+} from "react";
 
 import { hasChartConfigs, useConfiguratorState } from "@/configurator";
 
@@ -11,7 +23,7 @@ type Context = {
   computeContainerHeight: () => void;
 };
 
-const ChartTablePreviewContext = React.createContext<Context>({
+const ChartTablePreviewContext = createContext<Context>({
   state: false,
   setState: () => {},
   setStateRaw: () => {},
@@ -21,7 +33,7 @@ const ChartTablePreviewContext = React.createContext<Context>({
 });
 
 export const useChartTablePreview = () => {
-  const ctx = React.useContext(ChartTablePreviewContext);
+  const ctx = useContext(ChartTablePreviewContext);
 
   if (ctx === undefined) {
     throw Error(
@@ -43,9 +55,9 @@ export const ChartTablePreviewProvider = ({
   children: ReactNode;
 }) => {
   const [configuratorState] = useConfiguratorState(hasChartConfigs);
-  const [state, setStateRaw] = React.useState<boolean>(false);
-  const containerHeight = React.useRef("auto" as "auto" | number);
-  const containerRef = React.useRef<HTMLDivElement>(null);
+  const [state, setStateRaw] = useState<boolean>(false);
+  const containerHeight = useRef("auto" as "auto" | number);
+  const containerRef = useRef<HTMLDivElement>(null);
   const computeContainerHeight = () => {
     if (!containerRef.current) {
       return;
@@ -54,7 +66,7 @@ export const ChartTablePreviewProvider = ({
     const bcr = containerRef.current.getBoundingClientRect();
     containerHeight.current = bcr.height;
   };
-  const setState = React.useCallback(
+  const setState = useCallback(
     (v) => {
       computeContainerHeight();
 
@@ -63,11 +75,11 @@ export const ChartTablePreviewProvider = ({
     [setStateRaw]
   );
 
-  React.useEffect(() => {
+  useEffect(() => {
     containerHeight.current = "auto";
   }, [configuratorState.activeChartKey]);
 
-  const ctx = React.useMemo(() => {
+  const ctx = useMemo(() => {
     return {
       state,
       setState,

--- a/app/components/chart-with-filters.tsx
+++ b/app/components/chart-with-filters.tsx
@@ -1,5 +1,5 @@
 import dynamic from "next/dynamic";
-import React from "react";
+import React, { forwardRef } from "react";
 
 import { useQueryFilters } from "@/charts/shared/chart-helpers";
 import useSyncInteractiveFilters from "@/charts/shared/use-sync-interactive-filters";
@@ -151,7 +151,7 @@ type ChartWithFiltersProps = {
   chartConfig: ChartConfig;
 };
 
-export const ChartWithFilters = React.forwardRef<
+export const ChartWithFilters = forwardRef<
   HTMLDivElement,
   ChartWithFiltersProps
 >((props, ref) => {

--- a/app/components/confirmation-dialog.tsx
+++ b/app/components/confirmation-dialog.tsx
@@ -9,7 +9,7 @@ import {
   DialogProps,
   DialogTitle,
 } from "@mui/material";
-import React from "react";
+import React, { useState } from "react";
 
 const ConfirmationDialog = ({
   title,
@@ -26,7 +26,7 @@ const ConfirmationDialog = ({
   onClick: () => Promise<unknown> | void;
   onClose: NonNullable<DialogProps["onClose"]>;
 }) => {
-  const [loading, setLoading] = React.useState(false);
+  const [loading, setLoading] = useState(false);
 
   return (
     <Dialog

--- a/app/components/flex.tsx
+++ b/app/components/flex.tsx
@@ -1,7 +1,7 @@
 import { Box, BoxProps } from "@mui/material";
-import React from "react";
+import React, { forwardRef } from "react";
 
-const Flex = React.forwardRef((props: BoxProps, ref) => {
+const Flex = forwardRef((props: BoxProps, ref) => {
   return <Box ref={ref} display="flex" {...props} />;
 });
 

--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -36,6 +36,7 @@ import React, {
   useCallback,
   useContext,
   useMemo,
+  createContext,
 } from "react";
 
 import { useBrowseContext } from "@/browser/context";
@@ -280,9 +281,7 @@ const MenuPaper = styled(Paper, {
   WebkitOverflowScrolling: "touch",
 });
 
-const LoadingMenuPaperContext = React.createContext(
-  false as boolean | undefined
-);
+const LoadingMenuPaperContext = createContext(false as boolean | undefined);
 
 /**
  * Shows a loading indicator when hierarchy is loading

--- a/app/components/hint.tsx
+++ b/app/components/hint.tsx
@@ -13,7 +13,7 @@ import {
   useTheme,
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
-import React, { ReactNode } from "react";
+import React, { ReactNode, useState, useEffect } from "react";
 
 import Flex from "@/components/flex";
 import { MotionBox } from "@/components/presence";
@@ -101,10 +101,10 @@ const useLoadingStyles = makeStyles((theme: Theme) => ({
 type LoadingHintVariant = "regular" | "long";
 
 export const Loading = ({ delayMs = 1000 }: { delayMs?: number }) => {
-  const [variant, setVariant] = React.useState<LoadingHintVariant>("regular");
+  const [variant, setVariant] = useState<LoadingHintVariant>("regular");
   const classes = useLoadingStyles();
 
-  React.useEffect(() => {
+  useEffect(() => {
     const timeout = setTimeout(() => {
       setVariant("long");
     }, 7500);

--- a/app/components/metadata-panel-store.tsx
+++ b/app/components/metadata-panel-store.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { createContext, useContext } from "react";
 import { createStore, useStore } from "zustand";
 import shallow from "zustand/shallow";
 
@@ -54,17 +54,17 @@ export const createMetadataPanelStore = () =>
 export const useMetadataPanelStore: <T>(
   selector: (state: MetadataPanelState) => T
 ) => T = (selector) => {
-  const store = React.useContext(MetadataPanelStoreContext);
+  const store = useContext(MetadataPanelStoreContext);
 
   return useStore(store, selector, shallow);
 };
 
 export const useMetadataPanelStoreActions = () => {
-  const store = React.useContext(MetadataPanelStoreContext);
+  const store = useContext(MetadataPanelStoreContext);
 
   return useStore(store, (state) => state.actions);
 };
 
 const defaultStore = createMetadataPanelStore();
 
-export const MetadataPanelStoreContext = React.createContext(defaultStore);
+export const MetadataPanelStoreContext = createContext(defaultStore);

--- a/app/components/metadata-panel.tsx
+++ b/app/components/metadata-panel.tsx
@@ -26,7 +26,7 @@ import orderBy from "lodash/orderBy";
 import sortBy from "lodash/sortBy";
 import uniqBy from "lodash/uniqBy";
 import { useRouter } from "next/router";
-import React, { useMemo } from "react";
+import React, { useMemo, useState, useEffect, useCallback } from "react";
 
 import { DatasetMetadata } from "@/components/dataset-metadata";
 import { Error, Loading } from "@/components/hint";
@@ -248,7 +248,7 @@ export const MetadataPanel = (props: MetadataPanelProps) => {
   });
 
   // Close and reset the metadata panel when route has changed.
-  React.useEffect(() => {
+  useEffect(() => {
     const handleHashChange = () => {
       setOpen(false);
       reset();
@@ -426,9 +426,9 @@ const TabPanelData = ({
   );
   const { setSelectedDimension, clearSelectedDimension } =
     useMetadataPanelStoreActions();
-  const [inputValue, setInputValue] = React.useState("");
+  const [inputValue, setInputValue] = useState("");
 
-  const options = React.useMemo(() => {
+  const options = useMemo(() => {
     return dimensions.flatMap(
       (
         d
@@ -624,10 +624,10 @@ const TabPanelDataDimension = ({
 }) => {
   const classes = useOtherStyles();
   const { setSelectedDimension } = useMetadataPanelStoreActions();
-  const label = React.useMemo(() => {
+  const label = useMemo(() => {
     return getComponentLabel(dim as Dimension, cubeIri);
   }, [cubeIri, dim]);
-  const description = React.useMemo(() => {
+  const description = useMemo(() => {
     const description = getComponentDescription(dim, cubeIri);
 
     if (!expanded && description && description.length > 180) {
@@ -661,7 +661,7 @@ const TabPanelDataDimension = ({
     dim.iri,
   ]);
 
-  const handleClick = React.useCallback(() => {
+  const handleClick = useCallback(() => {
     if (!expanded) {
       setSelectedDimension(dim);
     }

--- a/app/components/row-actions.tsx
+++ b/app/components/row-actions.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, IconButton, Link, MenuItem, styled } from "@mui/material";
 import NextLink from "next/link";
-import React from "react";
+import React, { useRef } from "react";
 
 import ConfirmationDialog from "@/components/confirmation-dialog";
 import useDisclosure from "@/components/use-disclosure";
@@ -134,7 +134,7 @@ export const Action = (props: ActionProps & { as: "menuitem" | "button" }) => {
 
 export const RowActions = (props: ActionsProps) => {
   const { actions } = props;
-  const buttonRef = React.useRef<HTMLButtonElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
   const menuDisclosure = useDisclosure();
   const { isOpen, open, close } = menuDisclosure;
 

--- a/app/components/select-tree.tsx
+++ b/app/components/select-tree.tsx
@@ -22,8 +22,14 @@ import {
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import clsx from "clsx";
-import * as React from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  forwardRef,
+} from "react";
 
 import { Label } from "@/components/form";
 import { HierarchyValue } from "@/domain/data";
@@ -131,7 +137,7 @@ const useCustomTreeItemStyles = makeStyles<
   },
 }));
 
-const TreeItemContent = React.forwardRef<
+const TreeItemContent = forwardRef<
   unknown,
   {
     classes: Record<TreeItemContentClassKey, string>;
@@ -301,13 +307,13 @@ function SelectTree({
   const classes = useStyles({ disabled, open });
   const [filteredOptions, setFilteredOptions] = useState<Tree>([]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     setFilteredOptions(options);
   }, [options]);
 
-  const parentsRef = React.useRef({} as Record<NodeId, NodeId>);
-  const menuRef = React.useRef<PopoverActions>(null);
-  const inputRef = React.useRef<HTMLDivElement>();
+  const parentsRef = useRef({} as Record<NodeId, NodeId>);
+  const menuRef = useRef<PopoverActions>(null);
+  const inputRef = useRef<HTMLDivElement>();
 
   const defaultExpanded = useMemo(() => {
     if (!value && options.length > 0) {

--- a/app/components/tag.tsx
+++ b/app/components/tag.tsx
@@ -2,7 +2,7 @@ import { BoxProps, Typography, TypographyProps, styled } from "@mui/material";
 import { Theme } from "@mui/material/styles";
 import { makeStyles } from "@mui/styles";
 import clsx from "clsx";
-import React from "react";
+import React, { forwardRef } from "react";
 
 type TagType = "draft" | "theme" | "organization" | "termset" | "dimension";
 
@@ -39,7 +39,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-const Tag = React.forwardRef<
+const Tag = forwardRef<
   unknown,
   {
     children: React.ReactNode;

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -2,7 +2,7 @@
 import { fold } from "fp-ts/lib/Either";
 import { pipe } from "fp-ts/lib/function";
 import * as t from "io-ts";
-import React from "react";
+import { useMemo } from "react";
 
 import { Dimension, Measure, ObservationValue } from "@/domain/data";
 import { mkJoinById } from "@/graphql/join";
@@ -1335,7 +1335,7 @@ export const useChartConfigFilters = (
   chartConfig: ChartConfig,
   options?: Parameters<typeof getChartConfigFilters>[1]
 ): Filters => {
-  return React.useMemo(() => {
+  return useMemo(() => {
     return getChartConfigFilters(chartConfig.cubes, {
       cubeIri: options?.cubeIri,
       joined: options?.joined,

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -197,7 +197,7 @@ const useEnsurePossibleFilters = ({
   const [error, setError] = useState<Error>();
   const lastFilters = useRef<Record<string, Filters>>({});
   const client = useClient();
-  const joinByIris = React.useMemo(() => {
+  const joinByIris = useMemo(() => {
     return chartConfig.cubes.flatMap((cube) => cube.joinBy).filter(truthy);
   }, [chartConfig.cubes]);
 
@@ -326,7 +326,7 @@ const useFilterReorder = ({
   const chartConfig = getChartConfig(state);
   const locale = useLocale();
   const filters = getChartConfigFilters(chartConfig.cubes, { joined: true });
-  const joinByIris = React.useMemo(() => {
+  const joinByIris = useMemo(() => {
     return chartConfig.cubes.flatMap((cube) => cube.joinBy).filter(truthy);
   }, [chartConfig.cubes]);
   const { mappedFiltersIris } = useMemo(() => {

--- a/app/configurator/components/chart-controls/section.tsx
+++ b/app/configurator/components/chart-controls/section.tsx
@@ -18,6 +18,7 @@ import React, {
   useContext,
   useEffect,
   useMemo,
+  createContext,
 } from "react";
 
 import { Icon, IconName } from "@/icons";
@@ -91,7 +92,7 @@ const useSectionTitleStyles = makeStyles<Theme, SectionTitleStylesProps>(
   })
 );
 
-const ControlSectionContext = React.createContext({
+const ControlSectionContext = createContext({
   open: () => {},
   isOpen: false,
   close: () => {},

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -580,11 +580,11 @@ const ChartComboLineSingleYField = (
   const { fields } = chartConfig;
   const { y } = fields;
 
-  const numericalMeasures = React.useMemo(() => {
+  const numericalMeasures = useMemo(() => {
     return measures.filter(isNumericalMeasure);
   }, [measures]);
 
-  const unit = React.useMemo(() => {
+  const unit = useMemo(() => {
     const uniqueUnits = Array.from(
       new Set(
         y.componentIris.map((iri) => {
@@ -603,7 +603,7 @@ const ChartComboLineSingleYField = (
     return uniqueUnits[0];
   }, [numericalMeasures, y.componentIris]);
 
-  const getOptionGroups = React.useCallback(
+  const getOptionGroups = useCallback(
     (
       iri: string | null,
       {
@@ -644,17 +644,16 @@ const ChartComboLineSingleYField = (
     [numericalMeasures, y.componentIris, unit]
   );
 
-  const { addNewMeasureOptions, showAddNewMeasureButton } =
-    React.useMemo(() => {
-      const addNewMeasureOptions = getOptionGroups(null, { allowNone: true });
+  const { addNewMeasureOptions, showAddNewMeasureButton } = useMemo(() => {
+    const addNewMeasureOptions = getOptionGroups(null, { allowNone: true });
 
-      return {
-        addNewMeasureOptions,
-        showAddNewMeasureButton:
-          addNewMeasureOptions.flatMap(([_, v]) => v).filter((d) => !d.disabled)
-            .length > 1,
-      };
-    }, [getOptionGroups]);
+    return {
+      addNewMeasureOptions,
+      showAddNewMeasureButton:
+        addNewMeasureOptions.flatMap(([_, v]) => v).filter((d) => !d.disabled)
+          .length > 1,
+    };
+  }, [getOptionGroups]);
 
   return (
     <>
@@ -767,11 +766,11 @@ const ChartComboLineDualYField = (
   const { fields } = chartConfig;
   const { y } = fields;
 
-  const numericalMeasures = React.useMemo(() => {
+  const numericalMeasures = useMemo(() => {
     return measures.filter(isNumericalMeasure);
   }, [measures]);
 
-  const { leftAxisMeasure, rightAxisMeasure } = React.useMemo(() => {
+  const { leftAxisMeasure, rightAxisMeasure } = useMemo(() => {
     const leftAxisMeasure = numericalMeasures.find(
       (m) => m.iri === y.leftAxisComponentIri
     ) as Measure;
@@ -789,7 +788,7 @@ const ChartComboLineDualYField = (
     throw new Error("ChartComboYField can only be used with dual-unit charts!");
   }
 
-  const getOptionGroups = React.useCallback(
+  const getOptionGroups = useCallback(
     (orientation: "left" | "right") => {
       return getComboOptionGroups(numericalMeasures, (m) => {
         return orientation === "left"
@@ -882,11 +881,11 @@ const ChartComboLineColumnYField = (
   const { fields } = chartConfig;
   const { y } = fields;
 
-  const numericalMeasures = React.useMemo(() => {
+  const numericalMeasures = useMemo(() => {
     return measures.filter(isNumericalMeasure);
   }, [measures]);
 
-  const { lineMeasure, columnMeasure } = React.useMemo(() => {
+  const { lineMeasure, columnMeasure } = useMemo(() => {
     const lineMeasure = numericalMeasures.find(
       (m) => m.iri === y.lineComponentIri
     ) as Measure;
@@ -904,7 +903,7 @@ const ChartComboLineColumnYField = (
     throw new Error("ChartComboYField can only be used with dual-unit charts!");
   }
 
-  const getOptionGroups = React.useCallback(
+  const getOptionGroups = useCallback(
     (type: "line" | "column") => {
       return getComboOptionGroups(numericalMeasures, (m) => {
         return type === "line"

--- a/app/configurator/components/chart-type-selector.tsx
+++ b/app/configurator/components/chart-type-selector.tsx
@@ -8,7 +8,7 @@ import {
   Typography,
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
-import React from "react";
+import React, { useCallback } from "react";
 
 import {
   comboChartTypes,
@@ -62,7 +62,7 @@ export const ChartTypeSelector = (props: ChartTypeSelectorProps) => {
     measures
   );
 
-  const handleClick = React.useCallback(
+  const handleClick = useCallback(
     (e: React.SyntheticEvent<HTMLButtonElement, Event>) => {
       const newChartType = e.currentTarget.value as ChartType;
 

--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -2,7 +2,7 @@ import { Trans } from "@lingui/macro";
 import { Box, SxProps, Typography } from "@mui/material";
 import Button, { ButtonProps } from "@mui/material/Button";
 import { useRouter } from "next/router";
-import React from "react";
+import React, { useEffect } from "react";
 
 import { SelectDatasetStep } from "@/browser/select-dataset-step";
 import { META } from "@/charts";
@@ -95,7 +95,7 @@ const useAssureCorrectDataSource = (stateGuard: ConfiguratorState["state"]) => {
   const [state] = useConfiguratorState();
   const { dataSource, setDataSource } = useDataSourceStore();
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (state.state !== stateGuard) {
       return;
     }

--- a/app/configurator/components/field-date-picker.tsx
+++ b/app/configurator/components/field-date-picker.tsx
@@ -2,7 +2,7 @@ import { DatePicker, DatePickerProps, PickersDay } from "@mui/lab";
 import { DatePickerView } from "@mui/lab/DatePicker/shared";
 import { Box, TextField } from "@mui/material";
 import { timeFormat } from "d3-time-format";
-import React from "react";
+import React, { useCallback } from "react";
 
 import { Label } from "@/components/form";
 import { TimeUnit } from "@/graphql/resolver-types";
@@ -38,7 +38,7 @@ export const DatePickerField = (props: DatePickerFieldProps) => {
     dateFormat = timeFormat("%Y-%m-%d"),
     ...rest
   } = props;
-  const handleChange = React.useCallback(
+  const handleChange = useCallback(
     (date: Date | null) => {
       if (!date || isDateDisabled(date)) {
         return;

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -381,7 +381,7 @@ export const DataFilterTemporal = (props: DataFilterTemporalProps) => {
   ) : (
     _label
   );
-  const { minDate, maxDate, optionValues } = React.useMemo(() => {
+  const { minDate, maxDate, optionValues } = useMemo(() => {
     if (values.length) {
       const options = values.map((d) => {
         return {
@@ -404,7 +404,7 @@ export const DataFilterTemporal = (props: DataFilterTemporalProps) => {
       };
     }
   }, [values, parseDate]);
-  const isDateDisabled = React.useCallback(
+  const isDateDisabled = useCallback(
     (date: Date) => {
       return !optionValues.includes(formatDate(date));
     },

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -957,7 +957,7 @@ export const TimeFilter = (props: TimeFilterProps) => {
     });
   }, [dimension, formatLocale, timeFormatUnit]);
 
-  const getClosestDatesFromDateRange = React.useCallback(
+  const getClosestDatesFromDateRange = useCallback(
     (from: Date, to: Date) => {
       const getClosestDatesFromDateRange = makeGetClosestDatesFromDateRange(
         sortedOptions,

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -6,6 +6,7 @@ import React, {
   useCallback,
   useContext,
   useMemo,
+  createContext,
 } from "react";
 
 import { getFieldComponentIri, getInitialConfig } from "@/charts";
@@ -539,7 +540,7 @@ export const isMultiFilterFieldChecked = (
   return fieldChecked || !filter;
 };
 
-const MultiFilterContext = React.createContext({
+const MultiFilterContext = createContext({
   activeKeys: new Set() as Set<string>,
   allValues: [] as string[],
   cubeIri: "",

--- a/app/configurator/interactive-filters/time-slider.tsx
+++ b/app/configurator/interactive-filters/time-slider.tsx
@@ -1,6 +1,12 @@
 import { Box, Button, Typography } from "@mui/material";
 import orderBy from "lodash/orderBy";
-import React, { ChangeEvent } from "react";
+import React, {
+  ChangeEvent,
+  createContext,
+  useContext,
+  useMemo,
+  useEffect,
+} from "react";
 import { useSyncExternalStore } from "use-sync-external-store/shim";
 
 import { ChartState, useChartState } from "@/charts/shared/chart-state";
@@ -25,10 +31,10 @@ import {
 } from "@/utils/sorting-values";
 import useEvent from "@/utils/use-event";
 
-const TimelineContext = React.createContext<Timeline | undefined>(undefined);
+const TimelineContext = createContext<Timeline | undefined>(undefined);
 
 const useTimeline = () => {
-  const timeline = React.useContext(TimelineContext);
+  const timeline = useContext(TimelineContext);
 
   if (!timeline) {
     throw new Error(
@@ -56,7 +62,7 @@ export const TimeSlider = (props: TimeSliderProps) => {
     dimensions,
   } = props;
 
-  const dimension = React.useMemo(() => {
+  const dimension = useMemo(() => {
     return dimensions.find((d) => d.iri === componentIri);
   }, [componentIri, dimensions]);
   const temporal = isTemporalDimension(dimension);
@@ -75,7 +81,7 @@ export const TimeSlider = (props: TimeSliderProps) => {
     Exclude<ChartState, TableChartState>
   >;
   const dimensionFilter = filters[dimension.iri];
-  const timelineProps: TimelineProps = React.useMemo(() => {
+  const timelineProps: TimelineProps = useMemo(() => {
     const commonProps = {
       animationType,
       msDuration: animationDuration * 1000,
@@ -127,7 +133,7 @@ export const TimeSlider = (props: TimeSliderProps) => {
     dimensionFilter,
   ]);
 
-  const timeline = React.useMemo(() => {
+  const timeline = useMemo(() => {
     return new Timeline(timelineProps);
   }, [timelineProps]);
 
@@ -201,7 +207,7 @@ const Slider = () => {
   const timeSlider = useInteractiveFilters((d) => d.timeSlider);
   const setTimeSlider = useInteractiveFilters((d) => d.setTimeSlider);
 
-  const marks = React.useMemo(() => {
+  const marks = useMemo(() => {
     return timeline.domain.map((d) => ({ value: d })) ?? [];
   }, [timeline.domain]);
 
@@ -213,7 +219,7 @@ const Slider = () => {
     timeline.stop();
   });
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (timeline.type !== timeSlider.type) {
       setTimeSlider({
         type: timeline.type,

--- a/app/graphql/hooks.ts
+++ b/app/graphql/hooks.ts
@@ -1,4 +1,4 @@
-import React from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Client, useClient } from "urql";
 
 import {
@@ -25,7 +25,7 @@ import {
 } from "./query-hooks";
 
 const useQueryKey = (options: object) => {
-  return React.useMemo(() => {
+  return useMemo(() => {
     return JSON.stringify(options);
   }, [options]);
 };
@@ -50,7 +50,7 @@ export const makeUseQuery =
   ) =>
   (options: T & { keepPreviousData?: boolean }) => {
     const client = useClient();
-    const [result, setResult] = React.useState<{
+    const [result, setResult] = useState<{
       queryKey: string | null;
       data?: V | null;
       error?: Error;
@@ -58,7 +58,7 @@ export const makeUseQuery =
     }>({ fetching: !options.pause, queryKey: null, data: null });
     const { keepPreviousData } = options;
     const queryKey = useQueryKey(options);
-    const executeQuery = React.useCallback(
+    const executeQuery = useCallback(
       async (options: T) => {
         setResult((prev) => ({
           ...prev,
@@ -79,7 +79,7 @@ export const makeUseQuery =
       [queryKey]
     );
 
-    React.useEffect(() => {
+    useEffect(() => {
       if (options.pause) {
         return;
       }

--- a/app/icons/components/IcCheck.tsx
+++ b/app/icons/components/IcCheck.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 function SvgIcCheck(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg

--- a/app/icons/components/IcEmbed.tsx
+++ b/app/icons/components/IcEmbed.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 function SvgIcEmbed(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg

--- a/app/icons/components/IcGeographical.tsx
+++ b/app/icons/components/IcGeographical.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 function SvgIcGeographical(props: React.SVGProps<SVGSVGElement>) {
   return (

--- a/app/icons/components/IcInfo.tsx
+++ b/app/icons/components/IcInfo.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 function SvgIcInfo(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg

--- a/app/icons/components/IcMinus.tsx
+++ b/app/icons/components/IcMinus.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 function SvgIcMinus(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg

--- a/app/icons/components/IcOrganisations.tsx
+++ b/app/icons/components/IcOrganisations.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 function SvgIcOrganisations(props: React.SVGProps<SVGSVGElement>) {
   return (

--- a/app/icons/components/IcOrigin.tsx
+++ b/app/icons/components/IcOrigin.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 function SvgIcOrigin(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg

--- a/app/icons/components/IcPlay.tsx
+++ b/app/icons/components/IcPlay.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 function SvgIcPlay(props: React.SVGProps<SVGSVGElement>) {
   return (

--- a/app/icons/components/IcReset.tsx
+++ b/app/icons/components/IcReset.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 
 function SvgIcReset(props: React.SVGProps<SVGSVGElement>) {
   return (

--- a/app/icons/components/IcSortAscending.tsx
+++ b/app/icons/components/IcSortAscending.tsx
@@ -1,4 +1,4 @@
-import * as React from "react";
+import React from "react";
 function SvgIcSortAscending(props: React.SVGProps<SVGSVGElement>) {
   return (
     <svg

--- a/app/login/components/profile-content-tabs.tsx
+++ b/app/login/components/profile-content-tabs.tsx
@@ -4,7 +4,7 @@ import { Box, Tab, Theme } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import clsx from "clsx";
 import groupBy from "lodash/groupBy";
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 
 import { useUserConfigs } from "@/domain/user-configs";
 import { ProfileVisualizationsTable } from "@/login/components/profile-tables";
@@ -45,7 +45,7 @@ export const ProfileContentTabs = (props: ProfileContentTabsProps) => {
   const { userId } = props;
 
   const { data: userConfigs } = useUserConfigs();
-  const [value, setValue] = React.useState("home");
+  const [value, setValue] = useState("home");
   const handleChange = useEvent((_: React.SyntheticEvent, v: string) => {
     setValue(v);
   });

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -18,7 +18,7 @@ import {
 import { PUBLISHED_STATE } from "@prisma/client";
 import sortBy from "lodash/sortBy";
 import NextLink from "next/link";
-import React from "react";
+import React, { useMemo } from "react";
 
 import useDisclosure from "@/components/use-disclosure";
 import { ParsedConfig } from "@/db/config";
@@ -195,7 +195,7 @@ const ProfileVisualizationsRow = (props: ProfileVisualizationsRowProps) => {
     close: closeRename,
   } = useDisclosure();
 
-  const actions = React.useMemo(() => {
+  const actions = useMemo(() => {
     const actions: (ActionProps | null)[] = [
       {
         type: "link",
@@ -296,7 +296,7 @@ const ProfileVisualizationsRow = (props: ProfileVisualizationsRowProps) => {
     updateConfigMut,
   ]);
 
-  const chartTitle = React.useMemo(() => {
+  const chartTitle = useMemo(() => {
     const title = config.data.chartConfigs
       .map((d) => d.meta.title?.[locale] ?? false)
       .filter(truthy)

--- a/app/package.json
+++ b/app/package.json
@@ -171,6 +171,7 @@
     "@types/wellknown": "^0.5.1",
     "babel-core": "^7.0.0-bridge.0",
     "babel-plugin-module-resolver": "^4.1.0",
+    "eslint-plugin-deprecate": "^0.8.4",
     "eslint-plugin-jest": "^28.3.0",
     "jest": "^27.3.0",
     "playwright-testing-library": "^4.5.0",

--- a/app/pages/_preview.tsx
+++ b/app/pages/_preview.tsx
@@ -1,8 +1,8 @@
 import { Box } from "@mui/material";
-import React from "react";
+import React, { useEffect } from "react";
 
 const Page = () => {
-  React.useEffect(() => {
+  useEffect(() => {
     const iframe = document.getElementById("chart") as HTMLIFrameElement;
     iframe.onload = () => {
       const iframeWindow = iframe?.contentWindow as Window | undefined;

--- a/app/pages/create/[chartId].tsx
+++ b/app/pages/create/[chartId].tsx
@@ -1,6 +1,6 @@
 import { GetServerSideProps, NextPage } from "next";
 import Head from "next/head";
-import * as React from "react";
+import React, { useMemo } from "react";
 
 import { AppLayout } from "@/components/layout";
 import {
@@ -27,7 +27,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
 };
 
 const ChartConfiguratorPage: NextPage<PageProps> = ({ chartId }) => {
-  const metadataPanelStore = React.useMemo(() => {
+  const metadataPanelStore = useMemo(() => {
     return createMetadataPanelStore();
   }, []);
 

--- a/app/pages/v/[chartId].tsx
+++ b/app/pages/v/[chartId].tsx
@@ -16,7 +16,7 @@ import ErrorPage from "next/error";
 import Head from "next/head";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
-import React from "react";
+import React, { useState, useMemo, useEffect } from "react";
 
 import { ChartPublished } from "@/components/chart-published";
 import { PublishSuccess } from "@/components/hint";
@@ -79,7 +79,7 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
   const classes = useStyles();
 
   // Keep initial value of publishSuccess
-  const [publishSuccess] = React.useState(() => !!query.publishSuccess);
+  const [publishSuccess] = useState(() => !!query.publishSuccess);
   const { status, config } = deserializeProps(props);
 
   const session = useSession();
@@ -88,7 +88,7 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
     config.user_id &&
     config.user_id === session.data?.user.id;
 
-  const { key, state } = React.useMemo(() => {
+  const { key, state } = useMemo(() => {
     if (status === "found") {
       const state = {
         state: "PUBLISHED",
@@ -108,7 +108,7 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
   }, [config?.data, config?.key, status]);
   const chartConfig = state ? getChartConfig(state) : undefined;
 
-  React.useEffect(
+  useEffect(
     function removePublishSuccessFromURL() {
       // Remove publishSuccess from URL so that when reloading of sharing the link
       // to someone, there is no publishSuccess mention
@@ -120,7 +120,7 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
   );
 
   const { dataSource, setDataSource } = useDataSourceStore();
-  React.useEffect(
+  useEffect(
     function setCorrectDataSource() {
       if (status === "found" && config.data.dataSource.url !== dataSource.url) {
         setDataSource(config.data.dataSource);

--- a/app/stores/interactive-filters.tsx
+++ b/app/stores/interactive-filters.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { createContext, useState, useContext } from "react";
 import create, { StoreApi, UseBoundStore } from "zustand";
 
 import { CalculationType, FilterValueSingle } from "@/configurator";
@@ -126,7 +126,7 @@ const createInteractiveFiltersStore = () =>
     };
   });
 
-const InteractiveFiltersContext = React.createContext<
+const InteractiveFiltersContext = createContext<
   | [UseBoundStore<StoreApi<State>>, UseBoundStoreWithSelector<StoreApi<State>>]
   | undefined
 >(undefined);
@@ -134,7 +134,7 @@ const InteractiveFiltersContext = React.createContext<
 export const InteractiveFiltersProvider = ({
   children,
 }: React.PropsWithChildren<{}>) => {
-  const [state] = React.useState<
+  const [state] = useState<
     [UseBoundStore<StoreApi<State>>, UseBoundStoreWithSelector<StoreApi<State>>]
   >(() => {
     const store = createInteractiveFiltersStore();
@@ -151,7 +151,7 @@ export const InteractiveFiltersProvider = ({
 export const useInteractiveFilters = <T extends unknown>(
   selector: (state: ExtractState<StoreApi<State>>) => T
 ) => {
-  const ctx = React.useContext(InteractiveFiltersContext);
+  const ctx = useContext(InteractiveFiltersContext);
 
   if (!ctx) {
     throw new Error(
@@ -165,7 +165,7 @@ export const useInteractiveFilters = <T extends unknown>(
 };
 
 export const useInteractiveFiltersRaw = () => {
-  const ctx = React.useContext(InteractiveFiltersContext);
+  const ctx = useContext(InteractiveFiltersContext);
 
   if (!ctx) {
     throw new Error(

--- a/app/utils/embed.tsx
+++ b/app/utils/embed.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router";
-import React, { useContext, useMemo } from "react";
+import React, { useContext, useMemo, createContext } from "react";
 
 import useEvent from "@/utils/use-event";
 
@@ -14,7 +14,7 @@ export type EmbedOptions = {
   showMetadata?: boolean;
 };
 
-const EmbedOptionsContext = React.createContext([
+const EmbedOptionsContext = createContext([
   {} as EmbedOptions,
   (() => undefined) as (n: Partial<EmbedOptions>) => void,
 ] as const);

--- a/app/utils/l10n-provider.tsx
+++ b/app/utils/l10n-provider.tsx
@@ -1,6 +1,6 @@
 import { LocalizationProvider } from "@mui/lab";
 import DateAdapter from "@mui/lab/AdapterDateFns";
-import React from "react";
+import React, { useState, useEffect } from "react";
 
 import { Locale } from "@/locales/locales";
 
@@ -12,9 +12,9 @@ const AsyncLocalizationProvider = (
   props: React.PropsWithChildren<AsyncLocalizationProviderProps>
 ) => {
   const { locale, children } = props;
-  const [dateFnsLocale, setDateFnsLocale] = React.useState<object>();
+  const [dateFnsLocale, setDateFnsLocale] = useState<object>();
 
-  React.useEffect(() => {
+  useEffect(() => {
     const run = async () => {
       switch (locale) {
         case "en": {

--- a/app/utils/use-timed-previous.ts
+++ b/app/utils/use-timed-previous.ts
@@ -1,8 +1,8 @@
-import React from "react";
+import { useEffect, useState } from "react";
 
 export const useTimedPrevious = <T>(value: T, duration: number): T => {
-  const [previousValue, setPreviousValue] = React.useState<T>(value);
-  React.useEffect(() => {
+  const [previousValue, setPreviousValue] = useState<T>(value);
+  useEffect(() => {
     const timeoutId = setTimeout(() => {
       setPreviousValue(value);
     }, duration);

--- a/codemods/react-member-expressions.js
+++ b/codemods/react-member-expressions.js
@@ -1,0 +1,81 @@
+module.exports = function (file, api) {
+  /**
+   * @type import("jscodeshift")
+   */
+  const j = api.jscodeshift;
+
+  const root = j(file.source);
+  // Find all member expressions starting with 'React.'
+  const reactMemberExpressions = root
+    .find(j.MemberExpression, {
+      object: {
+        name: "React",
+      },
+    })
+    .filter((path) =>
+      // Filter only the properties you're interested in
+      [
+        "useMemo",
+        "useState",
+        "useContext",
+        "useEffect",
+        "createContext",
+        "useReducer",
+        "memo",
+        "forwardRef",
+        "useRef",
+        "useCallback",
+        "useImperativeHandle",
+        "createElement",
+      ].includes(path.node.property.name)
+    );
+
+  const namedImports = new Set();
+  reactMemberExpressions.forEach((path) => {
+    namedImports.add(path.value.property.name);
+  });
+
+  reactMemberExpressions.forEach((path) => {
+    path.replace(j.identifier(path.value.property.name));
+  });
+
+  // Add imports for named members if they don't exist
+  const reactImportDeclaration = root.find(j.ImportDeclaration, {
+    source: {
+      value: "react",
+    },
+  });
+
+  if (namedImports.size > 0) {
+    if (reactImportDeclaration.size() === 0) {
+      root
+        .find(j.ImportDeclaration)
+        .at(0)
+        .insertBefore(
+          `import { ${Array.from(namedImports).join(", ")} } from 'react`
+        );
+    } else {
+      // If React import exists, add missing named imports
+      //   console.log(reactImportDeclaration.get());
+      const reactImportNode = reactImportDeclaration.get().node;
+      const existingSpecifiers = new Set();
+
+      reactImportNode.specifiers.forEach((path) => {
+        existingSpecifiers.add(path.local.name);
+      });
+      const missingSpecifiers = Array.from(namedImports).filter(
+        (name) => !existingSpecifiers.has(name)
+      );
+
+      if (missingSpecifiers.length > 0) {
+        reactImportNode.specifiers.push(
+          ...missingSpecifiers.map((name) =>
+            j.importSpecifier(j.identifier(name), j.identifier(name))
+          )
+        );
+      }
+    }
+  }
+
+  return root.toSource();
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -212,20 +212,20 @@
   integrity sha512-uU27kfDRlhfKl+w1U6vp16IuvSLtjAxdArVXPa9BvLkrr7CYIsxH5adpHObeAGY/41+syctUWOZ140a2Rvkgjw==
 
 "@babel/core@7.12.9", "@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.10.5", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.12.9", "@babel/core@^7.14.6", "@babel/core@^7.18.9", "@babel/core@^7.21.0", "@babel/core@^7.23.0", "@babel/core@^7.23.2", "@babel/core@^7.23.9", "@babel/core@^7.7.2", "@babel/core@^7.7.5", "@babel/core@^7.7.7":
-  version "7.24.4"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.24.4.tgz#1f758428e88e0d8c563874741bc4ffc4f71a4717"
-  integrity sha512-MBVlMXP+kkl5394RBLSxxk/iLTeVGuXTV3cIDXavPpMMqnSnt6apKgan/U8O3USWZCWZT/TbgfEpKa4uMgN4Dg==
+  version "7.24.5"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.24.5.tgz#15ab5b98e101972d171aeef92ac70d8d6718f06a"
+  integrity sha512-tVQRucExLQ02Boi4vdPp49svNGcfL2GhdTCT9aldhXgCJVAI21EtRfBettiuLUwce/7r6bFdgs6JFkcdTiFttA==
   dependencies:
     "@ampproject/remapping" "^2.2.0"
     "@babel/code-frame" "^7.24.2"
-    "@babel/generator" "^7.24.4"
+    "@babel/generator" "^7.24.5"
     "@babel/helper-compilation-targets" "^7.23.6"
-    "@babel/helper-module-transforms" "^7.23.3"
-    "@babel/helpers" "^7.24.4"
-    "@babel/parser" "^7.24.4"
+    "@babel/helper-module-transforms" "^7.24.5"
+    "@babel/helpers" "^7.24.5"
+    "@babel/parser" "^7.24.5"
     "@babel/template" "^7.24.0"
-    "@babel/traverse" "^7.24.1"
-    "@babel/types" "^7.24.0"
+    "@babel/traverse" "^7.24.5"
+    "@babel/types" "^7.24.5"
     convert-source-map "^2.0.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
@@ -267,6 +267,16 @@
   integrity sha512-Xd6+v6SnjWVx/nus+y0l1sxMOTOMBkyL4+BIdbALyatQnAe/SRVjANeDPSCYaX+i1iJmuGSKf3Z+E+V/va1Hvw==
   dependencies:
     "@babel/types" "^7.24.0"
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.25"
+    jsesc "^2.5.1"
+
+"@babel/generator@^7.24.5":
+  version "7.24.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.24.5.tgz#e5afc068f932f05616b66713e28d0f04e99daeb3"
+  integrity sha512-x32i4hEXvr+iI0NEoEfDKzlemF8AmtOP8CcrRaEcpzysWuoEb1KknpcvMsHKPONoKZiDuItklgWhB18xEhr9PA==
+  dependencies:
+    "@babel/types" "^7.24.5"
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.25"
     jsesc "^2.5.1"
@@ -449,6 +459,13 @@
   dependencies:
     "@babel/types" "^7.22.15"
 
+"@babel/helper-module-imports@^7.24.3":
+  version "7.24.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.24.3.tgz#6ac476e6d168c7c23ff3ba3cf4f7841d46ac8128"
+  integrity sha512-viKb0F9f2s0BCS22QSF308z/+1YWKV/76mwt61NBzS5izMzDPwdq1pTrzf+Li3npBWX9KdQbkeCt1jSAM7lZqg==
+  dependencies:
+    "@babel/types" "^7.24.0"
+
 "@babel/helper-module-transforms@^7.14.5":
   version "7.15.8"
   resolved "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.8.tgz"
@@ -473,6 +490,17 @@
     "@babel/helper-simple-access" "^7.22.5"
     "@babel/helper-split-export-declaration" "^7.22.6"
     "@babel/helper-validator-identifier" "^7.22.20"
+
+"@babel/helper-module-transforms@^7.24.5":
+  version "7.24.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.24.5.tgz#ea6c5e33f7b262a0ae762fd5986355c45f54a545"
+  integrity sha512-9GxeY8c2d2mdQUP1Dye0ks3VDyIMS98kt/llQ2nUId8IsWqTF0l1LkSX0/uP7l7MCDrzXS009Hyhe2gzTiGW8A==
+  dependencies:
+    "@babel/helper-environment-visitor" "^7.22.20"
+    "@babel/helper-module-imports" "^7.24.3"
+    "@babel/helper-simple-access" "^7.24.5"
+    "@babel/helper-split-export-declaration" "^7.24.5"
+    "@babel/helper-validator-identifier" "^7.24.5"
 
 "@babel/helper-optimise-call-expression@^7.14.5", "@babel/helper-optimise-call-expression@^7.15.4":
   version "7.15.4"
@@ -555,6 +583,13 @@
   dependencies:
     "@babel/types" "^7.22.5"
 
+"@babel/helper-simple-access@^7.24.5":
+  version "7.24.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.24.5.tgz#50da5b72f58c16b07fbd992810be6049478e85ba"
+  integrity sha512-uH3Hmf5q5n7n8mz7arjUlDOCbttY/DW4DYhE6FUsjKJ/oYC1kQQUvwEQWxRwUpX9qQKRXeqLwWxrqilMrf32sQ==
+  dependencies:
+    "@babel/types" "^7.24.5"
+
 "@babel/helper-skip-transparent-expression-wrappers@^7.14.5":
   version "7.14.5"
   resolved "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.14.5.tgz"
@@ -583,6 +618,13 @@
   dependencies:
     "@babel/types" "^7.22.5"
 
+"@babel/helper-split-export-declaration@^7.24.5":
+  version "7.24.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.24.5.tgz#b9a67f06a46b0b339323617c8c6213b9055a78b6"
+  integrity sha512-5CHncttXohrHk8GWOFCcCl4oRD9fKosWlIRgWm4ql9VYioKm52Mk2xsmoohvm7f3JoiLSM5ZgJuRaf5QZZYd3Q==
+  dependencies:
+    "@babel/types" "^7.24.5"
+
 "@babel/helper-string-parser@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz#533f36457a25814cf1df6488523ad547d784a99f"
@@ -592,6 +634,11 @@
   version "7.23.4"
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz#9478c707febcbbe1ddb38a3d91a2e054ae622d83"
   integrity sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==
+
+"@babel/helper-string-parser@^7.24.1":
+  version "7.24.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.24.1.tgz#f99c36d3593db9540705d0739a1f10b5e20c696e"
+  integrity sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==
 
 "@babel/helper-validator-identifier@^7.12.11", "@babel/helper-validator-identifier@^7.14.9", "@babel/helper-validator-identifier@^7.15.7":
   version "7.15.7"
@@ -623,6 +670,11 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.5.tgz#9544ef6a33999343c8740fa51350f30eeaaaf193"
   integrity sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==
 
+"@babel/helper-validator-identifier@^7.24.5":
+  version "7.24.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.24.5.tgz#918b1a7fa23056603506370089bd990d8720db62"
+  integrity sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==
+
 "@babel/helper-validator-option@^7.14.5":
   version "7.14.5"
   resolved "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz"
@@ -650,6 +702,15 @@
     "@babel/template" "^7.24.0"
     "@babel/traverse" "^7.24.1"
     "@babel/types" "^7.24.0"
+
+"@babel/helpers@^7.24.5":
+  version "7.24.5"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.24.5.tgz#fedeb87eeafa62b621160402181ad8585a22a40a"
+  integrity sha512-CiQmBMMpMQHwM5m01YnrM6imUG1ebgYJ+fAIW4FZe6m4qHTPaRHti+R8cggAwkdz4oXhtO4/K9JWlh+8hIfR2Q==
+  dependencies:
+    "@babel/template" "^7.24.0"
+    "@babel/traverse" "^7.24.5"
+    "@babel/types" "^7.24.5"
 
 "@babel/highlight@^7.10.4":
   version "7.18.6"
@@ -697,10 +758,10 @@
     js-tokens "^4.0.0"
     picocolors "^1.0.0"
 
-"@babel/parser@7.12.16", "@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.12.13", "@babel/parser@^7.14.6", "@babel/parser@^7.14.7", "@babel/parser@^7.15.4", "@babel/parser@^7.20.15", "@babel/parser@^7.20.7", "@babel/parser@^7.21.2", "@babel/parser@^7.21.4", "@babel/parser@^7.22.15", "@babel/parser@^7.23.0", "@babel/parser@^7.24.0", "@babel/parser@^7.24.1", "@babel/parser@^7.24.4", "@babel/parser@^7.7.2":
-  version "7.24.4"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.24.4.tgz#234487a110d89ad5a3ed4a8a566c36b9453e8c88"
-  integrity sha512-zTvEBcghmeBma9QIGunWevvBAp4/Qu9Bdq+2k0Ot4fVMD6v3dsC9WOcRSKk7tRRyBM/53yKMJko9xOatGQAwSg==
+"@babel/parser@7.12.16", "@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.12.13", "@babel/parser@^7.14.6", "@babel/parser@^7.14.7", "@babel/parser@^7.15.4", "@babel/parser@^7.20.15", "@babel/parser@^7.20.7", "@babel/parser@^7.21.2", "@babel/parser@^7.21.4", "@babel/parser@^7.22.15", "@babel/parser@^7.23.0", "@babel/parser@^7.24.0", "@babel/parser@^7.24.1", "@babel/parser@^7.24.4", "@babel/parser@^7.24.5", "@babel/parser@^7.7.2":
+  version "7.24.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.24.5.tgz#4a4d5ab4315579e5398a82dcf636ca80c3392790"
+  integrity sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.23.3":
   version "7.23.3"
@@ -1851,6 +1912,22 @@
     debug "^4.3.1"
     globals "^11.1.0"
 
+"@babel/traverse@^7.24.5":
+  version "7.24.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.24.5.tgz#972aa0bc45f16983bf64aa1f877b2dd0eea7e6f8"
+  integrity sha512-7aaBLeDQ4zYcUFDUD41lJc1fG8+5IU9DaNSJAgal866FGvmD5EbWQgnEC6kO1gGLsX0esNkfnJSndbTXA3r7UA==
+  dependencies:
+    "@babel/code-frame" "^7.24.2"
+    "@babel/generator" "^7.24.5"
+    "@babel/helper-environment-visitor" "^7.22.20"
+    "@babel/helper-function-name" "^7.23.0"
+    "@babel/helper-hoist-variables" "^7.22.5"
+    "@babel/helper-split-export-declaration" "^7.24.5"
+    "@babel/parser" "^7.24.5"
+    "@babel/types" "^7.24.5"
+    debug "^4.3.1"
+    globals "^11.1.0"
+
 "@babel/types@7.12.13":
   version "7.12.13"
   resolved "https://registry.npmjs.org/@babel/types/-/types-7.12.13.tgz"
@@ -1919,6 +1996,15 @@
   dependencies:
     "@babel/helper-string-parser" "^7.23.4"
     "@babel/helper-validator-identifier" "^7.22.20"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.24.5":
+  version "7.24.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.24.5.tgz#7661930afc638a5383eb0c4aee59b74f38db84d7"
+  integrity sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==
+  dependencies:
+    "@babel/helper-string-parser" "^7.24.1"
+    "@babel/helper-validator-identifier" "^7.24.5"
     to-fast-properties "^2.0.0"
 
 "@base2/pretty-print-object@1.0.1":
@@ -13149,6 +13235,11 @@ eslint-module-utils@^2.7.4:
   integrity sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==
   dependencies:
     debug "^3.2.7"
+
+eslint-plugin-deprecate@^0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-deprecate/-/eslint-plugin-deprecate-0.8.4.tgz#1bbedca80f763cadf228c66a4cf639eb16aeca68"
+  integrity sha512-bzpQTyXNWXbMWRH77XiuzfAthOhQhizEZrTf7krRiMYrq6ENUsWfbCe8A3SeRNa4eW8T2QrHsg/lXmxLq9xXXA==
 
 eslint-plugin-import@^2.26.0:
   version "2.27.5"


### PR DESCRIPTION
- feat: Deprecate usage of React.{useMemo, etc..} in favor of named imports
- refactor: Remove React member expressions
