### PR TITLE
fix: Add dataSource in case it's missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
   - Ability to merge two cubes on multiple columns (for example on year and canton)
   - Ability to search via "concepts"
   - Color legend in maps now only displays values that are actually present in the data (except for ordinal components)
+- Fixes
+  - Data source if now added for legacy charts (defaults to PROD)
+  - Charts created with non-cached data source are now correctly migrated to cached one
 - Performance
   - Cube upgrade is done only once at client side, instead of being re-fetched in every server-side query
 

--- a/app/domain/datasource/constants.ts
+++ b/app/domain/datasource/constants.ts
@@ -2,6 +2,9 @@ import keyBy from "lodash/keyBy";
 
 import { WHITELISTED_DATA_SOURCES } from "../env";
 
+export const PROD_DATA_SOURCE_URL =
+  "https://lindas-cached.cluster.ldbar.ch/query";
+
 export const SOURCE_OPTIONS = [
   {
     value: "sparql+https://lindas-cached.cluster.ldbar.ch/query",

--- a/app/domain/datasource/constants.ts
+++ b/app/domain/datasource/constants.ts
@@ -2,6 +2,8 @@ import keyBy from "lodash/keyBy";
 
 import { WHITELISTED_DATA_SOURCES } from "../env";
 
+export const LEGACY_PROD_DATA_SOURCE_URL = "https://lindas.admin.ch/query";
+
 export const PROD_DATA_SOURCE_URL =
   "https://lindas-cached.cluster.ldbar.ch/query";
 

--- a/app/utils/chart-config/versioning.ts
+++ b/app/utils/chart-config/versioning.ts
@@ -3,6 +3,7 @@ import produce from "immer";
 import { DEFAULT_OTHER_COLOR_FIELD_OPACITY } from "@/charts/map/constants";
 import { ChartConfig, ConfiguratorState } from "@/config-types";
 import { mapValueIrisToColor } from "@/configurator/components/ui-helpers";
+import { PROD_DATA_SOURCE_URL } from "@/domain/datasource/constants";
 import { DEFAULT_CATEGORICAL_PALETTE_NAME } from "@/palettes";
 import { createChartId } from "@/utils/create-chart-id";
 
@@ -891,7 +892,7 @@ export const migrateChartConfig = makeMigrate<ChartConfig>(
   }
 );
 
-export const CONFIGURATOR_STATE_VERSION = "3.2.0";
+export const CONFIGURATOR_STATE_VERSION = "3.2.1";
 
 export const configuratorStateMigrations: Migration[] = [
   {
@@ -1108,6 +1109,27 @@ export const configuratorStateMigrations: Migration[] = [
 
         draft.chartConfigs = chartConfigs;
       });
+    },
+  },
+  {
+    description: "ALL (add dataSource in case it's missing)",
+    from: "3.2.0",
+    to: "3.2.1",
+    up: (config) => {
+      const newConfig = { ...config, version: "3.2.1" };
+
+      return produce(newConfig, (draft: any) => {
+        if (!draft.dataSource) {
+          draft.dataSource = {
+            type: "sparql",
+            url: PROD_DATA_SOURCE_URL,
+          };
+        }
+      });
+    },
+    down: (config) => {
+      const newConfig = { ...config, version: "3.2.0" };
+      return newConfig;
     },
   },
 ];

--- a/app/utils/chart-config/versioning.ts
+++ b/app/utils/chart-config/versioning.ts
@@ -3,7 +3,10 @@ import produce from "immer";
 import { DEFAULT_OTHER_COLOR_FIELD_OPACITY } from "@/charts/map/constants";
 import { ChartConfig, ConfiguratorState } from "@/config-types";
 import { mapValueIrisToColor } from "@/configurator/components/ui-helpers";
-import { PROD_DATA_SOURCE_URL } from "@/domain/datasource/constants";
+import {
+  LEGACY_PROD_DATA_SOURCE_URL,
+  PROD_DATA_SOURCE_URL,
+} from "@/domain/datasource/constants";
 import { DEFAULT_CATEGORICAL_PALETTE_NAME } from "@/palettes";
 import { createChartId } from "@/utils/create-chart-id";
 
@@ -1124,6 +1127,8 @@ export const configuratorStateMigrations: Migration[] = [
             type: "sparql",
             url: PROD_DATA_SOURCE_URL,
           };
+        } else if (draft.dataSource.url === LEGACY_PROD_DATA_SOURCE_URL) {
+          draft.dataSource.url = PROD_DATA_SOURCE_URL;
         }
       });
     },


### PR DESCRIPTION
This PR:
- adds `dataSource` in case it's missing (might be the case for very old chart configs), defaulting to PROD,
- migrates non-cached PROD `dataSource` to cached one.