### PR TITLE
fix: Sub-theme filters

### DIFF
--- a/app/browser/dataset-browse.tsx
+++ b/app/browser/dataset-browse.tsx
@@ -354,7 +354,7 @@ const encodeFilter = (filter: BrowseFilter) => {
       case "DataCubeOrganization":
         return "organization";
       case "DataCubeAbout":
-        throw new Error("Should not happen");
+        return "topic";
       case "Termset":
         return "termset";
       default:
@@ -394,18 +394,18 @@ const NavItem = ({
         {
           includeDrafts,
           search,
-          topic: level === 2 ? next.iri : undefined,
+          topic: level === 2 && !disableLink ? next.iri : undefined,
         },
         Boolean
       )
     );
     const newFilters = [...filters].filter(
       (f) =>
-        f.__typename !== "DataCubeAbout" &&
+        (disableLink ? true : f.__typename !== "DataCubeAbout") &&
         (level === 1 ? f.__typename !== next.__typename : true)
     );
 
-    if (level === 1) {
+    if (level === 1 || disableLink) {
       newFilters.push(next);
     }
 
@@ -413,7 +413,7 @@ const NavItem = ({
       newFilters,
       `/browse/${newFilters.map(encodeFilter).join("/")}?${extraURLParams}`,
     ] as const;
-  }, [includeDrafts, search, level, next, filters]);
+  }, [includeDrafts, search, level, next, filters, disableLink]);
 
   const [newFiltersRemove, removeFilterPath] = useMemo(() => {
     const extraURLParams = stringify(
@@ -446,10 +446,14 @@ const NavItem = ({
     >
       <ButtonBase
         className={classes.removeFilterButton}
-        onClick={(ev) => {
-          ev.preventDefault();
-          setFilters(newFiltersRemove);
-        }}
+        onClick={
+          disableLink
+            ? (e) => {
+                e.preventDefault();
+                setFilters(newFiltersRemove);
+              }
+            : undefined
+        }
       >
         <SvgIcClose width={24} height={24} />
       </ButtonBase>
@@ -501,13 +505,17 @@ const NavItem = ({
           >
             <MUILink
               className={classes.link}
-              href={path}
+              href={disableLink ? undefined : path}
               underline="none"
               variant="body2"
-              onClick={(ev) => {
-                ev.preventDefault();
-                setFilters(newFiltersAdd);
-              }}
+              onClick={
+                disableLink
+                  ? (e) => {
+                      e.preventDefault();
+                      setFilters(newFiltersAdd);
+                    }
+                  : undefined
+              }
             >
               {children}
             </MUILink>

--- a/app/browser/dataset-browse.tsx
+++ b/app/browser/dataset-browse.tsx
@@ -441,6 +441,8 @@ const NavItem = ({
       passHref
       legacyBehavior
       disabled={!!disableLink}
+      scroll={false}
+      shallow
     >
       <ButtonBase
         className={classes.removeFilterButton}
@@ -494,6 +496,8 @@ const NavItem = ({
             passHref
             legacyBehavior
             disabled={!!disableLink}
+            scroll={false}
+            shallow
           >
             <MUILink
               className={classes.link}

--- a/app/browser/dataset-browse.tsx
+++ b/app/browser/dataset-browse.tsx
@@ -523,10 +523,12 @@ const Subthemes = ({
   subthemes,
   filters,
   counts,
+  disableLinks,
 }: {
   subthemes: SearchCube["subthemes"];
   filters: BrowseFilter[];
   counts: Record<string, number>;
+  disableLinks?: boolean;
 }) => {
   return (
     <>
@@ -546,6 +548,7 @@ const Subthemes = ({
             active={filters[filters.length - 1]?.iri === d.iri}
             level={2}
             count={count}
+            disableLink={disableLinks}
           >
             {d.label}
           </NavItem>
@@ -867,6 +870,7 @@ export const SearchFilters = ({
               subthemes={subthemes}
               filters={filters}
               counts={counts}
+              disableLinks={disableNavLinks}
             />
           ) : null
         }

--- a/app/components/maybe-link.tsx
+++ b/app/components/maybe-link.tsx
@@ -1,5 +1,4 @@
-import { Link } from "@mui/material";
-import { LinkProps } from "next/link";
+import NextLink, { LinkProps } from "next/link";
 import React from "react";
 
 /** A link where the default link behavior can be disabled */
@@ -8,9 +7,11 @@ const MaybeLink = ({
   children,
   ...props
 }: LinkProps & { disabled: boolean; children: React.ReactNode }) => {
-  const Wrapper = disabled ? React.Fragment : Link;
-  const wrapperProps = disabled ? {} : props;
-  return <Wrapper {...wrapperProps}>{children}</Wrapper>;
+  if (disabled) {
+    return <>{children}</>;
+  }
+
+  return <NextLink {...props}>{children}</NextLink>;
 };
 
 export default MaybeLink;


### PR DESCRIPTION
Closes #1641

This PR fixes sub-theme filters both on regular search page (URL-based) and in the modal search when adding a chart based on another cube (in-app-state-based).

### How to test
**PR**
1. Go to [this link](https://visualization-tool-git-fix-subtheme-filters-ixt1.vercel.app/en/browse?dataSource=Prod).
2. Filter by **Federal Office for the Environment FOEN** (Organizations section).
3. ✅ Filter by **Climate** and see that it works.
4. Select **Greenhouse gas emissions by sector and gas** cube.
5. Start a new visualization.
6. Add a new chart based on another cube (click plus button, and afterwards a **Select dataset** button).
7. Filter by **Federal Office for the Environment FOEN** (Organizations section).
8. ✅ Filter by **Climate** and see that it works.

**TEST**
1. Go to [this link](https://test.visualize.admin.ch/en/browse?dataSource=Prod).
2. Filter by **Federal Office for the Environment FOEN** (Organizations section).
3. ❌ Filter by **Climate** and see that it doesn't work.
4. Select **Greenhouse gas emissions by sector and gas** cube.
5. Start a new visualization.
6. Add a new chart based on another cube (click plus button, and afterwards a **Select dataset** button).
7. Filter by **Federal Office for the Environment FOEN** (Organizations section).
8. ❌ Filter by **Climate** and see that it doesn't work.