### PR TITLE
fix cube search performance

### DIFF
--- a/app/rdf/query-cube-preview.ts
+++ b/app/rdf/query-cube-preview.ts
@@ -69,8 +69,8 @@ CONSTRUCT {
   ?observationValue schema:position ?observationPosition .
 } WHERE {
   VALUES ?cube { <${iri}> }
-  FILTER(EXISTS { ?cube a cube:Cube . }) {}
-  UNION {
+  FILTER(EXISTS { ?cube a cube:Cube . })
+  {
     ?cube cube:observationConstraint/sh:property ?dimension .
     ?dimension sh:path ?dimensionIri .
     OPTIONAL { ?dimension rdf:type ?dimensionType . }
@@ -107,9 +107,11 @@ CONSTRUCT {
     )}
     FILTER(?dimensionIri != cube:observedBy && ?dimensionIri != rdf:type)
   } UNION {
+    VALUES ?cube { <${iri}> }
     ?cube cube:observationConstraint/sh:property/sh:path ?observationPredicate .
-    { SELECT * WHERE {
-    { SELECT * WHERE {
+    { SELECT ?observation ?observationPredicate ?observationValue ?observationLabel ?observationPosition WHERE {
+    { SELECT ?observation WHERE {
+      VALUES ?cube { <${iri}> }
       ?cube cube:observationSet ?observationSet .
       ?observationSet cube:observation ?observation .
       FILTER(EXISTS { ?cube cube:observationConstraint/sh:property/sh:datatype cube:Undefined . } || NOT EXISTS { ?observation ?p ""^^cube:Undefined . })

--- a/app/rdf/query-search.ts
+++ b/app/rdf/query-search.ts
@@ -292,22 +292,24 @@ const mkScoresQuery = (
          creatorValues.includes(
            "https://register.ld.admin.ch/opendataswiss/org/bundesamt-fur-umwelt-bafu"
          )
-           ? "VALUES (?subthemeGraph ?subthemeTermset) { (<https://lindas.admin.ch/foen/themes> <https://register.ld.admin.ch/foen/theme>) }"
-           : ""
-       }
+           ? `
       OPTIONAL {
         ?iri schema:about ?subthemeIri .
+        VALUES (?subthemeGraph ?subthemeTermset) { (<https://lindas.admin.ch/foen/themes> <https://register.ld.admin.ch/foen/theme>) }
         GRAPH ?subthemeGraph {
           ?subthemeIri a schema:DefinedTerm ;
           schema:inDefinedTermSet ?subthemeTermset .
-          ${buildLocalizedSubQuery(
-            "subthemeIri",
-            "schema:name",
-            "subthemeLabel",
-            { locale }
-          )}
         }
-      }
+        ${buildLocalizedSubQuery(
+          "subthemeIri",
+          "schema:name",
+          "subthemeLabel",
+          { locale }
+        )}
+      } 
+      `
+           : ""
+       }
 
       ${makeVisualizeDatasetFilter({
         includeDrafts: !!includeDrafts,

--- a/app/rdf/query-search.ts
+++ b/app/rdf/query-search.ts
@@ -170,7 +170,6 @@ const mkScoresQuery = (
       dcterms:publisher ?publisher ;
       schema:about ?subthemeIri;
       schema:creativeWorkStatus ?status ;
-      schema:creativeWorkStatus <https://ld.admin.ch/vocabulary/CreativeWorkStatus/Published> ;
       schema:creator ?creatorIri ;
       schema:datePublished ?datePublished;
       schema:description ?description ;


### PR DESCRIPTION
currently cube search queries for subthemes regardless of the organization filter 
- effectively there is no need for this information unless foen org is chosen

currently the subtheme graph isn't constrained (unless org is foen)
- this leads to degraded performance by needlessly crawling among graphs