### PR TITLE
feat: Minimum chart height in a dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ You can also check the
   - Changing dashboard time range filter presets now correctly updates the
     charts
   - Merged cubes are now done on a chart basis and are not shared between charts
+  - Free canvas cards are now constrained in a way that their height can't be
+    too small so that content overflows or chart is not visible
 - Style
   - Cleaned up the chart footnotes and moved most of them to the metadata panel
     – it means that the footnotes don't look broken anymore for charts based on

--- a/app/charts/map/map.tsx
+++ b/app/charts/map/map.tsx
@@ -6,7 +6,7 @@ import { geoArea } from "d3-geo";
 import debounce from "lodash/debounce";
 import orderBy from "lodash/orderBy";
 import maplibreglraw from "maplibre-gl";
-import React, { useState, useMemo, useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Map, { LngLatLike, MapboxEvent } from "react-map-gl";
 
 import "maplibre-gl/dist/maplibre-gl.css";

--- a/app/charts/shared/containers.tsx
+++ b/app/charts/shared/containers.tsx
@@ -7,15 +7,17 @@ import { ReactNode, useEffect, useRef } from "react";
 import { useChartState } from "@/charts/shared/chart-state";
 import { CalculationToggle } from "@/charts/shared/interactive-filter-calculation-toggle";
 import { useObserverRef } from "@/charts/shared/use-size";
-import { ChartConfig } from "@/configurator";
+import {
+  ChartConfig,
+  hasChartConfigs,
+  useConfiguratorState,
+} from "@/configurator";
 import { useTransitionStore } from "@/stores/transition";
-
-export const MIN_CHART_HEIGHT = 300;
 
 export const useStyles = makeStyles<
   {},
   {},
-  ChartConfig["chartType"] | "chartContainer"
+  ChartConfig["chartType"] | "chartContainer" | "constrainMinHeight"
 >(() => ({
   chartContainer: {
     position: "relative",
@@ -30,7 +32,9 @@ export const useStyles = makeStyles<
     // the chart state function can get it and apply it to the plot area.
     // The ReactGridChartPreview component should also disable this behavior.
     aspectRatio: "5 / 2",
-    minHeight: MIN_CHART_HEIGHT,
+  },
+  constrainMinHeight: {
+    minHeight: 300,
   },
 
   // Chart type specific styles, if we need for example to set a specific aspect-ratio
@@ -54,14 +58,20 @@ export const ChartContainer = ({
   children: ReactNode;
   type: ChartConfig["chartType"];
 }) => {
+  const [state] = useConfiguratorState(hasChartConfigs);
   const ref = useObserverRef();
   const classes = useStyles();
-
   return (
     <div
       ref={ref}
       aria-hidden="true"
-      className={clsx(classes.chartContainer, classes[type])}
+      className={clsx(
+        classes.chartContainer,
+        classes[type],
+        state.layout.type === "dashboard" && state.layout.layout === "canvas"
+          ? null
+          : classes.constrainMinHeight
+      )}
     >
       {children}
     </div>

--- a/app/charts/shared/containers.tsx
+++ b/app/charts/shared/containers.tsx
@@ -7,11 +7,12 @@ import { ReactNode, useEffect, useRef } from "react";
 import { useChartState } from "@/charts/shared/chart-state";
 import { CalculationToggle } from "@/charts/shared/interactive-filter-calculation-toggle";
 import { useObserverRef } from "@/charts/shared/use-size";
-import { chartPanelLayoutGridClasses } from "@/components/chart-panel-layout-grid";
 import { ChartConfig } from "@/configurator";
 import { useTransitionStore } from "@/stores/transition";
 
-const useStyles = makeStyles<
+export const MIN_CHART_HEIGHT = 300;
+
+export const useStyles = makeStyles<
   {},
   {},
   ChartConfig["chartType"] | "chartContainer"
@@ -29,12 +30,7 @@ const useStyles = makeStyles<
     // the chart state function can get it and apply it to the plot area.
     // The ReactGridChartPreview component should also disable this behavior.
     aspectRatio: "5 / 2",
-    minHeight: 300,
-
-    [`.${chartPanelLayoutGridClasses.root} &`]: {
-      aspectRatio: "auto",
-      minHeight: 0,
-    },
+    minHeight: MIN_CHART_HEIGHT,
   },
 
   // Chart type specific styles, if we need for example to set a specific aspect-ratio
@@ -72,6 +68,8 @@ export const ChartContainer = ({
   );
 };
 
+export const CHART_CLASS_NAME = "chart";
+
 export const ChartSvg = ({ children }: { children: ReactNode }) => {
   const ref = useRef<SVGSVGElement>(null);
   const enableTransition = useTransitionStore((state) => state.enable);
@@ -97,6 +95,7 @@ export const ChartSvg = ({ children }: { children: ReactNode }) => {
   return (
     <svg
       ref={ref}
+      className={CHART_CLASS_NAME}
       width={width}
       style={{ position: "absolute", left: 0, top: 0 }}
     >

--- a/app/components/chart-panel-layout-grid.tsx
+++ b/app/components/chart-panel-layout-grid.tsx
@@ -5,7 +5,10 @@ import { useState } from "react";
 import { Layouts } from "react-grid-layout";
 
 import { ChartPanelLayoutTypeProps } from "@/components/chart-panel";
-import ChartGridLayout, { INITIAL_H, MAX_W } from "@/components/react-grid";
+import ChartGridLayout, {
+  getInitialTileHeight,
+  getInitialTileWidth,
+} from "@/components/react-grid";
 import { ReactGridLayoutsType, hasChartConfigs } from "@/configurator";
 import { useConfiguratorState } from "@/src";
 import { assert } from "@/utils/assert";
@@ -73,7 +76,10 @@ const ChartPanelLayoutCanvas = (props: ChartPanelLayoutTypeProps) => {
       draggableHandle={`.${chartPanelLayoutGridClasses.dragHandle}`}
       onLayoutChange={(_l, allLayouts) => handleChangeLayouts(allLayouts)}
       initialize={layouts["lg"].every((layout) => {
-        return layout.w === MAX_W / 4 && layout.h === INITIAL_H;
+        return (
+          layout.w === getInitialTileWidth() &&
+          layout.h === getInitialTileHeight()
+        );
       })}
     >
       {chartConfigs.map((chartConfig) => props.renderChart(chartConfig))}

--- a/app/components/chart-panel-layout-grid.tsx
+++ b/app/components/chart-panel-layout-grid.tsx
@@ -5,8 +5,8 @@ import { useState } from "react";
 import { Layouts } from "react-grid-layout";
 
 import { ChartPanelLayoutTypeProps } from "@/components/chart-panel";
-import ChartGridLayout from "@/components/react-grid";
-import { hasChartConfigs, ReactGridLayoutsType } from "@/configurator";
+import ChartGridLayout, { INITIAL_H, MAX_W } from "@/components/react-grid";
+import { ReactGridLayoutsType, hasChartConfigs } from "@/configurator";
 import { useConfiguratorState } from "@/src";
 import { assert } from "@/utils/assert";
 
@@ -72,6 +72,9 @@ const ChartPanelLayoutCanvas = (props: ChartPanelLayoutTypeProps) => {
       resize={state.state === "LAYOUTING"}
       draggableHandle={`.${chartPanelLayoutGridClasses.dragHandle}`}
       onLayoutChange={(_l, allLayouts) => handleChangeLayouts(allLayouts)}
+      initialize={layouts["lg"].every((layout) => {
+        return layout.w === MAX_W / 4 && layout.h === INITIAL_H;
+      })}
     >
       {chartConfigs.map((chartConfig) => props.renderChart(chartConfig))}
     </ChartGridLayout>

--- a/app/components/chart-panel-layout-grid.tsx
+++ b/app/components/chart-panel-layout-grid.tsx
@@ -32,18 +32,18 @@ const decodeLayouts = (layouts: Layouts) => {
 
 const ChartPanelLayoutCanvas = (props: ChartPanelLayoutTypeProps) => {
   const { chartConfigs } = props;
-  const [config, dispatch] = useConfiguratorState(hasChartConfigs);
+  const [state, dispatch] = useConfiguratorState(hasChartConfigs);
   const [layouts, setLayouts] = useState<Layouts>(() => {
     assert(
-      config.layout.type === "dashboard" && config.layout.layout === "canvas",
+      state.layout.type === "dashboard" && state.layout.layout === "canvas",
       "ChartPanelLayoutGrid should be rendered only for dashboard layout with canvas"
     );
 
-    return config.layout.layouts;
+    return state.layout.layouts;
   });
 
   const handleChangeLayouts = (layouts: Layouts) => {
-    const layout = config.layout;
+    const layout = state.layout;
     assert(
       layout.type === "dashboard" && layout.layout === "canvas",
       "ChartPanelLayoutGrid should be rendered only for dashboard layout with canvas"
@@ -66,9 +66,10 @@ const ChartPanelLayoutCanvas = (props: ChartPanelLayoutTypeProps) => {
 
   return (
     <ChartGridLayout
+      key={state.state}
       className={clsx(chartPanelLayoutGridClasses.root, props.className)}
       layouts={layouts}
-      resize={config.state === "LAYOUTING"}
+      resize={state.state === "LAYOUTING"}
       draggableHandle={`.${chartPanelLayoutGridClasses.dragHandle}`}
       onLayoutChange={(_l, allLayouts) => handleChangeLayouts(allLayouts)}
     >

--- a/app/components/chart-panel.tsx
+++ b/app/components/chart-panel.tsx
@@ -39,9 +39,13 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
+export const getChartWrapperId = (chartKey: string) =>
+  `chart-wrapper-${chartKey}`;
+
 export type ChartWrapperProps = BoxProps & {
   editing?: boolean;
   layoutType?: Layout["type"];
+  chartKey: string;
 };
 
 export const ChartWrapper = forwardRef<HTMLDivElement, ChartWrapperProps>(
@@ -52,6 +56,7 @@ export const ChartWrapper = forwardRef<HTMLDivElement, ChartWrapperProps>(
       <Box
         ref={ref}
         {...rest}
+        id={getChartWrapperId(props.chartKey)}
         className={clsx(classes.chartWrapper, props.className)}
       >
         {(editing || layoutType === "tab") && <ChartSelectionTabs />}

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -95,7 +95,11 @@ export const ChartPreview = (props: ChartPreviewProps) => {
         />
       ) : null}
       <ChartTablePreviewProvider key={state.activeChartKey}>
-        <ChartWrapper editing={editing} layoutType={layout.type}>
+        <ChartWrapper
+          editing={editing}
+          layoutType={layout.type}
+          chartKey={state.activeChartKey}
+        >
           <ChartPreviewInner dataSource={dataSource} />
         </ChartWrapper>
       </ChartTablePreviewProvider>
@@ -218,7 +222,7 @@ const DashboardPreview = (props: DashboardPreviewProps) => {
             cursor: "grabbing",
           }}
         >
-          <ChartWrapper>
+          <ChartWrapper chartKey="dragged">
             <ChartPreviewInner
               dataSource={dataSource}
               chartKey={activeChartKey}
@@ -243,7 +247,7 @@ const ReactGridChartPreview = forwardRef<
   const { children, chartKey, dataSource, ...rest } = props;
   return (
     <ChartTablePreviewProvider>
-      <ChartWrapper {...rest} ref={ref}>
+      <ChartWrapper {...rest} ref={ref} chartKey={chartKey}>
         <ChartPreviewInner
           dataSource={dataSource}
           chartKey={chartKey}
@@ -292,6 +296,7 @@ const DndChartPreview = (props: CommonChartPreviewProps) => {
         {...rest}
         ref={setRef}
         {...attributes}
+        chartKey={chartKey}
         style={{
           display: active ? "flex" : "contents",
           opacity: isDragging ? 0.2 : isOver ? 0.8 : 1,
@@ -330,10 +335,9 @@ const SingleURLsPreview = (props: SingleURLsPreviewProps) => {
       const checked = layout.publishableChartKeys.includes(chartConfig.key);
       const { publishableChartKeys: keys } = layout;
       const { key } = chartConfig;
-
       return (
         <ChartTablePreviewProvider>
-          <ChartWrapper>
+          <ChartWrapper chartKey={key}>
             <ChartPreviewInner
               dataSource={dataSource}
               chartKey={chartConfig.key}

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -70,6 +70,7 @@ const ChartPublishedIndividualChart = forwardRef<
         key={chartConfig.key}
         layoutType={state.layout.type}
         ref={ref}
+        chartKey={chartConfig.key}
         {...rest}
       >
         <ChartPublishedInner
@@ -152,7 +153,10 @@ export const ChartPublished = (props: ChartPublishedProps) => {
           </Flex>
           <ChartTablePreviewProvider>
             <DashboardInteractiveFilters />
-            <ChartWrapper layoutType={state.layout.type}>
+            <ChartWrapper
+              layoutType={state.layout.type}
+              chartKey={state.activeChartKey}
+            >
               <ChartPublishedInner
                 dataSource={dataSource}
                 state={state}

--- a/app/components/debug-panel/index.tsx
+++ b/app/components/debug-panel/index.tsx
@@ -2,18 +2,15 @@ import { CircularProgress } from "@mui/material";
 import dynamic from "next/dynamic";
 import { Suspense } from "react";
 
-import { flag } from "@/flags";
+import { useFlag } from "@/flags";
 
 import { DebugPanelProps } from "./DebugPanel";
 
 const LazyDebugPanel = dynamic(() => import("./DebugPanel"), { ssr: false });
 
-const shouldShowDebugPanel = () => {
-  return flag("debug") ?? process.env.NODE_ENV === "development";
-};
-
 const DebugPanel = (props: DebugPanelProps) => {
-  const show = shouldShowDebugPanel();
+  const flagActive = useFlag("debug");
+  const show = flagActive ?? process.env.NODE_ENV === "development";
 
   if (!show) {
     return null;

--- a/app/components/react-grid.stories.tsx
+++ b/app/components/react-grid.stories.tsx
@@ -91,6 +91,7 @@ export const Example = () => {
         onLayoutChange={(_layouts, allLayouts) => setLayouts(allLayouts)}
         layouts={layouts}
         resize
+        initialize={false}
       >
         {generateDOM({ count })}
       </ChartGridLayout>

--- a/app/components/react-grid.tsx
+++ b/app/components/react-grid.tsx
@@ -33,11 +33,11 @@ export const availableHandles: ResizeHandle[] = [
 
 /** In grid unit */
 const MAX_H = 10;
-const INITIAL_H = 7;
+export const INITIAL_H = 7;
 export const MIN_H = 1;
 
 /** In grid unit */
-const MAX_W = 4;
+export const MAX_W = 4;
 
 export const COLS = { lg: 4, md: 2, sm: 1, xs: 1, xxs: 1 };
 const ROW_HEIGHT = 100;
@@ -205,10 +205,11 @@ type ChartGridLayoutProps = {
   className: string;
   onLayoutChange: Function;
   resize?: boolean;
+  initialize: boolean;
 } & ComponentProps<typeof ResponsiveReactGridLayout>;
 
 export const ChartGridLayout = (props: ChartGridLayoutProps) => {
-  const { children, layouts, resize } = props;
+  const { children, layouts, resize, initialize } = props;
   const [mounted, setMounted] = useState(false);
   const mountedForSomeTime = useTimeout(250, mounted);
   const mountedRef = useRef(false);
@@ -255,7 +256,8 @@ export const ChartGridLayout = (props: ChartGridLayoutProps) => {
             return {
               ...x,
               minH,
-              h: minH,
+              // Do not reset once layouts have been enhanced at least once
+              h: initialize ? minH : Math.max(minH, x.h),
               maxW: MAX_W,
               w: Math.min(MAX_W, x.w),
               resizeHandles: resize ? availableHandles : [],
@@ -273,6 +275,7 @@ export const ChartGridLayout = (props: ChartGridLayoutProps) => {
       });
     });
   }, [
+    initialize,
     layouts,
     mountedForSomeTime,
     resize,

--- a/app/components/react-grid.tsx
+++ b/app/components/react-grid.tsx
@@ -214,11 +214,6 @@ export const ChartGridLayout = (props: ChartGridLayoutProps) => {
   const mountedRef = useRef(false);
   const chartContainerClasses = useChartContainerStyles();
 
-  useEffect(() => {
-    setMounted(false);
-    mountedRef.current = false;
-  }, [layouts]);
-
   const enhancedLayouts = useMemo(() => {
     let i = -1;
     const layoutsLength = Object.keys(layouts ?? {}).length;

--- a/app/components/react-grid.tsx
+++ b/app/components/react-grid.tsx
@@ -215,8 +215,11 @@ export const ChartGridLayout = (props: ChartGridLayoutProps) => {
   const chartContainerClasses = useChartContainerStyles();
 
   const enhancedLayouts = useMemo(() => {
-    return mapValues(layouts, (layouts) => {
-      return layouts.map((x, i) => {
+    let i = -1;
+    const layoutsLength = Object.keys(layouts ?? {}).length;
+    return mapValues(layouts, (layoutValues) => {
+      i++;
+      return layoutValues.map((x, j) => {
         let minH = MIN_H;
         if (mountedForSomeTime) {
           const chartWrapper = document.querySelector(
@@ -244,7 +247,7 @@ export const ChartGridLayout = (props: ChartGridLayoutProps) => {
           }
 
           if (!mountedRef.current) {
-            if (i === layouts.length - 1) {
+            if (i === layoutsLength - 1 && j === layoutValues.length - 1) {
               mountedRef.current = true;
             }
             return {

--- a/app/components/react-grid.tsx
+++ b/app/components/react-grid.tsx
@@ -210,7 +210,7 @@ type ChartGridLayoutProps = {
 export const ChartGridLayout = (props: ChartGridLayoutProps) => {
   const { children, layouts, resize } = props;
   const [mounted, setMounted] = useState(false);
-  const mountedForSomeTime = useTimeout(250, mounted);
+  const mountedForSomeTime = useTimeout(500, mounted);
   const mountedRef = useRef(false);
   const chartContainerClasses = useChartContainerStyles();
 

--- a/app/components/react-grid.tsx
+++ b/app/components/react-grid.tsx
@@ -210,9 +210,14 @@ type ChartGridLayoutProps = {
 export const ChartGridLayout = (props: ChartGridLayoutProps) => {
   const { children, layouts, resize } = props;
   const [mounted, setMounted] = useState(false);
-  const mountedForSomeTime = useTimeout(500, mounted);
+  const mountedForSomeTime = useTimeout(250, mounted);
   const mountedRef = useRef(false);
   const chartContainerClasses = useChartContainerStyles();
+
+  useEffect(() => {
+    setMounted(false);
+    mountedRef.current = false;
+  }, [layouts]);
 
   const enhancedLayouts = useMemo(() => {
     let i = -1;
@@ -227,7 +232,9 @@ export const ChartGridLayout = (props: ChartGridLayoutProps) => {
           ) as HTMLDivElement | null;
           if (chartWrapper) {
             const chartWrapperScrollHeight = chartWrapper.scrollHeight;
-            const chart = chartWrapper.querySelector(`svg.${CHART_CLASS_NAME}`);
+            const chart =
+              chartWrapper.querySelector(`.${CHART_CLASS_NAME}`) ??
+              chartWrapper.querySelector("canvas"); // map
             if (chart) {
               const chartHeight = chart.clientHeight;
               const minChartWrapperHeight =
@@ -293,7 +300,6 @@ export const ChartGridLayout = (props: ChartGridLayoutProps) => {
       useCSSTransforms={mounted}
       compactType="vertical"
       preventCollision={false}
-      style={{ opacity: mountedForSomeTime ? 1 : 0 }}
     >
       {children}
     </ResponsiveReactGridLayout>

--- a/app/components/react-grid.tsx
+++ b/app/components/react-grid.tsx
@@ -211,7 +211,7 @@ type ChartGridLayoutProps = {
 export const ChartGridLayout = (props: ChartGridLayoutProps) => {
   const { children, layouts, resize, initialize } = props;
   const [mounted, setMounted] = useState(false);
-  const mountedForSomeTime = useTimeout(250, mounted);
+  const mountedForSomeTime = useTimeout(500, mounted);
   const mountedRef = useRef(false);
   const chartContainerClasses = useChartContainerStyles();
 

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -1029,7 +1029,9 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
 
     case "LAYOUT_CHANGED":
       if (draft.state === "LAYOUTING") {
-        draft.layout = action.value;
+        if (!isEqual(draft.layout, action.value)) {
+          draft.layout = action.value;
+        }
       }
 
       return draft;


### PR DESCRIPTION
Closes #1637

### How to test
**PR**
1. Go to [this link](https://visualization-tool-git-feat-minimum-chart-height-in-b362d7-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9&dataSource=Prod).
2. Add a super-long title for the chart, e.g. _Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum._
3. Add a new pie chart.
4. Add the same long title to the chart.
5. Add a new map chart.
6. Add a new scatterplot chart.
7. Proceed to layout options.
8. Switch layout to dashboard / free canvas.
9. ✅ See that the charts initialized in min-height mode and the cards have dynamic heights based on the content.
10. ✅ Try to resize the cards vertically and see that they are constrained in a way that you can't make the chart invisible or the content overflowing.

**TEST**
1. Go to [this link](https://test.visualize.admin.ch/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9&dataSource=Prod).
2. Add a super-long title for the chart, e.g. _Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum._
3. Add a new pie chart.
4. Add the same long title to the chart.
5. Add a new map chart.
6. Add a new scatterplot chart.
7. Proceed to layout options.
8. Switch layout to dashboard / free canvas.
9. ❌ See that the charts initialized with the same, hard-coded height, and some of them and not visible or broken.
10. ❌ Try to resize the cards vertically and see that they are not constrained and you can make the chart invisible or the content overflowing.