### PR TITLE
fix: Column chart issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Fixes
+  - Map is now correctly centered after copying a chart or switching to layout
+    mode
+  - Table single filters now correctly display selected state
+  - Drag handles are now centered in table configurator
 
 # [4.7.4] - 2024-07-23
 

--- a/app/charts/table/table-state.tsx
+++ b/app/charts/table/table-state.tsx
@@ -156,7 +156,7 @@ const useTableState = (
   const memoizedData = useMemo(
     function replaceKeys() {
       // Only read keys once
-      const keys = Object.keys(chartData[0]);
+      const keys = Object.keys(chartData[0] ?? []);
       const lkey = keys.length;
       const slugifiedKeys = keys.map(getSlugifiedIri);
 

--- a/app/configurator/components/chart-controls/drag-and-drop-tab.tsx
+++ b/app/configurator/components/chart-controls/drag-and-drop-tab.tsx
@@ -42,7 +42,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     display: "flex",
     flexDirection: "column",
     alignItems: "center",
-    justifyContent: "flex-end",
+    justifyContent: "center",
     flexGrow: 0,
     flexShrink: 0,
     paddingBottom: 0,

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -1175,10 +1175,8 @@ export const DimensionValuesSingleFilter = ({
   const locale = useLocale();
   const sortedDimensionValues = useMemo(() => {
     const values = dimension.values;
-
     return [...values].sort(valueComparator(locale));
   }, [dimension?.values, locale]);
-
   return dimension ? (
     <>
       {sortedDimensionValues.map((dv) => {

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -526,10 +526,12 @@ export const useSingleFilterField = ({
     [dispatch, filters]
   );
 
-  // TODO Fix
+  const cubeIri = filters[0].cubeIri;
   const dimensionIri = filters[0].dimensionIri;
+  const chartConfig = getChartConfig(state);
+  const cube = chartConfig.cubes.find((cube) => cube.iri === cubeIri);
   const stateValue = isConfiguring(state)
-    ? get(getChartConfig(state), ["filters", dimensionIri, "value"], "")
+    ? get(cube, ["filters", dimensionIri, "value"], "")
     : "";
   const checked = stateValue === value;
 


### PR DESCRIPTION
Fixes #1674
Fixes #1632

## How to test
1. Go to [this link](https://visualization-tool-git-fix-column-side-panel-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/9&dataSource=Prod).
2. Switch to a table chart.
3. ✅ Look at the Columns section in the left panel and see that the drag handles are centered.
4. Click on the **Kanton** column.
5. Hide the column.
6. ✅ See that Zürich option is highlighted as selected and when clicking on the radio buttons, they are also correctly highlighted.