### PR TITLE
feat: Remove min height constraint on grid layout

### DIFF
--- a/app/charts/shared/containers.tsx
+++ b/app/charts/shared/containers.tsx
@@ -33,6 +33,7 @@ const useStyles = makeStyles<
 
     [`.${chartPanelLayoutGridClasses.root} &`]: {
       aspectRatio: "auto",
+      minHeight: 0,
     },
   },
 


### PR DESCRIPTION
Remove min height constraint on charts in grid layout

- Prevents footer to be cut when charts is resized vertically.
- :warning" Chart could become invisible if legend is too high (should be a problem that is less grave than having the footer cut)
