### PR TITLE
feat: Set up chart view statistics

### DIFF
--- a/app/db/config.ts
+++ b/app/db/config.ts
@@ -207,7 +207,7 @@ export const getConfigViewCount = async (configKey: string) => {
  * Increase the view count of a config.
  */
 export const increaseConfigViewCount = async (configKey: string) => {
-  await prisma.view.create({
+  await prisma.configView.create({
     data: {
       config_key: configKey,
     },

--- a/app/db/config.ts
+++ b/app/db/config.ts
@@ -185,6 +185,24 @@ export const getAllConfigs = async () => {
   return await Promise.all(parsedConfigs.map(upgradeDbConfig));
 };
 
+export const getConfigViewCount = async (configKey: string) => {
+  return await prisma.config
+    .findFirstOrThrow({
+      where: {
+        key: configKey,
+      },
+      include: {
+        _count: {
+          select: {
+            views: true,
+          },
+        },
+      },
+    })
+    .then((config) => config._count.views)
+    .catch(() => 0);
+};
+
 /**
  * Increase the view count of a config.
  */

--- a/app/db/config.ts
+++ b/app/db/config.ts
@@ -186,6 +186,17 @@ export const getAllConfigs = async () => {
 };
 
 /**
+ * Increase the view count of a config.
+ */
+export const increaseConfigViewCount = async (configKey: string) => {
+  await prisma.view.create({
+    data: {
+      config_key: configKey,
+    },
+  });
+};
+
+/**
  * Get config from a user.
  */
 export const getUserConfigs = async (userId: number) => {

--- a/app/pages/embed/[chartId].tsx
+++ b/app/pages/embed/[chartId].tsx
@@ -8,7 +8,7 @@ import {
   ConfiguratorStateProvider,
   ConfiguratorStatePublished,
 } from "@/configurator";
-import { getConfig } from "@/db/config";
+import { getConfig, increaseConfigViewCount } from "@/db/config";
 import { serializeProps } from "@/db/serialize";
 import { EmbedOptionsProvider } from "@/utils/embed";
 
@@ -30,6 +30,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
   const config = await getConfig(query.chartId as string);
 
   if (config?.data) {
+    await increaseConfigViewCount(config.key);
     return {
       props: serializeProps({
         status: "found",

--- a/app/pages/statistics.tsx
+++ b/app/pages/statistics.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable visualize-admin/no-large-sx */
 import { Box, Card, Tooltip, Typography } from "@mui/material";
 import { max, rollups, sum } from "d3-array";
+import { formatLocale } from "d3-format";
 import { timeFormat } from "d3-time-format";
 import { motion } from "framer-motion";
 import uniq from "lodash/uniq";
@@ -175,17 +176,19 @@ const Statistics = (props: Serialized<PageProps>) => {
           <StatsCard
             {...charts}
             title={(total) =>
-              `Visualize users created ${total} charts in total`
+              `Visualize users created ${formatInteger(total)} charts in total`
             }
             subtitle={(total, avgMonthlyCount) =>
-              `${total ? ` It's around ${avgMonthlyCount} chart${avgMonthlyCount > 1 ? "s" : ""} per month on average.` : ""}`
+              `${total ? ` It's around ${formatInteger(avgMonthlyCount)} chart${avgMonthlyCount > 1 ? "s" : ""} per month on average.` : ""}`
             }
           />
           <StatsCard
             {...views}
-            title={(total) => `Charts were viewed ${total} times in total`}
+            title={(total) =>
+              `Charts were viewed ${formatInteger(total)} times in total`
+            }
             subtitle={(total, avgMonthlyCount) =>
-              `${total ? ` It's around ${avgMonthlyCount} view${avgMonthlyCount > 1 ? "s" : ""} per month on average.` : ""}`
+              `${total ? ` It's around ${formatInteger(avgMonthlyCount)} view${avgMonthlyCount > 1 ? "s" : ""} per month on average.` : ""}`
             }
           />
         </Box>
@@ -398,7 +401,7 @@ const Bar = ({
           textAlign: "end",
         }}
       >
-        <Typography variant="caption">{count}</Typography>
+        <Typography variant="caption">{formatInteger(count)}</Typography>
       </Box>
       <Box
         sx={{
@@ -477,3 +480,12 @@ const StatsCard = (
     />
   );
 };
+
+const formatInteger = formatLocale({
+  decimal: ".",
+  thousands: "\u00a0",
+  grouping: [3],
+  currency: ["", "\u00a0 CHF"],
+  minus: "\u2212",
+  percent: "%",
+}).format(",d");

--- a/app/pages/statistics.tsx
+++ b/app/pages/statistics.tsx
@@ -173,24 +173,28 @@ const Statistics = (props: Serialized<PageProps>) => {
             my: [4, 6],
           }}
         >
-          <StatsCard
-            {...charts}
-            title={(total) =>
-              `Visualize users created ${formatInteger(total)} charts in total`
-            }
-            subtitle={(total, avgMonthlyCount) =>
-              `${total ? ` It's around ${formatInteger(avgMonthlyCount)} chart${avgMonthlyCount > 1 ? "s" : ""} per month on average.` : ""}`
-            }
-          />
-          <StatsCard
-            {...views}
-            title={(total) =>
-              `Charts were viewed ${formatInteger(total)} times in total`
-            }
-            subtitle={(total, avgMonthlyCount) =>
-              `${total ? ` It's around ${formatInteger(avgMonthlyCount)} view${avgMonthlyCount > 1 ? "s" : ""} per month on average.` : ""}`
-            }
-          />
+          {charts.countByDay.length > 0 && (
+            <StatsCard
+              {...charts}
+              title={(total) =>
+                `Visualize users created ${formatInteger(total)} charts in total`
+              }
+              subtitle={(total, avgMonthlyCount) =>
+                `${total ? ` It's around ${formatInteger(avgMonthlyCount)} chart${avgMonthlyCount > 1 ? "s" : ""} per month on average.` : ""}`
+              }
+            />
+          )}
+          {views.countByDay.length > 0 && (
+            <StatsCard
+              {...views}
+              title={(total) =>
+                `Charts were viewed ${formatInteger(total)} times in total`
+              }
+              subtitle={(total, avgMonthlyCount) =>
+                `${total ? ` It's around ${formatInteger(avgMonthlyCount)} view${avgMonthlyCount > 1 ? "s" : ""} per month on average.` : ""}`
+              }
+            />
+          )}
         </Box>
       </Box>
     </AppLayout>

--- a/app/pages/statistics.tsx
+++ b/app/pages/statistics.tsx
@@ -139,6 +139,7 @@ const groupByYearMonth = (
   );
   const start = countByDate[0][1].date;
   const end = countByDate[countByDate.length - 1][1].date;
+  if (start.getTime() !== end.getTime()) {
   for (let date = start; date <= end; date.setMonth(date.getMonth() + 1)) {
     if (!allYearMonthStrings.includes(formatYearMonth(date))) {
       countByDate.push([
@@ -149,6 +150,7 @@ const groupByYearMonth = (
           monthStr: formatShortMonth(date),
         },
       ]);
+      }
     }
   }
   countByDate.sort(([a], [b]) => b.localeCompare(a));

--- a/app/pages/v/[chartId].tsx
+++ b/app/pages/v/[chartId].tsx
@@ -24,7 +24,7 @@ import { ContentLayout } from "@/components/layout";
 import { PublishActions } from "@/components/publish-actions";
 import { ConfiguratorStatePublished, getChartConfig } from "@/config-types";
 import { ConfiguratorStateProvider } from "@/configurator/configurator-state";
-import { getConfig } from "@/db/config";
+import { getConfig, increaseConfigViewCount } from "@/db/config";
 import { deserializeProps, Serialized, serializeProps } from "@/db/serialize";
 import { useLocale } from "@/locales/use-locale";
 import { useDataSourceStore } from "@/stores/data-source";
@@ -49,8 +49,13 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
   const config = await getConfig(query.chartId as string);
 
   if (config && config.data) {
-    // TODO validate configuration
-    return { props: serializeProps({ status: "found", config }) };
+    await increaseConfigViewCount(config.key);
+    return {
+      props: serializeProps({
+        status: "found",
+        config,
+      }),
+    };
   }
 
   res.statusCode = 404;

--- a/app/pages/v/[chartId].tsx
+++ b/app/pages/v/[chartId].tsx
@@ -24,13 +24,8 @@ import { ContentLayout } from "@/components/layout";
 import { PublishActions } from "@/components/publish-actions";
 import { ConfiguratorStatePublished, getChartConfig } from "@/config-types";
 import { ConfiguratorStateProvider } from "@/configurator/configurator-state";
-import {
-  getConfig,
-  getConfigViewCount,
-  increaseConfigViewCount,
-} from "@/db/config";
+import { getConfig, increaseConfigViewCount } from "@/db/config";
 import { deserializeProps, Serialized, serializeProps } from "@/db/serialize";
-import SvgIcEye from "@/icons/components/IcEye";
 import { useLocale } from "@/locales/use-locale";
 import { useDataSourceStore } from "@/stores/data-source";
 import { EmbedOptionsProvider } from "@/utils/embed";
@@ -39,14 +34,12 @@ type PageProps =
   | {
       status: "notfound";
       config: null;
-      viewCount: null;
     }
   | {
       status: "found";
       config: Omit<PrismaConfig, "data"> & {
         data: Omit<ConfiguratorStatePublished, "activeField" | "state">;
       };
-      viewCount: number;
     };
 
 export const getServerSideProps: GetServerSideProps<PageProps> = async ({
@@ -57,12 +50,10 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({
 
   if (config && config.data) {
     await increaseConfigViewCount(config.key);
-    const viewCount = await getConfigViewCount(config.key);
     return {
       props: serializeProps({
         status: "found",
         config,
-        viewCount,
       }),
     };
   }
@@ -76,7 +67,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   actionBar: {
     backgroundColor: "white",
     padding: `${theme.spacing(3)} 2.25rem`,
-    justifyContent: "space-between",
+    justifyContent: "flex-end",
     alignItems: "center",
     display: "flex",
     width: "100%",
@@ -103,7 +94,7 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
 
   // Keep initial value of publishSuccess
   const [publishSuccess] = useState(() => !!query.publishSuccess);
-  const { status, config, viewCount } = deserializeProps(props);
+  const { status, config } = deserializeProps(props);
 
   const session = useSession();
   const canEdit =
@@ -174,13 +165,6 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
       </Head>
       <ContentLayout>
         <Box className={classes.actionBar}>
-          {viewCount ? (
-            <Typography className={classes.viewCount} variant="caption">
-              <SvgIcEye /> {viewCount}
-            </Typography>
-          ) : (
-            <span />
-          )}
           <PublishActions configKey={key} locale={locale} />
         </Box>
         <Box

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -23,7 +23,7 @@ model Config {
   user    User? @relation(fields: [user_id], references: [id])
   user_id Int?
 
-  views View[]
+  views ConfigView[]
 
   published_state PUBLISHED_STATE @default(PUBLISHED)
 
@@ -39,14 +39,14 @@ model User {
   @@map("users")
 }
 
-model View {
+model ConfigView {
   id        Int      @id @default(autoincrement())
   viewed_at DateTime @default(now()) @db.Timestamp(6)
 
   config    Config @relation(fields: [config_key], references: [key])
   config_key String
 
-  @@map("view")
+  @@map("config_view")
 }
 
 model OldMigrations {

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -23,6 +23,8 @@ model Config {
   user    User? @relation(fields: [user_id], references: [id])
   user_id Int?
 
+  views View[]
+
   published_state PUBLISHED_STATE @default(PUBLISHED)
 
   @@map("config")
@@ -35,6 +37,16 @@ model User {
   Config Config[] @relation()
 
   @@map("users")
+}
+
+model View {
+  id        Int      @id @default(autoincrement())
+  viewed_at DateTime @default(now()) @db.Timestamp(6)
+
+  config    Config @relation(fields: [config_key], references: [key])
+  config_key String
+
+  @@map("view")
 }
 
 model OldMigrations {


### PR DESCRIPTION
Closes #1611
Contributes towards #1596

## Chart view analytics

This PR sets up a new `ConfigView` table in our database which is used to track the chart views. We store every chart view, to potentially be able to make use of this information in the future and e.g. show charts trending in the last week or month, to understand at what time of the day the charts are viewed, how the metrics are influenced by e.g. Open Linked Day events, etc.

A chart view is counted when:
- there's a visit to `/v/` page,
- there's a visit to `/embed/` page,

or precisely, when `getServerSideProps` function is triggered for these pages.

## View statistics

There's also a new card that shows statistics on views in the Statistics page (see [this link)](https://visualization-tool-git-feat-set-up-chart-view-statistics-ixt1.vercel.app/statistics). The card will be shown when the first views are recorded in the database (the screenshot comes from my local development environment).

<img width="1500" alt="Screenshot 2024-06-13 at 15 26 08" src="https://github.com/visualize-admin/visualization-tool/assets/52032047/1a235716-652b-45ba-98a4-b027116f8343">
