### PR TITLE
feat: Add unit to map legend

### DIFF
--- a/app/charts/map/map-legend.tsx
+++ b/app/charts/map/map-legend.tsx
@@ -107,6 +107,9 @@ export const MapLegend = ({
               sx={{ marginLeft: `${MARGIN.left}px` }}
             >
               {areaLayer.colors.component.label}
+              {areaLayer.colors.component.unit
+                ? ` (${areaLayer.colors.component.unit})`
+                : ""}
             </Typography>
             {areaLayer.colors.type === "continuous" ? (
               areaLayer.colors.interpolationType === "linear" ? (


### PR DESCRIPTION
Closes #1657

## How to test
1. Go to [this link](https://visualization-tool-git-feat-improve-map-legend-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9&dataSource=Prod).
2. Switch to a map chart.
3. ✅ See that the color measure unit is visible in the legend title.