### PR TITLE
use `POST` to avoid `414 URI too long` for longer queries

### DIFF
--- a/app/rdf/query-termsets.ts
+++ b/app/rdf/query-termsets.ts
@@ -32,7 +32,9 @@ SELECT DISTINCT (COUNT(distinct ?iri) as ?count) ?termsetIri ?termsetLabel WHERE
       cubeIriVar: "?iri",
     }).toString()}
 
-  }      GROUP BY ?termsetIri ?termsetLabel`
+  }      GROUP BY ?termsetIri ?termsetLabel`, {
+    operation: "postUrlencoded",
+  }
   );
 
   return qs.map((result) => ({


### PR DESCRIPTION
@bprusinowski just caught by accident...
`GET` can in some cases result in `414 URI too long`

proposition:
apply `POST` as for the other queries :+1: - THX for your review