### PR TITLE
Chart data wrapper key

### DIFF
--- a/app/charts/chart-data-wrapper.tsx
+++ b/app/charts/chart-data-wrapper.tsx
@@ -1,7 +1,12 @@
 import { makeStyles } from "@mui/styles";
 import { AnimatePresence } from "framer-motion";
 import keyBy from "lodash/keyBy";
-import React, { createElement, useEffect, useMemo } from "react";
+import React, {
+  ComponentProps,
+  createElement,
+  useEffect,
+  useMemo,
+} from "react";
 
 import { A11yTable } from "@/charts/shared/a11y-table";
 import { useLoadingState } from "@/charts/shared/chart-loading-state";
@@ -39,7 +44,7 @@ const useStyles = makeStyles(() => ({
  * - Provides observations, dimensions and measures to the chart Component
  * - Handles loading & error state
  */
-export const ChartDataWrapper = <
+const ChartDataWrapperInner = <
   TChartConfig extends ChartConfig,
   TOtherProps,
   TChartComponent extends React.ElementType,
@@ -198,6 +203,23 @@ export const ChartDataWrapper = <
   } else {
     return null;
   }
+};
+
+/**
+ * Makes sure the ChartDataWrapper is re-rendered when the cube iris and/or joinBy change.
+ * This ensures that data hooks do not keep stale data.
+ */
+export const ChartDataWrapper = (
+  props: ComponentProps<typeof ChartDataWrapperInner>
+) => {
+  const key = useMemo(
+    () =>
+      props.chartConfig.cubes
+        .map((c) => `${c.iri}${c.joinBy ? `:${c.joinBy}` : ""}`)
+        .join(" / "),
+    [props.chartConfig.cubes]
+  );
+  return <ChartDataWrapperInner key={key} {...props} />;
 };
 
 const Error = ({ message }: { message: string }) => {

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -1,4 +1,4 @@
-import produce, { createDraft, current, Draft } from "immer";
+import produce, { createDraft, current, Draft, isDraft } from "immer";
 import { WritableDraft } from "immer/dist/internal";
 import get from "lodash/get";
 import isEqual from "lodash/isEqual";
@@ -1107,7 +1107,11 @@ const withLogging = <TState, TAction extends { type: unknown }>(
 ) => {
   return (state: Draft<TState>, action: TAction) => {
     const res = reducer(state, action);
-    console.log(`Action: ${action.type}`, action, res);
+    console.log(
+      `Action: ${action.type}`,
+      action,
+      isDraft(state) ? current(state) : state
+    );
     return res;
   };
 };


### PR DESCRIPTION
fix: No JoinBy dimension found in cube

When merging some datasets together, we ended up with a "no joinBy dimension
found in cube" error in chart hooks. It seems it is due to stale data
inside useQuery hooks. To prevent those, we unmount the whole ChartDataWrapper
and remount it when cubeIris and or joinBy change.

Fix https://github.com/visualize-admin/visualization-tool/issues/1475
