### PR TITLE
fix: Correctly initialize time filters in dashboard

### DIFF
--- a/app/components/dashboard-interactive-filters.tsx
+++ b/app/components/dashboard-interactive-filters.tsx
@@ -116,16 +116,6 @@ const DashboardTimeRangeSlider = ({
     timeUnit ? presetToTimeRange(presets, timeUnit) : undefined
   );
 
-  useEffect(
-    function initTimeRangeAfterDataFetch() {
-      if (timeRange || !timeUnit) {
-        return;
-      }
-      setTimeRange(presetToTimeRange(presets, timeUnit));
-    },
-    [timeRange, timeUnit, presets]
-  );
-
   const { min, max } = useMemo(() => {
     if (!timeUnit || !presets) {
       return { min: 0, max: 0 };
@@ -166,6 +156,21 @@ const DashboardTimeRangeSlider = ({
         setTimeRange([value[0], value[1]]);
       }
     }
+  );
+
+  useEffect(
+    function initTimeRangeAfterDataFetch() {
+      if (timeRange || !timeUnit) {
+        return;
+      }
+
+      const parser = timeUnitToParser[timeUnit];
+      handleChangeSlider(filter.componentIri, [
+        toUnixSeconds(parser(presets.from)),
+        toUnixSeconds(parser(presets.to)),
+      ]);
+    },
+    [timeRange, timeUnit, presets, handleChangeSlider, filter.componentIri]
   );
 
   const mountedForSomeTime = useTimeout(500, mounted);


### PR DESCRIPTION
Fixes #1618

## How to test
**PR**
1. Go to [this link](https://visualization-tool-git-fix-dashboard-filter-initialization-ixt1.vercel.app/en/v/RuxtIhQLBvM7?dataSource=Prod).
2. ✅ See that the chart is loaded correctly (only shows years between 2017 and 2020).

**TEST**
1. Go to [this link](https://test.visualize.admin.ch/en/v/vHwhkeidxzHz?dataSource=Prod).
2. ❌ See that the chart is not loaded correctly (shows full data – between 2014 and 2022, while slider is constrained to 2017-2020).