### PR TITLE
ensure status in Draft|Published

### DIFF
--- a/app/rdf/query-utils.ts
+++ b/app/rdf/query-utils.ts
@@ -58,7 +58,8 @@ export const makeVisualizeDatasetFilter = (options?: {
     ${cubeIriVar} schema:workExample <https://ld.admin.ch/application/visualize> .
     ${
       includeDrafts
-        ? ""
+        ? `{ ${cubeIriVar} schema:creativeWorkStatus <https://ld.admin.ch/vocabulary/CreativeWorkStatus/Published> . } 
+          UNION { ${cubeIriVar} schema:creativeWorkStatus <https://ld.admin.ch/vocabulary/CreativeWorkStatus/Draft> . }`
         : `${cubeIriVar} schema:creativeWorkStatus <https://ld.admin.ch/vocabulary/CreativeWorkStatus/Published> .`
     }
     ${cubeIriVar} cube:observationConstraint ?shape .


### PR DESCRIPTION
ensure only Draft|Published are shown
WRT https://github.com/zazuko/cube-creator/wiki/LINDAS-Specifics#needed-attributes-that-a-cube-shows-up-on-visualizeadminch

there are rare cases with different status i.e. https://s.zazuko.com/m6iuJB which shouldn't be shown

nb: this PR also makes results more consistent with https://github.com/visualize-admin/visualization-tool/blob/eef59af39594123bacc535484df6654550830fa1/app/rdf/queries.ts#L69-L74

cc @bprusinowski 