### PR TITLE
Dashboard canvas works in published mode

### DIFF
--- a/app/components/chart-panel-layout-grid.tsx
+++ b/app/components/chart-panel-layout-grid.tsx
@@ -67,7 +67,7 @@ const ChartPanelLayoutCanvas = (props: ChartPanelLayoutTypeProps) => {
     <ChartGridLayout
       className={chartPanelLayoutGridClasses.root}
       layouts={layouts}
-      resize
+      resize={config.state === "LAYOUTING"}
       draggableHandle={`.${chartPanelLayoutGridClasses.dragHandle}`}
       onLayoutChange={(_l, allLayouts) => handleChangeLayouts(allLayouts)}
     >

--- a/app/components/chart-panel-layout-grid.tsx
+++ b/app/components/chart-panel-layout-grid.tsx
@@ -5,7 +5,7 @@ import { Layouts } from "react-grid-layout";
 
 import { ChartPanelLayoutTypeProps } from "@/components/chart-panel";
 import ChartGridLayout from "@/components/react-grid";
-import { isLayouting, ReactGridLayoutsType } from "@/configurator";
+import { hasChartConfigs, ReactGridLayoutsType } from "@/configurator";
 import { useConfiguratorState } from "@/src";
 import { assert } from "@/utils/assert";
 
@@ -31,7 +31,7 @@ const decodeLayouts = (layouts: Layouts) => {
 
 const ChartPanelLayoutCanvas = (props: ChartPanelLayoutTypeProps) => {
   const { chartConfigs } = props;
-  const [config, dispatch] = useConfiguratorState(isLayouting);
+  const [config, dispatch] = useConfiguratorState(hasChartConfigs);
   const [layouts, setLayouts] = useState<Layouts>(() => {
     assert(
       config.layout.type === "dashboard" && config.layout.layout === "canvas",

--- a/app/components/chart-panel.tsx
+++ b/app/components/chart-panel.tsx
@@ -1,7 +1,7 @@
 import { Box, BoxProps, Theme } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import clsx from "clsx";
-import React, { forwardRef, HTMLProps } from "react";
+import React, { HTMLProps, forwardRef } from "react";
 
 import ChartPanelLayoutCanvas, {
   chartPanelLayoutGridClasses,


### PR DESCRIPTION
Dashboard canvas works in published mode

I had not repercuted some of the improvements from chart-preview to chart-published.
Passing ref, className, and children is necessary for react-grid-layout to work
correctly.
