### PR TITLE
fix: ODS links when identifier already contains organization

### DIFF
--- a/app/utils/opendata.spec.ts
+++ b/app/utils/opendata.spec.ts
@@ -1,0 +1,19 @@
+import { DataCubeMetadata } from "@/domain/data";
+import { makeOpenDataLink } from "@/utils/opendata";
+
+describe("makeOpenDataLink", () => {
+  it("should remove creator slug from identifier", () => {
+    const orgSuffix = "exampleOrg";
+    const cube = {
+      identifier: `https://ld.admin.ch/data/123@${orgSuffix}`,
+      creator: {
+        iri: `https://register.ld.admin.ch/opendataswiss/org/${orgSuffix}`,
+      },
+      workExamples: ["https://ld.admin.ch/application/opendataswiss"],
+    } as DataCubeMetadata;
+
+    expect(makeOpenDataLink("de", cube)).toBe(
+      `https://opendata.swiss/de/perma/${encodeURIComponent(`https://ld.admin.ch/data/123@${orgSuffix}`)}`
+    );
+  });
+});

--- a/app/utils/opendata.ts
+++ b/app/utils/opendata.ts
@@ -11,10 +11,13 @@ export const makeOpenDataLink = (lang: string, cube: DataCubeMetadata) => {
     return;
   }
 
+  const creatorSlug = creatorIri.replace(
+    "https://register.ld.admin.ch/opendataswiss/org/",
+    ""
+  );
+
   return `https://opendata.swiss/${lang}/perma/${encodeURIComponent(
-    `${identifier}@${creatorIri.replace(
-      "https://register.ld.admin.ch/opendataswiss/org/",
-      ""
-    )}`
+    // Sometimes the identifier is prefixed with the creator slug
+    `${identifier.replace(`@${creatorSlug}`, "")}@${creatorSlug}`
   )}`;
 };


### PR DESCRIPTION
Fixes #1656

## How to reproduce
1. Go to [this link](https://visualize.admin.ch/en/browse?dataset=https%3A%2F%2Fenvironment.ld.admin.ch%2Ffoen%2Fnfi%2Fnfi_C-1029%2Fcube%2F2024-1&dataSource=Prod).
2. Click the `OpenData.swiss` button in the left sidebar.
3. ❌ See that there's an error page displayed.

## How to test
1. Go to [this link](https://visualization-tool-git-fix-opendata-link-ixt1.vercel.app/en/browse?previous=%7B%22order%22%3A%22SCORE%22%2C%22search%22%3A%22nfi%22%7D&dataset=https%3A%2F%2Fenvironment.ld.admin.ch%2Ffoen%2Fnfi%2Fnfi_T-changes%2Fcube%2F2024-1&dataSource=Prod).
2. Click the `OpenData.swiss` button in the left sidebar.
3. ✅ See that the page opened with errors.