### PR TITLE
feat: Make initial free canvas charts smaller

### DIFF
--- a/app/components/react-grid.tsx
+++ b/app/components/react-grid.tsx
@@ -290,9 +290,9 @@ export const generateLayout = function ({
       })
       .with("tiles", () => {
         return {
-          x: ((i % 2) * MAX_W) / 2,
+          x: ((i % 4) * MAX_W) / 4,
           y: Math.floor(i / 2) * INITIAL_H,
-          w: MAX_W / 2,
+          w: MAX_W / 4,
           h: INITIAL_H,
           i: i.toString(),
           resizeHandles: [],

--- a/app/configurator/components/layout-configurator.tsx
+++ b/app/configurator/components/layout-configurator.tsx
@@ -466,7 +466,6 @@ const migrateLayout = (
       layouts: {
         lg: generated.map((l, i) => ({
           ...l,
-
           // We must pay attention to correctly change the i value to
           // chart config key, as it is used to identify the layout
           i: chartConfigs[i].key,

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -1148,7 +1148,7 @@ export function ensureDashboardLayoutAreCorrect(
       for (const chartConfig of newConfigs) {
         let chartX = curX;
         let chartY = curY;
-        let chartW = 2;
+        let chartW = 1;
         let chartH = MIN_H;
         canvasLayouts.push({
           i: chartConfig.key,


### PR DESCRIPTION
## How to test
**PR**
1. Go to [this link](https://visualization-tool-git-feat-another-dashboards-impr-f30f7c-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9&dataSource=Prod&flag__layouter.dashboard.free-canvas=true).
2. Add two more charts.
3. Proceed to layout options.
4. Switch to a Free Canvas Dashboard layout.
5. ✅ See that all charts are initialized next to each other (max four in one row).

**TEST**
1. Go to [this link](https://test.visualize.admin.ch/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9&dataSource=Prod&flag__layouter.dashboard.free-canvas=true).
2. Add two more charts.
3. Proceed to layout options.
4. Switch to a Free Canvas Dashboard layout.
5. ❌ See that the charts are initialized next to each other and below each other (max two in one row).