### PR TITLE
fix: Use cache bounded as prescribed by the warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ You can also check the [release page](https://github.com/visualize-admin/visuali
 
 # Unreleased
 
-Nothing yet.
+- Fix
+  - Use bounded cache for Apollo Server, removing vulnerability from DDOS attacks
 
 # [4.6.0] - 2024-06-05
 

--- a/app/pages/api/graphql.ts
+++ b/app/pages/api/graphql.ts
@@ -41,6 +41,7 @@ const server = new ApolloServer({
     return response;
   },
   context: createContext,
+  cache: "bounded",
   introspection: true,
   plugins:
     process.env.NODE_ENV === "production"


### PR DESCRIPTION
The default cache of Apollo 3 is using an unbounded cache by default,
which would be vulnerable to denial of service attacks.

The warning was issued when the application was started and Philipp from
Abraxas told us about that.

> Persisted queries are enabled and are using an unbounded cache. Your
> server is vulnerable to denial of service attacks via memory exhaustion.
> Set `cache: "bounded"` or `persistedQueries: false` in your ApolloServer
> constructor, or see https://go.apollo.dev/s/cache-backends for other
> alternatives.
