### PR TITLE
fix: Saving draft dashboard from layout options

### DIFF
--- a/app/components/chart-selection-tabs.tsx
+++ b/app/components/chart-selection-tabs.tsx
@@ -474,7 +474,11 @@ export const SaveDraftButton = ({
           published_state: PUBLISHED_STATE.DRAFT,
         });
         if (saved) {
-          const config = await initChartStateFromChartEdit(client, saved.key);
+          const config = await initChartStateFromChartEdit(
+            client,
+            saved.key,
+            state.state
+          );
 
           if (!config) {
             return;


### PR DESCRIPTION
Fixes #1603

This PR makes sure that we set the correct configurator state when saving the dashboard from layout mode for the first time (no entry in the database yet).