### PR TITLE
fix: improve preview speed on Stardog >= 10

### DIFF
--- a/app/rdf/query-cube-preview.ts
+++ b/app/rdf/query-cube-preview.ts
@@ -110,7 +110,9 @@ CONSTRUCT {
     VALUES ?cube { <${iri}> }
     ?cube cube:observationConstraint/sh:property/sh:path ?observationPredicate .
     { SELECT ?observation ?observationPredicate ?observationValue ?observationLabel ?observationPosition WHERE {
-    { SELECT ?observation WHERE {
+    { 
+#pragma evaluate on  ## improve preview speed (wrt Stardog issue 2094 on Stardog >= 10 // see also SBAR-1122)
+      SELECT ?observation WHERE {
       VALUES ?cube { <${iri}> }
       ?cube cube:observationSet ?observationSet .
       ?observationSet cube:observation ?observation .


### PR DESCRIPTION
wrt Stardog issue 2094
see also SBAR-1122

@bprusinowski can you please push this urgent workaround to the upcoming release? THX
Context: The goal is to mitigate unusual long preview query times i.e. preview on Strompreise would take ~60s otherwise :/

cc @sosiology @adintegra 