### PR TITLE
Dashboard tiles layout

### DIFF
--- a/app/charts/area/areas-state-props.ts
+++ b/app/charts/area/areas-state-props.ts
@@ -25,7 +25,7 @@ export type AreasStateVariables = BaseVariables &
   SegmentVariables;
 
 export const useAreasStateVariables = (
-  props: ChartProps<AreaConfig> & { aspectRatio: number }
+  props: ChartProps<AreaConfig>
 ): AreasStateVariables => {
   const { chartConfig, observations, dimensionsByIri, measuresByIri } = props;
   const { fields } = chartConfig;
@@ -63,7 +63,7 @@ export const useAreasStateVariables = (
 };
 
 export const useAreasStateData = (
-  chartProps: ChartProps<AreaConfig> & { aspectRatio: number },
+  chartProps: ChartProps<AreaConfig>,
   variables: AreasStateVariables
 ): ChartStateData => {
   const { chartConfig, observations } = chartProps;

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -46,7 +46,7 @@ import {
 } from "@/charts/shared/stacked-helpers";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
-import { useWidth } from "@/charts/shared/use-width";
+import { useHeight, useWidth } from "@/charts/shared/use-width";
 import { AreaConfig } from "@/configurator";
 import { Observation } from "@/domain/data";
 import { useFormatNumber, useTimeFormatUnit } from "@/formatters";
@@ -75,11 +75,11 @@ export type AreasState = CommonChartState &
   };
 
 const useAreasState = (
-  chartProps: ChartProps<AreaConfig> & { aspectRatio: number },
+  chartProps: ChartProps<AreaConfig>,
   variables: AreasStateVariables,
   data: ChartStateData
 ): AreasState => {
-  const { chartConfig, aspectRatio } = chartProps;
+  const { chartConfig } = chartProps;
   const {
     xDimension,
     getX,
@@ -104,6 +104,7 @@ const useAreasState = (
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   const width = useWidth();
+  const height = useHeight();
   const formatNumber = useFormatNumber({ decimals: "auto" });
   const formatters = useChartFormatters(chartProps);
   const timeFormatUnit = useTimeFormatUnit();
@@ -325,7 +326,7 @@ const useAreasState = (
   const { left, bottom } = useChartPadding({
     yScale: paddingYScale,
     width,
-    aspectRatio,
+    height,
     interactiveFiltersConfig,
     formatNumber,
     normalize,
@@ -336,7 +337,7 @@ const useAreasState = (
     bottom,
     left,
   };
-  const bounds = getChartBounds(width, margins, aspectRatio);
+  const bounds = getChartBounds(width, margins, height);
   const { chartWidth, chartHeight } = bounds;
 
   /** Adjust scales according to dimensions */
@@ -434,9 +435,7 @@ const useAreasState = (
 };
 
 const AreaChartProvider = (
-  props: React.PropsWithChildren<
-    ChartProps<AreaConfig> & { aspectRatio: number }
-  >
+  props: React.PropsWithChildren<ChartProps<AreaConfig>>
 ) => {
   const { children, ...chartProps } = props;
   const variables = useAreasStateVariables(chartProps);
@@ -449,9 +448,7 @@ const AreaChartProvider = (
 };
 
 export const AreaChart = (
-  props: React.PropsWithChildren<
-    ChartProps<AreaConfig> & { aspectRatio: number }
-  >
+  props: React.PropsWithChildren<ChartProps<AreaConfig>>
 ) => {
   return (
     <InteractionProvider>

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -31,7 +31,7 @@ export const ChartAreas = memo((props: ChartProps<AreaConfig>) => {
 
   return (
     <AreaChart {...props}>
-      <ChartContainer>
+      <ChartContainer type="area">
         <ChartSvg>
           <AxisTime /> <AxisHeightLinear />
           <Areas /> <AxisTimeDomain />

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -30,7 +30,7 @@ export const ChartAreas = memo((props: ChartProps<AreaConfig>) => {
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   return (
-    <AreaChart aspectRatio={0.4} {...props}>
+    <AreaChart {...props}>
       <ChartContainer>
         <ChartSvg>
           <AxisTime /> <AxisHeightLinear />

--- a/app/charts/chart-data-wrapper.tsx
+++ b/app/charts/chart-data-wrapper.tsx
@@ -1,7 +1,8 @@
-import { Box } from "@mui/material";
+import { Theme } from "@mui/material/styles";
+import { makeStyles } from "@mui/styles";
 import { AnimatePresence } from "framer-motion";
 import keyBy from "lodash/keyBy";
-import React, { useMemo, useEffect, createElement } from "react";
+import React, { createElement, useEffect, useMemo } from "react";
 
 import { A11yTable } from "@/charts/shared/a11y-table";
 import { useLoadingState } from "@/charts/shared/chart-loading-state";
@@ -23,6 +24,15 @@ import { DataCubeObservationFilter } from "@/graphql/query-hooks";
 import { useLocale } from "@/src";
 
 type ElementProps<RE> = RE extends React.ElementType<infer P> ? P : never;
+
+const useStyles = makeStyles((theme: Theme) => ({
+  dataWrapper: {
+    position: "relative",
+    width: "100%",
+    display: "flex",
+    flexDirection: "column",
+  },
+}));
 
 /**
  * Responsible for fetching the data for the chart.
@@ -59,6 +69,7 @@ export const ChartDataWrapper = <
   error?: Error;
 }) => {
   const chartLoadingState = useLoadingState();
+  const classes = useStyles();
 
   const locale = useLocale();
   const commonQueryVariables = {
@@ -152,9 +163,9 @@ export const ChartDataWrapper = <
     const title = metadata.map((d) => d.title).join(", ");
 
     return (
-      <Box
+      <div
+        className={classes.dataWrapper}
         data-chart-loaded={!chartLoadingState.loading}
-        sx={{ position: "relative", width: "100%" }}
       >
         {observations.length > 0 && (
           <A11yTable
@@ -182,7 +193,7 @@ export const ChartDataWrapper = <
             <NoDataHint />
           ) : null}
         </AnimatePresence>
-      </Box>
+      </div>
     );
   } else {
     return null;

--- a/app/charts/chart-data-wrapper.tsx
+++ b/app/charts/chart-data-wrapper.tsx
@@ -29,6 +29,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   dataWrapper: {
     position: "relative",
     width: "100%",
+    height: "100%",
     display: "flex",
     flexDirection: "column",
   },

--- a/app/charts/chart-data-wrapper.tsx
+++ b/app/charts/chart-data-wrapper.tsx
@@ -1,4 +1,3 @@
-import { Theme } from "@mui/material/styles";
 import { makeStyles } from "@mui/styles";
 import { AnimatePresence } from "framer-motion";
 import keyBy from "lodash/keyBy";
@@ -25,7 +24,7 @@ import { useLocale } from "@/src";
 
 type ElementProps<RE> = RE extends React.ElementType<infer P> ? P : never;
 
-const useStyles = makeStyles((theme: Theme) => ({
+const useStyles = makeStyles(() => ({
   dataWrapper: {
     position: "relative",
     width: "100%",

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -44,7 +44,7 @@ export const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
     <>
       {fields.segment?.componentIri && fields.segment.type === "stacked" ? (
         <StackedColumnsChart {...props}>
-          <ChartContainer>
+          <ChartContainer type="column">
             <ChartSvg>
               <AxisHeightLinear /> <AxisWidthBand />
               <ColumnsStacked /> <AxisWidthBandDomain />
@@ -72,7 +72,7 @@ export const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
         </StackedColumnsChart>
       ) : fields.segment?.componentIri && fields.segment.type === "grouped" ? (
         <GroupedColumnChart {...props}>
-          <ChartContainer>
+          <ChartContainer type="column">
             <ChartSvg>
               <AxisHeightLinear />
               <AxisWidthBand />
@@ -103,7 +103,7 @@ export const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
         </GroupedColumnChart>
       ) : (
         <ColumnChart {...props}>
-          <ChartContainer>
+          <ChartContainer type="column">
             <ChartSvg>
               <AxisHeightLinear />
               <AxisWidthBand />

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -43,7 +43,7 @@ export const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
   return (
     <>
       {fields.segment?.componentIri && fields.segment.type === "stacked" ? (
-        <StackedColumnsChart aspectRatio={0.4} {...props}>
+        <StackedColumnsChart {...props}>
           <ChartContainer>
             <ChartSvg>
               <AxisHeightLinear /> <AxisWidthBand />
@@ -71,7 +71,7 @@ export const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
           </ChartControlsContainer>
         </StackedColumnsChart>
       ) : fields.segment?.componentIri && fields.segment.type === "grouped" ? (
-        <GroupedColumnChart aspectRatio={0.4} {...props}>
+        <GroupedColumnChart {...props}>
           <ChartContainer>
             <ChartSvg>
               <AxisHeightLinear />
@@ -102,7 +102,7 @@ export const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
           </ChartControlsContainer>
         </GroupedColumnChart>
       ) : (
-        <ColumnChart aspectRatio={0.4} {...props}>
+        <ColumnChart {...props}>
           <ChartContainer>
             <ChartSvg>
               <AxisHeightLinear />

--- a/app/charts/column/columns-grouped-state-props.ts
+++ b/app/charts/column/columns-grouped-state-props.ts
@@ -34,7 +34,7 @@ export type ColumnsGroupedStateVariables = BaseVariables &
   RenderingVariables;
 
 export const useColumnsGroupedStateVariables = (
-  props: ChartProps<ColumnConfig> & { aspectRatio: number }
+  props: ChartProps<ColumnConfig>
 ): ColumnsGroupedStateVariables => {
   const {
     chartConfig,
@@ -111,7 +111,7 @@ export const useColumnsGroupedStateVariables = (
 };
 
 export const useColumnsGroupedStateData = (
-  chartProps: ChartProps<ColumnConfig> & { aspectRatio: number },
+  chartProps: ChartProps<ColumnConfig>,
   variables: ColumnsGroupedStateVariables
 ): ChartStateData => {
   const { chartConfig, observations } = chartProps;

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -36,7 +36,7 @@ import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
 import { getCenteredTooltipPlacement } from "@/charts/shared/interaction/tooltip-box";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
-import { useWidth } from "@/charts/shared/use-width";
+import { useHeight, useWidth } from "@/charts/shared/use-width";
 import { ColumnConfig } from "@/configurator";
 import { Observation } from "@/domain/data";
 import { formatNumberWithUnit, useFormatNumber } from "@/formatters";
@@ -65,11 +65,11 @@ export type GroupedColumnsState = CommonChartState &
   };
 
 const useColumnsGroupedState = (
-  chartProps: ChartProps<ColumnConfig> & { aspectRatio: number },
+  chartProps: ChartProps<ColumnConfig>,
   variables: ColumnsGroupedStateVariables,
   data: ChartStateData
 ): GroupedColumnsState => {
-  const { aspectRatio, chartConfig } = chartProps;
+  const { chartConfig } = chartProps;
   const {
     xDimension,
     getX,
@@ -99,6 +99,7 @@ const useColumnsGroupedState = (
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   const width = useWidth();
+  const height = useHeight();
   const formatNumber = useFormatNumber({ decimals: "auto" });
   const formatters = useChartFormatters(chartProps);
 
@@ -331,7 +332,7 @@ const useColumnsGroupedState = (
   const { left, bottom } = useChartPadding({
     yScale: paddingYScale,
     width,
-    aspectRatio,
+    height,
     interactiveFiltersConfig,
     animationPresent: !!fields.animation,
     formatNumber,
@@ -343,7 +344,7 @@ const useColumnsGroupedState = (
     bottom,
     left,
   };
-  const bounds = getChartBounds(width, margins, aspectRatio);
+  const bounds = getChartBounds(width, margins, height);
   const { chartWidth, chartHeight } = bounds;
 
   // Adjust of scales based on chart dimensions
@@ -434,9 +435,7 @@ const useColumnsGroupedState = (
 };
 
 const GroupedColumnChartProvider = (
-  props: React.PropsWithChildren<
-    ChartProps<ColumnConfig> & { aspectRatio: number }
-  >
+  props: React.PropsWithChildren<ChartProps<ColumnConfig>>
 ) => {
   const { children, ...chartProps } = props;
   const variables = useColumnsGroupedStateVariables(chartProps);
@@ -449,9 +448,7 @@ const GroupedColumnChartProvider = (
 };
 
 export const GroupedColumnChart = (
-  props: React.PropsWithChildren<
-    ChartProps<ColumnConfig> & { aspectRatio: number }
-  >
+  props: React.PropsWithChildren<ChartProps<ColumnConfig>>
 ) => {
   return (
     <InteractionProvider>

--- a/app/charts/column/columns-stacked-state-props.ts
+++ b/app/charts/column/columns-stacked-state-props.ts
@@ -31,7 +31,7 @@ export type ColumnsStackedStateVariables = BaseVariables &
   RenderingVariables;
 
 export const useColumnsStackedStateVariables = (
-  props: ChartProps<ColumnConfig> & { aspectRatio: number }
+  props: ChartProps<ColumnConfig>
 ): ColumnsStackedStateVariables => {
   const {
     chartConfig,
@@ -105,7 +105,7 @@ export type ColumnsStackedStateData = ChartStateData & {
 };
 
 export const useColumnsStackedStateData = (
-  chartProps: ChartProps<ColumnConfig> & { aspectRatio: number },
+  chartProps: ChartProps<ColumnConfig>,
   variables: ColumnsStackedStateVariables
 ): ColumnsStackedStateData => {
   const { chartConfig, observations } = chartProps;

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -48,7 +48,7 @@ import {
 } from "@/charts/shared/stacked-helpers";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
-import { useWidth } from "@/charts/shared/use-width";
+import { useHeight, useWidth } from "@/charts/shared/use-width";
 import { ColumnConfig } from "@/configurator";
 import { Observation } from "@/domain/data";
 import { useFormatNumber } from "@/formatters";
@@ -81,11 +81,11 @@ export type StackedColumnsState = CommonChartState &
   };
 
 const useColumnsStackedState = (
-  chartProps: ChartProps<ColumnConfig> & { aspectRatio: number },
+  chartProps: ChartProps<ColumnConfig>,
   variables: ColumnsStackedStateVariables,
   data: ColumnsStackedStateData
 ): StackedColumnsState => {
-  const { aspectRatio, chartConfig } = chartProps;
+  const { chartConfig } = chartProps;
   const {
     xDimension,
     getX,
@@ -112,6 +112,7 @@ const useColumnsStackedState = (
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   const width = useWidth();
+  const height = useHeight();
   const formatNumber = useFormatNumber({ decimals: "auto" });
   const formatters = useChartFormatters(chartProps);
   const calculationType = useChartInteractiveFilters((d) => d.calculation.type);
@@ -384,7 +385,7 @@ const useColumnsStackedState = (
   const { left, bottom } = useChartPadding({
     yScale: paddingYScale,
     width,
-    aspectRatio,
+    height,
     interactiveFiltersConfig,
     animationPresent: !!fields.animation,
     formatNumber,
@@ -397,7 +398,7 @@ const useColumnsStackedState = (
     bottom,
     left,
   };
-  const bounds = getChartBounds(width, margins, aspectRatio);
+  const bounds = getChartBounds(width, margins, height);
   const { chartWidth, chartHeight } = bounds;
 
   xScale.range([0, chartWidth]);
@@ -494,9 +495,7 @@ const useColumnsStackedState = (
 };
 
 const StackedColumnsChartProvider = (
-  props: React.PropsWithChildren<
-    ChartProps<ColumnConfig> & { aspectRatio: number }
-  >
+  props: React.PropsWithChildren<ChartProps<ColumnConfig>>
 ) => {
   const { children, ...chartProps } = props;
   const variables = useColumnsStackedStateVariables(chartProps);
@@ -509,9 +508,7 @@ const StackedColumnsChartProvider = (
 };
 
 export const StackedColumnsChart = (
-  props: React.PropsWithChildren<
-    ChartProps<ColumnConfig> & { aspectRatio: number }
-  >
+  props: React.PropsWithChildren<ChartProps<ColumnConfig>>
 ) => {
   return (
     <InteractionProvider>

--- a/app/charts/column/columns-state-props.ts
+++ b/app/charts/column/columns-state-props.ts
@@ -29,7 +29,7 @@ export type ColumnsStateVariables = BaseVariables &
   RenderingVariables;
 
 export const useColumnsStateVariables = (
-  props: ChartProps<ColumnConfig> & { aspectRatio: number }
+  props: ChartProps<ColumnConfig>
 ): ColumnsStateVariables => {
   const {
     chartConfig,
@@ -99,7 +99,7 @@ export const useColumnsStateVariables = (
 };
 
 export const useColumnsStateData = (
-  chartProps: ChartProps<ColumnConfig> & { aspectRatio: number },
+  chartProps: ChartProps<ColumnConfig>,
   variables: ColumnsStateVariables
 ): ChartStateData => {
   const { chartConfig, observations } = chartProps;

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -29,7 +29,7 @@ import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
 import { getCenteredTooltipPlacement } from "@/charts/shared/interaction/tooltip-box";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
-import { useWidth } from "@/charts/shared/use-width";
+import { useHeight, useWidth } from "@/charts/shared/use-width";
 import { ColumnConfig } from "@/configurator";
 import { Observation } from "@/domain/data";
 import {
@@ -55,11 +55,11 @@ export type ColumnsState = CommonChartState &
   };
 
 const useColumnsState = (
-  chartProps: ChartProps<ColumnConfig> & { aspectRatio: number },
+  chartProps: ChartProps<ColumnConfig>,
   variables: ColumnsStateVariables,
   data: ChartStateData
 ): ColumnsState => {
-  const { aspectRatio, chartConfig } = chartProps;
+  const { chartConfig } = chartProps;
   const {
     xDimension,
     getX,
@@ -78,6 +78,7 @@ const useColumnsState = (
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   const width = useWidth();
+  const height = useHeight();
   const formatNumber = useFormatNumber({ decimals: "auto" });
   const formatters = useChartFormatters(chartProps);
   const timeFormatUnit = useTimeFormatUnit();
@@ -190,7 +191,7 @@ const useColumnsState = (
   const { left, bottom } = useChartPadding({
     yScale: paddingYScale,
     width,
-    aspectRatio,
+    height,
     interactiveFiltersConfig,
     animationPresent: !!fields.animation,
     formatNumber,
@@ -202,7 +203,8 @@ const useColumnsState = (
     bottom,
     left,
   };
-  const bounds = getChartBounds(width, margins, aspectRatio);
+
+  const bounds = getChartBounds(width, margins, height);
   const { chartWidth, chartHeight } = bounds;
 
   xScale.range([0, chartWidth]);
@@ -267,9 +269,7 @@ const useColumnsState = (
 };
 
 const ColumnChartProvider = (
-  props: React.PropsWithChildren<
-    ChartProps<ColumnConfig> & { aspectRatio: number }
-  >
+  props: React.PropsWithChildren<ChartProps<ColumnConfig>>
 ) => {
   const { children, ...chartProps } = props;
   const variables = useColumnsStateVariables(chartProps);
@@ -282,9 +282,7 @@ const ColumnChartProvider = (
 };
 
 export const ColumnChart = (
-  props: React.PropsWithChildren<
-    ChartProps<ColumnConfig> & { aspectRatio: number }
-  >
+  props: React.PropsWithChildren<ChartProps<ColumnConfig>>
 ) => {
   return (
     <InteractionProvider>

--- a/app/charts/combo/chart-combo-line-column.tsx
+++ b/app/charts/combo/chart-combo-line-column.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import { memo } from "react";
 
 import { ChartDataWrapper } from "@/charts/chart-data-wrapper";
 import { InteractionColumns } from "@/charts/column/overlay-columns";
@@ -27,7 +27,7 @@ export const ChartComboLineColumn = memo(
     const { interactiveFiltersConfig } = chartConfig;
 
     return (
-      <ComboLineColumnChart aspectRatio={0.4} {...props}>
+      <ComboLineColumnChart {...props}>
         <ChartContainer>
           <ChartSvg>
             <AxisHeightLinearDual orientation="left" />

--- a/app/charts/combo/chart-combo-line-column.tsx
+++ b/app/charts/combo/chart-combo-line-column.tsx
@@ -28,7 +28,7 @@ export const ChartComboLineColumn = memo(
 
     return (
       <ComboLineColumnChart {...props}>
-        <ChartContainer>
+        <ChartContainer type="comboLineColumn">
           <ChartSvg>
             <AxisHeightLinearDual orientation="left" />
             <AxisHeightLinearDual orientation="right" />

--- a/app/charts/combo/chart-combo-line-dual.tsx
+++ b/app/charts/combo/chart-combo-line-dual.tsx
@@ -28,7 +28,7 @@ export const ChartComboLineDual = memo(
 
     return (
       <ComboLineDualChart {...props}>
-        <ChartContainer>
+        <ChartContainer type="comboLineDual">
           <ChartSvg>
             <AxisHeightLinearDual orientation="left" />
             <AxisHeightLinearDual orientation="right" /> <AxisTime />

--- a/app/charts/combo/chart-combo-line-dual.tsx
+++ b/app/charts/combo/chart-combo-line-dual.tsx
@@ -1,4 +1,4 @@
-import React, { memo } from "react";
+import { memo } from "react";
 
 import { ChartDataWrapper } from "@/charts/chart-data-wrapper";
 import { AxisHeightLinearDual } from "@/charts/combo/axis-height-linear-dual";
@@ -27,7 +27,7 @@ export const ChartComboLineDual = memo(
     const { interactiveFiltersConfig } = chartConfig;
 
     return (
-      <ComboLineDualChart aspectRatio={0.4} {...props}>
+      <ComboLineDualChart {...props}>
         <ChartContainer>
           <ChartSvg>
             <AxisHeightLinearDual orientation="left" />

--- a/app/charts/combo/chart-combo-line-single.tsx
+++ b/app/charts/combo/chart-combo-line-single.tsx
@@ -39,7 +39,7 @@ export const ChartComboLineSingle = memo(
 
     return (
       <ComboLineSingleChart {...props}>
-        <ChartContainer>
+        <ChartContainer type="comboLineSingle">
           <ChartSvg>
             <AxisHeightLinear /> <AxisTime /> <AxisTimeDomain />
             <ComboLineSingle />

--- a/app/charts/combo/chart-combo-line-single.tsx
+++ b/app/charts/combo/chart-combo-line-single.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useCallback } from "react";
+import { memo, useCallback } from "react";
 
 import { ChartDataWrapper } from "@/charts/chart-data-wrapper";
 import { ComboLineSingle } from "@/charts/combo/combo-line-single";
@@ -38,7 +38,7 @@ export const ChartComboLineSingle = memo(
     );
 
     return (
-      <ComboLineSingleChart aspectRatio={0.4} {...props}>
+      <ComboLineSingleChart {...props}>
         <ChartContainer>
           <ChartSvg>
             <AxisHeightLinear /> <AxisTime /> <AxisTimeDomain />

--- a/app/charts/combo/combo-line-column-state-props.ts
+++ b/app/charts/combo/combo-line-column-state-props.ts
@@ -39,7 +39,7 @@ export type ComboLineColumnStateVariables = BaseVariables &
   RenderingVariables;
 
 export const useComboLineColumnStateVariables = (
-  props: ChartProps<ComboLineColumnConfig> & { aspectRatio: number }
+  props: ChartProps<ComboLineColumnConfig>
 ): ComboLineColumnStateVariables => {
   const {
     chartConfig,
@@ -127,7 +127,7 @@ export const useComboLineColumnStateVariables = (
 };
 
 export const useComboLineColumnStateData = (
-  chartProps: ChartProps<ComboLineColumnConfig> & { aspectRatio: number },
+  chartProps: ChartProps<ComboLineColumnConfig>,
   variables: ComboLineColumnStateVariables
 ): ChartStateData => {
   const { chartConfig, observations } = chartProps;

--- a/app/charts/combo/combo-line-column-state.tsx
+++ b/app/charts/combo/combo-line-column-state.tsx
@@ -62,17 +62,18 @@ export type ComboLineColumnState = CommonChartState &
   };
 
 const useComboLineColumnState = (
-  chartProps: ChartProps<ComboLineColumnConfig> & { aspectRatio: number },
+  chartProps: ChartProps<ComboLineColumnConfig>,
   variables: ComboLineColumnStateVariables,
   data: ChartStateData
 ): ComboLineColumnState => {
-  const { chartConfig, aspectRatio } = chartProps;
+  const { chartConfig } = chartProps;
   const { getX, getXAsDate } = variables;
   const { chartData, scalesData, timeRangeData, paddingData, allData } = data;
   const { fields, interactiveFiltersConfig } = chartConfig;
   const xKey = fields.x.componentIri;
   const {
     width,
+    height,
     formatNumber,
     timeFormatUnit,
     chartWideData,
@@ -129,14 +130,12 @@ const useComboLineColumnState = (
   const { left, bottom } = useChartPadding({
     yScale: paddingLeftYScale,
     width,
-    aspectRatio,
+    height,
     interactiveFiltersConfig,
     formatNumber,
     bandDomain: xDomain,
   });
-  const fakeRightTicks = paddingRightYScale.ticks(
-    getTickNumber(width * aspectRatio)
-  );
+  const fakeRightTicks = paddingRightYScale.ticks(getTickNumber(height));
   const maxRightTickWidth = Math.max(
     ...fakeRightTicks.map(
       (d) =>
@@ -146,7 +145,7 @@ const useComboLineColumnState = (
   );
   const right = Math.max(maxRightTickWidth, 40);
   const margins = getMargins({ left, right, bottom });
-  const bounds = getChartBounds(width, margins, aspectRatio);
+  const bounds = getChartBounds(width, margins, height);
   const { chartWidth, chartHeight } = bounds;
   const xScales = [xScale, xScaleTime, xScaleTimeRange];
   const yScales = [yScale, yScaleLeft, yScaleRight];
@@ -210,9 +209,7 @@ const useComboLineColumnState = (
 };
 
 const ComboLineColumnChartProvider = (
-  props: React.PropsWithChildren<
-    ChartProps<ComboLineColumnConfig> & { aspectRatio: number }
-  >
+  props: React.PropsWithChildren<ChartProps<ComboLineColumnConfig>>
 ) => {
   const { children, ...chartProps } = props;
   const variables = useComboLineColumnStateVariables(chartProps);
@@ -225,9 +222,7 @@ const ComboLineColumnChartProvider = (
 };
 
 export const ComboLineColumnChart = (
-  props: React.PropsWithChildren<
-    ChartProps<ComboLineColumnConfig> & { aspectRatio: number }
-  >
+  props: React.PropsWithChildren<ChartProps<ComboLineColumnConfig>>
 ) => {
   return (
     <InteractionProvider>

--- a/app/charts/combo/combo-line-dual-state-props.ts
+++ b/app/charts/combo/combo-line-dual-state-props.ts
@@ -31,7 +31,7 @@ export type ComboLineDualStateVariables = BaseVariables &
   NumericalYComboLineDualVariables;
 
 export const useComboLineDualStateVariables = (
-  props: ChartProps<ComboLineDualConfig> & { aspectRatio: number }
+  props: ChartProps<ComboLineDualConfig>
 ): ComboLineDualStateVariables => {
   const { chartConfig, dimensionsByIri, measuresByIri } = props;
   const { fields } = chartConfig;
@@ -88,7 +88,7 @@ export const useComboLineDualStateVariables = (
 };
 
 export const useComboLineDualStateData = (
-  chartProps: ChartProps<ComboLineDualConfig> & { aspectRatio: number },
+  chartProps: ChartProps<ComboLineDualConfig>,
   variables: ComboLineDualStateVariables
 ): ChartStateData => {
   const { chartConfig, observations } = chartProps;

--- a/app/charts/combo/combo-line-dual-state.tsx
+++ b/app/charts/combo/combo-line-dual-state.tsx
@@ -56,17 +56,18 @@ export type ComboLineDualState = CommonChartState &
   };
 
 const useComboLineDualState = (
-  chartProps: ChartProps<ComboLineDualConfig> & { aspectRatio: number },
+  chartProps: ChartProps<ComboLineDualConfig>,
   variables: ComboLineDualStateVariables,
   data: ChartStateData
 ): ComboLineDualState => {
-  const { chartConfig, aspectRatio } = chartProps;
+  const { chartConfig } = chartProps;
   const { xDimension, getX, getXAsString } = variables;
   const { chartData, scalesData, timeRangeData, paddingData, allData } = data;
   const { fields, interactiveFiltersConfig } = chartConfig;
   const xKey = fields.x.componentIri;
   const {
     width,
+    height,
     formatNumber,
     timeFormatUnit,
     chartWideData,
@@ -111,13 +112,11 @@ const useComboLineDualState = (
   const { left, bottom } = useChartPadding({
     yScale: paddingLeftYScale,
     width,
-    aspectRatio,
+    height,
     interactiveFiltersConfig,
     formatNumber,
   });
-  const fakeRightTicks = paddingRightYScale.ticks(
-    getTickNumber(width * aspectRatio)
-  );
+  const fakeRightTicks = paddingRightYScale.ticks(getTickNumber(height));
   const maxRightTickWidth = Math.max(
     ...fakeRightTicks.map(
       (d) =>
@@ -127,7 +126,7 @@ const useComboLineDualState = (
   );
   const right = Math.max(maxRightTickWidth, 40);
   const margins = getMargins({ left, right, bottom });
-  const bounds = getChartBounds(width, margins, aspectRatio);
+  const bounds = getChartBounds(width, margins, height);
   const { chartWidth, chartHeight } = bounds;
   const xScales = [xScale, xScaleTimeRange];
   const yScales = [yScale, yScaleLeft, yScaleRight];
@@ -192,9 +191,7 @@ const useComboLineDualState = (
 };
 
 const ComboLineDualChartProvider = (
-  props: React.PropsWithChildren<
-    ChartProps<ComboLineDualConfig> & { aspectRatio: number }
-  >
+  props: React.PropsWithChildren<ChartProps<ComboLineDualConfig>>
 ) => {
   const { children, ...chartProps } = props;
   const variables = useComboLineDualStateVariables(chartProps);
@@ -207,9 +204,7 @@ const ComboLineDualChartProvider = (
 };
 
 export const ComboLineDualChart = (
-  props: React.PropsWithChildren<
-    ChartProps<ComboLineDualConfig> & { aspectRatio: number }
-  >
+  props: React.PropsWithChildren<ChartProps<ComboLineDualConfig>>
 ) => {
   return (
     <InteractionProvider>

--- a/app/charts/combo/combo-line-single-state-props.ts
+++ b/app/charts/combo/combo-line-single-state-props.ts
@@ -27,7 +27,7 @@ export type ComboLineSingleStateVariables = BaseVariables &
   NumericalYComboLineSingleVariables;
 
 export const useComboLineSingleStateVariables = (
-  props: ChartProps<ComboLineSingleConfig> & { aspectRatio: number }
+  props: ChartProps<ComboLineSingleConfig>
 ): ComboLineSingleStateVariables => {
   const { chartConfig, dimensionsByIri, measuresByIri } = props;
   const { fields } = chartConfig;
@@ -71,7 +71,7 @@ export const useComboLineSingleStateVariables = (
 };
 
 export const useComboLineSingleStateData = (
-  chartProps: ChartProps<ComboLineSingleConfig> & { aspectRatio: number },
+  chartProps: ChartProps<ComboLineSingleConfig>,
   variables: ComboLineSingleStateVariables
 ): ChartStateData => {
   const { chartConfig, observations } = chartProps;

--- a/app/charts/combo/combo-line-single-state.tsx
+++ b/app/charts/combo/combo-line-single-state.tsx
@@ -47,11 +47,11 @@ export type ComboLineSingleState = CommonChartState &
   };
 
 const useComboLineSingleState = (
-  chartProps: ChartProps<ComboLineSingleConfig> & { aspectRatio: number },
+  chartProps: ChartProps<ComboLineSingleConfig>,
   variables: ComboLineSingleStateVariables,
   data: ChartStateData
 ): ComboLineSingleState => {
-  const { chartConfig, aspectRatio, measuresByIri } = chartProps;
+  const { chartConfig, measuresByIri } = chartProps;
   const { xDimension, getX, getXAsString } = variables;
   const { chartData, scalesData, timeRangeData, paddingData, allData } = data;
   const { fields, interactiveFiltersConfig } = chartConfig;
@@ -75,6 +75,7 @@ const useComboLineSingleState = (
   const xKey = fields.x.componentIri;
   const {
     width,
+    height,
     formatNumber,
     timeFormatUnit,
     chartWideData,
@@ -102,12 +103,12 @@ const useComboLineSingleState = (
   const { left, bottom } = useChartPadding({
     yScale: paddingYScale,
     width,
-    aspectRatio,
+    height,
     interactiveFiltersConfig,
     formatNumber,
   });
   const margins = getMargins({ left, bottom });
-  const bounds = getChartBounds(width, margins, aspectRatio);
+  const bounds = getChartBounds(width, margins, height);
   const { chartWidth, chartHeight } = bounds;
   const xScales = [xScale, xScaleTimeRange];
   const yScales = [yScale];
@@ -169,9 +170,7 @@ const useComboLineSingleState = (
 };
 
 const ComboLineSingleChartProvider = (
-  props: React.PropsWithChildren<
-    ChartProps<ComboLineSingleConfig> & { aspectRatio: number }
-  >
+  props: React.PropsWithChildren<ChartProps<ComboLineSingleConfig>>
 ) => {
   const { children, ...chartProps } = props;
   const variables = useComboLineSingleStateVariables(chartProps);
@@ -184,9 +183,7 @@ const ComboLineSingleChartProvider = (
 };
 
 export const ComboLineSingleChart = (
-  props: React.PropsWithChildren<
-    ChartProps<ComboLineSingleConfig> & { aspectRatio: number }
-  >
+  props: React.PropsWithChildren<ChartProps<ComboLineSingleConfig>>
 ) => {
   return (
     <InteractionProvider>

--- a/app/charts/combo/combo-state.ts
+++ b/app/charts/combo/combo-state.ts
@@ -2,7 +2,7 @@ import { extent, groups, max, min, sum } from "d3-array";
 import { scaleLinear, scaleOrdinal, scaleTime } from "d3-scale";
 import { useMemo } from "react";
 
-import { useWidth } from "@/charts/shared/use-width";
+import { useHeight, useWidth } from "@/charts/shared/use-width";
 import { Observation } from "@/domain/data";
 import { useFormatNumber, useTimeFormatUnit } from "@/formatters";
 
@@ -32,6 +32,7 @@ export const useCommonComboState = (options: UseCommonComboStateOptions) => {
   } = options;
 
   const width = useWidth();
+  const height = useHeight();
   const formatNumber = useFormatNumber({ decimals: "auto" });
   const timeFormatUnit = useTimeFormatUnit();
 
@@ -82,6 +83,7 @@ export const useCommonComboState = (options: UseCommonComboStateOptions) => {
 
   return {
     width,
+    height,
     formatNumber,
     timeFormatUnit,
     chartWideData,

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -31,7 +31,7 @@ export const ChartLines = memo((props: ChartProps<LineConfig>) => {
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   return (
-    <LineChart aspectRatio={0.4} {...props}>
+    <LineChart {...props}>
       <ChartContainer>
         <ChartSvg>
           <AxisHeightLinear /> <AxisTime /> <AxisTimeDomain />

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -32,7 +32,7 @@ export const ChartLines = memo((props: ChartProps<LineConfig>) => {
 
   return (
     <LineChart {...props}>
-      <ChartContainer>
+      <ChartContainer type="line">
         <ChartSvg>
           <AxisHeightLinear /> <AxisTime /> <AxisTimeDomain />
           <Lines />

--- a/app/charts/line/lines-state-props.ts
+++ b/app/charts/line/lines-state-props.ts
@@ -26,7 +26,7 @@ export type LinesStateVariables = BaseVariables &
   SegmentVariables;
 
 export const useLinesStateVariables = (
-  props: ChartProps<LineConfig> & { aspectRatio: number }
+  props: ChartProps<LineConfig>
 ): LinesStateVariables => {
   const { chartConfig, observations, dimensionsByIri, measuresByIri } = props;
   const { fields } = chartConfig;
@@ -66,7 +66,7 @@ export const useLinesStateVariables = (
 // TODO: same as Area chart, useTemporalXData, except for plottable data deps.
 // Check if getX shouldn't be included here.
 export const useLinesStateData = (
-  chartProps: ChartProps<LineConfig> & { aspectRatio: number },
+  chartProps: ChartProps<LineConfig>,
   variables: LinesStateVariables
 ): ChartStateData => {
   const { chartConfig, observations } = chartProps;

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -31,7 +31,7 @@ import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
 import { getCenteredTooltipPlacement } from "@/charts/shared/interaction/tooltip-box";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
-import { useWidth } from "@/charts/shared/use-width";
+import { useHeight, useWidth } from "@/charts/shared/use-width";
 import { LineConfig } from "@/configurator";
 import { Observation } from "@/domain/data";
 import {
@@ -64,11 +64,11 @@ export type LinesState = CommonChartState &
   };
 
 const useLinesState = (
-  chartProps: ChartProps<LineConfig> & { aspectRatio: number },
+  chartProps: ChartProps<LineConfig>,
   variables: LinesStateVariables,
   data: ChartStateData
 ): LinesState => {
-  const { chartConfig, aspectRatio } = chartProps;
+  const { chartConfig } = chartProps;
   const {
     xDimension,
     getX,
@@ -92,6 +92,7 @@ const useLinesState = (
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   const width = useWidth();
+  const height = useHeight();
   const formatNumber = useFormatNumber({ decimals: "auto" });
   const timeFormatUnit = useTimeFormatUnit();
   const formatters = useChartFormatters(chartProps);
@@ -204,7 +205,7 @@ const useLinesState = (
   const { left, bottom } = useChartPadding({
     yScale: paddingYScale,
     width,
-    aspectRatio,
+    height,
     interactiveFiltersConfig,
     formatNumber,
   });
@@ -214,7 +215,7 @@ const useLinesState = (
     bottom,
     left,
   };
-  const bounds = getChartBounds(width, margins, aspectRatio);
+  const bounds = getChartBounds(width, margins, height);
   const { chartWidth, chartHeight } = bounds;
 
   xScale.range([0, chartWidth]);
@@ -291,9 +292,7 @@ const useLinesState = (
 };
 
 const LineChartProvider = (
-  props: React.PropsWithChildren<
-    ChartProps<LineConfig> & { aspectRatio: number }
-  >
+  props: React.PropsWithChildren<ChartProps<LineConfig>>
 ) => {
   const { children, ...chartProps } = props;
   const variables = useLinesStateVariables(chartProps);
@@ -306,9 +305,7 @@ const LineChartProvider = (
 };
 
 export const LineChart = (
-  props: React.PropsWithChildren<
-    ChartProps<LineConfig> & { aspectRatio: number }
-  >
+  props: React.PropsWithChildren<ChartProps<LineConfig>>
 ) => {
   return (
     <InteractionProvider>

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo } from "react";
+import { memo, useMemo } from "react";
 
 import { ChartDataWrapper } from "@/charts/chart-data-wrapper";
 import { shouldRenderMap } from "@/charts/map/helpers";
@@ -134,7 +134,7 @@ export const ChartMap = memo((props: ChartMapProps) => {
   const filters = useChartConfigFilters(chartConfig);
   return (
     <MapChart {...props}>
-      <ChartContainer>
+      <ChartContainer type="map">
         <MapComponent />
         <MapTooltip />
       </ChartContainer>

--- a/app/charts/map/map-state.tsx
+++ b/app/charts/map/map-state.tsx
@@ -185,9 +185,11 @@ const useMapState = (
     symbolLayer?.componentIri !== undefined &&
     areaLayer.componentIri === symbolLayer.componentIri;
 
+  const height = width * 0.5;
   const bounds = {
     width,
-    height: width * 0.5,
+    height,
+    aspectRatio: height / width,
     margins: {
       top: 0,
       right: 0,

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -33,7 +33,7 @@ export const ChartPie = memo((props: ChartProps<PieConfig>) => {
   }
 
   return (
-    <PieChart aspectRatio={0.4} {...props}>
+    <PieChart {...props}>
       <ChartContainer>
         <ChartSvg>
           <Pie />

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -34,7 +34,7 @@ export const ChartPie = memo((props: ChartProps<PieConfig>) => {
 
   return (
     <PieChart {...props}>
-      <ChartContainer>
+      <ChartContainer type="pie">
         <ChartSvg>
           <Pie />
         </ChartSvg>

--- a/app/charts/pie/pie-state-props.ts
+++ b/app/charts/pie/pie-state-props.ts
@@ -21,7 +21,7 @@ export type PieStateVariables = BaseVariables &
   RenderingVariables;
 
 export const usePieStateVariables = (
-  props: ChartProps<PieConfig> & { aspectRatio: number }
+  props: ChartProps<PieConfig>
 ): PieStateVariables => {
   const {
     chartConfig,
@@ -59,7 +59,7 @@ export const usePieStateVariables = (
 };
 
 export const usePieStateData = (
-  chartProps: ChartProps<PieConfig> & { aspectRatio: number },
+  chartProps: ChartProps<PieConfig>,
   variables: PieStateVariables
 ): ChartStateData => {
   const { chartConfig, observations } = chartProps;

--- a/app/charts/pie/pie-state.tsx
+++ b/app/charts/pie/pie-state.tsx
@@ -19,7 +19,7 @@ import {
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
-import { useWidth } from "@/charts/shared/use-width";
+import { useHeight, useWidth } from "@/charts/shared/use-width";
 import { PieConfig } from "@/configurator";
 import { Dimension, Observation } from "@/domain/data";
 import { formatNumberWithUnit, useFormatNumber } from "@/formatters";
@@ -41,11 +41,11 @@ export type PieState = CommonChartState &
   };
 
 const usePieState = (
-  chartProps: ChartProps<PieConfig> & { aspectRatio: number },
+  chartProps: ChartProps<PieConfig>,
   variables: PieStateVariables,
   data: ChartStateData
 ): PieState => {
-  const { chartConfig, aspectRatio } = chartProps;
+  const { chartConfig } = chartProps;
   const {
     yMeasure,
     getY,
@@ -61,6 +61,7 @@ const usePieState = (
   const { fields } = chartConfig;
 
   const width = useWidth();
+  const height = useHeight();
   const formatNumber = useFormatNumber();
   const formatters = useChartFormatters(chartProps);
 
@@ -147,7 +148,7 @@ const usePieState = (
     bottom: 40,
     left: 40,
   };
-  const bounds = getChartBounds(width, margins, aspectRatio);
+  const bounds = getChartBounds(width, margins, height);
   const { chartWidth, chartHeight } = bounds;
 
   // Pie values
@@ -262,9 +263,7 @@ const usePieState = (
 };
 
 const PieChartProvider = (
-  props: React.PropsWithChildren<
-    ChartProps<PieConfig> & { aspectRatio: number }
-  >
+  props: React.PropsWithChildren<ChartProps<PieConfig>>
 ) => {
   const { children, ...chartProps } = props;
   const variables = usePieStateVariables(chartProps);
@@ -277,9 +276,7 @@ const PieChartProvider = (
 };
 
 export const PieChart = (
-  props: React.PropsWithChildren<
-    ChartProps<PieConfig> & { aspectRatio: number }
-  >
+  props: React.PropsWithChildren<ChartProps<PieConfig>>
 ) => {
   return (
     <InteractionProvider>

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -35,7 +35,7 @@ export const ChartScatterplot = memo((props: ChartProps<ScatterPlotConfig>) => {
   const { fields, interactiveFiltersConfig } = chartConfig;
   const filters = useChartConfigFilters(chartConfig);
   return (
-    <ScatterplotChart aspectRatio={0.4} {...props}>
+    <ScatterplotChart {...props}>
       <ChartContainer>
         <ChartSvg>
           <AxisWidthLinear />

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -36,7 +36,7 @@ export const ChartScatterplot = memo((props: ChartProps<ScatterPlotConfig>) => {
   const filters = useChartConfigFilters(chartConfig);
   return (
     <ScatterplotChart {...props}>
-      <ChartContainer>
+      <ChartContainer type="scatterplot">
         <ChartSvg>
           <AxisWidthLinear />
           <AxisHeightLinear />

--- a/app/charts/scatterplot/scatterplot-state-props.ts
+++ b/app/charts/scatterplot/scatterplot-state-props.ts
@@ -24,7 +24,7 @@ export type ScatterplotStateVariables = BaseVariables &
   RenderingVariables;
 
 export const useScatterplotStateVariables = (
-  props: ChartProps<ScatterPlotConfig> & { aspectRatio: number }
+  props: ChartProps<ScatterPlotConfig>
 ): ScatterplotStateVariables => {
   const {
     chartConfig,
@@ -66,7 +66,7 @@ export const useScatterplotStateVariables = (
 };
 
 export const useScatterplotStateData = (
-  chartProps: ChartProps<ScatterPlotConfig> & { aspectRatio: number },
+  chartProps: ChartProps<ScatterPlotConfig>,
   variables: ScatterplotStateVariables
 ): ChartStateData => {
   const { chartConfig, observations } = chartProps;

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -21,7 +21,7 @@ import {
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
 import { TooltipScatterplot } from "@/charts/shared/interaction/tooltip-content";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
-import { useWidth } from "@/charts/shared/use-width";
+import { useHeight, useWidth } from "@/charts/shared/use-width";
 import { ScatterPlotConfig, SortingField } from "@/configurator";
 import { Observation } from "@/domain/data";
 import { useFormatNumber } from "@/formatters";
@@ -45,11 +45,11 @@ export type ScatterplotState = CommonChartState &
   };
 
 const useScatterplotState = (
-  chartProps: ChartProps<ScatterPlotConfig> & { aspectRatio: number },
+  chartProps: ChartProps<ScatterPlotConfig>,
   variables: ScatterplotStateVariables,
   data: ChartStateData
 ): ScatterplotState => {
-  const { chartConfig, aspectRatio } = chartProps;
+  const { chartConfig } = chartProps;
   const {
     getX,
     xAxisLabel,
@@ -65,6 +65,7 @@ const useScatterplotState = (
   const { fields, interactiveFiltersConfig } = chartConfig;
 
   const width = useWidth();
+  const height = useHeight();
   const formatNumber = useFormatNumber({ decimals: "auto" });
 
   const segmentsByValue = useMemo(() => {
@@ -145,7 +146,7 @@ const useScatterplotState = (
   const { left, bottom } = useChartPadding({
     yScale: paddingYScale,
     width,
-    aspectRatio,
+    height,
     interactiveFiltersConfig,
     animationPresent: !!fields.animation,
     formatNumber,
@@ -156,7 +157,7 @@ const useScatterplotState = (
     bottom,
     left,
   };
-  const bounds = getChartBounds(width, margins, aspectRatio);
+  const bounds = getChartBounds(width, margins, height);
   const { chartWidth, chartHeight } = bounds;
 
   xScale.range([0, chartWidth]);
@@ -220,9 +221,7 @@ const useScatterplotState = (
 };
 
 const ScatterplotChartProvider = (
-  props: React.PropsWithChildren<
-    ChartProps<ScatterPlotConfig> & { aspectRatio: number }
-  >
+  props: React.PropsWithChildren<ChartProps<ScatterPlotConfig>>
 ) => {
   const { children, ...chartProps } = props;
   const variables = useScatterplotStateVariables(chartProps);
@@ -235,9 +234,7 @@ const ScatterplotChartProvider = (
 };
 
 export const ScatterplotChart = (
-  props: React.PropsWithChildren<
-    ChartProps<ScatterPlotConfig> & { aspectRatio: number }
-  >
+  props: React.PropsWithChildren<ChartProps<ScatterPlotConfig>>
 ) => {
   return (
     <InteractionProvider>

--- a/app/charts/shared/chart-dimensions.tsx
+++ b/app/charts/shared/chart-dimensions.tsx
@@ -12,7 +12,7 @@ import { getTextWidth } from "@/utils/get-text-width";
 type ComputeChartPaddingProps = {
   yScale: d3.ScaleLinear<number, number>;
   width: number;
-  aspectRatio: number;
+  height: number;
   interactiveFiltersConfig: ChartConfig["interactiveFiltersConfig"];
   animationPresent?: boolean;
   formatNumber: (n: number) => string;
@@ -24,19 +24,20 @@ const computeChartPadding = (props: ComputeChartPaddingProps) => {
   const {
     yScale,
     width,
-    aspectRatio,
+    height,
     interactiveFiltersConfig,
     animationPresent,
     formatNumber,
     bandDomain,
     normalize,
   } = props;
+
   // Fake ticks to compute maximum tick length as
   // we need to take into account n between [0, 1] where numbers
   // with decimals have greater text length than the extremes.
   // Width * aspectRatio is taken as an approximation of chartHeight
   // since we do not have access to chartHeight yet.
-  const fakeTicks = yScale.ticks(getTickNumber(width * aspectRatio));
+  const fakeTicks = yScale.ticks(getTickNumber(width * height));
   const minLeftTickWidth =
     !!interactiveFiltersConfig?.calculation.active || normalize
       ? getTextWidth("100%", { fontSize: TICK_FONT_SIZE }) + TICK_PADDING
@@ -68,7 +69,7 @@ export const useChartPadding = (props: ComputeChartPaddingProps) => {
   const {
     yScale,
     width,
-    aspectRatio,
+    height,
     interactiveFiltersConfig,
     animationPresent,
     formatNumber,
@@ -80,7 +81,7 @@ export const useChartPadding = (props: ComputeChartPaddingProps) => {
     return computeChartPadding({
       yScale,
       width,
-      aspectRatio,
+      height,
       interactiveFiltersConfig,
       animationPresent,
       formatNumber,
@@ -90,7 +91,7 @@ export const useChartPadding = (props: ComputeChartPaddingProps) => {
   }, [
     yScale,
     width,
-    aspectRatio,
+    height,
     interactiveFiltersConfig,
     animationPresent,
     formatNumber,
@@ -102,16 +103,17 @@ export const useChartPadding = (props: ComputeChartPaddingProps) => {
 export const getChartBounds = (
   width: number,
   margins: Margins,
-  aspectRatio: number
+  height: number
 ): Bounds => {
   const { left, top, right, bottom } = margins;
 
   const chartWidth = width - left - right;
-  const chartHeight = chartWidth * aspectRatio;
+  const chartHeight = height - top - bottom;
 
   return {
     width,
     height: chartHeight + top + bottom,
+    aspectRatio: chartHeight / chartWidth,
     margins,
     chartWidth,
     chartHeight,

--- a/app/charts/shared/chart-dimensions.tsx
+++ b/app/charts/shared/chart-dimensions.tsx
@@ -23,7 +23,6 @@ type ComputeChartPaddingProps = {
 const computeChartPadding = (props: ComputeChartPaddingProps) => {
   const {
     yScale,
-    width,
     height,
     interactiveFiltersConfig,
     animationPresent,

--- a/app/charts/shared/chart-dimensions.tsx
+++ b/app/charts/shared/chart-dimensions.tsx
@@ -35,7 +35,7 @@ const computeChartPadding = (props: ComputeChartPaddingProps) => {
   // Fake ticks to compute maximum tick length as
   // we need to take into account n between [0, 1] where numbers
   // with decimals have greater text length than the extremes.
-  const fakeTicks = yScale.ticks(getTickNumber(width * height));
+  const fakeTicks = yScale.ticks(getTickNumber(height));
   const minLeftTickWidth =
     !!interactiveFiltersConfig?.calculation.active || normalize
       ? getTextWidth("100%", { fontSize: TICK_FONT_SIZE }) + TICK_PADDING

--- a/app/charts/shared/chart-dimensions.tsx
+++ b/app/charts/shared/chart-dimensions.tsx
@@ -35,8 +35,6 @@ const computeChartPadding = (props: ComputeChartPaddingProps) => {
   // Fake ticks to compute maximum tick length as
   // we need to take into account n between [0, 1] where numbers
   // with decimals have greater text length than the extremes.
-  // Width * aspectRatio is taken as an approximation of chartHeight
-  // since we do not have access to chartHeight yet.
   const fakeTicks = yScale.ticks(getTickNumber(width * height));
   const minLeftTickWidth =
     !!interactiveFiltersConfig?.calculation.active || normalize

--- a/app/charts/shared/containers.tsx
+++ b/app/charts/shared/containers.tsx
@@ -1,5 +1,6 @@
 import { Box, BoxProps } from "@mui/material";
 import { makeStyles } from "@mui/styles";
+import clsx from "clsx";
 import { select } from "d3-selection";
 import { ReactNode, useEffect, useRef } from "react";
 
@@ -7,9 +8,14 @@ import { useChartState } from "@/charts/shared/chart-state";
 import { CalculationToggle } from "@/charts/shared/interactive-filter-calculation-toggle";
 import { useObserverRef } from "@/charts/shared/use-width";
 import { chartPanelLayoutGridClasses } from "@/components/chart-panel-layout-grid";
+import { ChartConfig } from "@/configurator";
 import { useTransitionStore } from "@/stores/transition";
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles<
+  {},
+  {},
+  ChartConfig["chartType"] | "chartContainer"
+>(() => ({
   chartContainer: {
     position: "relative",
     width: "100%",
@@ -21,14 +27,37 @@ const useStyles = makeStyles(() => ({
       aspectRatio: "auto",
     },
   },
+
+  // Chart type specific styles, if we need for example to set a specific aspect-ratio
+  // for a specific chart type
+  area: {},
+  column: {},
+  comboLineColumn: {},
+  comboLineDual: {},
+  comboLineSingle: {},
+  line: {},
+  map: {},
+  pie: {},
+  scatterplot: {},
+  table: {},
 }));
 
-export const ChartContainer = ({ children }: { children: ReactNode }) => {
+export const ChartContainer = ({
+  children,
+  type,
+}: {
+  children: ReactNode;
+  type: ChartConfig["chartType"];
+}) => {
   const ref = useObserverRef();
   const classes = useStyles();
 
   return (
-    <div ref={ref} aria-hidden="true" className={classes.chartContainer}>
+    <div
+      ref={ref}
+      aria-hidden="true"
+      className={clsx(classes.chartContainer, classes[type])}
+    >
       {children}
     </div>
   );

--- a/app/charts/shared/containers.tsx
+++ b/app/charts/shared/containers.tsx
@@ -1,4 +1,5 @@
 import { Box, BoxProps } from "@mui/material";
+import { makeStyles } from "@mui/styles";
 import { select } from "d3-selection";
 import { ReactNode, useEffect, useRef } from "react";
 
@@ -6,23 +7,21 @@ import { useChartState } from "@/charts/shared/chart-state";
 import { CalculationToggle } from "@/charts/shared/interactive-filter-calculation-toggle";
 import { useTransitionStore } from "@/stores/transition";
 
+const useStyles = makeStyles(() => ({
+  chartContainer: {
+    position: "relative",
+    width: "100%",
+    overflow: "hidden",
+    flexGrow: 1,
+  },
+}));
+
 export const ChartContainer = ({ children }: { children: ReactNode }) => {
   const ref = useRef<HTMLDivElement>(null);
+  const classes = useStyles();
 
   return (
-    <div
-      ref={ref}
-      aria-hidden="true"
-      className="chart-container"
-      style={{
-        position: "relative",
-        width: "100%",
-        height: "100%",
-        overflow: "hidden",
-        minHeight: 250,
-        aspectRatio: "5 / 2",
-      }}
-    >
+    <div ref={ref} aria-hidden="true" className={classes.chartContainer}>
       {children}
     </div>
   );

--- a/app/charts/shared/containers.tsx
+++ b/app/charts/shared/containers.tsx
@@ -5,6 +5,8 @@ import { ReactNode, useEffect, useRef } from "react";
 
 import { useChartState } from "@/charts/shared/chart-state";
 import { CalculationToggle } from "@/charts/shared/interactive-filter-calculation-toggle";
+import { useObserverRef } from "@/charts/shared/use-width";
+import { chartPanelLayoutGridClasses } from "@/components/chart-panel-layout-grid";
 import { useTransitionStore } from "@/stores/transition";
 
 const useStyles = makeStyles(() => ({
@@ -13,11 +15,16 @@ const useStyles = makeStyles(() => ({
     width: "100%",
     overflow: "hidden",
     flexGrow: 1,
+    aspectRatio: "5 / 2",
+
+    [`.${chartPanelLayoutGridClasses.root} &`]: {
+      aspectRatio: "auto",
+    },
   },
 }));
 
 export const ChartContainer = ({ children }: { children: ReactNode }) => {
-  const ref = useRef<HTMLDivElement>(null);
+  const ref = useObserverRef();
   const classes = useStyles();
 
   return (

--- a/app/charts/shared/containers.tsx
+++ b/app/charts/shared/containers.tsx
@@ -1,6 +1,6 @@
 import { Box, BoxProps } from "@mui/material";
 import { select } from "d3-selection";
-import React, { ReactNode, useEffect, useRef } from "react";
+import { ReactNode, useEffect, useRef } from "react";
 
 import { useChartState } from "@/charts/shared/chart-state";
 import { CalculationToggle } from "@/charts/shared/interactive-filter-calculation-toggle";
@@ -8,34 +8,21 @@ import { useTransitionStore } from "@/stores/transition";
 
 export const ChartContainer = ({ children }: { children: ReactNode }) => {
   const ref = useRef<HTMLDivElement>(null);
-  const enableTransition = useTransitionStore((state) => state.enable);
-  const transitionDuration = useTransitionStore((state) => state.duration);
-  const {
-    bounds: { width, height },
-  } = useChartState();
-
-  useEffect(() => {
-    if (ref.current) {
-      // Initialize height on mount
-      if (!ref.current.style.height) {
-        ref.current.style.height = `${height}px`;
-      }
-
-      const sel = select(ref.current);
-
-      if (enableTransition) {
-        sel
-          .transition()
-          .duration(transitionDuration)
-          .style("height", `${height}px`);
-      } else {
-        sel.style("height", `${height}px`);
-      }
-    }
-  }, [height, enableTransition, transitionDuration]);
 
   return (
-    <div ref={ref} aria-hidden="true" style={{ position: "relative", width }}>
+    <div
+      ref={ref}
+      aria-hidden="true"
+      className="chart-container"
+      style={{
+        position: "relative",
+        width: "100%",
+        height: "100%",
+        overflow: "hidden",
+        minHeight: 250,
+        aspectRatio: "5 / 2",
+      }}
+    >
       {children}
     </div>
   );

--- a/app/charts/shared/use-width.tsx
+++ b/app/charts/shared/use-width.tsx
@@ -1,3 +1,4 @@
+import { makeStyles } from "@mui/styles";
 import {
   createContext,
   ReactNode,
@@ -29,12 +30,19 @@ export type Bounds = {
 const INITIAL_WIDTH = 1;
 const INITIAL_HEIGHT = 1;
 
+const useStyles = makeStyles(() => ({
+  chartObserver: {
+    display: "flex",
+    minHeight: "100%",
+  },
+}));
+
 export const Observer = ({ children }: { children: ReactNode }) => {
   const [ref, width, height] = useResizeObserver<HTMLDivElement>();
   const prev = useTimedPrevious(width, 500);
   const isResizing = prev !== width;
   const setEnableTransition = useTransitionStore((state) => state.setEnable);
-
+  const classes = useStyles();
   useEffect(
     () => setEnableTransition(!isResizing),
     [isResizing, setEnableTransition]
@@ -43,10 +51,7 @@ export const Observer = ({ children }: { children: ReactNode }) => {
   const size = useMemo(() => ({ width, height }), [width, height]);
 
   return (
-    <div
-      ref={ref}
-      style={{ display: "flex", minHeight: "100%", outline: "1px solid red" }}
-    >
+    <div ref={ref} className={classes.chartObserver}>
       <ChartObserverContext.Provider value={size}>
         {children}
       </ChartObserverContext.Provider>

--- a/app/charts/shared/use-width.tsx
+++ b/app/charts/shared/use-width.tsx
@@ -1,4 +1,10 @@
-import React, { createContext, ReactNode, useContext, useEffect } from "react";
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useMemo,
+} from "react";
 
 import { useTransitionStore } from "@/stores/transition";
 import { useResizeObserver } from "@/utils/use-resize-observer";
@@ -20,9 +26,10 @@ export type Bounds = {
 };
 
 const INITIAL_WIDTH = 1;
+const INITIAL_HEIGHT = 1;
 
 export const Observer = ({ children }: { children: ReactNode }) => {
-  const [ref, width] = useResizeObserver<HTMLDivElement>();
+  const [ref, width, height] = useResizeObserver<HTMLDivElement>();
   const prev = useTimedPrevious(width, 500);
   const isResizing = prev !== width;
   const setEnableTransition = useTransitionStore((state) => state.setEnable);
@@ -32,16 +39,21 @@ export const Observer = ({ children }: { children: ReactNode }) => {
     [isResizing, setEnableTransition]
   );
 
+  const size = useMemo(() => ({ width, height }), [width, height]);
+
   return (
     <div ref={ref} style={{ display: "flex", minHeight: "100%" }}>
-      <ChartObserverContext.Provider value={width}>
+      <ChartObserverContext.Provider value={size}>
         {children}
       </ChartObserverContext.Provider>
     </div>
   );
 };
 
-const ChartObserverContext = createContext(INITIAL_WIDTH);
+const ChartObserverContext = createContext({
+  width: INITIAL_WIDTH,
+  height: INITIAL_HEIGHT,
+});
 
 export const useWidth = () => {
   const ctx = useContext(ChartObserverContext);
@@ -52,5 +64,17 @@ export const useWidth = () => {
     );
   }
 
-  return ctx;
+  return ctx.width;
+};
+
+export const useHeight = () => {
+  const ctx = useContext(ChartObserverContext);
+
+  if (ctx === undefined) {
+    throw Error(
+      "You need to wrap your component in <ChartObserverContextProvider /> to useWidth()"
+    );
+  }
+
+  return ctx.height;
 };

--- a/app/charts/shared/use-width.tsx
+++ b/app/charts/shared/use-width.tsx
@@ -1,4 +1,3 @@
-import { makeStyles } from "@mui/styles";
 import {
   createContext,
   ReactNode,
@@ -27,32 +26,29 @@ export type Bounds = {
   aspectRatio: number;
 };
 
-const useStyles = makeStyles(() => ({
-  chartObserver: {
-    display: "flex",
-    minHeight: "100%",
-  },
-}));
-
 export const Observer = ({ children }: { children: ReactNode }) => {
   const [ref, width, height] = useResizeObserver<HTMLDivElement>();
   const prev = useTimedPrevious(width, 500);
   const isResizing = prev !== width;
   const setEnableTransition = useTransitionStore((state) => state.setEnable);
-  const classes = useStyles();
   useEffect(
     () => setEnableTransition(!isResizing),
     [isResizing, setEnableTransition]
   );
 
-  const size = useMemo(() => ({ width, height }), [width, height]);
+  const size = useMemo(
+    () => ({
+      width,
+      height,
+      ref,
+    }),
+    [width, height, ref]
+  );
 
   return (
-    <div ref={ref} className={classes.chartObserver}>
-      <ChartObserverContext.Provider value={size}>
-        {children}
-      </ChartObserverContext.Provider>
-    </div>
+    <ChartObserverContext.Provider value={size}>
+      {children}
+    </ChartObserverContext.Provider>
   );
 };
 
@@ -62,6 +58,7 @@ const ChartObserverContext = createContext(
     | {
         width: number;
         height: number;
+        ref: (node: HTMLDivElement) => void;
       }
 );
 
@@ -87,4 +84,16 @@ export const useHeight = () => {
   }
 
   return ctx.height;
+};
+
+export const useObserverRef = () => {
+  const ctx = useContext(ChartObserverContext);
+
+  if (ctx === undefined) {
+    throw Error(
+      "You need to wrap your component in <ChartObserverContextProvider /> to useWidth()"
+    );
+  }
+
+  return ctx.ref;
 };

--- a/app/charts/shared/use-width.tsx
+++ b/app/charts/shared/use-width.tsx
@@ -31,10 +31,9 @@ export const Observer = ({ children }: { children: ReactNode }) => {
   const prev = useTimedPrevious(width, 500);
   const isResizing = prev !== width;
   const setEnableTransition = useTransitionStore((state) => state.setEnable);
-  useEffect(
-    () => setEnableTransition(!isResizing),
-    [isResizing, setEnableTransition]
-  );
+  useEffect(() => {
+    setEnableTransition(!isResizing);
+  }, [isResizing, setEnableTransition]);
 
   const size = useMemo(
     () => ({
@@ -79,7 +78,7 @@ export const useHeight = () => {
 
   if (ctx === undefined) {
     throw Error(
-      "You need to wrap your component in <ChartObserverContextProvider /> to useWidth()"
+      "You need to wrap your component in <ChartObserverContextProvider /> to useHeight()"
     );
   }
 
@@ -91,7 +90,7 @@ export const useObserverRef = () => {
 
   if (ctx === undefined) {
     throw Error(
-      "You need to wrap your component in <ChartObserverContextProvider /> to useWidth()"
+      "You need to wrap your component in <ChartObserverContextProvider /> to useObserverRef()"
     );
   }
 

--- a/app/charts/shared/use-width.tsx
+++ b/app/charts/shared/use-width.tsx
@@ -27,9 +27,6 @@ export type Bounds = {
   aspectRatio: number;
 };
 
-const INITIAL_WIDTH = 1;
-const INITIAL_HEIGHT = 1;
-
 const useStyles = makeStyles(() => ({
   chartObserver: {
     display: "flex",
@@ -59,10 +56,14 @@ export const Observer = ({ children }: { children: ReactNode }) => {
   );
 };
 
-const ChartObserverContext = createContext({
-  width: INITIAL_WIDTH,
-  height: INITIAL_HEIGHT,
-});
+const ChartObserverContext = createContext(
+  undefined as
+    | undefined
+    | {
+        width: number;
+        height: number;
+      }
+);
 
 export const useWidth = () => {
   const ctx = useContext(ChartObserverContext);

--- a/app/charts/shared/use-width.tsx
+++ b/app/charts/shared/use-width.tsx
@@ -23,6 +23,7 @@ export type Bounds = {
   margins: Margins;
   chartWidth: number;
   chartHeight: number;
+  aspectRatio: number;
 };
 
 const INITIAL_WIDTH = 1;
@@ -42,7 +43,10 @@ export const Observer = ({ children }: { children: ReactNode }) => {
   const size = useMemo(() => ({ width, height }), [width, height]);
 
   return (
-    <div ref={ref} style={{ display: "flex", minHeight: "100%" }}>
+    <div
+      ref={ref}
+      style={{ display: "flex", minHeight: "100%", outline: "1px solid red" }}
+    >
       <ChartObserverContext.Provider value={size}>
         {children}
       </ChartObserverContext.Provider>

--- a/app/charts/table/table-state.tsx
+++ b/app/charts/table/table-state.tsx
@@ -129,9 +129,12 @@ const useTableState = (
   };
   const chartWidth = width - margins.left - margins.right; // We probably don't need this
   const chartHeight = Math.min(TABLE_HEIGHT, chartData.length * rowHeight);
+
+  const height = chartHeight + margins.top + margins.bottom;
   const bounds = {
     width,
-    height: chartHeight + margins.top + margins.bottom,
+    height,
+    aspectRatio: height / width,
     margins,
     chartWidth,
     chartHeight,

--- a/app/components/chart-panel-layout-grid.tsx
+++ b/app/components/chart-panel-layout-grid.tsx
@@ -6,9 +6,10 @@ import { Layouts } from "react-grid-layout";
 import { ObjectInspector } from "react-inspector";
 
 import { ChartPanelLayoutTypeProps } from "@/components/chart-panel";
-import ChartGridLayout, { generateLayout } from "@/components/react-grid";
+import ChartGridLayout from "@/components/react-grid";
 import { ReactGridLayoutsType, isLayouting } from "@/configurator";
 import { useConfiguratorState } from "@/src";
+import { assert } from "@/utils/assert";
 
 export const chartPanelLayoutGridClasses = {
   root: "chart-panel-grid-layout",
@@ -18,26 +19,20 @@ const ChartPanelLayoutGrid = (props: ChartPanelLayoutTypeProps) => {
   const { chartConfigs } = props;
   const [config, dispatch] = useConfiguratorState(isLayouting);
   const [layouts, setLayouts] = useState<Layouts>(() => {
-    if (
-      config.layout.type === "dashboard" &&
-      config.layout.layout === "tiles"
-    ) {
-      return config.layout.layouts;
-    }
-    return {
-      lg: generateLayout({
-        count: props.chartConfigs.length,
-        layout: "tiles",
-      }),
-    };
+    assert(
+      config.layout.type === "dashboard" && config.layout.layout === "tiles",
+      "ChartPanelLayoutGrid should be rendered only for dashboard layout with tiles"
+    );
+
+    return config.layout.layouts;
   });
 
   const handleChangeLayouts = (layouts: Layouts) => {
     const layout = config.layout;
-    if (layout.type !== "dashboard" || layout.layout !== "tiles") {
-      // Should not happen
-      return;
-    }
+    assert(
+      layout.type === "dashboard" && layout.layout === "tiles",
+      "ChartPanelLayoutGrid should be rendered only for dashboard layout with tiles"
+    );
 
     const parsedLayouts = pipe(
       ReactGridLayoutsType.decode(layouts),

--- a/app/components/chart-panel-layout-grid.tsx
+++ b/app/components/chart-panel-layout-grid.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import { fold } from "fp-ts/lib/Either";
 import { pipe } from "fp-ts/lib/function";
 import { useState } from "react";
@@ -8,6 +9,10 @@ import { ChartPanelLayoutTypeProps } from "@/components/chart-panel";
 import ChartGridLayout, { generateLayout } from "@/components/react-grid";
 import { ReactGridLayoutsType, isLayouting } from "@/configurator";
 import { useConfiguratorState } from "@/src";
+
+export const chartPanelLayoutGridClasses = {
+  root: "chart-panel-grid-layout",
+};
 
 const ChartPanelLayoutGrid = (props: ChartPanelLayoutTypeProps) => {
   const { chartConfigs } = props;
@@ -63,7 +68,7 @@ const ChartPanelLayoutGrid = (props: ChartPanelLayoutTypeProps) => {
   return (
     <>
       <ChartGridLayout
-        className={"layout"}
+        className={clsx("layout", chartPanelLayoutGridClasses.root)}
         layouts={layouts}
         resize
         onLayoutChange={(_l, allLayouts) => handleChangeLayouts(allLayouts)}

--- a/app/components/chart-panel-layout-grid.tsx
+++ b/app/components/chart-panel-layout-grid.tsx
@@ -15,6 +15,21 @@ export const chartPanelLayoutGridClasses = {
   root: "chart-panel-grid-layout",
 };
 
+const decodeLayouts = (layouts: Layouts) => {
+  return pipe(
+    ReactGridLayoutsType.decode(layouts),
+    fold(
+      (err) => {
+        console.error("Error while decoding react-grid-layout", err);
+        return undefined;
+      },
+      (d) => {
+        return d;
+      }
+    )
+  );
+};
+
 const ChartPanelLayoutGrid = (props: ChartPanelLayoutTypeProps) => {
   const { chartConfigs } = props;
   const [config, dispatch] = useConfiguratorState(isLayouting);
@@ -34,18 +49,7 @@ const ChartPanelLayoutGrid = (props: ChartPanelLayoutTypeProps) => {
       "ChartPanelLayoutGrid should be rendered only for dashboard layout with tiles"
     );
 
-    const parsedLayouts = pipe(
-      ReactGridLayoutsType.decode(layouts),
-      fold(
-        (err) => {
-          console.error("Error while decoding react-grid-layout", err);
-          return undefined;
-        },
-        (d) => {
-          return d;
-        }
-      )
-    );
+    const parsedLayouts = decodeLayouts(layouts);
     if (!parsedLayouts) {
       return;
     }

--- a/app/components/chart-panel-layout-grid.tsx
+++ b/app/components/chart-panel-layout-grid.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+import { Layouts } from "react-grid-layout";
+
+import { ChartPanelLayoutTypeProps } from "@/components/chart-panel";
+import ChartGridLayout, {
+  availableHandles,
+  generateLayout,
+} from "@/components/react-grid";
+
+const ChartPanelLayoutGrid = (props: ChartPanelLayoutTypeProps) => {
+  const { chartConfigs } = props;
+  const [resizeHandles, setResizeHandles] = useState(() => availableHandles);
+  const [layouts, setLayouts] = useState<Layouts>(() => {
+    return {
+      lg: generateLayout({
+        count: props.chartConfigs.length,
+        layout: "tiles",
+      }),
+    };
+  });
+  useEffect(() => {
+    setLayouts({
+      lg: generateLayout({
+        count: chartConfigs.length,
+        layout: "tiles",
+      }),
+    });
+  }, [chartConfigs.length, resizeHandles]);
+
+  return (
+    <ChartGridLayout
+      className={"layout"}
+      layouts={layouts}
+      resize
+      resizeHandles={resizeHandles}
+      onLayoutChange={(_l, allLayouts) => setLayouts(allLayouts)}
+    >
+      {chartConfigs.map((chartConfig) => props.renderChart(chartConfig))}
+    </ChartGridLayout>
+  );
+};
+
+export default ChartPanelLayoutGrid;

--- a/app/components/chart-panel-layout-grid.tsx
+++ b/app/components/chart-panel-layout-grid.tsx
@@ -13,6 +13,7 @@ import { assert } from "@/utils/assert";
 
 export const chartPanelLayoutGridClasses = {
   root: "chart-panel-grid-layout",
+  dragHandle: "chart-panel-grid-layout-drag-handle",
 };
 
 const decodeLayouts = (layouts: Layouts) => {
@@ -70,6 +71,7 @@ const ChartPanelLayoutGrid = (props: ChartPanelLayoutTypeProps) => {
         className={clsx("layout", chartPanelLayoutGridClasses.root)}
         layouts={layouts}
         resize
+        draggableHandle={`.${chartPanelLayoutGridClasses.dragHandle}`}
         onLayoutChange={(_l, allLayouts) => handleChangeLayouts(allLayouts)}
       >
         {chartConfigs.map((chartConfig) => props.renderChart(chartConfig))}

--- a/app/components/chart-panel-layout-grid.tsx
+++ b/app/components/chart-panel-layout-grid.tsx
@@ -1,16 +1,24 @@
-import { useEffect, useState } from "react";
+import { fold } from "fp-ts/lib/Either";
+import { pipe } from "fp-ts/lib/function";
+import { useState } from "react";
 import { Layouts } from "react-grid-layout";
+import { ObjectInspector } from "react-inspector";
 
 import { ChartPanelLayoutTypeProps } from "@/components/chart-panel";
-import ChartGridLayout, {
-  availableHandles,
-  generateLayout,
-} from "@/components/react-grid";
+import ChartGridLayout, { generateLayout } from "@/components/react-grid";
+import { ReactGridLayoutsType, isLayouting } from "@/configurator";
+import { useConfiguratorState } from "@/src";
 
 const ChartPanelLayoutGrid = (props: ChartPanelLayoutTypeProps) => {
   const { chartConfigs } = props;
-  const [resizeHandles, setResizeHandles] = useState(() => availableHandles);
+  const [config, dispatch] = useConfiguratorState(isLayouting);
   const [layouts, setLayouts] = useState<Layouts>(() => {
+    if (
+      config.layout.type === "dashboard" &&
+      config.layout.layout === "tiles"
+    ) {
+      return config.layout.layouts;
+    }
     return {
       lg: generateLayout({
         count: props.chartConfigs.length,
@@ -18,25 +26,52 @@ const ChartPanelLayoutGrid = (props: ChartPanelLayoutTypeProps) => {
       }),
     };
   });
-  useEffect(() => {
-    setLayouts({
-      lg: generateLayout({
-        count: chartConfigs.length,
-        layout: "tiles",
-      }),
+
+  const handleChangeLayouts = (layouts: Layouts) => {
+    const layout = config.layout;
+    if (layout.type !== "dashboard" || layout.layout !== "tiles") {
+      // Should not happen
+      return;
+    }
+
+    const parsedLayouts = pipe(
+      ReactGridLayoutsType.decode(layouts),
+      fold(
+        (err) => {
+          console.error("Error while decoding react-grid-layout", err);
+          return undefined;
+        },
+        (d) => {
+          return d;
+        }
+      )
+    );
+    if (!parsedLayouts) {
+      return;
+    }
+
+    dispatch({
+      type: "LAYOUT_CHANGED",
+      value: {
+        ...layout,
+        layouts: parsedLayouts,
+      },
     });
-  }, [chartConfigs.length, resizeHandles]);
+    setLayouts(layouts);
+  };
 
   return (
-    <ChartGridLayout
-      className={"layout"}
-      layouts={layouts}
-      resize
-      resizeHandles={resizeHandles}
-      onLayoutChange={(_l, allLayouts) => setLayouts(allLayouts)}
-    >
-      {chartConfigs.map((chartConfig) => props.renderChart(chartConfig))}
-    </ChartGridLayout>
+    <>
+      <ChartGridLayout
+        className={"layout"}
+        layouts={layouts}
+        resize
+        onLayoutChange={(_l, allLayouts) => handleChangeLayouts(allLayouts)}
+      >
+        {chartConfigs.map((chartConfig) => props.renderChart(chartConfig))}
+      </ChartGridLayout>
+      <ObjectInspector data={layouts} />
+    </>
   );
 };
 

--- a/app/components/chart-panel-layout-vertical.tsx
+++ b/app/components/chart-panel-layout-vertical.tsx
@@ -1,13 +1,6 @@
-import { ChartConfig } from "@/config-types";
+import { ChartPanelLayoutTypeProps } from "@/components/chart-panel";
 
-type ChartPanelLayoutVerticalProps = {
-  chartConfigs: ChartConfig[];
-  renderChart: (chartConfig: ChartConfig) => JSX.Element;
-};
-
-export const ChartPanelLayoutVertical = (
-  props: ChartPanelLayoutVerticalProps
-) => {
+export const ChartPanelLayoutVertical = (props: ChartPanelLayoutTypeProps) => {
   const { chartConfigs, renderChart } = props;
   return <>{chartConfigs.map(renderChart)}</>;
 };

--- a/app/components/chart-panel.tsx
+++ b/app/components/chart-panel.tsx
@@ -3,6 +3,7 @@ import { makeStyles } from "@mui/styles";
 import clsx from "clsx";
 import React, { HTMLProps, forwardRef } from "react";
 
+import ChartPanelLayoutGrid from "@/components/chart-panel-layout-grid";
 import { ChartPanelLayoutTall } from "@/components/chart-panel-layout-tall";
 import { ChartPanelLayoutVertical } from "@/components/chart-panel-layout-vertical";
 import { ChartSelectionTabs } from "@/components/chart-selection-tabs";
@@ -14,7 +15,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     flexDirection: "column",
     gap: theme.spacing(4),
   },
-  chartWrapper: {
+  chartWrapperInner: {
     display: "contents",
     overflow: "hidden",
     width: "auto",
@@ -32,10 +33,10 @@ export const ChartWrapper = forwardRef<HTMLDivElement, ChartWrapperProps>(
     const { children, editing, layoutType, ...rest } = props;
     const classes = useStyles();
     return (
-      <Box ref={ref} {...rest} sx={{ ...rest.sx, display: "contents" }}>
+      <Box ref={ref} {...rest}>
         {(editing || layoutType === "tab") && <ChartSelectionTabs />}
         <Box
-          className={classes.chartWrapper}
+          className={classes.chartWrapperInner}
           sx={{ minHeight: [150, 300, 500] }}
         >
           {children}
@@ -52,7 +53,7 @@ type ChartPanelLayoutProps = React.PropsWithChildren<{
 }> &
   HTMLProps<HTMLDivElement>;
 
-type ChartPanelLayoutTypeProps = {
+export type ChartPanelLayoutTypeProps = {
   chartConfigs: ChartConfig[];
   renderChart: (chartConfig: ChartConfig) => JSX.Element;
 };
@@ -63,6 +64,7 @@ const Wrappers: Record<
 > = {
   vertical: ChartPanelLayoutVertical,
   tall: ChartPanelLayoutTall,
+  tiles: ChartPanelLayoutGrid,
 };
 
 export const ChartPanelLayout = (props: ChartPanelLayoutProps) => {

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -21,6 +21,7 @@ import {
   ChartWrapper,
   ChartWrapperProps,
 } from "@/components/chart-panel";
+import { chartPanelLayoutGridClasses } from "@/components/chart-panel-layout-grid";
 import {
   ChartTablePreviewProvider,
   useChartTablePreview,
@@ -214,7 +215,16 @@ const ReactGridChartPreview = forwardRef<
   return (
     <ChartTablePreviewProvider>
       <ChartWrapper {...rest} ref={ref}>
-        <ChartPreviewInner dataSource={dataSource} chartKey={chartKey}>
+        <ChartPreviewInner
+          dataSource={dataSource}
+          chartKey={chartKey}
+          actionElementSlot={
+            <DragHandle
+              dragging
+              className={chartPanelLayoutGridClasses.dragHandle}
+            />
+          }
+        >
           {children}
         </ChartPreviewInner>
       </ChartWrapper>

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -214,7 +214,9 @@ const ReactGridChartPreview = forwardRef<
   return (
     <ChartTablePreviewProvider>
       <ChartWrapper {...rest} ref={ref}>
-        <ChartPreviewInner dataSource={dataSource} chartKey={chartKey} />
+        <ChartPreviewInner dataSource={dataSource} chartKey={chartKey}>
+          {children}
+        </ChartPreviewInner>
       </ChartWrapper>
     </ChartTablePreviewProvider>
   );
@@ -336,6 +338,7 @@ type ChartPreviewInnerProps = ChartPreviewProps & {
   chartKey?: string | null;
   actionElementSlot?: React.ReactNode;
   disableMetadataPanel?: boolean;
+  children?: React.ReactNode;
 };
 
 export const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
@@ -388,6 +391,7 @@ export const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
 
   return (
     <Box className={chartClasses.root}>
+      {props.children}
       <ChartErrorBoundary resetKeys={[state]}>
         {/* FIXME: adapt to design */}
         {metadata?.dataCubesMetadata.some(

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -21,7 +21,6 @@ import {
   ChartWrapper,
   ChartWrapperProps,
 } from "@/components/chart-panel";
-import { DragHandle } from "@/components/chart-selection-tabs";
 import {
   ChartTablePreviewProvider,
   useChartTablePreview,
@@ -29,6 +28,7 @@ import {
 import { useChartStyles } from "@/components/chart-utils";
 import { ChartWithFilters } from "@/components/chart-with-filters";
 import DebugPanel from "@/components/debug-panel";
+import { DragHandle } from "@/components/drag-handle";
 import Flex from "@/components/flex";
 import { Checkbox } from "@/components/form";
 import { HintYellow } from "@/components/hint";

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -521,7 +521,7 @@ export const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
                   dimensions={dimensions}
                 />
                 {/* Wrap in div for subgrid layout */}
-                <div>
+                <div className="debug-panel">
                   <DebugPanel configurator interactiveFilters />
                 </div>
               </InteractiveFiltersChartProvider>

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -497,6 +497,7 @@ export const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
                     minWidth: 0,
                     height: containerHeight.current,
                     paddingTop: 16,
+                    flexGrow: 1,
                   }}
                 >
                   {isTablePreview ? (

--- a/app/components/chart-selection-tabs.tsx
+++ b/app/components/chart-selection-tabs.tsx
@@ -2,7 +2,6 @@ import { t, Trans } from "@lingui/macro";
 import { TabContext } from "@mui/lab";
 import {
   Box,
-  BoxProps,
   Button,
   Grow,
   Popover,
@@ -15,13 +14,7 @@ import { PUBLISHED_STATE } from "@prisma/client";
 import { useSession } from "next-auth/react";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import React, {
-  createContext,
-  useContext,
-  useState,
-  useEffect,
-  forwardRef,
-} from "react";
+import React, { createContext, useContext, useEffect, useState } from "react";
 import { DragDropContext, Draggable, Droppable } from "react-beautiful-dnd";
 import { useClient } from "urql";
 import { useDebounce } from "use-debounce";
@@ -58,6 +51,7 @@ import { replaceLinks } from "@/utils/ui-strings";
 import useEvent from "@/utils/use-event";
 import { useMutate } from "@/utils/use-fetch-data";
 
+import { DragHandle } from "./drag-handle";
 import { useLocalSnack } from "./use-local-snack";
 
 type TabsState = {
@@ -662,7 +656,7 @@ const TabsInner = (props: TabsInnerProps) => {
   );
 };
 
-const useIconStyles = makeStyles<
+export const useIconStyles = makeStyles<
   Theme,
   { active: boolean | undefined; dragging: boolean | undefined }
 >(({ palette, spacing }) => ({
@@ -754,27 +748,3 @@ const TabContent = (props: TabContentProps) => {
     </Flex>
   );
 };
-
-type DragHandleProps = BoxProps & {
-  dragging?: boolean;
-};
-
-export const DragHandle = forwardRef<HTMLDivElement, DragHandleProps>(
-  (props, ref) => {
-    const { dragging, ...rest } = props;
-    const classes = useIconStyles({ active: false, dragging });
-
-    return (
-      <Box
-        ref={ref}
-        {...rest}
-        className={classes.dragIconWrapper}
-        sx={{
-          color: dragging ? "secondary.active" : "secondary.disabled",
-        }}
-      >
-        <Icon name="dragndrop" />
-      </Box>
-    );
-  }
-);

--- a/app/components/chart-utils.ts
+++ b/app/components/chart-utils.ts
@@ -1,6 +1,8 @@
 import { Theme } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 
+import { chartPanelLayoutGridClasses } from "@/components/chart-panel-layout-grid";
+
 /** Generic styles shared between `ChartPreview` and `ChartPublished`. */
 export const useChartStyles = makeStyles<Theme>((theme) => ({
   root: {
@@ -14,7 +16,10 @@ export const useChartStyles = makeStyles<Theme>((theme) => ({
     border: "1px solid",
     borderColor: theme.palette.divider,
     color: theme.palette.grey[800],
-    display: "flex",
-    flexDirection: "column",
+
+    [`.${chartPanelLayoutGridClasses.root} &`]: {
+      display: "flex",
+      flexDirection: "column",
+    },
   },
 }));

--- a/app/components/chart-utils.ts
+++ b/app/components/chart-utils.ts
@@ -8,10 +8,13 @@ export const useChartStyles = makeStyles<Theme>((theme) => ({
     gridTemplateRows: "subgrid",
     /** Should stay in sync with the number of rows contained in a chart */
     gridRow: "span 6",
+    height: "100%",
     padding: theme.spacing(6),
     backgroundColor: theme.palette.background.paper,
     border: "1px solid",
     borderColor: theme.palette.divider,
     color: theme.palette.grey[800],
+    display: "flex",
+    flexDirection: "column",
   },
 }));

--- a/app/components/chart-with-filters.tsx
+++ b/app/components/chart-with-filters.tsx
@@ -162,7 +162,7 @@ export const ChartWithFilters = forwardRef<
     <div
       className="chart-with-filters"
       ref={ref}
-      style={{ width: "100%", height: "100%" }}
+      style={{ width: "100%", flexGrow: 1 }}
     >
       <Observer>
         <GenericChart {...props} />

--- a/app/components/chart-with-filters.tsx
+++ b/app/components/chart-with-filters.tsx
@@ -1,3 +1,4 @@
+import { makeStyles } from "@mui/styles";
 import dynamic from "next/dynamic";
 import { forwardRef } from "react";
 
@@ -151,19 +152,22 @@ type ChartWithFiltersProps = {
   chartConfig: ChartConfig;
 };
 
+const useStyles = makeStyles(() => ({
+  chartWithFilters: {
+    width: "100%",
+    height: "100%",
+  },
+}));
+
 export const ChartWithFilters = forwardRef<
   HTMLDivElement,
   ChartWithFiltersProps
 >((props, ref) => {
   useSyncInteractiveFilters(props.chartConfig);
+  const classes = useStyles();
 
   return (
-    // Minimum aspect ratio for any chart (0.4)
-    <div
-      className="chart-with-filters"
-      ref={ref}
-      style={{ width: "100%", flexGrow: 1 }}
-    >
+    <div className={classes.chartWithFilters} ref={ref}>
       <Observer>
         <GenericChart {...props} />
       </Observer>

--- a/app/components/chart-with-filters.tsx
+++ b/app/components/chart-with-filters.tsx
@@ -1,5 +1,5 @@
 import dynamic from "next/dynamic";
-import React, { forwardRef } from "react";
+import { forwardRef } from "react";
 
 import { useQueryFilters } from "@/charts/shared/chart-helpers";
 import useSyncInteractiveFilters from "@/charts/shared/use-sync-interactive-filters";
@@ -159,7 +159,11 @@ export const ChartWithFilters = forwardRef<
 
   return (
     // Minimum aspect ratio for any chart (0.4)
-    <div ref={ref} style={{ width: "100%", aspectRatio: "5 / 2" }}>
+    <div
+      className="chart-with-filters"
+      ref={ref}
+      style={{ width: "100%", height: "100%" }}
+    >
       <Observer>
         <GenericChart {...props} />
       </Observer>

--- a/app/components/drag-handle.tsx
+++ b/app/components/drag-handle.tsx
@@ -1,4 +1,5 @@
 import { Box, BoxProps } from "@mui/material";
+import clsx from "clsx";
 import { forwardRef } from "react";
 
 import { Icon } from "@/icons";
@@ -18,7 +19,7 @@ export const DragHandle = forwardRef<HTMLDivElement, DragHandleProps>(
       <Box
         ref={ref}
         {...rest}
-        className={classes.dragIconWrapper}
+        className={clsx(classes.dragIconWrapper, props.className)}
         sx={{
           color: dragging ? "secondary.active" : "secondary.disabled",
         }}

--- a/app/components/drag-handle.tsx
+++ b/app/components/drag-handle.tsx
@@ -1,0 +1,30 @@
+import { Box, BoxProps } from "@mui/material";
+import { forwardRef } from "react";
+
+import { Icon } from "@/icons";
+
+import { useIconStyles } from "./chart-selection-tabs";
+
+type DragHandleProps = BoxProps & {
+  dragging?: boolean;
+};
+
+export const DragHandle = forwardRef<HTMLDivElement, DragHandleProps>(
+  (props, ref) => {
+    const { dragging, ...rest } = props;
+    const classes = useIconStyles({ active: false, dragging });
+
+    return (
+      <Box
+        ref={ref}
+        {...rest}
+        className={classes.dragIconWrapper}
+        sx={{
+          color: dragging ? "secondary.active" : "secondary.disabled",
+        }}
+      >
+        <Icon name="dragndrop" />
+      </Box>
+    );
+  }
+);

--- a/app/components/react-grid.tsx
+++ b/app/components/react-grid.tsx
@@ -4,12 +4,7 @@ import clsx from "clsx";
 import map from "lodash/map";
 import mapValues from "lodash/mapValues";
 import range from "lodash/range";
-import {
-  ComponentProps,
-  useEffect,
-  useMemo,
-  useState
-} from "react";
+import { ComponentProps, useEffect, useMemo, useState } from "react";
 import { Layout, Responsive, WidthProvider } from "react-grid-layout";
 import { match } from "ts-pattern";
 
@@ -17,10 +12,6 @@ const ResponsiveReactGridLayout = WidthProvider(Responsive);
 
 export type ResizeHandle = NonNullable<Layout["resizeHandles"]>[number];
 export type GridLayout = "horizontal" | "vertical" | "wide" | "tall";
-
-
-
-const ResponsiveGridLayout = WidthProvider(Responsive);
 
 export const availableHandles: ResizeHandle[] = [
   "s",
@@ -41,7 +32,7 @@ const MIN_H = 2;
 const MAX_W = 4;
 
 const COLS = { lg: 4, md: 2, sm: 1, xs: 1, xxs: 1 };
-const ROW_HEIGHT = 300;
+const ROW_HEIGHT = 500;
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {
@@ -170,7 +161,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       transform: "rotate(45deg)",
     },
     "& .react-grid-item:not(.react-grid-placeholder)": {
-      background: theme.palette.background.paper,
+      background: "#eee",
       border: theme.palette.divider,
       boxShadow: theme.shadows[1],
     },
@@ -228,7 +219,7 @@ export const ChartGridLayout = (props: ChartGridLayoutProps) => {
 
   const classes = useStyles();
   return (
-    <ResponsiveGridLayout
+    <ResponsiveReactGridLayout
       {...props}
       layouts={enhancedLayouts}
       className={clsx(classes.root, props.className)}
@@ -240,22 +231,22 @@ export const ChartGridLayout = (props: ChartGridLayoutProps) => {
       preventCollision={false}
     >
       {children}
-    </ResponsiveGridLayout>
+    </ResponsiveReactGridLayout>
   );
 };
 
 export const generateLayout = function ({
-  resizeHandles,
   count,
   maxWidth = MAX_W,
   maxHeight = MAX_H,
   layout,
+  resizeHandles,
 }: {
-  resizeHandles: ResizeHandle[];
   count: number;
   maxWidth?: number;
   maxHeight?: number;
-  layout: "horizontal" | "vertical" | "wide" | "tall";
+  layout: "horizontal" | "vertical" | "wide" | "tall" | "tiles";
+  resizeHandles?: ResizeHandle[];
 }) {
   return map(range(0, count), (_item, i) => {
     return match(layout)
@@ -288,6 +279,16 @@ export const generateLayout = function ({
           y: i === 0 ? 0 : h * (i - 1),
           w: maxWidth / 2,
           h: i === 0 ? maxHeight : h,
+          i: i.toString(),
+          resizeHandles,
+        };
+      })
+      .with("tiles", () => {
+        return {
+          x: i % 3,
+          y: Math.floor(i / 3),
+          w: 4,
+          h: 4,
           i: i.toString(),
           resizeHandles,
         };

--- a/app/components/react-grid.tsx
+++ b/app/components/react-grid.tsx
@@ -25,14 +25,14 @@ export const availableHandles: ResizeHandle[] = [
 ];
 
 /** In grid unit */
-const MAX_H = 4;
-const MIN_H = 2;
+const MAX_H = 10;
+const MIN_H = 5;
 
 /** In grid unit */
 const MAX_W = 4;
 
 const COLS = { lg: 4, md: 2, sm: 1, xs: 1, xxs: 1 };
-const ROW_HEIGHT = 500;
+const ROW_HEIGHT = 100;
 
 const useStyles = makeStyles((theme: Theme) => ({
   root: {

--- a/app/components/react-grid.tsx
+++ b/app/components/react-grid.tsx
@@ -26,6 +26,7 @@ export const availableHandles: ResizeHandle[] = [
 
 /** In grid unit */
 const MAX_H = 10;
+const INITIAL_H = 7;
 const MIN_H = 5;
 
 /** In grid unit */
@@ -285,12 +286,12 @@ export const generateLayout = function ({
       })
       .with("tiles", () => {
         return {
-          x: i % 3,
-          y: Math.floor(i / 3),
-          w: 4,
-          h: 4,
+          x: ((i % 2) * MAX_W) / 2,
+          y: Math.floor(i / 2) * INITIAL_H,
+          w: MAX_W / 2,
+          h: INITIAL_H,
           i: i.toString(),
-          resizeHandles,
+          resizeHandles: [],
         };
       })
       .with("wide", () => {

--- a/app/components/react-grid.tsx
+++ b/app/components/react-grid.tsx
@@ -91,12 +91,12 @@ const useStyles = makeStyles((theme: Theme) => ({
     "& .react-grid-item.react-grid-placeholder.placeholder-resizing": {
       transition: "none",
     },
-    "& .react-grid-item > .react-resizable-handle": {
+    "& .react-grid-item .react-resizable-handle": {
       position: "absolute",
       width: "20px",
       height: "20px",
     },
-    "& .react-grid-item > .react-resizable-handle::after": {
+    "& .react-grid-item .react-resizable-handle::after": {
       content: '""',
       position: "absolute",
       right: "3px",
@@ -106,57 +106,57 @@ const useStyles = makeStyles((theme: Theme) => ({
       borderRight: "2px solid rgba(0, 0, 0, 0.4)",
       borderBottom: "2px solid rgba(0, 0, 0, 0.4)",
     },
-    "& .react-resizable-hide > .react-resizable-handle": {
+    "& .react-resizable-hide .react-resizable-handle": {
       display: "none",
     },
-    "& .react-grid-item > .react-resizable-handle.react-resizable-handle-sw": {
+    "& .react-grid-item .react-resizable-handle.react-resizable-handle-sw": {
       bottom: "0",
       left: "0",
       cursor: "sw-resize",
       transform: "rotate(90deg)",
     },
-    "& .react-grid-item > .react-resizable-handle.react-resizable-handle-se": {
+    "& .react-grid-item .react-resizable-handle.react-resizable-handle-se": {
       bottom: "0",
       right: "0",
       cursor: "se-resize",
     },
-    "& .react-grid-item > .react-resizable-handle.react-resizable-handle-nw": {
+    "& .react-grid-item .react-resizable-handle.react-resizable-handle-nw": {
       top: "0",
       left: "0",
       cursor: "nw-resize",
       transform: "rotate(180deg)",
     },
-    "& .react-grid-item > .react-resizable-handle.react-resizable-handle-ne": {
+    "& .react-grid-item .react-resizable-handle.react-resizable-handle-ne": {
       top: "0",
       right: "0",
       cursor: "ne-resize",
       transform: "rotate(270deg)",
     },
-    "& .react-grid-item > .react-resizable-handle.react-resizable-handle-w, & .react-grid-item > .react-resizable-handle.react-resizable-handle-e":
+    "& .react-grid-item .react-resizable-handle.react-resizable-handle-w, & .react-grid-item .react-resizable-handle.react-resizable-handle-e":
       {
         top: "50%",
         marginTop: "-10px",
         cursor: "ew-resize",
       },
-    "& .react-grid-item > .react-resizable-handle.react-resizable-handle-w": {
+    "& .react-grid-item .react-resizable-handle.react-resizable-handle-w": {
       left: "0",
       transform: "rotate(135deg)",
     },
-    "& .react-grid-item > .react-resizable-handle.react-resizable-handle-e": {
+    "& .react-grid-item .react-resizable-handle.react-resizable-handle-e": {
       right: "0",
       transform: "rotate(315deg)",
     },
-    "& .react-grid-item > .react-resizable-handle.react-resizable-handle-n, & .react-grid-item > .react-resizable-handle.react-resizable-handle-s":
+    "& .react-grid-item .react-resizable-handle.react-resizable-handle-n, & .react-grid-item .react-resizable-handle.react-resizable-handle-s":
       {
         left: "50%",
         marginLeft: "-10px",
         cursor: "ns-resize",
       },
-    "& .react-grid-item > .react-resizable-handle.react-resizable-handle-n": {
+    "& .react-grid-item .react-resizable-handle.react-resizable-handle-n": {
       top: "0",
       transform: "rotate(225deg)",
     },
-    "& .react-grid-item > .react-resizable-handle.react-resizable-handle-s": {
+    "& .react-grid-item .react-resizable-handle.react-resizable-handle-s": {
       bottom: "0",
       transform: "rotate(45deg)",
     },

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -1147,9 +1147,6 @@ const ReactGridLayoutType = t.type({
   x: t.number,
   y: t.number,
   i: t.string,
-  maxW: t.union([t.number, t.undefined]),
-  minH: t.union([t.number, t.undefined]),
-  maxH: t.union([t.number, t.undefined]),
   resizeHandles: t.union([t.array(ResizeHandle), t.undefined]),
 });
 

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -1130,28 +1130,55 @@ const DataSource = t.type({
 });
 export type DataSource = t.TypeOf<typeof DataSource>;
 
+const ResizeHandle = t.keyof({
+  s: null,
+  w: null,
+  e: null,
+  n: null,
+  sw: null,
+  nw: null,
+  se: null,
+  ne: null,
+});
+
+const ReactGridLayoutType = t.type({
+  w: t.number,
+  h: t.number,
+  x: t.number,
+  y: t.number,
+  i: t.string,
+  maxW: t.union([t.number, t.undefined]),
+  minH: t.union([t.number, t.undefined]),
+  maxH: t.union([t.number, t.undefined]),
+  resizeHandles: t.union([t.array(ResizeHandle), t.undefined]),
+});
+
+export const ReactGridLayoutsType = t.record(
+  t.string,
+  t.array(ReactGridLayoutType)
+);
+
 const Layout = t.intersection([
   t.type({
     activeField: t.union([t.undefined, t.string]),
+    meta: Meta,
   }),
   t.union([
     t.type({
       type: t.literal("tab"),
-      meta: Meta,
     }),
     t.type({
       type: t.literal("dashboard"),
-      layout: t.union([
-        t.literal("vertical"),
-        t.literal("tall"),
-        t.literal("tiles"),
-      ]),
-      meta: Meta,
+      layout: t.union([t.literal("vertical"), t.literal("tall")]),
+    }),
+    t.type({
+      type: t.literal("dashboard"),
+      layout: t.literal("tiles"),
+      layouts: ReactGridLayoutsType,
     }),
     t.type({
       type: t.literal("singleURLs"),
       publishableChartKeys: t.array(t.string),
-      meta: Meta,
     }),
   ]),
 ]);

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -1141,7 +1141,11 @@ const Layout = t.intersection([
     }),
     t.type({
       type: t.literal("dashboard"),
-      layout: t.union([t.literal("vertical"), t.literal("tall")]),
+      layout: t.union([
+        t.literal("vertical"),
+        t.literal("tall"),
+        t.literal("tiles"),
+      ]),
       meta: Meta,
     }),
     t.type({

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -490,7 +490,7 @@ const useFilterReorder = ({
     if (missingDimensions && missingDimensions.length > 0) {
       missingDimensions.forEach(handleAddDimensionFilter);
     }
-  }, [missingDimensions]);
+  }, [handleAddDimensionFilter, missingDimensions]);
 
   return {
     handleRemoveDimensionFilter,

--- a/app/configurator/components/layout-configurator.tsx
+++ b/app/configurator/components/layout-configurator.tsx
@@ -53,6 +53,7 @@ const LayoutLayoutConfigurator = () => {
             >
               <LayoutButton type="tall" layout={layout} />
               <LayoutButton type="vertical" layout={layout} />
+              <LayoutButton type="tiles" layout={layout} />
             </Box>
           </ControlSectionContent>
         </ControlSection>

--- a/app/configurator/components/layout-configurator.tsx
+++ b/app/configurator/components/layout-configurator.tsx
@@ -1,8 +1,10 @@
 import { Trans } from "@lingui/macro";
 import { Box } from "@mui/material";
 import capitalize from "lodash/capitalize";
+import omit from "lodash/omit";
 
-import { LayoutDashboard } from "@/config-types";
+import { generateLayout } from "@/components/react-grid";
+import { ChartConfig, LayoutDashboard } from "@/config-types";
 import { LayoutAnnotator } from "@/configurator/components/annotators";
 import {
   ControlSection,
@@ -68,9 +70,40 @@ type LayoutButtonProps = {
   layout: LayoutDashboard;
 };
 
+const migrateLayout = (
+  layout: LayoutDashboard,
+  newLayoutType: LayoutDashboard["layout"],
+  chartConfigs: ChartConfig[]
+): LayoutDashboard => {
+  if (newLayoutType === "tiles") {
+    const generated = generateLayout({
+      count: chartConfigs.length,
+      layout: "tiles",
+    });
+    return {
+      ...layout,
+      layout: newLayoutType,
+      layouts: {
+        lg: generated.map((l, i) => ({
+          ...l,
+
+          // We must pay attention to correctly change the i value to
+          // chart config key, as it is used to identify the layout
+          i: chartConfigs[i].key,
+        })),
+      },
+    };
+  } else {
+    return {
+      ...omit(layout, "layouts"),
+      layout: newLayoutType,
+    };
+  }
+};
+
 const LayoutButton = (props: LayoutButtonProps) => {
   const { type, layout } = props;
-  const [_, dispatch] = useConfiguratorState(isLayouting);
+  const [config, dispatch] = useConfiguratorState(isLayouting);
 
   return (
     <IconButton
@@ -79,10 +112,7 @@ const LayoutButton = (props: LayoutButtonProps) => {
       onClick={() => {
         dispatch({
           type: "LAYOUT_CHANGED",
-          value: {
-            ...layout,
-            layout: type,
-          },
+          value: migrateLayout(layout, type, config.chartConfigs),
         });
       }}
     />

--- a/app/docs/charts.stories.tsx
+++ b/app/docs/charts.stories.tsx
@@ -80,7 +80,7 @@ const ColumnsStory = {
             dimensionsByIri={keyBy(columnDimensions, (d: Dimension) => d.iri)}
             chartConfig={chartConfig}
           >
-            <ChartContainer>
+            <ChartContainer type="column">
               <ChartSvg>
                 <AxisHeightLinear />
                 <AxisWidthBand />
@@ -129,7 +129,7 @@ const ScatterplotStory = {
             measuresByIri={keyBy(scatterplotMeasures, (d) => d.iri)}
             chartConfig={scatterplotChartConfig}
           >
-            <ChartContainer>
+            <ChartContainer type="scatterplot">
               <ChartSvg>
                 <AxisWidthLinear />
                 <AxisHeightLinear />

--- a/app/docs/charts.stories.tsx
+++ b/app/docs/charts.stories.tsx
@@ -79,7 +79,6 @@ const ColumnsStory = {
             dimensions={columnDimensions}
             dimensionsByIri={keyBy(columnDimensions, (d: Dimension) => d.iri)}
             chartConfig={chartConfig}
-            aspectRatio={0.4}
           >
             <ChartContainer>
               <ChartSvg>
@@ -129,7 +128,6 @@ const ScatterplotStory = {
             measures={scatterplotMeasures}
             measuresByIri={keyBy(scatterplotMeasures, (d) => d.iri)}
             chartConfig={scatterplotChartConfig}
-            aspectRatio={1}
           >
             <ChartContainer>
               <ChartSvg>

--- a/app/docs/datatable.stories.tsx
+++ b/app/docs/datatable.stories.tsx
@@ -33,7 +33,7 @@ const DataTableStory: StoryObj = {
             measuresByIri={keyBy(tableMeasures, (d) => d.iri)}
             chartConfig={tableConfig}
           >
-            <ChartContainer>
+            <ChartContainer type="table">
               <Table />
             </ChartContainer>
           </TableChart>

--- a/app/docs/lines.stories.tsx
+++ b/app/docs/lines.stories.tsx
@@ -58,7 +58,7 @@ const LineChartStory = () => (
           measuresByIri={keyBy(measures, (d) => d.iri)}
           chartConfig={chartConfig}
         >
-          <ChartContainer>
+          <ChartContainer type="line">
             <ChartSvg>
               <BrushTime />
               <AxisHeightLinear /> <AxisTime /> <AxisTimeDomain />

--- a/app/docs/lines.stories.tsx
+++ b/app/docs/lines.stories.tsx
@@ -57,7 +57,6 @@ const LineChartStory = () => (
           measures={measures}
           measuresByIri={keyBy(measures, (d) => d.iri)}
           chartConfig={chartConfig}
-          aspectRatio={0.4}
         >
           <ChartContainer>
             <ChartSvg>

--- a/app/docs/tooltip.stories.tsx
+++ b/app/docs/tooltip.stories.tsx
@@ -105,7 +105,6 @@ const TooltipBoxStory = () => (
           },
           activeField: undefined,
         }}
-        aspectRatio={0.4}
       >
         <Flex>
           <div style={{ width: 200, height: 150, position: "relative" }}>
@@ -271,7 +270,6 @@ const TooltipContentStory = {
           },
           activeField: undefined,
         }}
-        aspectRatio={0.4}
       >
         <div style={{ width: 200, height: 150, position: "relative" }}>
           <Dot />
@@ -340,7 +338,6 @@ export const TooltipContentStory2 = {
           },
           activeField: undefined,
         }}
-        aspectRatio={0.4}
       >
         <div style={{ width: 200, height: 150, position: "relative" }}>
           <Dot />

--- a/app/test/__fixtures/config/int/configs.ts
+++ b/app/test/__fixtures/config/int/configs.ts
@@ -22,11 +22,11 @@ const configs: TestConfig[] = [
   //   name: "Column - Waldfläsche (standard error bars)",
   //   slug: "column-waldflasche",
   // },
-  {
-    chartId: "I0KucujlOLgb",
-    name: "Line - State accounts (segmented)",
-    slug: "line-state-accounts",
-  },
+  // {
+  //   chartId: "I0KucujlOLgb",
+  //   name: "Line - State accounts (segmented)",
+  //   slug: "line-state-accounts",
+  // },
   {
     chartId: "Z6Re21LHbOoP",
     name: "Pie - Red list",

--- a/app/utils/use-resize-observer.ts
+++ b/app/utils/use-resize-observer.ts
@@ -1,5 +1,6 @@
 import { ResizeObserver } from "@juggle/resize-observer";
-import { useEffect, useState, useRef } from "react";
+import { useEventCallback } from "@mui/material";
+import { useEffect, useRef, useState } from "react";
 
 export const useResizeObserver = <T extends Element>() => {
   const roRef = useRef<ResizeObserver>();
@@ -7,7 +8,7 @@ export const useResizeObserver = <T extends Element>() => {
   const [width, changeWidth] = useState(1);
   const [height, changeHeight] = useState(1);
 
-  const handleRef = (node: T) => {
+  const handleRef = useEventCallback((node: T) => {
     if (!node) {
       return;
     }
@@ -29,23 +30,28 @@ export const useResizeObserver = <T extends Element>() => {
         // Prevent flickering when scrollbars appear and triggers another resize
         // by only resizing when difference to current measurement is above a certain threshold
         changeWidth((width) =>
-          Math.abs(newWidth - width) > 16 ? newWidth : width
+          Math.abs(newWidth - width) > 16 && newWidth > 0 ? newWidth : width
         );
         changeHeight((height) =>
-          Math.abs(newHeight - height) > 16 ? newHeight : height
+          Math.abs(newHeight - height) > 16 && newHeight > 0
+            ? newHeight
+            : height
         );
       });
     }
 
     roRef.current.observe(elRef.current);
-  };
+  });
 
   useEffect(() => {
+    if (elRef.current) {
+      handleRef(elRef.current);
+    }
     return () => {
       roRef.current?.disconnect();
       roRef.current = undefined;
     };
-  }, []);
+  }, [handleRef]);
 
   return [handleRef, width, height] as const;
 };


### PR DESCRIPTION
## Tiles layout

In this PR is implemented the tiles layout where the user can move and resize the charts at will.
It makes use of react-grid-layout under the hood and the react grid layouts are saved under
the chart config.

To be able to have charts inside blocks that are resizable, I had to change how the aspect ratio
was dealt with within the charts: previously the charts would all have an aspect ratio (deep
within them), and would compute their height based on this. This would make it impossible to
have charts inside fixed boxes, since the height of the chart could overflow the box because
of the aspect ratio.

This is why I had to remove the constrain of aspect ratio for the dashboard tiles layout. This
was done through the removal of the aspect ratio in all charts. Now they all render based
on the available space they have.

To keep the previous behavior, the chart container now puts a default "5 / 2" aspect ratio,
which ensures that charts have the same space as before. It would be possible to have
a different aspect ratio for each chart via CSS.

For the dashboard layout, the chart container removes the aspect ratio constraint, and the
chart containers take all the space available.
