### PR TITLE
Fix: cube query filters not found

### DIFF
--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -17,7 +17,7 @@ import {
   useDataCubesMetadataQuery,
   useDataCubesObservationsQuery,
 } from "@/graphql/hooks";
-import { Icon, getChartIcon } from "@/icons";
+import { getChartIcon, Icon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
 import { assert } from "@/utils/assert";
 import { useEmbedOptions } from "@/utils/embed";

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -23,8 +23,8 @@ import { DashboardInteractiveFilters } from "@/components/dashboard-interactive-
 import Flex from "@/components/flex";
 import { HintBlue, HintRed, HintYellow } from "@/components/hint";
 import {
-  MetadataPanelStoreContext,
   createMetadataPanelStore,
+  MetadataPanelStoreContext,
 } from "@/components/metadata-panel-store";
 import {
   ChartConfig,
@@ -187,7 +187,7 @@ type ChartPublishInnerProps = {
   children?: React.ReactNode;
 };
 
-const ChartPublishedInner = (props: ChartPublishInnerProps) => {
+const ChartPublishedInnerImpl = (props: ChartPublishInnerProps) => {
   const {
     dataSource = DEFAULT_DATA_SOURCE,
     state,
@@ -405,3 +405,9 @@ const ChartPublishedInner = (props: ChartPublishInnerProps) => {
     </MetadataPanelStoreContext.Provider>
   );
 };
+
+const ChartPublishedInner = (props: ChartPublishInnerProps) => (
+  // Enforce re-mounting of the component when the chart config changes
+  // to ensure we do not use any out of date data.
+  <ChartPublishedInnerImpl {...props} key={props.chartConfig.key} />
+);


### PR DESCRIPTION
In https://github.com/visualize-admin/visualization-tool/pull/1571, we  introduce the use of cube query filters, but this does not play well with tab layout when components are reused.

Some of the data hooks were reused, introducing a mismatch between what was fetched inside the hooks and the new chartConfig.

To force remounting, I used a key on ChartPublishedInner and made it so that we cannot forget it.

This fixes going to the second chart of https://test.visualize.admin.ch/en/v/FeByTTGfNhxL