### PR TITLE
fix: Menu alignment

### DIFF
--- a/app/components/arrow-menu.tsx
+++ b/app/components/arrow-menu.tsx
@@ -1,41 +1,48 @@
 import { Menu, paperClasses, styled } from "@mui/material";
 
-export const ArrowMenuTopBottom = styled(Menu)(({ theme }) => ({
+const commonBeforeStyles: Partial<CSSStyleDeclaration> = {
+  content: '" "',
+  display: "block",
+  background: "white",
+  width: "10px",
+  height: "10px",
+  transform: "rotate(45deg)",
+  position: "absolute",
+  margin: "auto",
+};
+
+export const ArrowMenuTopCenter = styled(Menu)({
   [`& .${paperClasses.root}`]: {
-    overflowY: "visible",
-    overflowX: "visible",
+    overflow: "visible",
     "&:before": {
-      content: '" "',
-      display: "block",
-      background: theme.palette.background.paper,
-      width: 10,
-      height: 10,
-      transform: "rotate(45deg)",
-      position: "absolute",
-      margin: "auto",
+      ...commonBeforeStyles,
+      top: -5,
+      left: "0%",
+      right: 0,
+    },
+  },
+});
+
+export const ArrowMenuTopBottom = styled(Menu)({
+  [`& .${paperClasses.root}`]: {
+    overflow: "visible",
+    "&:before": {
+      ...commonBeforeStyles,
       top: -5,
       left: "calc(100% - 40px)",
       right: 0,
     },
   },
-}));
+});
 
-export const ArrowMenuBottomTop = styled(Menu)(({ theme }) => ({
+export const ArrowMenuBottomTop = styled(Menu)({
   [`& .${paperClasses.root}`]: {
-    overflowY: "visible",
-    overflowX: "visible",
+    overflow: "visible",
     "&:before": {
-      content: '" "',
-      display: "block",
-      background: theme.palette.background.paper,
-      width: 10,
-      height: 10,
-      transform: "rotate(45deg)",
-      position: "absolute",
-      margin: "auto",
+      ...commonBeforeStyles,
       bottom: -5,
       left: 0,
       right: "calc(100% - 40px)",
     },
   },
-}));
+});

--- a/app/components/chart-selection-tabs.tsx
+++ b/app/components/chart-selection-tabs.tsx
@@ -25,7 +25,7 @@ import { useClient } from "urql";
 import { useDebounce } from "use-debounce";
 
 import { extractChartConfigComponentIris } from "@/charts/shared/chart-helpers";
-import { ArrowMenuTopBottom } from "@/components/arrow-menu";
+import { ArrowMenuTopCenter } from "@/components/arrow-menu";
 import { DuplicateChartMenuActionItem } from "@/components/chart-shared";
 import Flex from "@/components/flex";
 import { MenuActionItem } from "@/components/menu-action-item";
@@ -276,7 +276,7 @@ const TabsEditable = (props: TabsEditableProps) => {
       ) : null}
 
       {tabsState.popoverType === "edit" ? (
-        <ArrowMenuTopBottom
+        <ArrowMenuTopCenter
           id="chart-selection-popover"
           open={tabsState.popoverOpen}
           anchorEl={popoverAnchorEl}
@@ -322,7 +322,7 @@ const TabsEditable = (props: TabsEditableProps) => {
               }}
             />
           )}
-        </ArrowMenuTopBottom>
+        </ArrowMenuTopCenter>
       ) : null}
     </>
   );


### PR DESCRIPTION
Closes #1660

## How to test
1. Go to [this link](https://visualization-tool-git-fix-menu-alignment-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9&dataSource=Prod).
2. Click on a chevron next to chart icon in the top tabs.
3. ✅ See that the popover's arrow is correctly centered.