### PR TITLE
feat: Dashboard time range filter and merging of cubes improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ You can also check the
     eggs in the application
   - Published charts now have a "more options" button with two actions - "Share"
     and "Table view"
+  - Shared dashboard time range filters are now rendered as one `Date` filter
+    that can be used to filter all charts in the dashboard. Date range is
+    combined from all charts in the dashboard and the "lowest" time unit is used
+    in the time slider (e.g. if one chart has a year resolution and another has
+    a month resolution, the time slider will show months)
 - Fixes
   - Fixed using a time range brush in column charts when X dimension is a
     `TemporalEntityDimension`
@@ -49,6 +54,9 @@ You can also check the
     several charts e.g. in a dashboard
   - Sub-theme filters now work correctly both in the search page and in the
     dataset selection modal when adding a new chart based on another cube
+  - Changing dashboard time range filter presets now correctly updates the
+    charts
+  - Merged cubes are now done on a chart basis and are not shared between charts
 - Style
   - Cleaned up the chart footnotes and moved most of them to the metadata panel
     – it means that the footnotes don't look broken anymore for charts based on
@@ -58,6 +66,8 @@ You can also check the
     them
   - Updated style of the buttons that open metadata panel
   - Data download menu now opens on click, not hover
+  - Removed unnecessary row gaps in the dashboard layout when e.g. title or
+    description is missing
 
 # [4.6.1] - 2024-06-05
 

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -40,13 +40,11 @@ const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
   const { chartConfig, dimensions } = props;
   const { fields, interactiveFiltersConfig } = chartConfig;
   const filters = useChartConfigFilters(chartConfig);
-  const { sharedTimeRangeFilters } = useDashboardInteractiveFilters();
-
+  const dashboardFilters = useDashboardInteractiveFilters();
   const showTimeBrush = shouldShowBrush(
     interactiveFiltersConfig,
-    sharedTimeRangeFilters
+    dashboardFilters.timeRange
   );
