### PR TITLE
Shared filter configurator filter

### DIFF
--- a/app/configurator/components/layout-configurator.tsx
+++ b/app/configurator/components/layout-configurator.tsx
@@ -213,7 +213,7 @@ const LayoutSharedFiltersConfigurator = () => {
                   return null;
                 }
                 return (
-                  <>
+                  <Fragment key={filter.componentIri}>
                     <Box
                       display="flex"
                       alignItems="center"
@@ -251,7 +251,7 @@ const LayoutSharedFiltersConfigurator = () => {
                       sharedFilter={sharedFilter}
                       dimension={dimension}
                     />
-                  </>
+                  </Fragment>
                 );
               })}
             </Stack>

--- a/app/configurator/components/layout-configurator.tsx
+++ b/app/configurator/components/layout-configurator.tsx
@@ -190,6 +190,14 @@ const LayoutSharedFiltersConfigurator = () => {
   switch (layout.type) {
     case "tab":
     case "dashboard":
+      const shownFilters = potentialSharedFilters.filter((filter) => {
+        const dimension = dimensionsByIri[filter.componentIri];
+        return dimension && canDimensionBeTimeFiltered(dimension);
+      });
+
+      if (!shownFilters.length) {
+        return null;
+      }
       return (
         <ControlSection
           role="tablist"
@@ -205,13 +213,9 @@ const LayoutSharedFiltersConfigurator = () => {
           </SubsectionTitle>
           <ControlSectionContent>
             <Stack gap="0.5rem">
-              {potentialSharedFilters.map((filter) => {
+              {shownFilters.map((filter) => {
                 const dimension = dimensionsByIri[filter.componentIri];
                 const sharedFilter = sharedFiltersByIri[filter.componentIri];
-
-                if (!dimension || !canDimensionBeTimeFiltered(dimension)) {
-                  return null;
-                }
                 return (
                   <Fragment key={filter.componentIri}>
                     <Box

--- a/app/configurator/components/layout-configurator.tsx
+++ b/app/configurator/components/layout-configurator.tsx
@@ -11,7 +11,7 @@ import {
 import capitalize from "lodash/capitalize";
 import keyBy from "lodash/keyBy";
 import omit from "lodash/omit";
-import { useMemo } from "react";
+import { Fragment, useMemo } from "react";
 
 import { DataFilterGenericDimensionProps } from "@/charts/shared/chart-data-filters";
 import { Select } from "@/components/form";
@@ -46,7 +46,8 @@ import {
 } from "@/domain/data";
 import { useFlag } from "@/flags";
 import { useTimeFormatLocale, useTimeFormatUnit } from "@/formatters";
-import { useAllCubesComponents } from "@/graphql/hooks";
+import { useConfigsCubeComponents } from "@/graphql/hooks";
+import { useLocale } from "@/src";
 import {
   SharedFilter,
   useDashboardInteractiveFilters,
@@ -113,7 +114,13 @@ const LayoutSharedFiltersConfigurator = () => {
   const { sharedFilters, potentialSharedFilters } =
     useDashboardInteractiveFilters();
 
-  const { data } = useAllCubesComponents(state);
+  const locale = useLocale();
+  const [{ data }] = useConfigsCubeComponents({
+    variables: {
+      state,
+      locale: locale,
+    },
+  });
 
   const dimensionsByIri = useMemo(() => {
     const res: Record<string, Dimension> = {};

--- a/app/domain/user-configs.ts
+++ b/app/domain/user-configs.ts
@@ -2,21 +2,29 @@ import { useCallback } from "react";
 
 import { ParsedConfig } from "@/db/config";
 import { fetchChartConfig, fetchChartConfigs } from "@/utils/chart-config/api";
-import { UseFetchDataOptions, useFetchData } from "@/utils/use-fetch-data";
+import { useFetchData, UseFetchDataOptions } from "@/utils/use-fetch-data";
 
 export const userConfigsKey = ["userConfigs"];
 const userConfigKey = (t: string) => ["userConfigs", t];
 
 export const useUserConfigs = (options?: UseFetchDataOptions<ParsedConfig[]>) =>
-  useFetchData(userConfigsKey, fetchChartConfigs, options);
+  useFetchData({
+    queryKey: userConfigsKey,
+    queryFn: fetchChartConfigs,
+    options,
+  });
 
 export const useUserConfig = (
   chartId: string | undefined,
   options?: UseFetchDataOptions
 ) => {
   let queryFn = useCallback(() => fetchChartConfig(chartId ?? ""), [chartId]);
-  return useFetchData(userConfigKey(chartId!), queryFn, {
-    enable: !!chartId,
-    ...options,
+  return useFetchData({
+    queryKey: userConfigKey(chartId!),
+    queryFn,
+    options: {
+      enable: !!chartId,
+      ...options,
+    },
   });
 };

--- a/app/graphql/hooks.spec.tsx
+++ b/app/graphql/hooks.spec.tsx
@@ -15,7 +15,9 @@ describe("makeUseQuery", () => {
     });
   });
 
-  const useMockQuery = makeUseQuery(mockQuery);
+  const useMockQuery = makeUseQuery({
+    fetch: mockQuery,
+  });
 
   afterEach(() => {
     mockQuery.mockClear();

--- a/app/homepage/examples.tsx
+++ b/app/homepage/examples.tsx
@@ -70,11 +70,14 @@ type ExampleProps = {
 const Example = (props: ExampleProps) => {
   const { queryKey, configuratorState, headline, description, reverse } = props;
   const client = useClient();
-  const { data, error } = useFetchData([queryKey], () => {
-    return upgradeConfiguratorState(configuratorState, {
-      client,
-      dataSource: configuratorState.dataSource,
-    });
+  const { data, error } = useFetchData({
+    queryKey: [queryKey],
+    queryFn: () => {
+      return upgradeConfiguratorState(configuratorState, {
+        client,
+        dataSource: configuratorState.dataSource,
+      });
+    },
   });
 
   return data ? (

--- a/app/utils/promises.ts
+++ b/app/utils/promises.ts
@@ -1,0 +1,23 @@
+type PromiserFunction<T, U> = (item: T) => Promise<U>;
+
+export async function allDeduped<T, U>(params: {
+  items: T[];
+  promiser: PromiserFunction<T, U>;
+  key: (item: T) => string;
+}): Promise<U[]> {
+  const { items, promiser, key } = params;
+  const promises: Record<string, Promise<U>> = {};
+  const results = await Promise.all(
+    items.map((item) => {
+      const k = key(item);
+      if (!promises[k]) {
+        const promise = promiser(item);
+        promises[k] = promise;
+        return promise;
+      } else {
+        return promises[k];
+      }
+    })
+  );
+  return results;
+}

--- a/app/utils/use-fetch-data.ts
+++ b/app/utils/use-fetch-data.ts
@@ -82,11 +82,15 @@ const useCacheKey = (cache: QueryCache, queryKey: QueryKey) => {
  * Two useFetchData on the same queryKey will result in only 1 queryFn called. Both useFetchData
  * will share the same cache and data.
  */
-export const useFetchData = <TData>(
-  queryKey: any[],
-  queryFn: () => Promise<TData>,
-  options: Partial<UseFetchDataOptions<TData>> = {}
-) => {
+export const useFetchData = <TData>({
+  queryKey,
+  queryFn,
+  options = {},
+}: {
+  queryKey: any[];
+  queryFn: () => Promise<TData>;
+  options?: Partial<UseFetchDataOptions<TData>>;
+}) => {
   const { enable = true, defaultData } = options;
 
   const cached = cache.get(queryKey) as QueryCacheValue<TData>;


### PR DESCRIPTION
The shared filter configurator would fetch all the components for all cubes at once,
when in fact they should be fetched independently for each chart config. This PR
fixes that. It takes care of deduping fetching of components for the same cube
filter values.