-
   return (
     <>
       {fields.segment?.componentIri && fields.segment.type === "stacked" ? (

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -40,11 +40,11 @@ const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
   const { chartConfig, dimensions } = props;
   const { fields, interactiveFiltersConfig } = chartConfig;
   const filters = useChartConfigFilters(chartConfig);
-  const { sharedFilters } = useDashboardInteractiveFilters();
+  const { sharedTimeRangeFilters } = useDashboardInteractiveFilters();
 
   const showTimeBrush = shouldShowBrush(
     interactiveFiltersConfig,
-    sharedFilters
+    sharedTimeRangeFilters
   );
 
   return (

--- a/app/charts/combo/chart-combo-line-column.tsx
+++ b/app/charts/combo/chart-combo-line-column.tsx
@@ -26,7 +26,7 @@ const ChartComboLineColumn = memo(
   (props: ChartProps<ComboLineColumnConfig>) => {
     const { chartConfig } = props;
     const { interactiveFiltersConfig } = chartConfig;
-    const { sharedFilters } = useDashboardInteractiveFilters();
+    const { sharedTimeRangeFilters } = useDashboardInteractiveFilters();
 
     return (
       <ComboLineColumnChart {...props}>
@@ -37,9 +37,10 @@ const ChartComboLineColumn = memo(
             <AxisWidthBand />
             <ComboLineColumn />
             <InteractionColumns />
-            {shouldShowBrush(interactiveFiltersConfig, sharedFilters) && (
-              <BrushTime />
-            )}
+            {shouldShowBrush(
+              interactiveFiltersConfig,
+              sharedTimeRangeFilters
+            ) && <BrushTime />}
           </ChartSvg>
           <HoverDotMultiple />
           <Ruler rotate />

--- a/app/charts/combo/chart-combo-line-column.tsx
+++ b/app/charts/combo/chart-combo-line-column.tsx
@@ -26,8 +26,7 @@ const ChartComboLineColumn = memo(
   (props: ChartProps<ComboLineColumnConfig>) => {
     const { chartConfig } = props;
     const { interactiveFiltersConfig } = chartConfig;
-    const { sharedTimeRangeFilters } = useDashboardInteractiveFilters();
-
+    const dashboardFilters = useDashboardInteractiveFilters();
     return (
       <ComboLineColumnChart {...props}>
         <ChartContainer type="comboLineColumn">
@@ -39,7 +38,7 @@ const ChartComboLineColumn = memo(
             <InteractionColumns />
             {shouldShowBrush(
               interactiveFiltersConfig,
-              sharedTimeRangeFilters
+              dashboardFilters.timeRange
             ) && <BrushTime />}
           </ChartSvg>
           <HoverDotMultiple />

--- a/app/charts/combo/chart-combo-line-dual.tsx
+++ b/app/charts/combo/chart-combo-line-dual.tsx
@@ -25,7 +25,7 @@ export const ChartComboLineDualVisualization = (
 const ChartComboLineDual = memo((props: ChartProps<ComboLineDualConfig>) => {
   const { chartConfig } = props;
   const { interactiveFiltersConfig } = chartConfig;
-  const { sharedFilters } = useDashboardInteractiveFilters();
+  const { sharedTimeRangeFilters } = useDashboardInteractiveFilters();
 
   return (
     <ComboLineDualChart {...props}>
@@ -36,9 +36,10 @@ const ChartComboLineDual = memo((props: ChartProps<ComboLineDualConfig>) => {
           <AxisTimeDomain />
           <ComboLineDual />
           <InteractionHorizontal />
-          {shouldShowBrush(interactiveFiltersConfig, sharedFilters) && (
-            <BrushTime />
-          )}
+          {shouldShowBrush(
+            interactiveFiltersConfig,
+            sharedTimeRangeFilters
+          ) && <BrushTime />}
         </ChartSvg>
         <HoverDotMultiple />
         <Ruler />

--- a/app/charts/combo/chart-combo-line-dual.tsx
+++ b/app/charts/combo/chart-combo-line-dual.tsx
@@ -25,8 +25,7 @@ export const ChartComboLineDualVisualization = (
 const ChartComboLineDual = memo((props: ChartProps<ComboLineDualConfig>) => {
   const { chartConfig } = props;
   const { interactiveFiltersConfig } = chartConfig;
-  const { sharedTimeRangeFilters } = useDashboardInteractiveFilters();
-
+  const dashboardFilters = useDashboardInteractiveFilters();
   return (
     <ComboLineDualChart {...props}>
       <ChartContainer type="comboLineDual">
@@ -38,7 +37,7 @@ const ChartComboLineDual = memo((props: ChartProps<ComboLineDualConfig>) => {
           <InteractionHorizontal />
           {shouldShowBrush(
             interactiveFiltersConfig,
-            sharedTimeRangeFilters
+            dashboardFilters.timeRange
           ) && <BrushTime />}
         </ChartSvg>
         <HoverDotMultiple />

--- a/app/charts/combo/chart-combo-line-single.tsx
+++ b/app/charts/combo/chart-combo-line-single.tsx
@@ -26,7 +26,8 @@ const ChartComboLineSingle = memo(
   (props: ChartProps<ComboLineSingleConfig>) => {
     const { chartConfig } = props;
     const { interactiveFiltersConfig } = chartConfig;
-    const { sharedFilters } = useDashboardInteractiveFilters();
+    const { sharedTimeRangeFilters } = useDashboardInteractiveFilters();
+
     return (
       <ComboLineSingleChart {...props}>
         <ChartContainer type="comboLineSingle">
@@ -34,9 +35,10 @@ const ChartComboLineSingle = memo(
             <AxisHeightLinear /> <AxisTime /> <AxisTimeDomain />
             <ComboLineSingle />
             <InteractionHorizontal />
-            {shouldShowBrush(interactiveFiltersConfig, sharedFilters) && (
-              <BrushTime />
-            )}
+            {shouldShowBrush(
+              interactiveFiltersConfig,
+              sharedTimeRangeFilters
+            ) && <BrushTime />}
           </ChartSvg>
           <HoverDotMultiple />
           <Ruler />

--- a/app/charts/combo/chart-combo-line-single.tsx
+++ b/app/charts/combo/chart-combo-line-single.tsx
@@ -26,8 +26,7 @@ const ChartComboLineSingle = memo(
   (props: ChartProps<ComboLineSingleConfig>) => {
     const { chartConfig } = props;
     const { interactiveFiltersConfig } = chartConfig;
-    const { sharedTimeRangeFilters } = useDashboardInteractiveFilters();
-
+    const dashboardFilters = useDashboardInteractiveFilters();
     return (
       <ComboLineSingleChart {...props}>
         <ChartContainer type="comboLineSingle">
@@ -37,7 +36,7 @@ const ChartComboLineSingle = memo(
             <InteractionHorizontal />
             {shouldShowBrush(
               interactiveFiltersConfig,
-              sharedTimeRangeFilters
+              dashboardFilters.timeRange
             ) && <BrushTime />}
           </ChartSvg>
           <HoverDotMultiple />

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -30,8 +30,7 @@ export const ChartLinesVisualization = (
 const ChartLines = memo((props: ChartProps<LineConfig>) => {
   const { chartConfig } = props;
   const { fields, interactiveFiltersConfig } = chartConfig;
-  const { sharedFilters } = useDashboardInteractiveFilters();
-
+  const dashboardFilters = useDashboardInteractiveFilters();
   return (
     <LineChart {...props}>
       <ChartContainer type="line">
@@ -40,9 +39,10 @@ const ChartLines = memo((props: ChartProps<LineConfig>) => {
           <Lines />
           <ErrorWhiskers />
           <InteractionHorizontal />
-          {shouldShowBrush(interactiveFiltersConfig, sharedFilters) && (
-            <BrushTime />
-          )}
+          {shouldShowBrush(
+            interactiveFiltersConfig,
+            dashboardFilters.timeRange
+          ) && <BrushTime />}
         </ChartSvg>
 
         <Ruler />

--- a/app/charts/shared/brush/index.tsx
+++ b/app/charts/shared/brush/index.tsx
@@ -17,12 +17,12 @@ import {
   ComboLineColumnConfig,
   ComboLineDualConfig,
   ComboLineSingleConfig,
+  DashboardTimeRangeFilter,
   LineConfig,
 } from "@/configurator";
 import { Observation } from "@/domain/data";
 import { useFormatFullDateAuto } from "@/formatters";
 import {
-  SharedTimeRangeFilter,
   useChartInteractiveFilters,
   useInteractiveFiltersGetState,
 } from "@/stores/interactive-filters";
@@ -44,16 +44,10 @@ export const shouldShowBrush = (
         | ColumnConfig
       )["interactiveFiltersConfig"]
     | undefined,
-  sharedTimeRangeFilters: SharedTimeRangeFilter[] | undefined
+  dashboardTimeRange: DashboardTimeRangeFilter | undefined
 ) => {
   const chartTimeRange = interactiveFiltersConfig?.timeRange;
-  const chartTimeRangeIri = chartTimeRange?.componentIri;
-  const sharedFilter = sharedTimeRangeFilters?.find(
-    (x) => x.componentIri === chartTimeRangeIri
-  );
-  return (
-    (chartTimeRange?.active && !sharedFilter) || sharedFilter?.active == false
-  );
+  return chartTimeRange?.active && !dashboardTimeRange?.active;
 };
 
 export const BrushTime = () => {

--- a/app/charts/shared/brush/index.tsx
+++ b/app/charts/shared/brush/index.tsx
@@ -22,7 +22,7 @@ import {
 import { Observation } from "@/domain/data";
 import { useFormatFullDateAuto } from "@/formatters";
 import {
-  SharedFilter,
+  SharedTimeRangeFilter,
   useChartInteractiveFilters,
   useInteractiveFiltersGetState,
 } from "@/stores/interactive-filters";
@@ -44,12 +44,12 @@ export const shouldShowBrush = (
         | ColumnConfig
       )["interactiveFiltersConfig"]
     | undefined,
-  sharedFilters: SharedFilter[] | undefined
+  sharedTimeRangeFilters: SharedTimeRangeFilter[] | undefined
 ) => {
   const chartTimeRange = interactiveFiltersConfig?.timeRange;
   const chartTimeRangeIri = chartTimeRange?.componentIri;
-  const sharedFilter = sharedFilters?.find(
-    (x) => x.type === "timeRange" && x.componentIri === chartTimeRangeIri
+  const sharedFilter = sharedTimeRangeFilters?.find(
+    (x) => x.componentIri === chartTimeRangeIri
   );
   return (
     (chartTimeRange?.active && !sharedFilter) || sharedFilter?.active == false

--- a/app/charts/shared/chart-state.ts
+++ b/app/charts/shared/chart-state.ts
@@ -56,7 +56,6 @@ import {
   isTemporalEntityDimension,
 } from "@/domain/data";
 import { Has } from "@/domain/types";
-import { getOriginalIris, isJoinById } from "@/graphql/join";
 import { ScaleType, TimeUnit } from "@/graphql/resolver-types";
 import {
   useChartInteractiveFilters,
@@ -511,23 +510,11 @@ export const useChartData = (
   const interactiveToTime = timeRange.to?.getTime();
   const dashboardFilters = useDashboardInteractiveFilters();
   const interactiveTimeRangeFilters = useMemo(() => {
-    const isDashboardFilterActive =
-      !!dashboardFilters.sharedTimeRangeFilters.find((f) => {
-        const timeRangeFilterIri = interactiveTimeRange?.componentIri;
-        if (!timeRangeFilterIri) {
-          return false;
-        }
-        return isJoinById(timeRangeFilterIri)
-          ? getOriginalIris(timeRangeFilterIri, chartConfig).includes(
-              f.componentIri
-            )
-          : f.componentIri === timeRangeFilterIri;
-      });
     const interactiveTimeRangeFilter: ValuePredicate | null =
       getXAsDate &&
       interactiveFromTime &&
       interactiveToTime &&
-      (interactiveTimeRange?.active || isDashboardFilterActive)
+      (interactiveTimeRange?.active || dashboardFilters.timeRange?.active)
         ? (d: Observation) => {
             const time = getXAsDate(d).getTime();
             return time >= interactiveFromTime && time <= interactiveToTime;
@@ -536,13 +523,11 @@ export const useChartData = (
 
     return interactiveTimeRangeFilter ? [interactiveTimeRangeFilter] : [];
   }, [
-    dashboardFilters.sharedTimeRangeFilters,
+    dashboardFilters.timeRange,
     getXAsDate,
     interactiveFromTime,
     interactiveToTime,
     interactiveTimeRange?.active,
-    interactiveTimeRange?.componentIri,
-    chartConfig,
   ]);
 
   // interactive time slider

--- a/app/charts/shared/chart-state.ts
+++ b/app/charts/shared/chart-state.ts
@@ -511,10 +511,10 @@ export const useChartData = (
   const interactiveToTime = timeRange.to?.getTime();
   const dashboardFilters = useDashboardInteractiveFilters();
   const interactiveTimeRangeFilters = useMemo(() => {
-    const isDashboardFilterActive = !!dashboardFilters.sharedFilters.find(
-      (f) => {
+    const isDashboardFilterActive =
+      !!dashboardFilters.sharedTimeRangeFilters.find((f) => {
         const timeRangeFilterIri = interactiveTimeRange?.componentIri;
-        if (f.type !== "timeRange" || !timeRangeFilterIri) {
+        if (!timeRangeFilterIri) {
           return false;
         }
         return isJoinById(timeRangeFilterIri)
@@ -522,8 +522,7 @@ export const useChartData = (
               f.componentIri
             )
           : f.componentIri === timeRangeFilterIri;
-      }
-    );
+      });
     const interactiveTimeRangeFilter: ValuePredicate | null =
       getXAsDate &&
       interactiveFromTime &&
@@ -537,7 +536,7 @@ export const useChartData = (
 
     return interactiveTimeRangeFilter ? [interactiveTimeRangeFilter] : [];
   }, [
-    dashboardFilters.sharedFilters,
+    dashboardFilters.sharedTimeRangeFilters,
     getXAsDate,
     interactiveFromTime,
     interactiveToTime,

--- a/app/components/chart-filters-list.tsx
+++ b/app/components/chart-filters-list.tsx
@@ -52,11 +52,11 @@ export const ChartFiltersList = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      cubeFilters: cubeQueryFilters.map((filter) => ({
-        iri: filter.iri,
-        componentIris: filter.componentIris,
-        filters: filter.filters,
-        joinBy: filter.joinBy,
+      cubeFilters: chartConfig.cubes.map((cube) => ({
+        iri: cube.iri,
+        componentIris: extractChartConfigComponentIris({ chartConfig }),
+        filters: cubeQueryFilters.find((f) => f.iri === cube.iri)?.filters,
+        joinBy: cube.joinBy,
         loadValues: true,
       })),
     },

--- a/app/components/chart-filters-list.tsx
+++ b/app/components/chart-filters-list.tsx
@@ -52,13 +52,16 @@ export const ChartFiltersList = ({
       sourceType: dataSource.type,
       sourceUrl: dataSource.url,
       locale,
-      cubeFilters: chartConfig.cubes.map((cube) => ({
-        iri: cube.iri,
-        componentIris: extractChartConfigComponentIris({ chartConfig }),
-        filters: cubeQueryFilters.find((f) => f.iri === cube.iri)?.filters,
-        joinBy: cube.joinBy,
-        loadValues: true,
-      })),
+      cubeFilters: chartConfig.cubes.map((cube) => {
+        const f = cubeQueryFilters.find((f) => f.iri === cube.iri);
+        return {
+          iri: f?.iri ?? cube.iri,
+          componentIris: f?.componentIris,
+          filters: f?.filters,
+          joinBy: f?.joinBy,
+          loadValues: true,
+        };
+      }),
     },
   });
   const allFilters = useMemo(() => {

--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -78,7 +78,7 @@ export const ChartFootnotes = ({
   const formatLocale = useTimeFormatLocale();
 
   return (
-    <Box sx={{ "& > :not(:last-child)": { mb: 3 } }}>
+    <Box sx={{ mt: 1, "& > :not(:last-child)": { mb: 3 } }}>
       {data?.dataCubesMetadata.map((metadata) => (
         <div key={metadata.iri}>
           <ChartFootnotesLegend

--- a/app/components/chart-panel-layout-tall.tsx
+++ b/app/components/chart-panel-layout-tall.tsx
@@ -48,7 +48,8 @@ const ChartPanelLayoutTallRow = (props: ChartPanelLayoutTallRowProps) => {
               xs: "1fr",
               md: "calc(50% - 8px) calc(50% - 8px)",
             },
-            gap: "16px",
+            gridAutoRows: "min-content",
+            columnGap: 4,
           }}
         >
           {row.chartConfigs.map(row.renderChart)}

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -461,6 +461,7 @@ const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
                 >
                   <Flex
                     sx={{
+                      height: "fit-content",
                       justifyContent:
                         configuring || chartConfig.meta.title[locale]
                           ? "space-between"
@@ -484,12 +485,10 @@ const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
                             : undefined
                         }
                       />
-                    ) : // We need to have a span here to keep the space between the
-                    // title and the chart (subgrid layout)
-                    state.layout.type === "dashboard" ? (
-                      <span>&nbsp;</span>
                     ) : (
-                      <span />
+                      // We need to have a span here to keep the space between the
+                      // title and the chart (subgrid layout)
+                      <span style={{ height: 1 }} />
                     )}
                     <Box
                       sx={{
@@ -519,12 +518,10 @@ const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
                           : undefined
                       }
                     />
-                  ) : // We need to have a span here to keep the space between the
-                  // title and the chart (subgrid layout)
-                  state.layout.type === "dashboard" ? (
-                    <span>&nbsp;</span>
                   ) : (
-                    <span />
+                    // We need to have a span here to keep the space between the
+                    // title and the chart (subgrid layout)
+                    <span style={{ height: 1 }} />
                   )}
                   <ChartControls
                     dataSource={dataSource}

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -324,6 +324,7 @@ const ChartPublishedInnerImpl = (props: ChartPublishInnerProps) => {
             <InteractiveFiltersChartProvider chartConfigKey={chartConfig.key}>
               <Flex
                 sx={{
+                  height: "fit-content",
                   justifyContent: meta.title[locale]
                     ? "space-between"
                     : "flex-end",
@@ -335,12 +336,10 @@ const ChartPublishedInnerImpl = (props: ChartPublishInnerProps) => {
                     text={meta.title[locale]}
                     smaller={state.layout.type === "dashboard"}
                   />
-                ) : // We need to have a span here to keep the space between the
-                // title and the chart (subgrid layout)
-                state.layout.type === "dashboard" ? (
-                  <span>&nbsp;</span>
                 ) : (
-                  <span />
+                  // We need to have a span here to keep the space between the
+                  // title and the chart (subgrid layout)
+                  <span style={{ height: 1 }} />
                 )}
                 <ChartMoreButton
                   configKey={configKey}
@@ -352,12 +351,10 @@ const ChartPublishedInnerImpl = (props: ChartPublishInnerProps) => {
                   text={meta.description[locale]}
                   smaller={state.layout.type === "dashboard"}
                 />
-              ) : // We need to have a span here to keep the space between the
-              // title and the chart (subgrid layout)
-              state.layout.type === "dashboard" ? (
-                <span>&nbsp;</span>
               ) : (
-                <span />
+                // We need to have a span here to keep the space between the
+                // title and the chart (subgrid layout)
+                <span style={{ height: 1 }} />
               )}
               <ChartControls
                 dataSource={dataSource}

--- a/app/components/dashboard-interactive-filters.tsx
+++ b/app/components/dashboard-interactive-filters.tsx
@@ -22,7 +22,7 @@ import { useConfigsCubeComponents } from "@/graphql/hooks";
 import { TimeUnit } from "@/graphql/query-hooks";
 import { useLocale } from "@/src";
 import {
-  SharedFilter,
+  SharedTimeRangeFilter,
   useDashboardInteractiveFilters,
 } from "@/stores/interactive-filters";
 import { assert } from "@/utils/assert";
@@ -81,7 +81,7 @@ const DashboardTimeRangeSlider = ({
   filter,
   mounted,
 }: {
-  filter: Extract<SharedFilter, { type: "timeRange" }>;
+  filter: SharedTimeRangeFilter;
   mounted: boolean;
 }) => {
   const classes = useStyles();
@@ -183,7 +183,7 @@ const DashboardTimeRangeSlider = ({
 
   const mountedForSomeTime = useTimeout(500, mounted);
 
-  if (!filter || !timeRange || filter.type !== "timeRange" || !filter.active) {
+  if (!filter || !timeRange || !filter.active) {
     return null;
   }
 
@@ -208,22 +208,24 @@ export const DashboardInteractiveFilters = () => {
 
   return (
     <>
-      {dashboardInteractiveFilters.sharedFilters.map((filter) => {
-        if (filter.type !== "timeRange" || !filter.active) {
-          return null;
-        }
+      {dashboardInteractiveFilters.sharedTimeRangeFilters
+        .slice(1)
+        .map((filter) => {
+          if (!filter.active) {
+            return null;
+          }
 
-        return (
-          <Collapse in={filter.active} key={filter.componentIri}>
-            <div>
-              <DashboardTimeRangeSlider
-                filter={filter}
-                mounted={filter.active}
-              />
-            </div>
-          </Collapse>
-        );
-      })}
+          return (
+            <Collapse in={filter.active} key={filter.componentIri}>
+              <div>
+                <DashboardTimeRangeSlider
+                  filter={filter}
+                  mounted={filter.active}
+                />
+              </div>
+            </Collapse>
+          );
+        })}
     </>
   );
 };

--- a/app/components/dashboard-interactive-filters.tsx
+++ b/app/components/dashboard-interactive-filters.tsx
@@ -9,22 +9,15 @@ import { makeStyles } from "@mui/styles";
 import { useEffect, useMemo, useState } from "react";
 
 import {
-  hasChartConfigs,
+  DashboardTimeRangeFilter,
   InteractiveFiltersTimeRange,
-  useConfiguratorState,
 } from "@/configurator";
 import {
   timeUnitToFormatter,
   timeUnitToParser,
 } from "@/configurator/components/ui-helpers";
-import { canDimensionBeTimeFiltered } from "@/domain/data";
-import { useConfigsCubeComponents } from "@/graphql/hooks";
 import { TimeUnit } from "@/graphql/query-hooks";
-import { useLocale } from "@/src";
-import {
-  SharedTimeRangeFilter,
-  useDashboardInteractiveFilters,
-} from "@/stores/interactive-filters";
+import { useDashboardInteractiveFilters } from "@/stores/interactive-filters";
 import { assert } from "@/utils/assert";
 
 import { useTimeout } from "../hooks/use-timeout";
@@ -57,7 +50,7 @@ const valueToTimeRange = (value: number[]) => {
 };
 
 const presetToTimeRange = (
-  presets: InteractiveFiltersTimeRange["presets"],
+  presets: Pick<InteractiveFiltersTimeRange["presets"], "from" | "to">,
   timeUnit: TimeUnit
 ) => {
   if (!timeUnit) {
@@ -81,43 +74,27 @@ const DashboardTimeRangeSlider = ({
   filter,
   mounted,
 }: {
-  filter: SharedTimeRangeFilter;
+  filter: DashboardTimeRangeFilter;
   mounted: boolean;
 }) => {
   const classes = useStyles();
-
   const dashboardInteractiveFilters = useDashboardInteractiveFilters();
-
-  const [state] = useConfiguratorState(hasChartConfigs);
-  const locale = useLocale();
-
-  const [data] = useConfigsCubeComponents({
-    variables: {
-      state,
-      locale,
-    },
-  });
-
-  const timeUnit = useMemo(() => {
-    const dim = data?.data?.dataCubesComponents?.dimensions?.find(
-      (d) => d.iri === filter.componentIri
-    );
-    return canDimensionBeTimeFiltered(dim) ? dim.timeUnit : undefined;
-  }, [data?.data?.dataCubesComponents?.dimensions, filter.componentIri]);
-
   const presets = filter.presets;
   assert(
     presets,
     "Filter presets should be defined when time range filter is rendered"
   );
 
+  const timeUnit = filter.timeUnit as TimeUnit;
+
   // In Unix timestamp
   const [timeRange, setTimeRange] = useState(() =>
+    // timeUnit can still be an empty string
     timeUnit ? presetToTimeRange(presets, timeUnit) : undefined
   );
 
   const { min, max } = useMemo(() => {
-    if (!timeUnit || !presets) {
+    if (!timeUnit) {
       return { min: 0, max: 0 };
     }
     const parser = timeUnitToParser[timeUnit];
@@ -133,65 +110,61 @@ const DashboardTimeRangeSlider = ({
     if (!timeUnit) {
       return "";
     }
-    const d = new Date(value * 1000);
-    return timeUnitToFormatter[timeUnit](d);
+    const date = new Date(value * 1000);
+    return timeUnitToFormatter[timeUnit](date);
   });
 
-  const handleChangeSlider = useEventCallback(
-    (componentIri: string, value: number | number[]) => {
-      assert(Array.isArray(value), "Value should be an array of two numbers");
-      if (!componentIri || !timeUnit) {
-        return;
-      }
-      const newTimeRange = valueToTimeRange(value);
-      if (!newTimeRange) {
-        return;
-      }
-      for (const [_getState, _useStore, store] of Object.values(
-        dashboardInteractiveFilters.stores
-      )) {
-        store.setState({ timeRange: newTimeRange });
-        setTimeRange([value[0], value[1]]);
-      }
+  const handleChangeSlider = useEventCallback((value: number | number[]) => {
+    assert(Array.isArray(value), "Value should be an array of two numbers");
+    if (!timeUnit) {
+      return;
     }
-  );
+    const newTimeRange = valueToTimeRange(value);
+    if (!newTimeRange) {
+      return;
+    }
+    for (const [_getState, _useStore, store] of Object.values(
+      dashboardInteractiveFilters.stores
+    )) {
+      store.setState({ timeRange: newTimeRange });
+      setTimeRange([value[0], value[1]]);
+    }
+  });
 
   useEffect(
     function initTimeRangeAfterDataFetch() {
       if (timeRange || !timeUnit) {
         return;
       }
-
       const parser = timeUnitToParser[timeUnit];
-      handleChangeSlider(filter.componentIri, [
+      handleChangeSlider([
         toUnixSeconds(parser(presets.from)),
         toUnixSeconds(parser(presets.to)),
       ]);
     },
-    [timeRange, timeUnit, presets, handleChangeSlider, filter.componentIri]
+    [timeRange, timeUnit, presets, handleChangeSlider]
   );
 
   useEffect(() => {
-    if (filter.presets.from && filter.presets.to && timeUnit) {
+    if (presets.from && presets.to && timeUnit) {
       const parser = timeUnitToParser[timeUnit];
       setTimeRange([
-        toUnixSeconds(parser(filter.presets.from)),
-        toUnixSeconds(parser(filter.presets.to)),
+        toUnixSeconds(parser(presets.from)),
+        toUnixSeconds(parser(presets.to)),
       ]);
     }
-  }, [filter.presets.from, filter.presets.to, timeUnit]);
+  }, [presets.from, presets.to, timeUnit]);
 
   const mountedForSomeTime = useTimeout(500, mounted);
 
-  if (!filter || !timeRange || !filter.active) {
+  if (!timeRange || !filter.active) {
     return null;
   }
 
   return (
     <Slider
       className={classes.slider}
-      key={filter.componentIri}
-      onChange={(_ev, value) => handleChangeSlider(filter.componentIri, value)}
+      onChange={(_ev, value) => handleChangeSlider(value)}
       min={min}
       max={max}
       valueLabelFormat={valueLabelFormat}
@@ -204,30 +177,17 @@ const DashboardTimeRangeSlider = ({
 };
 
 export const DashboardInteractiveFilters = () => {
-  const dashboardInteractiveFilters = useDashboardInteractiveFilters();
-
-  return (
-    <>
-      {dashboardInteractiveFilters.sharedTimeRangeFilters
-        .slice(1)
-        .map((filter) => {
-          if (!filter.active) {
-            return null;
-          }
-
-          return (
-            <Collapse in={filter.active} key={filter.componentIri}>
-              <div>
-                <DashboardTimeRangeSlider
-                  filter={filter}
-                  mounted={filter.active}
-                />
-              </div>
-            </Collapse>
-          );
-        })}
-    </>
-  );
+  const { timeRange } = useDashboardInteractiveFilters();
+  return timeRange?.active ? (
+    <Collapse in={timeRange.active}>
+      <div>
+        <DashboardTimeRangeSlider
+          filter={timeRange}
+          mounted={timeRange.active}
+        />
+      </div>
+    </Collapse>
+  ) : null;
 };
 
 function stepFromTimeUnit(timeUnit: TimeUnit | undefined) {

--- a/app/components/dashboard-interactive-filters.tsx
+++ b/app/components/dashboard-interactive-filters.tsx
@@ -150,9 +150,7 @@ const DashboardTimeRangeSlider = ({
       for (const [_getState, _useStore, store] of Object.values(
         dashboardInteractiveFilters.stores
       )) {
-        store.setState({
-          timeRange: newTimeRange,
-        });
+        store.setState({ timeRange: newTimeRange });
         setTimeRange([value[0], value[1]]);
       }
     }
@@ -172,6 +170,16 @@ const DashboardTimeRangeSlider = ({
     },
     [timeRange, timeUnit, presets, handleChangeSlider, filter.componentIri]
   );
+
+  useEffect(() => {
+    if (filter.presets.from && filter.presets.to && timeUnit) {
+      const parser = timeUnitToParser[timeUnit];
+      setTimeRange([
+        toUnixSeconds(parser(filter.presets.from)),
+        toUnixSeconds(parser(filter.presets.to)),
+      ]);
+    }
+  }, [filter.presets.from, filter.presets.to, timeUnit]);
 
   const mountedForSomeTime = useTimeout(500, mounted);
 

--- a/app/components/metadata-panel.tsx
+++ b/app/components/metadata-panel.tsx
@@ -475,7 +475,7 @@ const DataPanel = ({
       }[] => {
         if (isJoinByComponent(component)) {
           return (component.originalIris ?? []).map((x) => ({
-            label: getComponentLabel(component, x.cubeIri),
+            label: getComponentLabel(component, { cubeIri: x.cubeIri }),
             value: {
               ...omit(component, "originalIris"),
               cubeIri: x.cubeIri,
@@ -674,7 +674,7 @@ const ComponentTabPanel = ({
   const classes = useOtherStyles();
   const { setSelectedDimension } = useMetadataPanelStoreActions();
   const label = useMemo(
-    () => getComponentLabel(component, cubeIri),
+    () => getComponentLabel(component, { cubeIri }),
     [cubeIri, component]
   );
   const description = useMemo(() => {

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -1157,11 +1157,8 @@ export type DashboardFilterTimeRange = t.TypeOf<
   typeof DashboardFilterTimeRange
 >;
 
-const DashboardFilter = DashboardFilterTimeRange; // Will be replaced by an union later
-export type DashboardFilter = t.TypeOf<typeof DashboardFilter>;
-
 const DashboardFiltersConfig = t.type({
-  filters: t.array(DashboardFilter),
+  timeRangeFilters: t.array(DashboardFilterTimeRange),
 });
 export type DashboardFiltersConfig = t.TypeOf<typeof DashboardFiltersConfig>;
 

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -1142,23 +1142,21 @@ export type Layout = t.TypeOf<typeof Layout>;
 export type LayoutType = Layout["type"];
 export type LayoutDashboard = Extract<Layout, { type: "dashboard" }>;
 
-const DashboardFilterTimeRange = t.type({
-  type: t.literal("timeRange"),
+const DashboardTimeRangeFilter = t.type({
   active: t.boolean,
-  componentIri: t.string,
+  timeUnit: t.string,
   presets: t.type({
-    type: t.literal("range"),
     from: t.string,
     to: t.string,
   }),
 });
 
-export type DashboardFilterTimeRange = t.TypeOf<
-  typeof DashboardFilterTimeRange
+export type DashboardTimeRangeFilter = t.TypeOf<
+  typeof DashboardTimeRangeFilter
 >;
 
 const DashboardFiltersConfig = t.type({
-  timeRangeFilters: t.array(DashboardFilterTimeRange),
+  timeRange: DashboardTimeRangeFilter,
 });
 export type DashboardFiltersConfig = t.TypeOf<typeof DashboardFiltersConfig>;
 

--- a/app/configurator/components/add-dataset-dialog.mock.ts
+++ b/app/configurator/components/add-dataset-dialog.mock.ts
@@ -101,6 +101,6 @@ export const photovoltaikChartStateMock: ConfiguratorStateConfiguringChart = {
   ],
   activeChartKey: "8-5RW138pTDA",
   dashboardFilters: {
-    filters: [],
+    timeRangeFilters: [],
   },
 };

--- a/app/configurator/components/add-dataset-dialog.mock.ts
+++ b/app/configurator/components/add-dataset-dialog.mock.ts
@@ -101,6 +101,13 @@ export const photovoltaikChartStateMock: ConfiguratorStateConfiguringChart = {
   ],
   activeChartKey: "8-5RW138pTDA",
   dashboardFilters: {
-    timeRangeFilters: [],
+    timeRange: {
+      active: false,
+      timeUnit: "",
+      presets: {
+        from: "",
+        to: "",
+      },
+    },
   },
 };

--- a/app/configurator/components/add-dataset-dialog.tsx
+++ b/app/configurator/components/add-dataset-dialog.tsx
@@ -903,10 +903,10 @@ export const DatasetDialog = ({
 
   const handleSubmit = (ev: FormEvent<HTMLFormElement>) => {
     ev.preventDefault();
-    const formdata = Object.fromEntries(
+    const formData = Object.fromEntries(
       new FormData(ev.currentTarget).entries()
     );
-    setQuery(formdata.search as string);
+    setQuery(formData.search as string);
   };
 
   const handleClose: DialogProps["onClose"] = useEventCallback((ev, reason) => {
@@ -1257,6 +1257,7 @@ const useAddDataset = () => {
           JSON.stringify(state)
         ) as ConfiguratorStateConfiguringChart;
         addDatasetInConfig(nextState, addDatasetOptions);
+        console.log("nextState", nextState);
 
         const allCubes = uniqBy(
           nextState.chartConfigs.flatMap((x) => x.cubes),

--- a/app/configurator/components/add-dataset-dialog.tsx
+++ b/app/configurator/components/add-dataset-dialog.tsx
@@ -1257,7 +1257,6 @@ const useAddDataset = () => {
           JSON.stringify(state)
         ) as ConfiguratorStateConfiguringChart;
         addDatasetInConfig(nextState, addDatasetOptions);
-        console.log("nextState", nextState);
 
         const allCubes = uniqBy(
           nextState.chartConfigs.flatMap((x) => x.cubes),

--- a/app/configurator/components/add-dataset-dialog.tsx
+++ b/app/configurator/components/add-dataset-dialog.tsx
@@ -48,7 +48,6 @@ import groupBy from "lodash/groupBy";
 import keyBy from "lodash/keyBy";
 import maxBy from "lodash/maxBy";
 import uniq from "lodash/uniq";
-import uniqBy from "lodash/uniqBy";
 import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import { useClient } from "urql";
 
@@ -61,6 +60,7 @@ import {
   addDatasetInConfig,
   ConfiguratorStateConfiguringChart,
   DataSource,
+  getChartConfig,
   isConfiguring,
   useConfiguratorState,
 } from "@/configurator";
@@ -1257,18 +1257,16 @@ const useAddDataset = () => {
           JSON.stringify(state)
         ) as ConfiguratorStateConfiguringChart;
         addDatasetInConfig(nextState, addDatasetOptions);
+        const chartConfig = getChartConfig(nextState, state.activeChartKey);
 
-        const allCubes = uniqBy(
-          nextState.chartConfigs.flatMap((x) => x.cubes),
-          (x) => x.iri
-        );
         const res = await executeDataCubesComponentsQuery(client, {
-          locale: locale,
+          locale,
           sourceType,
           sourceUrl,
-          cubeFilters: allCubes.map((cube) => ({
+          cubeFilters: chartConfig.cubes.map((cube) => ({
             iri: cube.iri,
             joinBy: cube.joinBy,
+            componentIris: undefined,
             loadValues: true,
           })),
         });
@@ -1276,6 +1274,7 @@ const useAddDataset = () => {
         if (res.error || !res.data) {
           throw new Error("Could not fetch dimensions and measures");
         }
+
         dispatch({
           type: "DATASET_ADD",
           value: addDatasetOptions,
@@ -1284,7 +1283,7 @@ const useAddDataset = () => {
         const possibleType = getPossibleChartTypes({
           dimensions: dimensions,
           measures: measures,
-          cubeCount: allCubes.length,
+          cubeCount: chartConfig.cubes.length,
         });
         dispatch({
           type: "CHART_TYPE_CHANGED",

--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -193,8 +193,11 @@ const ConfigureChartStep = () => {
             <ChartConfiguratorTable state={state} />
           ) : (
             // Need to use key to force re-render when switching between charts
-            // to fix stale data issues
-            <ChartConfigurator key={state.activeChartKey} state={state} />
+            // or adding / removing cubes to fix stale data issues
+            <ChartConfigurator
+              key={`${chartConfig.key}_${chartConfig.cubes.length}`}
+              state={state}
+            />
           )}
         </PanelBodyWrapper>
         <PanelBodyWrapper type="M">

--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -192,7 +192,9 @@ const ConfigureChartStep = () => {
           {chartConfig.chartType === "table" ? (
             <ChartConfiguratorTable state={state} />
           ) : (
-            <ChartConfigurator state={state} />
+            // Need to use key to force re-render when switching between charts
+            // to fix stale data issues
+            <ChartConfigurator key={state.activeChartKey} state={state} />
           )}
         </PanelBodyWrapper>
         <PanelBodyWrapper type="M">

--- a/app/configurator/components/ui-helpers.ts
+++ b/app/configurator/components/ui-helpers.ts
@@ -313,16 +313,19 @@ export const canUseAbbreviations = (d?: Component): boolean => {
  *   - Temporal dimensions will get labelled via their time unit
  * - If you need the dimension label in the context of a cube, pass the cube iri
  */
-export const getComponentLabel = (dim: Component, cubeIri?: string) => {
-  if (isJoinByComponent(dim)) {
+export const getComponentLabel = (
+  component: Component,
+  { cubeIri }: { cubeIri?: string } = {}
+) => {
+  if (isJoinByComponent(component)) {
     const original =
-      cubeIri && dim.originalIris.find((i) => i.cubeIri === cubeIri);
+      cubeIri && component.originalIris.find((i) => i.cubeIri === cubeIri);
     if (original) {
       return original.label;
     }
 
-    if (dim.__typename === "TemporalDimension") {
-      switch (dim.timeUnit) {
+    if (component.__typename === "TemporalDimension") {
+      switch (component.timeUnit) {
         case TimeUnit.Year:
           return t({ id: `time-units.Year`, message: "Year" });
         case TimeUnit.Month:
@@ -339,9 +342,11 @@ export const getComponentLabel = (dim: Component, cubeIri?: string) => {
           return t({ id: `time-units.Second`, message: "Second" });
       }
     }
-    return dim.originalIris[0].label ?? "NO LABEL";
+
+    return component.originalIris[0].label ?? "NO LABEL";
   }
-  return dim.label;
+
+  return component.label;
 };
 
 /**

--- a/app/configurator/configurator-state/actions.tsx
+++ b/app/configurator/configurator-state/actions.tsx
@@ -270,14 +270,9 @@ export type ConfiguratorStateAction =
       };
     }
   | {
-      type: "DASHBOARD_TIME_RANGE_FILTER_ADD";
-      value: DashboardFiltersConfig["timeRangeFilters"][number];
+      type: "DASHBOARD_TIME_RANGE_FILTER_UPDATE";
+      value: DashboardFiltersConfig["timeRange"];
     }
   | {
       type: "DASHBOARD_TIME_RANGE_FILTER_REMOVE";
-      value: DashboardFiltersConfig["timeRangeFilters"][number]["componentIri"];
-    }
-  | {
-      type: "DASHBOARD_TIME_RANGE_FILTER_UPDATE";
-      value: DashboardFiltersConfig["timeRangeFilters"][number];
     };

--- a/app/configurator/configurator-state/actions.tsx
+++ b/app/configurator/configurator-state/actions.tsx
@@ -270,14 +270,14 @@ export type ConfiguratorStateAction =
       };
     }
   | {
-      type: "DASHBOARD_FILTER_ADD";
-      value: DashboardFiltersConfig["filters"][number];
+      type: "DASHBOARD_TIME_RANGE_FILTER_ADD";
+      value: DashboardFiltersConfig["timeRangeFilters"][number];
     }
   | {
-      type: "DASHBOARD_FILTER_REMOVE";
-      value: DashboardFiltersConfig["filters"][number]["componentIri"];
+      type: "DASHBOARD_TIME_RANGE_FILTER_REMOVE";
+      value: DashboardFiltersConfig["timeRangeFilters"][number]["componentIri"];
     }
   | {
-      type: "DASHBOARD_FILTER_UPDATE";
-      value: DashboardFiltersConfig["filters"][number];
+      type: "DASHBOARD_TIME_RANGE_FILTER_UPDATE";
+      value: DashboardFiltersConfig["timeRangeFilters"][number];
     };

--- a/app/configurator/configurator-state/index.tsx
+++ b/app/configurator/configurator-state/index.tsx
@@ -264,35 +264,34 @@ export const addDatasetInConfig = function (
     };
   }
 ) {
+  const chartConfig = getChartConfig(config, config.activeChartKey);
   const { iri, joinBy } = options;
-  for (const chartConfig of config.chartConfigs) {
-    chartConfig.cubes[0].joinBy = joinBy.left;
-    chartConfig.cubes.push({
-      iri: iri,
-      publishIri: iri,
-      joinBy: joinBy.right,
-      filters: {},
-    });
+  chartConfig.cubes[0].joinBy = joinBy.left;
+  chartConfig.cubes.push({
+    iri: iri,
+    publishIri: iri,
+    joinBy: joinBy.right,
+    filters: {},
+  });
 
-    // Need to go over fields, and replace any IRI part of the joinBy by "joinBy"
-    const { encodings } = getChartSpec(chartConfig);
-    const encodingAndFields = encodings.map(
-      (e) =>
-        [
-          e,
-          chartConfig.fields[e.field as keyof typeof chartConfig.fields] as any,
-        ] as const
-    );
-    for (const [encoding, field] of encodingAndFields) {
-      if (!field) {
-        continue;
-      }
-      for (const iriAttribute of encoding.iriAttributes) {
-        const value = get(field, iriAttribute);
-        const index = joinBy.left.indexOf(value) ?? joinBy.right.indexOf(value);
-        if (index > -1) {
-          set(field, iriAttribute, mkJoinById(index));
-        }
+  // Need to go over fields, and replace any IRI part of the joinBy by "joinBy"
+  const { encodings } = getChartSpec(chartConfig);
+  const encodingAndFields = encodings.map(
+    (e) =>
+      [
+        e,
+        chartConfig.fields[e.field as keyof typeof chartConfig.fields] as any,
+      ] as const
+  );
+  for (const [encoding, field] of encodingAndFields) {
+    if (!field) {
+      continue;
+    }
+    for (const iriAttribute of encoding.iriAttributes) {
+      const value = get(field, iriAttribute);
+      const index = joinBy.left.indexOf(value) ?? joinBy.right.indexOf(value);
+      if (index > -1) {
+        set(field, iriAttribute, mkJoinById(index));
       }
     }
   }

--- a/app/configurator/configurator-state/initial.tsx
+++ b/app/configurator/configurator-state/initial.tsx
@@ -38,7 +38,14 @@ export const getInitialConfiguringConfigBasedOnCube = (props: {
     chartConfigs: [chartConfig],
     activeChartKey: chartConfig.key,
     dashboardFilters: {
-      timeRangeFilters: [],
+      timeRange: {
+        active: false,
+        timeUnit: "",
+        presets: {
+          from: "",
+          to: "",
+        },
+      },
     },
   };
 };

--- a/app/configurator/configurator-state/initial.tsx
+++ b/app/configurator/configurator-state/initial.tsx
@@ -38,7 +38,7 @@ export const getInitialConfiguringConfigBasedOnCube = (props: {
     chartConfigs: [chartConfig],
     activeChartKey: chartConfig.key,
     dashboardFilters: {
-      filters: [],
+      timeRangeFilters: [],
     },
   };
 };

--- a/app/configurator/configurator-state/mocks.ts
+++ b/app/configurator/configurator-state/mocks.ts
@@ -62,7 +62,7 @@ export const configStateMock = {
     ],
     activeChartKey: "abc",
     dashboardFilters: {
-      filters: [],
+      timeRangeFilters: [],
     },
   },
   groupedColumnChart: {
@@ -198,7 +198,7 @@ export const configStateMock = {
     ],
     activeChartKey: "2of7iJAjccuj",
     dashboardFilters: {
-      filters: [],
+      timeRangeFilters: [],
     },
   },
 } satisfies Record<string, ConfiguratorState>;

--- a/app/configurator/configurator-state/mocks.ts
+++ b/app/configurator/configurator-state/mocks.ts
@@ -62,7 +62,14 @@ export const configStateMock = {
     ],
     activeChartKey: "abc",
     dashboardFilters: {
-      timeRangeFilters: [],
+      timeRange: {
+        active: false,
+        timeUnit: "",
+        presets: {
+          from: "",
+          to: "",
+        },
+      },
     },
   },
   groupedColumnChart: {
@@ -198,7 +205,14 @@ export const configStateMock = {
     ],
     activeChartKey: "2of7iJAjccuj",
     dashboardFilters: {
-      timeRangeFilters: [],
+      timeRange: {
+        active: false,
+        timeUnit: "",
+        presets: {
+          from: "",
+          to: "",
+        },
+      },
     },
   },
 } satisfies Record<string, ConfiguratorState>;

--- a/app/configurator/configurator-state/reducer.spec.tsx
+++ b/app/configurator/configurator-state/reducer.spec.tsx
@@ -127,12 +127,12 @@ describe("add dataset", () => {
       addAction
     ) as ConfiguratorStatePublishing;
 
-    getCachedComponents.mockImplementation((_, cubes) => {
+    getCachedComponents.mockImplementation((options) => {
       // TODO Cubes join by need to be reset at the moment, will change
       // when we have more than 2 cubes
-      expect(cubes.map((x) => x.joinBy).every((x) => x === undefined)).toBe(
-        true
-      );
+      expect(
+        options.cubeFilters.map((x) => x.joinBy).every((x) => x === undefined)
+      ).toBe(true);
       return getCachedComponentsMock.electricyPricePerCantonDimensions;
     });
     const newState2 = runReducer(

--- a/app/configurator/configurator-state/reducer.spec.tsx
+++ b/app/configurator/configurator-state/reducer.spec.tsx
@@ -141,7 +141,7 @@ describe("add dataset", () => {
     ) as ConfiguratorStatePublishing;
     const config = newState2.chartConfigs[0] as MapConfig;
     expect(config.cubes.length).toBe(1);
-    expect(config.chartType).toEqual("column");
+    expect(config.chartType).toEqual("map");
   });
 });
 

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -4,7 +4,6 @@ import get from "lodash/get";
 import isEqual from "lodash/isEqual";
 import setWith from "lodash/setWith";
 import sortBy from "lodash/sortBy";
-import uniqBy from "lodash/uniqBy";
 import unset from "lodash/unset";
 import { Reducer } from "use-immer";
 
@@ -26,6 +25,7 @@ import {
   ColorMapping,
   ColumnStyleCategory,
   ConfiguratorState,
+  DashboardTimeRangeFilter,
   enableLayouting,
   Filters,
   GenericField,
@@ -1057,48 +1057,27 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       newDraft.activeChartKey = action.value.chartKey;
       return newDraft;
 
-    case "DASHBOARD_TIME_RANGE_FILTER_ADD":
-      if (isLayouting(draft)) {
-        setWith(
-          draft,
-          "dashboardFilters.timeRangeFilters",
-          uniqBy(
-            [...(draft.dashboardFilters?.timeRangeFilters ?? []), action.value],
-            (x) => x.componentIri
-          ),
-          Object
-        );
-      }
-
-      return draft;
-
     case "DASHBOARD_TIME_RANGE_FILTER_UPDATE":
       if (isLayouting(draft)) {
-        const idx = draft.dashboardFilters?.timeRangeFilters.findIndex(
-          (f) => f.componentIri === action.value.componentIri
-        );
-
-        if (idx !== undefined && idx > -1) {
-          const newFilters = [
-            ...(draft.dashboardFilters?.timeRangeFilters ?? []),
-          ];
-          newFilters.splice(idx, 1, action.value);
-          setWith(
-            draft,
-            "dashboardFilters.timeRangeFilters",
-            newFilters,
-            Object
-          );
-        }
+        setWith(draft, "dashboardFilters.timeRange", action.value, Object);
       }
       return draft;
 
     case "DASHBOARD_TIME_RANGE_FILTER_REMOVE":
       if (isLayouting(draft)) {
-        const newFilters = draft.dashboardFilters?.timeRangeFilters.filter(
-          (f) => f.componentIri !== action.value
+        setWith(
+          draft,
+          "dashboardFilters.timeRange",
+          {
+            active: false,
+            timeUnit: "",
+            presets: {
+              from: "",
+              to: "",
+            },
+          } as DashboardTimeRangeFilter,
+          Object
         );
-        setWith(draft, "dashboardFilters.timeRangeFilters", newFilters, Object);
       }
       return draft;
 

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -1057,13 +1057,13 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       newDraft.activeChartKey = action.value.chartKey;
       return newDraft;
 
-    case "DASHBOARD_FILTER_ADD":
+    case "DASHBOARD_TIME_RANGE_FILTER_ADD":
       if (isLayouting(draft)) {
         setWith(
           draft,
-          "dashboardFilters.filters",
+          "dashboardFilters.timeRangeFilters",
           uniqBy(
-            [...(draft.dashboardFilters?.filters ?? []), action.value],
+            [...(draft.dashboardFilters?.timeRangeFilters ?? []), action.value],
             (x) => x.componentIri
           ),
           Object
@@ -1072,26 +1072,33 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
 
       return draft;
 
-    case "DASHBOARD_FILTER_UPDATE":
+    case "DASHBOARD_TIME_RANGE_FILTER_UPDATE":
       if (isLayouting(draft)) {
-        const idx = draft.dashboardFilters?.filters.findIndex(
+        const idx = draft.dashboardFilters?.timeRangeFilters.findIndex(
           (f) => f.componentIri === action.value.componentIri
         );
 
         if (idx !== undefined && idx > -1) {
-          const newFilters = [...(draft.dashboardFilters?.filters ?? [])];
+          const newFilters = [
+            ...(draft.dashboardFilters?.timeRangeFilters ?? []),
+          ];
           newFilters.splice(idx, 1, action.value);
-          setWith(draft, "dashboardFilters.filters", newFilters, Object);
+          setWith(
+            draft,
+            "dashboardFilters.timeRangeFilters",
+            newFilters,
+            Object
+          );
         }
       }
       return draft;
 
-    case "DASHBOARD_FILTER_REMOVE":
+    case "DASHBOARD_TIME_RANGE_FILTER_REMOVE":
       if (isLayouting(draft)) {
-        const newFilters = draft.dashboardFilters?.filters.filter(
+        const newFilters = draft.dashboardFilters?.timeRangeFilters.filter(
           (f) => f.componentIri !== action.value
         );
-        setWith(draft, "dashboardFilters.filters", newFilters, Object);
+        setWith(draft, "dashboardFilters.timeRangeFilters", newFilters, Object);
       }
       return draft;
 

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -361,14 +361,14 @@ export const handleChartFieldChanged = (
     selectedValues: actionSelectedValues,
   } = action.value;
   const f = get(chartConfig.fields, field);
-  const dataCubesComponents = getCachedComponents(
-    draft.dataSource,
-    chartConfig.cubes.map((cube) => ({
+  const dataCubesComponents = getCachedComponents({
+    locale,
+    dataSource: draft.dataSource,
+    cubeFilters: chartConfig.cubes.map((cube) => ({
       iri: cube.iri,
       joinBy: cube.joinBy,
     })),
-    locale
-  );
+  });
   const dimensions = dataCubesComponents?.dimensions ?? [];
   const measures = dataCubesComponents?.measures ?? [];
   const components = [...dimensions, ...measures];
@@ -418,14 +418,14 @@ export const handleChartOptionChanged = (
     const { locale, path, field, value } = action.value;
     const chartConfig = getChartConfig(draft);
     const updatePath = field === null ? path : `fields["${field}"].${path}`;
-    const dataCubesComponents = getCachedComponents(
-      draft.dataSource,
-      chartConfig.cubes.map((cube) => ({
+    const dataCubesComponents = getCachedComponents({
+      locale,
+      dataSource: draft.dataSource,
+      cubeFilters: chartConfig.cubes.map((cube) => ({
         iri: cube.iri,
         joinBy: cube.joinBy,
       })),
-      locale
-    );
+    });
 
     const dimensions = dataCubesComponents?.dimensions ?? [];
     const measures = dataCubesComponents?.measures ?? [];
@@ -575,14 +575,14 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       if (isConfiguring(draft)) {
         const { locale, chartKey, chartType } = action.value;
         const chartConfig = getChartConfig(draft, chartKey);
-        const dataCubesComponents = getCachedComponents(
-          draft.dataSource,
-          chartConfig.cubes.map((cube) => ({
+        const dataCubesComponents = getCachedComponents({
+          locale,
+          dataSource: draft.dataSource,
+          cubeFilters: chartConfig.cubes.map((cube) => ({
             iri: cube.iri,
             joinBy: cube.joinBy,
           })),
-          locale
-        );
+        });
         const dimensions = dataCubesComponents?.dimensions;
         const measures = dataCubesComponents?.measures;
 
@@ -621,14 +621,14 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       if (isConfiguring(draft)) {
         const chartConfig = getChartConfig(draft);
         delete (chartConfig.fields as GenericFields)[action.value.field];
-        const dataCubesComponents = getCachedComponents(
-          draft.dataSource,
-          chartConfig.cubes.map((cube) => ({
+        const dataCubesComponents = getCachedComponents({
+          locale: action.value.locale,
+          dataSource: draft.dataSource,
+          cubeFilters: chartConfig.cubes.map((cube) => ({
             iri: cube.iri,
             joinBy: cube.joinBy,
           })),
-          action.value.locale
-        );
+        });
         const dimensions = dataCubesComponents?.dimensions ?? [];
         const newConfig = deriveFiltersFromFields(chartConfig, { dimensions });
         const index = draft.chartConfigs.findIndex(
@@ -872,14 +872,14 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       if (isConfiguring(draft)) {
         const chartConfig =
           createDraft(action.value.chartConfig) ?? getChartConfig(draft);
-        const dataCubesComponents = getCachedComponents(
-          draft.dataSource,
-          chartConfig.cubes.map((cube) => ({
+        const dataCubesComponents = getCachedComponents({
+          locale: action.value.locale,
+          dataSource: draft.dataSource,
+          cubeFilters: chartConfig.cubes.map((cube) => ({
             iri: cube.iri,
             joinBy: cube.joinBy,
           })),
-          action.value.locale
-        );
+        });
 
         if (dataCubesComponents) {
           const cubes = current(chartConfig.cubes);
@@ -922,15 +922,14 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
         const newCubes = chartConfig.cubes.filter(
           (c) => c.iri !== removedCubeIri
         );
-        const dataCubesComponents = getCachedComponents(
-          draft.dataSource,
-          newCubes.map((cube) => ({
+        const dataCubesComponents = getCachedComponents({
+          locale,
+          dataSource: draft.dataSource,
+          cubeFilters: newCubes.map((cube) => ({
             iri: cube.iri,
-            // Only keep joinBy while we have more than one cube
             joinBy: newCubes.length > 1 ? cube.joinBy : undefined,
           })),
-          locale
-        );
+        });
 
         if (!dataCubesComponents) {
           throw new Error(

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -948,7 +948,9 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
           cubeCount: iris.length,
         });
         const initialConfig = getInitialConfig({
-          chartType: possibleChartTypes[0],
+          chartType: possibleChartTypes.includes(chartConfig.chartType)
+            ? chartConfig.chartType
+            : possibleChartTypes[0],
           iris,
           dimensions,
           measures,

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -761,7 +761,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
             };
           } else {
             console.warn(
-              `Could not set filter, no cube in chat config was found with iri ${cubeIri}`
+              `Could not set filter, no cube in chart config was found with iri ${cubeIri}`
             );
           }
         }

--- a/app/configurator/interactive-filters/time-slider.tsx
+++ b/app/configurator/interactive-filters/time-slider.tsx
@@ -145,7 +145,9 @@ export const TimeSlider = (props: TimeSliderProps) => {
   }, [timelineProps]);
 
   if (
-    dashboardFilters.sharedFilters.find((x) => x.componentIri === componentIri)
+    dashboardFilters.sharedTimeRangeFilters.find(
+      (x) => x.componentIri === componentIri
+    )
   ) {
     return null;
   }

--- a/app/configurator/interactive-filters/time-slider.tsx
+++ b/app/configurator/interactive-filters/time-slider.tsx
@@ -144,11 +144,7 @@ export const TimeSlider = (props: TimeSliderProps) => {
     return new Timeline(timelineProps);
   }, [timelineProps]);
 
-  if (
-    dashboardFilters.sharedTimeRangeFilters.find(
-      (x) => x.componentIri === componentIri
-    )
-  ) {
+  if (dashboardFilters.timeRange?.active) {
     return null;
   }
 

--- a/app/docs/charts.stories.tsx
+++ b/app/docs/charts.stories.tsx
@@ -68,7 +68,7 @@ const ColumnsStory = {
         },
         chartConfigs: [chartConfig],
         activeChartKey: "scatterplot",
-        dashboardFilters: { filters: [] },
+        dashboardFilters: { timeRangeFilters: [] },
       }}
     >
       <InteractiveFiltersProvider chartConfigs={[chartConfig]}>
@@ -98,8 +98,7 @@ const ColumnsStory = {
   ),
 };
 
-export { ColumnsStory as Columns };
-export { ScatterplotStory as Scatterplot };
+export { ColumnsStory as Columns, ScatterplotStory as Scatterplot };
 
 const ScatterplotStory = {
   render: () => (
@@ -119,7 +118,7 @@ const ScatterplotStory = {
         },
         chartConfigs: [chartConfig],
         activeChartKey: "scatterplot",
-        dashboardFilters: { filters: [] },
+        dashboardFilters: { timeRangeFilters: [] },
       }}
     >
       <InteractiveFiltersProvider chartConfigs={[chartConfig]}>

--- a/app/docs/charts.stories.tsx
+++ b/app/docs/charts.stories.tsx
@@ -68,7 +68,16 @@ const ColumnsStory = {
         },
         chartConfigs: [chartConfig],
         activeChartKey: "scatterplot",
-        dashboardFilters: { timeRangeFilters: [] },
+        dashboardFilters: {
+          timeRange: {
+            active: false,
+            timeUnit: "",
+            presets: {
+              from: "",
+              to: "",
+            },
+          },
+        },
       }}
     >
       <InteractiveFiltersProvider chartConfigs={[chartConfig]}>
@@ -118,7 +127,16 @@ const ScatterplotStory = {
         },
         chartConfigs: [chartConfig],
         activeChartKey: "scatterplot",
-        dashboardFilters: { timeRangeFilters: [] },
+        dashboardFilters: {
+          timeRange: {
+            active: false,
+            timeUnit: "",
+            presets: {
+              from: "",
+              to: "",
+            },
+          },
+        },
       }}
     >
       <InteractiveFiltersProvider chartConfigs={[chartConfig]}>

--- a/app/docs/fixtures.ts
+++ b/app/docs/fixtures.ts
@@ -89,7 +89,7 @@ export const states: ConfiguratorState[] = [
     ],
     activeChartKey: "column",
     dashboardFilters: {
-      filters: [],
+      timeRangeFilters: [],
     },
   },
 ];

--- a/app/docs/fixtures.ts
+++ b/app/docs/fixtures.ts
@@ -89,7 +89,14 @@ export const states: ConfiguratorState[] = [
     ],
     activeChartKey: "column",
     dashboardFilters: {
-      timeRangeFilters: [],
+      timeRange: {
+        active: false,
+        timeUnit: "",
+        presets: {
+          from: "",
+          to: "",
+        },
+      },
     },
   },
 ];

--- a/app/docs/lines.stories.tsx
+++ b/app/docs/lines.stories.tsx
@@ -46,7 +46,16 @@ const LineChartStory = () => (
       },
       chartConfigs: [chartConfig],
       activeChartKey: "line",
-      dashboardFilters: { timeRangeFilters: [] },
+      dashboardFilters: {
+        timeRange: {
+          active: false,
+          timeUnit: "",
+          presets: {
+            from: "",
+            to: "",
+          },
+        },
+      },
     }}
   >
     <InteractiveFiltersProvider chartConfigs={[chartConfig]}>

--- a/app/docs/lines.stories.tsx
+++ b/app/docs/lines.stories.tsx
@@ -46,7 +46,7 @@ const LineChartStory = () => (
       },
       chartConfigs: [chartConfig],
       activeChartKey: "line",
-      dashboardFilters: { filters: [] },
+      dashboardFilters: { timeRangeFilters: [] },
     }}
   >
     <InteractiveFiltersProvider chartConfigs={[chartConfig]}>

--- a/app/graphql/hooks.ts
+++ b/app/graphql/hooks.ts
@@ -224,7 +224,7 @@ export const executeDataCubesComponentsQuery = async (
   }
 
   const { dimensions: firstDimensions = [], measures: firstMeasures = [] } =
-    queries[0].data?.dataCubeComponents || {};
+    queries[0]?.data?.dataCubeComponents || {};
   assert(firstDimensions !== undefined, "Undefined dimensions");
   assert(firstMeasures !== undefined, "Undefined measures");
 
@@ -331,7 +331,7 @@ export const executeDataCubesObservationsQuery = async (
     queries.length > 1
       ? mergeObservations(queries)
       : // If we are fetching data from a single cube, we can just return the data
-        queries[0].data?.dataCubeObservations?.data!;
+        queries[0]?.data?.dataCubeObservations?.data!;
 
   return {
     data: {

--- a/app/graphql/hooks.ts
+++ b/app/graphql/hooks.ts
@@ -224,7 +224,7 @@ export const executeDataCubesComponentsQuery = async (
   }
 
   const { dimensions: firstDimensions = [], measures: firstMeasures = [] } =
-    queries[0]?.data?.dataCubeComponents || {};
+    queries[0].data?.dataCubeComponents || {};
   assert(firstDimensions !== undefined, "Undefined dimensions");
   assert(firstMeasures !== undefined, "Undefined measures");
 
@@ -331,7 +331,7 @@ export const executeDataCubesObservationsQuery = async (
     queries.length > 1
       ? mergeObservations(queries)
       : // If we are fetching data from a single cube, we can just return the data
-        queries[0]?.data?.dataCubeObservations?.data!;
+        queries[0].data?.dataCubeObservations?.data!;
 
   return {
     data: {

--- a/app/graphql/hooks.ts
+++ b/app/graphql/hooks.ts
@@ -183,14 +183,6 @@ export const executeDataCubesComponentsQuery = async (
   onFetching?: () => void
 ) => {
   const { locale, sourceType, sourceUrl, cubeFilters } = variables;
-
-  if (cubeFilters.length > 1 && !cubeFilters.every((f) => f.joinBy)) {
-    console.log({ cubeFilters });
-    throw new Error(
-      "When fetching data from multiple cubes, all cube filters must have joinBy property set."
-    );
-  }
-
   const queries = await Promise.all(
     cubeFilters.map((cubeFilter) => {
       const cubeVariables = {
@@ -255,7 +247,6 @@ export const executeDataCubesComponentsQuery = async (
                     dataCubeComponents !== undefined,
                     "Undefined dataCubeComponents"
                   );
-                  assert(joinBy, "Undefined joinBy");
                   return {
                     dataCubeComponents,
                     joinBy,
@@ -279,16 +270,6 @@ export const useDataCubesComponentsQuery = makeUseQuery<
   DataCubesComponentsOptions,
   DataCubesComponentsData
 >({
-  check: (variables: DataCubesComponentsOptions["variables"]) => {
-    const { cubeFilters } = variables;
-    if (cubeFilters.length > 1 && !cubeFilters.every((f) => f.joinBy)) {
-      console.log({ cubeFilters });
-      throw new Error(
-        "When fetching data from multiple cubes, all cube filters must have joinBy property set."
-      );
-    }
-  },
-
   fetch: executeDataCubesComponentsQuery,
 });
 
@@ -371,15 +352,6 @@ export const useDataCubesObservationsQuery = makeUseQuery<
   DataCubesObservationsOptions,
   DataCubesObservationsData
 >({
-  check: (variables) => {
-    const { cubeFilters } = variables;
-
-    if (cubeFilters.length > 1 && !cubeFilters.every((f) => f.joinBy)) {
-      throw new Error(
-        "When fetching data from multiple cubes, all cube filters must have joinBy property set."
-      );
-    }
-  },
   fetch: executeDataCubesObservationsQuery,
 });
 

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -815,6 +815,10 @@ msgid "controls.section.shared-filters"
 msgstr "Geteilte Filter"
 
 #: app/configurator/components/layout-configurator.tsx
+msgid "controls.section.shared-filters.date"
+msgstr "Datum"
+
+#: app/configurator/components/layout-configurator.tsx
 msgid "controls.section.shared-filters.shared-switch"
 msgstr "Geteilt"
 

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -815,6 +815,10 @@ msgid "controls.section.shared-filters"
 msgstr "Shared filters"
 
 #: app/configurator/components/layout-configurator.tsx
+msgid "controls.section.shared-filters.date"
+msgstr "Date"
+
+#: app/configurator/components/layout-configurator.tsx
 msgid "controls.section.shared-filters.shared-switch"
 msgstr "Shared"
 

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -815,6 +815,10 @@ msgid "controls.section.shared-filters"
 msgstr "Filtres partagés"
 
 #: app/configurator/components/layout-configurator.tsx
+msgid "controls.section.shared-filters.date"
+msgstr "Date"
+
+#: app/configurator/components/layout-configurator.tsx
 msgid "controls.section.shared-filters.shared-switch"
 msgstr "Partagé"
 

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -815,6 +815,10 @@ msgid "controls.section.shared-filters"
 msgstr "Filtri condivisi"
 
 #: app/configurator/components/layout-configurator.tsx
+msgid "controls.section.shared-filters.date"
+msgstr "Data"
+
+#: app/configurator/components/layout-configurator.tsx
 msgid "controls.section.shared-filters.shared-switch"
 msgstr "Condiviso"
 

--- a/app/rdf/mappings.ts
+++ b/app/rdf/mappings.ts
@@ -32,3 +32,13 @@ export const timeUnitFormats = new Map<TimeUnit, string>([
   [TimeUnit.Minute, "%Y-%m-%dT%H:%M"],
   [TimeUnit.Second, "%Y-%m-%dT%H:%M:%S"],
 ]);
+
+export const timeUnitOrder = new Map<TimeUnit, number>([
+  [TimeUnit.Year, 0],
+  [TimeUnit.Month, 1],
+  [TimeUnit.Week, 2],
+  [TimeUnit.Day, 3],
+  [TimeUnit.Hour, 4],
+  [TimeUnit.Minute, 5],
+  [TimeUnit.Second, 6],
+]);

--- a/app/urql-cache.tsx
+++ b/app/urql-cache.tsx
@@ -15,27 +15,31 @@ import { Locale } from "@/locales/locales";
  * Reads components from client cache, reading cube by cube.
  * Components are not joined in cache, but transformed here.
  */
-export const getCachedComponents = (
-  dataSource: DataSource,
-  cubeFilters: DataCubeComponentFilter[],
-  locale: Locale
-): DataCubeComponents | undefined => {
+export const getCachedComponents = ({
+  locale,
+  dataSource,
+  cubeFilters,
+}: {
+  locale: Locale;
+  dataSource: DataSource;
+  cubeFilters: DataCubeComponentFilter[];
+}): DataCubeComponents | undefined => {
   const queries = cubeFilters
     .map((cubeFilter) => {
       return client.readQuery<
         DataCubeComponentsQuery,
         DataCubeComponentsQueryVariables
       >(DataCubeComponentsDocument, {
+        locale,
         sourceType: dataSource.type,
         sourceUrl: dataSource.url,
-        locale,
         cubeFilter: {
           iri: cubeFilter.iri,
           componentIris: undefined,
           joinBy: cubeFilter.joinBy,
           loadValues: true,
         },
-      })!;
+      });
     })
     .filter(truthy);
   return {

--- a/app/utils/chart-config/versioning.ts
+++ b/app/utils/chart-config/versioning.ts
@@ -931,7 +931,7 @@ export const migrateChartConfig = makeMigrate<ChartConfig>(
   }
 );
 
-export const CONFIGURATOR_STATE_VERSION = "3.4.0";
+export const CONFIGURATOR_STATE_VERSION = "3.5.0";
 
 export const configuratorStateMigrations: Migration[] = [
   {
@@ -1230,6 +1230,31 @@ export const configuratorStateMigrations: Migration[] = [
 
         draft.chartConfigs = chartConfigs;
       });
+    },
+  },
+  {
+    description: "ALL (modify dashboardFilters)",
+    from: "3.4.0",
+    to: "3.5.0",
+    up: (config) => {
+      const newConfig = {
+        ...config,
+        version: "3.5.0",
+        dashboardFilters: {
+          timeRangeFilters: config.dashboardFilters.filters,
+        },
+      };
+      return newConfig;
+    },
+    down: (config) => {
+      const newConfig = {
+        ...config,
+        version: "3.4.0",
+        dashboardFilters: {
+          filters: config.dashboardFilters.timeRangeFilters,
+        },
+      };
+      return newConfig;
     },
   },
 ];

--- a/app/utils/chart-config/versioning.ts
+++ b/app/utils/chart-config/versioning.ts
@@ -1237,21 +1237,48 @@ export const configuratorStateMigrations: Migration[] = [
     from: "3.4.0",
     to: "3.5.0",
     up: (config) => {
+      const oldTimeRangeFilter = config.dashboardFilters.filters[0];
       const newConfig = {
         ...config,
         version: "3.5.0",
         dashboardFilters: {
-          timeRangeFilters: config.dashboardFilters.filters,
+          timeRange: {
+            active: oldTimeRangeFilter?.active ?? false,
+            timeUnit: "",
+            presets: {
+              from: oldTimeRangeFilter?.from ?? "",
+              to: oldTimeRangeFilter?.to ?? "",
+            },
+          } ?? {
+            active: false,
+            timeUnit: "",
+            presets: {
+              from: "",
+              to: "",
+            },
+          },
         },
       };
       return newConfig;
     },
     down: (config) => {
+      const oldTimeRangeFilter = config.dashboardFilters.timeRange;
       const newConfig = {
         ...config,
         version: "3.4.0",
         dashboardFilters: {
-          filters: config.dashboardFilters.timeRangeFilters,
+          filters: [
+            {
+              type: "timeRange",
+              active: oldTimeRangeFilter.active,
+              componentIri: "",
+              presets: {
+                type: "range",
+                from: oldTimeRangeFilter.presets.from,
+                to: oldTimeRangeFilter.presets.to,
+              },
+            },
+          ],
         },
       };
       return newConfig;


### PR DESCRIPTION
Closes #1636

This PR refactors some areas of the application related to merging of cubes, so that we merge cubes in the context of a given chart config, instead of every config at the same time. This eliminates some bugs when dealing with several charts based on different cubes, and adding a new dataset to one of them after already having several charts.

It also simplifies the dashboard time range filter so that there is only one common filter for every temporal X dimension used in the charts. This means that we create a "combined" dimension that uses "lowest" time unit and are able to filter every chart afterwards with only one slider element.

### How to test
**PR**
1. Go to [this link](https://visualization-tool-git-feat-shared-dashboard-filter-53f2dc-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9&dataSource=Prod).
2. Add a new chart (line).
3. Merge a second dataset to the chart (Gebäudeprogramm - Anzahl unterstützter Gesuche).
4. Add a new chart based on another cube (Bathing water quality).
5. Add a new area chart, so that there are four charts in total.
6. Proceed to layout options.
7. Switch to dashboard / free canvas layout.
8. ✅ See that there's one generic shared `Date` filter available.
9. Toggle the filter on.
10. ✅ See that the range encompasses every temporal X dimension (starts at 21.05.2007) and that it has a day resolution (lowest resolution based on year [Photovoltaikanlagen and Gebäudeprogramm datasets] and day [Bathing water quality dataset] temporal dimensions).
11. See that the time slider appeared on top.
12. Use the time slider to filter the charts, and see that every one of them reacts to the filtering.
13. ✅ Reset the time slider to the full extent, and use the left date picker to select a new date, e.g. in June 2017. See that the charts reacted to the new selection.

**TEST**
1. Go to [this link](https://test.visualize.admin.ch/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9&dataSource=Prod).
2. Add a new chart (line).
3. Merge a second dataset to the chart (Gebäudeprogramm - Anzahl unterstützter Gesuche).
4. Add a new chart based on another cube (Bathing water quality).
5. Add a new area chart, so that there are four charts in total.
6. Proceed to layout options.
7. Switch to dashboard / free canvas layout.
8. ❌ See that there are two shared filters available (1. Jahr der Vergütung, Jahr and 2. Date), which are not generic, but connected to 1. first two charts and 2. last two charts.
9. Toggle the filters on.
10. ❌ See that the ranges are implicitly based on year and day dimensions from different cubes.
11. See that the time slider appeared on top.
12. Use the time slider to filter the charts, and see that every one of them reacts to the filtering.
13. ❌ Reset the time slider to the full extent, and use the left date picker in the `Date` field to select a new date, e.g. in June 2017. See that the charts didn't react to the new selection.