### PR TITLE
feat: Categorical dashboard filters

### DIFF
--- a/app/browse/datatable.tsx
+++ b/app/browse/datatable.tsx
@@ -20,7 +20,11 @@ import {
 } from "@/charts/shared/chart-helpers";
 import { Loading } from "@/components/hint";
 import { OpenMetadataPanelWrapper } from "@/components/metadata-panel";
-import { ChartConfig, DataSource } from "@/config-types";
+import {
+  ChartConfig,
+  DashboardFiltersConfig,
+  DataSource,
+} from "@/config-types";
 import {
   Component,
   Dimension,
@@ -229,10 +233,12 @@ export const DataSetPreviewTable = ({
 export const DataSetTable = ({
   dataSource,
   chartConfig,
+  dashboardFilters,
   sx,
 }: {
   dataSource: DataSource;
   chartConfig: ChartConfig;
+  dashboardFilters: DashboardFiltersConfig | undefined;
   sx?: SxProps<Theme>;
 }) => {
   const locale = useLocale();
@@ -269,7 +275,11 @@ export const DataSetTable = ({
       ...componentsData.dataCubesComponents.measures,
     ]);
   }, [componentsData?.dataCubesComponents]);
-  const queryFilters = useQueryFilters({ chartConfig, componentIris });
+  const queryFilters = useQueryFilters({
+    chartConfig,
+    dashboardFilters,
+    componentIris,
+  });
   const [{ data: observationsData }] = useDataCubesObservationsQuery({
     variables: {
       ...commonQueryVariables,

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -25,8 +25,9 @@ import {
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { ColumnConfig, useChartConfigFilters } from "@/config-types";
+import { hasChartConfigs } from "@/configurator";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
-import { useDashboardInteractiveFilters } from "@/stores/interactive-filters";
+import { useConfiguratorState } from "@/src";
 
 import { ChartProps, VisualizationProps } from "../shared/ChartProps";
 
@@ -40,10 +41,10 @@ const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
   const { chartConfig, dimensions } = props;
   const { fields, interactiveFiltersConfig } = chartConfig;
   const filters = useChartConfigFilters(chartConfig);
-  const dashboardFilters = useDashboardInteractiveFilters();
+  const [{ dashboardFilters }] = useConfiguratorState(hasChartConfigs);
   const showTimeBrush = shouldShowBrush(
     interactiveFiltersConfig,
-    dashboardFilters.timeRange
+    dashboardFilters?.timeRange
   );
   return (
     <>

--- a/app/charts/combo/chart-combo-line-column.tsx
+++ b/app/charts/combo/chart-combo-line-column.tsx
@@ -12,7 +12,8 @@ import { HoverDotMultiple } from "@/charts/shared/interaction/hover-dots-multipl
 import { Ruler } from "@/charts/shared/interaction/ruler";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { ComboLineColumnConfig } from "@/config-types";
-import { useDashboardInteractiveFilters } from "@/stores/interactive-filters";
+import { hasChartConfigs } from "@/configurator";
+import { useConfiguratorState } from "@/src";
 
 import { ChartProps, VisualizationProps } from "../shared/ChartProps";
 
@@ -26,7 +27,7 @@ const ChartComboLineColumn = memo(
   (props: ChartProps<ComboLineColumnConfig>) => {
     const { chartConfig } = props;
     const { interactiveFiltersConfig } = chartConfig;
-    const dashboardFilters = useDashboardInteractiveFilters();
+    const [{ dashboardFilters }] = useConfiguratorState(hasChartConfigs);
     return (
       <ComboLineColumnChart {...props}>
         <ChartContainer>
@@ -38,7 +39,7 @@ const ChartComboLineColumn = memo(
             <InteractionColumns />
             {shouldShowBrush(
               interactiveFiltersConfig,
-              dashboardFilters.timeRange
+              dashboardFilters?.timeRange
             ) && <BrushTime />}
           </ChartSvg>
           <HoverDotMultiple />

--- a/app/charts/combo/chart-combo-line-dual.tsx
+++ b/app/charts/combo/chart-combo-line-dual.tsx
@@ -12,7 +12,8 @@ import { Ruler } from "@/charts/shared/interaction/ruler";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import { ComboLineDualConfig } from "@/config-types";
-import { useDashboardInteractiveFilters } from "@/stores/interactive-filters";
+import { hasChartConfigs } from "@/configurator";
+import { useConfiguratorState } from "@/src";
 
 import { ChartProps, VisualizationProps } from "../shared/ChartProps";
 
@@ -25,7 +26,7 @@ export const ChartComboLineDualVisualization = (
 const ChartComboLineDual = memo((props: ChartProps<ComboLineDualConfig>) => {
   const { chartConfig } = props;
   const { interactiveFiltersConfig } = chartConfig;
-  const dashboardFilters = useDashboardInteractiveFilters();
+  const [{ dashboardFilters }] = useConfiguratorState(hasChartConfigs);
   return (
     <ComboLineDualChart {...props}>
       <ChartContainer>
@@ -37,7 +38,7 @@ const ChartComboLineDual = memo((props: ChartProps<ComboLineDualConfig>) => {
           <InteractionHorizontal />
           {shouldShowBrush(
             interactiveFiltersConfig,
-            dashboardFilters.timeRange
+            dashboardFilters?.timeRange
           ) && <BrushTime />}
         </ChartSvg>
         <HoverDotMultiple />

--- a/app/charts/combo/chart-combo-line-single.tsx
+++ b/app/charts/combo/chart-combo-line-single.tsx
@@ -12,7 +12,8 @@ import { Ruler } from "@/charts/shared/interaction/ruler";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import { ComboLineSingleConfig } from "@/config-types";
-import { useDashboardInteractiveFilters } from "@/stores/interactive-filters";
+import { hasChartConfigs } from "@/configurator";
+import { useConfiguratorState } from "@/src";
 
 import { ChartProps, VisualizationProps } from "../shared/ChartProps";
 
@@ -26,7 +27,7 @@ const ChartComboLineSingle = memo(
   (props: ChartProps<ComboLineSingleConfig>) => {
     const { chartConfig } = props;
     const { interactiveFiltersConfig } = chartConfig;
-    const dashboardFilters = useDashboardInteractiveFilters();
+    const [{ dashboardFilters }] = useConfiguratorState(hasChartConfigs);
     return (
       <ComboLineSingleChart {...props}>
         <ChartContainer>
@@ -36,7 +37,7 @@ const ChartComboLineSingle = memo(
             <InteractionHorizontal />
             {shouldShowBrush(
               interactiveFiltersConfig,
-              dashboardFilters.timeRange
+              dashboardFilters?.timeRange
             ) && <BrushTime />}
           </ChartSvg>
           <HoverDotMultiple />

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -17,7 +17,7 @@ import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
 import { InteractionHorizontal } from "@/charts/shared/overlay-horizontal";
 import { LineConfig } from "@/config-types";
-import { useDashboardInteractiveFilters } from "@/stores/interactive-filters";
+import { hasChartConfigs, useConfiguratorState } from "@/configurator";
 
 import { ChartProps, VisualizationProps } from "../shared/ChartProps";
 
@@ -30,7 +30,7 @@ export const ChartLinesVisualization = (
 const ChartLines = memo((props: ChartProps<LineConfig>) => {
   const { chartConfig } = props;
   const { fields, interactiveFiltersConfig } = chartConfig;
-  const dashboardFilters = useDashboardInteractiveFilters();
+  const [{ dashboardFilters }] = useConfiguratorState(hasChartConfigs);
   return (
     <LineChart {...props}>
       <ChartContainer>
@@ -41,7 +41,7 @@ const ChartLines = memo((props: ChartProps<LineConfig>) => {
           <InteractionHorizontal />
           {shouldShowBrush(
             interactiveFiltersConfig,
-            dashboardFilters.timeRange
+            dashboardFilters?.timeRange
           ) && <BrushTime />}
         </ChartSvg>
 

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -116,6 +116,7 @@ export const useChartDataFiltersState = ({
     dataSource,
     chartConfig,
     preparedFilters,
+    dashboardFilters,
   });
   return {
     open,
@@ -539,20 +540,19 @@ export const DataFilterTemporalDimension = ({
   );
 };
 
-type EnsurePossibleInteractiveFiltersProps = {
-  dataSource: DataSource;
-  chartConfig: ChartConfig;
-  preparedFilters?: PreparedFilter[];
-};
-
 /**
  * This runs every time the state changes and it ensures that the selected interactive
  * filters return at least 1 observation. Otherwise they are reloaded.
+ *
+ * This behavior is disabled when the dashboard filters are active.
  */
-const useEnsurePossibleInteractiveFilters = (
-  props: EnsurePossibleInteractiveFiltersProps
-) => {
-  const { dataSource, chartConfig, preparedFilters } = props;
+const useEnsurePossibleInteractiveFilters = (props: {
+  dataSource: DataSource;
+  chartConfig: ChartConfig;
+  dashboardFilters: DashboardFiltersConfig | undefined;
+  preparedFilters?: PreparedFilter[];
+}) => {
+  const { dataSource, chartConfig, dashboardFilters, preparedFilters } = props;
   const [, dispatch] = useConfiguratorState();
   const loadingState = useLoadingState();
   const [error, setError] = useState<Error>();
@@ -569,7 +569,10 @@ const useEnsurePossibleInteractiveFilters = (
 
   useEffect(() => {
     const run = async () => {
-      if (!filtersByCubeIri) {
+      if (
+        !filtersByCubeIri ||
+        dashboardFilters?.dataFilters.componentIris.length
+      ) {
         return;
       }
 
@@ -667,6 +670,7 @@ const useEnsurePossibleInteractiveFilters = (
     loadingState,
     filtersByCubeIri,
     getInteractiveFiltersState,
+    dashboardFilters?.dataFilters.componentIris.length,
   ]);
 
   return { error };

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -17,6 +17,7 @@ import { Loading } from "@/components/hint";
 import { OpenMetadataPanelWrapper } from "@/components/metadata-panel";
 import SelectTree from "@/components/select-tree";
 import {
+  areDataFiltersActive,
   ChartConfig,
   DashboardFiltersConfig,
   DataSource,
@@ -567,12 +568,11 @@ const useEnsurePossibleInteractiveFilters = (props: {
     }, {});
   }, [preparedFilters]);
 
+  const dataFiltersActive = areDataFiltersActive(dashboardFilters);
+
   useEffect(() => {
     const run = async () => {
-      if (
-        !filtersByCubeIri ||
-        dashboardFilters?.dataFilters.componentIris.length
-      ) {
+      if (!filtersByCubeIri || dataFiltersActive) {
         return;
       }
 
@@ -670,7 +670,7 @@ const useEnsurePossibleInteractiveFilters = (props: {
     loadingState,
     filtersByCubeIri,
     getInteractiveFiltersState,
-    dashboardFilters?.dataFilters.componentIris.length,
+    dataFiltersActive,
   ]);
 
   return { error };

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -18,6 +18,7 @@ import { OpenMetadataPanelWrapper } from "@/components/metadata-panel";
 import SelectTree from "@/components/select-tree";
 import {
   ChartConfig,
+  DashboardFiltersConfig,
   DataSource,
   Filters,
   getFiltersByMappingStatus,
@@ -66,9 +67,11 @@ type PreparedFilter = {
 export const useChartDataFiltersState = ({
   dataSource,
   chartConfig,
+  dashboardFilters,
 }: {
   dataSource: DataSource;
   chartConfig: ChartConfig;
+  dashboardFilters: DashboardFiltersConfig | undefined;
 }) => {
   const componentIris =
     chartConfig.interactiveFiltersConfig?.dataFilters.componentIris;
@@ -81,6 +84,7 @@ export const useChartDataFiltersState = ({
   const { loading } = useLoadingState();
   const queryFilters = useQueryFilters({
     chartConfig,
+    dashboardFilters,
     allowNoneValues: true,
     componentIris,
   });
@@ -107,6 +111,7 @@ export const useChartDataFiltersState = ({
       };
     });
   }, [chartConfig, componentIris, queryFilters]);
+  // TODO: disable when dashboard filters are active?
   const { error } = useEnsurePossibleInteractiveFilters({
     dataSource,
     chartConfig,
@@ -371,7 +376,9 @@ export type DataFilterGenericDimensionProps = {
   disabled: boolean;
 };
 
-const DataFilterGenericDimension = (props: DataFilterGenericDimensionProps) => {
+export const DataFilterGenericDimension = (
+  props: DataFilterGenericDimensionProps
+) => {
   const { dimension, value, onChange, options: propOptions, disabled } = props;
   const { label, isKeyDimension } = dimension;
   const noneLabel = t({
@@ -420,7 +427,7 @@ type DataFilterHierarchyDimensionProps = {
   disabled: boolean;
 };
 
-const DataFilterHierarchyDimension = (
+export const DataFilterHierarchyDimension = (
   props: DataFilterHierarchyDimensionProps
 ) => {
   const { dimension, value, onChange, hierarchy, disabled } = props;
@@ -475,7 +482,7 @@ const DataFilterHierarchyDimension = (
   );
 };
 
-const DataFilterTemporalDimension = ({
+export const DataFilterTemporalDimension = ({
   dimension,
   value,
   onChange,

--- a/app/charts/shared/chart-dimensions.tsx
+++ b/app/charts/shared/chart-dimensions.tsx
@@ -9,11 +9,11 @@ import { Bounds, Margins } from "@/charts/shared/use-size";
 import { CHART_GRID_MIN_HEIGHT } from "@/components/react-grid";
 import {
   ChartConfig,
+  DashboardFiltersConfig,
   hasChartConfigs,
   isLayoutingFreeCanvas,
   useConfiguratorState,
 } from "@/configurator";
-import { useDashboardInteractiveFilters } from "@/stores/interactive-filters";
 import { getTextWidth } from "@/utils/get-text-width";
 
 type ComputeChartPaddingProps = {
@@ -29,7 +29,7 @@ type ComputeChartPaddingProps = {
 
 const computeChartPadding = (
   props: ComputeChartPaddingProps & {
-    dashboardFilters: ReturnType<typeof useDashboardInteractiveFilters>;
+    dashboardFilters: DashboardFiltersConfig | undefined;
   }
 ) => {
   const {
@@ -61,7 +61,7 @@ const computeChartPadding = (
   );
 
   let bottom =
-    (!dashboardFilters.timeRange?.active &&
+    (!dashboardFilters?.timeRange.active &&
       !!interactiveFiltersConfig?.timeRange.active) ||
     animationPresent
       ? BRUSH_BOTTOM_SPACE
@@ -87,7 +87,7 @@ export const useChartPadding = (props: ComputeChartPaddingProps) => {
     bandDomain,
     normalize,
   } = props;
-  const dashboardFilters = useDashboardInteractiveFilters();
+  const [{ dashboardFilters }] = useConfiguratorState(hasChartConfigs);
   return useMemo(() => {
     return computeChartPadding({
       yScale,

--- a/app/charts/shared/chart-helpers.spec.tsx
+++ b/app/charts/shared/chart-helpers.spec.tsx
@@ -93,6 +93,7 @@ describe("useQueryFilters", () => {
       line1Fixture.data.chartConfig.chartType as ChartType,
       line1Fixture.data.chartConfig.filters as Filters,
       commonInteractiveFiltersConfig,
+      undefined,
       commonInteractiveFiltersState.dataFilters
     );
     expect(queryFilters[col("3")]).toEqual({
@@ -110,6 +111,7 @@ describe("useQueryFilters", () => {
           active: true,
         },
       }),
+      undefined,
       commonInteractiveFiltersState.dataFilters
     );
 
@@ -128,6 +130,7 @@ describe("useQueryFilters", () => {
           active: true,
         },
       }),
+      undefined,
       merge({}, commonInteractiveFiltersState, {
         dataFilters: {
           [col("3")]: {
@@ -171,7 +174,7 @@ describe("useQueryFilters", () => {
     >(
       (props: Parameters<typeof useQueryFilters>[0]) => useQueryFilters(props),
       {
-        initialProps: { chartConfig },
+        initialProps: { chartConfig, dashboardFilters: undefined },
       }
     );
 

--- a/app/charts/shared/chart-helpers.spec.tsx
+++ b/app/charts/shared/chart-helpers.spec.tsx
@@ -14,7 +14,10 @@ import {
 } from "@/configurator";
 import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import { mkJoinById } from "@/graphql/join";
-import { InteractiveFiltersState } from "@/stores/interactive-filters";
+import {
+  InteractiveFiltersState,
+  useChartInteractiveFilters,
+} from "@/stores/interactive-filters";
 import dualLine1Fixture from "@/test/__fixtures/config/dev/chartConfig-photovoltaik-und-gebaudeprogramm.json";
 import map1Fixture from "@/test/__fixtures/config/int/map-nfi.json";
 import line1Fixture from "@/test/__fixtures/config/prod/line-1.json";
@@ -184,6 +187,80 @@ describe("useQueryFilters", () => {
         componentIris: undefined,
         filters: {
           A_1: { type: "single", value: "A_1_1" },
+          A_2: { type: "single", value: "A_2_1" },
+        },
+        joinBy: undefined,
+      },
+      {
+        iri: "B",
+        componentIris: undefined,
+        filters: { B_1: { type: "single", value: "B_1_1" } },
+        joinBy: undefined,
+      },
+    ]);
+  });
+
+  it("should handle correctly dashboard filters", () => {
+    (useChartInteractiveFilters as jest.Mock).mockImplementation(() => ({}));
+
+    const chartConfig = {
+      chartType: "line",
+      interactiveFiltersConfig: {
+        dataFilters: {
+          active: true,
+        },
+      },
+      cubes: [
+        {
+          iri: "A",
+          filters: {
+            A_1: { type: "single", value: "A_1_5" },
+            A_2: { type: "single", value: "A_2_1" },
+          },
+        },
+        {
+          iri: "B",
+          filters: {
+            B_1: { type: "single", value: "B_1_1" },
+          },
+        },
+      ],
+    } as any as ChartConfig;
+    const { result: queryFilters } = renderHook<
+      ReturnType<typeof useQueryFilters>,
+      Parameters<typeof useQueryFilters>[0]
+    >(
+      (props: Parameters<typeof useQueryFilters>[0]) => useQueryFilters(props),
+      {
+        initialProps: {
+          chartConfig,
+          dashboardFilters: {
+            timeRange: {
+              active: false,
+              timeUnit: "ms",
+              presets: {
+                from: "2021-01-01",
+                to: "2021-12-31",
+              },
+            },
+            dataFilters: {
+              componentIris: ["A_1"],
+              filters: {
+                A_1: { type: "single", value: "A_1_Data_Filter" },
+                A_2: { type: "single", value: "A_2_3" },
+              },
+            },
+          },
+        },
+      }
+    );
+
+    expect(queryFilters.current).toEqual([
+      {
+        iri: "A",
+        componentIris: undefined,
+        filters: {
+          A_1: { type: "single", value: "A_1_Data_Filter" },
           A_2: { type: "single", value: "A_2_1" },
         },
         joinBy: undefined,

--- a/app/charts/shared/chart-helpers.tsx
+++ b/app/charts/shared/chart-helpers.tsx
@@ -25,9 +25,9 @@ import {
   ComboChartConfig,
   DashboardFiltersConfig,
   GenericField,
-  NumericalColorField,
   getChartConfigFilters,
   isComboChartConfig,
+  NumericalColorField,
 } from "@/configurator";
 import { parseDate } from "@/configurator/components/ui-helpers";
 import { FIELD_VALUE_NONE } from "@/configurator/constants";
@@ -35,9 +35,9 @@ import {
   Component,
   Dimension,
   DimensionValue,
+  getTemporalEntityValue,
   Observation,
   ObservationValue,
-  getTemporalEntityValue,
 } from "@/domain/data";
 import { truthy } from "@/domain/types";
 import { getOriginalIris, isJoinById } from "@/graphql/join";
@@ -91,7 +91,9 @@ export const useQueryFilters = ({
   allowNoneValues?: boolean;
   componentIris?: string[];
 }): DataCubeObservationFilter[] => {
-  const chartDataFilters = useChartInteractiveFilters((d) => d.dataFilters);
+  const chartInteractiveFilters = useChartInteractiveFilters(
+    (d) => d.dataFilters
+  );
   return useMemo(() => {
     return chartConfig.cubes.map((cube) => {
       const cubeFilters = getChartConfigFilters(chartConfig.cubes, {
@@ -103,7 +105,7 @@ export const useQueryFilters = ({
       // track of interactive data filters per cube.
       // Only include data filters that are part of the chart config.
       const cubeDataFilters = Object.fromEntries(
-        Object.entries(chartDataFilters).filter(([key]) =>
+        Object.entries(chartInteractiveFilters).filter(([key]) =>
           cubeFiltersKeys.includes(key)
         )
       );
@@ -126,7 +128,7 @@ export const useQueryFilters = ({
     chartConfig.cubes,
     chartConfig.chartType,
     chartConfig.interactiveFiltersConfig,
-    chartDataFilters,
+    chartInteractiveFilters,
     componentIris,
     dashboardFilters,
     allowNoneValues,

--- a/app/charts/shared/chart-state.ts
+++ b/app/charts/shared/chart-state.ts
@@ -32,6 +32,8 @@ import {
   GenericField,
   InteractiveFiltersConfig,
   getAnimationField,
+  hasChartConfigs,
+  useConfiguratorState,
 } from "@/configurator";
 import {
   parseDate,
@@ -57,10 +59,7 @@ import {
 } from "@/domain/data";
 import { Has } from "@/domain/types";
 import { ScaleType, TimeUnit } from "@/graphql/resolver-types";
-import {
-  useChartInteractiveFilters,
-  useDashboardInteractiveFilters,
-} from "@/stores/interactive-filters";
+import { useChartInteractiveFilters } from "@/stores/interactive-filters";
 
 export type ChartState =
   | AreasState
@@ -508,13 +507,13 @@ export const useChartData = (
   // interactive time range
   const interactiveFromTime = timeRange.from?.getTime();
   const interactiveToTime = timeRange.to?.getTime();
-  const dashboardFilters = useDashboardInteractiveFilters();
+  const [{ dashboardFilters }] = useConfiguratorState(hasChartConfigs);
   const interactiveTimeRangeFilters = useMemo(() => {
     const interactiveTimeRangeFilter: ValuePredicate | null =
       getXAsDate &&
       interactiveFromTime &&
       interactiveToTime &&
-      (interactiveTimeRange?.active || dashboardFilters.timeRange?.active)
+      (interactiveTimeRange?.active || dashboardFilters?.timeRange.active)
         ? (d: Observation) => {
             const time = getXAsDate(d).getTime();
             return time >= interactiveFromTime && time <= interactiveToTime;
@@ -523,7 +522,7 @@ export const useChartData = (
 
     return interactiveTimeRangeFilter ? [interactiveTimeRangeFilter] : [];
   }, [
-    dashboardFilters.timeRange,
+    dashboardFilters?.timeRange,
     getXAsDate,
     interactiveFromTime,
     interactiveToTime,

--- a/app/charts/shared/use-sync-interactive-filters.spec.tsx
+++ b/app/charts/shared/use-sync-interactive-filters.spec.tsx
@@ -101,7 +101,10 @@ const setup = ({
       calculation: d.calculation,
     }));
     const [useModified, setUseModified] = useState(false);
-    useSyncInteractiveFilters(useModified ? modifiedChartConfig : chartConfig);
+    useSyncInteractiveFilters(
+      useModified ? modifiedChartConfig : chartConfig,
+      undefined
+    );
 
     return (
       <div>

--- a/app/charts/shared/use-sync-interactive-filters.tsx
+++ b/app/charts/shared/use-sync-interactive-filters.tsx
@@ -68,8 +68,11 @@ const useSyncInteractiveFilters = (
           [key: string]: FilterValueSingle;
         }>((obj, iri) => {
           const configFilter = filters[iri];
+          const dashboardFilter = dashboardFilters?.dataFilters.filters[iri];
 
-          if (Object.keys(dataFilters).includes(iri)) {
+          if (dashboardFilter?.type === "single") {
+            obj[iri] = dashboardFilter;
+          } else if (Object.keys(dataFilters).includes(iri)) {
             obj[iri] = dataFilters[iri];
           } else if (configFilter?.type === "single") {
             obj[iri] = configFilter;
@@ -81,7 +84,12 @@ const useSyncInteractiveFilters = (
       setDataFilters(newInteractiveDataFilters);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [componentIris, setDataFilters]);
+  }, [
+    componentIris,
+    dashboardComponentIris,
+    dashboardFilters?.dataFilters.filters,
+    setDataFilters,
+  ]);
 
   const changes = useFilterChanges(filters);
   useEffect(() => {

--- a/app/charts/shared/use-sync-interactive-filters.tsx
+++ b/app/charts/shared/use-sync-interactive-filters.tsx
@@ -10,6 +10,7 @@ import {
 import { parseDate } from "@/configurator/components/ui-helpers";
 import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import useFilterChanges from "@/configurator/use-filter-changes";
+import { truthy } from "@/domain/types";
 import { useChartInteractiveFilters } from "@/stores/interactive-filters";
 
 /**
@@ -68,17 +69,16 @@ const useSyncInteractiveFilters = (
 
   useEffect(() => {
     if (newPotentialInteractiveDataFilters) {
-      const newInteractiveDataFilters =
-        newPotentialInteractiveDataFilters.reduce(
-          (obj, iri) => {
+      const newInteractiveDataFilters = Object.fromEntries(
+        Object.entries(newPotentialInteractiveDataFilters)
+          .map(([iri]) => {
             const dashboardFilter = dashboardFilters?.dataFilters.filters[iri];
-            if (dashboardFilter?.type === "single") {
-              obj[iri] = dashboardFilter;
-            }
-            return obj;
-          },
-          {} as { [key: string]: FilterValueSingle }
-        );
+            return dashboardFilter?.type === "single"
+              ? ([iri, dashboardFilter] as const)
+              : null;
+          })
+          .filter(truthy)
+      );
 
       setDataFilters(newInteractiveDataFilters);
     }

--- a/app/charts/shared/use-sync-interactive-filters.tsx
+++ b/app/charts/shared/use-sync-interactive-filters.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo } from "react";
 
 import {
   ChartConfig,
+  DashboardFiltersConfig,
   FilterValueSingle,
   isSegmentInConfig,
   useChartConfigFilters,
@@ -18,7 +19,10 @@ import { useChartInteractiveFilters } from "@/stores/interactive-filters";
  *   inside the interactive filters
  *
  */
-const useSyncInteractiveFilters = (chartConfig: ChartConfig) => {
+const useSyncInteractiveFilters = (
+  chartConfig: ChartConfig,
+  dashboardFilters: DashboardFiltersConfig | undefined
+) => {
   const { interactiveFiltersConfig } = chartConfig;
   const filters = useChartConfigFilters(chartConfig);
   const resetCategories = useChartInteractiveFilters((d) => d.resetCategories);
@@ -52,23 +56,27 @@ const useSyncInteractiveFilters = (chartConfig: ChartConfig) => {
 
   // Data Filters
   const componentIris = interactiveFiltersConfig?.dataFilters.componentIris;
+  const dashboardComponentIris = dashboardFilters?.dataFilters.componentIris;
   useEffect(() => {
     if (componentIris) {
       // If dimension is already in use as interactive filter, use it,
-      // otherwise, default to editor config filter dimension value.
-      const newInteractiveDataFilters = componentIris.reduce<{
-        [key: string]: FilterValueSingle;
-      }>((obj, iri) => {
-        const configFilter = filters[iri];
+      // otherwise, default to editor config filter dimension value (only
+      // if dashboard filters are not set).
+      const newInteractiveDataFilters = componentIris
+        .concat(dashboardComponentIris ?? [])
+        .reduce<{
+          [key: string]: FilterValueSingle;
+        }>((obj, iri) => {
+          const configFilter = filters[iri];
 
-        if (Object.keys(dataFilters).includes(iri)) {
-          obj[iri] = dataFilters[iri];
-        } else if (configFilter?.type === "single") {
-          obj[iri] = configFilter;
-        }
+          if (Object.keys(dataFilters).includes(iri)) {
+            obj[iri] = dataFilters[iri];
+          } else if (configFilter?.type === "single") {
+            obj[iri] = configFilter;
+          }
 
-        return obj;
-      }, {});
+          return obj;
+        }, {});
 
       setDataFilters(newInteractiveDataFilters);
     }

--- a/app/components/chart-filters-list.tsx
+++ b/app/components/chart-filters-list.tsx
@@ -9,6 +9,7 @@ import {
 import { OpenMetadataPanelWrapper } from "@/components/metadata-panel";
 import {
   ChartConfig,
+  DashboardFiltersConfig,
   DataSource,
   FilterValue,
   getAnimationField,
@@ -28,11 +29,13 @@ export const ChartFiltersList = ({
   cubeIri,
   dataSource,
   chartConfig,
+  dashboardFilters,
   components,
 }: {
   cubeIri: string;
   dataSource: DataSource;
   chartConfig: ChartConfig;
+  dashboardFilters: DashboardFiltersConfig | undefined;
   components: Component[];
 }) => {
   const locale = useLocale();
@@ -41,6 +44,7 @@ export const ChartFiltersList = ({
   const animationField = getAnimationField(chartConfig);
   const queryFilters = useQueryFilters({
     chartConfig,
+    dashboardFilters,
     componentIris: extractChartConfigComponentIris({ chartConfig }),
   });
   const cubeQueryFilters = useMemo(() => {

--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -12,6 +12,7 @@ import {
   ComboLineColumnConfig,
   ComboLineDualConfig,
   ComboLineSingleConfig,
+  DashboardFiltersConfig,
   DataSource,
 } from "@/configurator";
 import { Component, Measure } from "@/domain/data";
@@ -43,11 +44,13 @@ export const useFootnotesStyles = makeStyles<Theme, { useMarginTop: boolean }>(
 export const ChartFootnotes = ({
   dataSource,
   chartConfig,
+  dashboardFilters,
   components,
   showVisualizeLink = false,
 }: {
   dataSource: DataSource;
   chartConfig: ChartConfig;
+  dashboardFilters: DashboardFiltersConfig | undefined;
   components: Component[];
   showVisualizeLink?: boolean;
 }) => {
@@ -89,6 +92,7 @@ export const ChartFootnotes = ({
           <ChartFiltersList
             dataSource={dataSource}
             chartConfig={chartConfig}
+            dashboardFilters={dashboardFilters}
             components={components}
             cubeIri={metadata.iri}
           />

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -89,9 +89,10 @@ export const ChartPreview = (props: ChartPreviewProps) => {
     // we switch tabs in the configurator, otherwise we end up with the wrong
     // data in the downstream hooks (useDataCubesMetadataQuery, etc.)
     <>
-      {state.state !== "CONFIGURING_CHART" ? (
+      {!isConfiguring(state) ? (
         <DashboardInteractiveFilters
           key={state.chartConfigs.map((x) => x.key).join(",")}
+          sx={{ mb: 4 }}
         />
       ) : null}
       <ChartTablePreviewProvider key={state.activeChartKey}>
@@ -531,6 +532,7 @@ const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
                   <ChartControls
                     dataSource={dataSource}
                     chartConfig={chartConfig}
+                    dashboardFilters={state.dashboardFilters}
                     metadataPanelProps={{
                       components: allComponents,
                       top: BANNER_MARGIN_TOP,
@@ -549,6 +551,7 @@ const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
                       <DataSetTable
                         dataSource={dataSource}
                         chartConfig={chartConfig}
+                        dashboardFilters={state.dashboardFilters}
                         sx={{ width: "100%", maxHeight: "100%" }}
                       />
                     ) : (
@@ -556,12 +559,14 @@ const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
                         dataSource={dataSource}
                         componentIris={componentIris}
                         chartConfig={chartConfig}
+                        dashboardFilters={state.dashboardFilters}
                       />
                     )}
                   </div>
                   <ChartFootnotes
                     dataSource={dataSource}
                     chartConfig={chartConfig}
+                    dashboardFilters={state.dashboardFilters}
                     components={allComponents}
                   />
                   {/* Wrap in div for subgrid layout */}

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -79,32 +79,39 @@ export const ChartPreview = (props: ChartPreviewProps) => {
   const [state] = useConfiguratorState(hasChartConfigs);
   const editing = isConfiguring(state);
   const { layout } = state;
+  const metadataPanelStore = useMemo(() => {
+    return createMetadataPanelStore();
+  }, []);
 
-  return layout.type === "dashboard" && !editing ? (
-    <DashboardPreview dataSource={dataSource} layoutType={layout.layout} />
-  ) : layout.type === "singleURLs" && !editing ? (
-    <SingleURLsPreview dataSource={dataSource} layout={layout} />
-  ) : (
-    // Important to keep the key here to force re-rendering of the chart when
-    // we switch tabs in the configurator, otherwise we end up with the wrong
-    // data in the downstream hooks (useDataCubesMetadataQuery, etc.)
-    <>
-      {!isConfiguring(state) ? (
-        <DashboardInteractiveFilters
-          key={state.chartConfigs.map((x) => x.key).join(",")}
-          sx={{ mb: 4 }}
-        />
-      ) : null}
-      <ChartTablePreviewProvider key={state.activeChartKey}>
-        <ChartWrapper
-          editing={editing}
-          layoutType={layout.type}
-          chartKey={state.activeChartKey}
-        >
-          <ChartPreviewInner dataSource={dataSource} />
-        </ChartWrapper>
-      </ChartTablePreviewProvider>
-    </>
+  return (
+    <MetadataPanelStoreContext.Provider value={metadataPanelStore}>
+      {layout.type === "dashboard" && !editing ? (
+        <DashboardPreview dataSource={dataSource} layoutType={layout.layout} />
+      ) : layout.type === "singleURLs" && !editing ? (
+        <SingleURLsPreview dataSource={dataSource} layout={layout} />
+      ) : (
+        // Important to keep the key here to force re-rendering of the chart when
+        // we switch tabs in the configurator, otherwise we end up with the wrong
+        // data in the downstream hooks (useDataCubesMetadataQuery, etc.)
+        <>
+          {!isConfiguring(state) ? (
+            <DashboardInteractiveFilters
+              key={state.chartConfigs.map((x) => x.key).join(",")}
+              sx={{ mb: 4 }}
+            />
+          ) : null}
+          <ChartTablePreviewProvider key={state.activeChartKey}>
+            <ChartWrapper
+              editing={editing}
+              layoutType={layout.type}
+              chartKey={state.activeChartKey}
+            >
+              <ChartPreviewInner dataSource={dataSource} />
+            </ChartWrapper>
+          </ChartTablePreviewProvider>
+        </>
+      )}
+    </MetadataPanelStoreContext.Provider>
   );
 };
 
@@ -425,86 +432,47 @@ const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
 
     return [...dimensions, ...measures];
   }, [dimensions, measures]);
-  const metadataPanelStore = useMemo(() => {
-    return createMetadataPanelStore();
-  }, []);
 
   return (
-    <MetadataPanelStoreContext.Provider value={metadataPanelStore}>
-      <Box className={chartClasses.root}>
-        {props.children}
-        <ChartErrorBoundary resetKeys={[state]}>
-          {hasChartConfigs(state) && (
-            <>
-              <Head>
-                <title key="title">
-                  {!chartConfig.meta.title[locale]
-                    ? // FIXME: adapt to design
-                      metadata?.dataCubesMetadata.map((d) => d.title).join(", ")
-                    : chartConfig.meta.title[locale]}{" "}
-                  - visualize.admin.ch
-                </title>
-              </Head>
-              <LoadingStateProvider>
-                <InteractiveFiltersChartProvider
-                  chartConfigKey={chartConfig.key}
+    <Box className={chartClasses.root}>
+      {props.children}
+      <ChartErrorBoundary resetKeys={[state]}>
+        {hasChartConfigs(state) && (
+          <>
+            <Head>
+              <title key="title">
+                {!chartConfig.meta.title[locale]
+                  ? // FIXME: adapt to design
+                    metadata?.dataCubesMetadata.map((d) => d.title).join(", ")
+                  : chartConfig.meta.title[locale]}{" "}
+                - visualize.admin.ch
+              </title>
+            </Head>
+            <LoadingStateProvider>
+              <InteractiveFiltersChartProvider chartConfigKey={chartConfig.key}>
+                <Flex
+                  sx={{
+                    height: "fit-content",
+                    justifyContent:
+                      configuring || chartConfig.meta.title[locale]
+                        ? "space-between"
+                        : "flex-end",
+                    alignItems: "flex-start",
+                    gap: 2,
+                  }}
                 >
-                  <Flex
-                    sx={{
-                      height: "fit-content",
-                      justifyContent:
-                        configuring || chartConfig.meta.title[locale]
-                          ? "space-between"
-                          : "flex-end",
-                      alignItems: "flex-start",
-                      gap: 2,
-                    }}
-                  >
-                    {configuring || chartConfig.meta.title[locale] ? (
-                      <Title
-                        text={chartConfig.meta.title[locale]}
-                        lighterColor
-                        smaller={state.layout.type === "dashboard"}
-                        onClick={
-                          configuring
-                            ? () =>
-                                dispatch({
-                                  type: "CHART_ACTIVE_FIELD_CHANGED",
-                                  value: "title",
-                                })
-                            : undefined
-                        }
-                      />
-                    ) : (
-                      // We need to have a span here to keep the space between the
-                      // title and the chart (subgrid layout)
-                      <span style={{ height: 1 }} />
-                    )}
-                    <Box
-                      sx={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: 2,
-                        mt: "-0.33rem",
-                      }}
-                    >
-                      <ChartMoreButton chartKey={chartConfig.key} />
-                      {actionElementSlot}
-                    </Box>
-                  </Flex>
-                  {configuring || chartConfig.meta.description[locale] ? (
-                    <Description
-                      text={chartConfig.meta.description[locale]}
+                  {configuring || chartConfig.meta.title[locale] ? (
+                    <Title
+                      text={chartConfig.meta.title[locale]}
                       lighterColor
                       smaller={state.layout.type === "dashboard"}
                       onClick={
                         configuring
-                          ? () => {
+                          ? () =>
                               dispatch({
                                 type: "CHART_ACTIVE_FIELD_CHANGED",
-                                value: "description",
-                              });
-                            }
+                                value: "title",
+                              })
                           : undefined
                       }
                     />
@@ -513,72 +481,104 @@ const ChartPreviewInner = (props: ChartPreviewInnerProps) => {
                     // title and the chart (subgrid layout)
                     <span style={{ height: 1 }} />
                   )}
-                  <Box sx={{ mt: 4 }}>
-                    {metadata?.dataCubesMetadata.some(
-                      (d) =>
-                        d.publicationStatus === DataCubePublicationStatus.Draft
-                    ) && (
-                      <Box sx={{ mb: 4 }}>
-                        <HintYellow>
-                          <Trans id="dataset.publicationStatus.draft.warning">
-                            Careful, this dataset is only a draft.
-                            <br />
-                            <strong>Don&apos;t use for reporting!</strong>
-                          </Trans>
-                        </HintYellow>
-                      </Box>
-                    )}
-                  </Box>
-                  <ChartControls
-                    dataSource={dataSource}
-                    chartConfig={chartConfig}
-                    dashboardFilters={state.dashboardFilters}
-                    metadataPanelProps={{
-                      components: allComponents,
-                      top: BANNER_MARGIN_TOP,
-                    }}
-                  />
-                  <div
-                    ref={containerRef}
-                    style={{
-                      minWidth: 0,
-                      height: containerHeight,
-                      paddingTop: 16,
-                      flexGrow: 1,
+                  <Box
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 2,
+                      mt: "-0.33rem",
                     }}
                   >
-                    {isTable ? (
-                      <DataSetTable
-                        dataSource={dataSource}
-                        chartConfig={chartConfig}
-                        dashboardFilters={state.dashboardFilters}
-                        sx={{ width: "100%", maxHeight: "100%" }}
-                      />
-                    ) : (
-                      <ChartWithFilters
-                        dataSource={dataSource}
-                        componentIris={componentIris}
-                        chartConfig={chartConfig}
-                        dashboardFilters={state.dashboardFilters}
-                      />
-                    )}
-                  </div>
-                  <ChartFootnotes
-                    dataSource={dataSource}
-                    chartConfig={chartConfig}
-                    dashboardFilters={state.dashboardFilters}
-                    components={allComponents}
+                    <ChartMoreButton chartKey={chartConfig.key} />
+                    {actionElementSlot}
+                  </Box>
+                </Flex>
+                {configuring || chartConfig.meta.description[locale] ? (
+                  <Description
+                    text={chartConfig.meta.description[locale]}
+                    lighterColor
+                    smaller={state.layout.type === "dashboard"}
+                    onClick={
+                      configuring
+                        ? () => {
+                            dispatch({
+                              type: "CHART_ACTIVE_FIELD_CHANGED",
+                              value: "description",
+                            });
+                          }
+                        : undefined
+                    }
                   />
-                  {/* Wrap in div for subgrid layout */}
-                  <div className="debug-panel">
-                    <DebugPanel configurator interactiveFilters />
-                  </div>
-                </InteractiveFiltersChartProvider>
-              </LoadingStateProvider>
-            </>
-          )}
-        </ChartErrorBoundary>
-      </Box>
-    </MetadataPanelStoreContext.Provider>
+                ) : (
+                  // We need to have a span here to keep the space between the
+                  // title and the chart (subgrid layout)
+                  <span style={{ height: 1 }} />
+                )}
+                <Box sx={{ mt: 4 }}>
+                  {metadata?.dataCubesMetadata.some(
+                    (d) =>
+                      d.publicationStatus === DataCubePublicationStatus.Draft
+                  ) && (
+                    <Box sx={{ mb: 4 }}>
+                      <HintYellow>
+                        <Trans id="dataset.publicationStatus.draft.warning">
+                          Careful, this dataset is only a draft.
+                          <br />
+                          <strong>Don&apos;t use for reporting!</strong>
+                        </Trans>
+                      </HintYellow>
+                    </Box>
+                  )}
+                </Box>
+                <ChartControls
+                  dataSource={dataSource}
+                  chartConfig={chartConfig}
+                  dashboardFilters={state.dashboardFilters}
+                  metadataPanelProps={{
+                    components: allComponents,
+                    top: BANNER_MARGIN_TOP,
+                  }}
+                />
+                <div
+                  ref={containerRef}
+                  style={{
+                    minWidth: 0,
+                    height: containerHeight,
+                    paddingTop: 16,
+                    flexGrow: 1,
+                  }}
+                >
+                  {isTable ? (
+                    <DataSetTable
+                      dataSource={dataSource}
+                      chartConfig={chartConfig}
+                      dashboardFilters={state.dashboardFilters}
+                      sx={{ width: "100%", maxHeight: "100%" }}
+                    />
+                  ) : (
+                    <ChartWithFilters
+                      dataSource={dataSource}
+                      componentIris={componentIris}
+                      chartConfig={chartConfig}
+                      dashboardFilters={state.dashboardFilters}
+                    />
+                  )}
+                </div>
+                <ChartFootnotes
+                  dataSource={dataSource}
+                  chartConfig={chartConfig}
+                  dashboardFilters={state.dashboardFilters}
+                  components={allComponents}
+                />
+                {/* Wrap in div for subgrid layout */}
+                <div className="debug-panel">
+                  <DebugPanel configurator interactiveFilters />
+                </div>
+              </InteractiveFiltersChartProvider>
+            </LoadingStateProvider>
+          </>
+        )}
+      </ChartErrorBoundary>
+    </Box>
   );
 };

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -11,8 +11,8 @@ import { Box } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import Head from "next/head";
 import React, {
-  ReactNode,
   forwardRef,
+  ReactNode,
   useCallback,
   useMemo,
   useState,
@@ -45,17 +45,17 @@ import Flex from "@/components/flex";
 import { Checkbox } from "@/components/form";
 import { HintYellow } from "@/components/hint";
 import {
-  MetadataPanelStoreContext,
   createMetadataPanelStore,
+  MetadataPanelStoreContext,
 } from "@/components/metadata-panel-store";
 import { BANNER_MARGIN_TOP } from "@/components/presence";
 import {
   ChartConfig,
   DataSource,
-  Layout,
   getChartConfig,
   hasChartConfigs,
   isConfiguring,
+  Layout,
   useConfiguratorState,
 } from "@/configurator";
 import { Description, Title } from "@/configurator/components/annotators";

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -152,7 +152,7 @@ export const ChartPublished = (props: ChartPublishedProps) => {
             )}
           </Flex>
           <ChartTablePreviewProvider>
-            <DashboardInteractiveFilters />
+            <DashboardInteractiveFilters sx={{ mb: 4 }} />
             <ChartWrapper
               layoutType={state.layout.type}
               chartKey={state.activeChartKey}
@@ -365,6 +365,7 @@ const ChartPublishedInnerImpl = (props: ChartPublishInnerProps) => {
               <ChartControls
                 dataSource={dataSource}
                 chartConfig={chartConfig}
+                dashboardFilters={state.dashboardFilters}
                 metadataPanelProps={{
                   components: allComponents,
                   container: rootRef.current,
@@ -386,6 +387,7 @@ const ChartPublishedInnerImpl = (props: ChartPublishInnerProps) => {
                   <DataSetTable
                     dataSource={dataSource}
                     chartConfig={chartConfig}
+                    dashboardFilters={state.dashboardFilters}
                     sx={{ maxHeight: "100%" }}
                   />
                 ) : (
@@ -393,12 +395,14 @@ const ChartPublishedInnerImpl = (props: ChartPublishInnerProps) => {
                     dataSource={dataSource}
                     componentIris={componentIris}
                     chartConfig={chartConfig}
+                    dashboardFilters={state.dashboardFilters}
                   />
                 )}
               </div>
               <ChartFootnotes
                 dataSource={dataSource}
                 chartConfig={chartConfig}
+                dashboardFilters={state.dashboardFilters}
                 components={allComponents}
                 showVisualizeLink={state.chartConfigs.length === 1}
               />

--- a/app/components/chart-shared.tsx
+++ b/app/components/chart-shared.tsx
@@ -15,6 +15,7 @@ import { MenuActionItem } from "@/components/menu-action-item";
 import { MetadataPanel } from "@/components/metadata-panel";
 import {
   ChartConfig,
+  DashboardFiltersConfig,
   DataSource,
   getChartConfig,
   hasChartConfigs,
@@ -50,19 +51,27 @@ export const useChartStyles = makeStyles<Theme>((theme) => ({
 export const ChartControls = ({
   dataSource,
   chartConfig,
+  dashboardFilters,
   metadataPanelProps,
 }: {
   dataSource: DataSource;
   chartConfig: ChartConfig;
+  dashboardFilters: DashboardFiltersConfig | undefined;
   metadataPanelProps: Omit<
     ComponentProps<typeof MetadataPanel>,
-    "dataSource" | "chartConfig"
+    "dataSource" | "chartConfig" | "dashboardFilters"
   >;
 }) => {
-  const showFilters = chartConfig.interactiveFiltersConfig?.dataFilters.active;
+  const showFilters =
+    chartConfig.interactiveFiltersConfig?.dataFilters.active &&
+    chartConfig.interactiveFiltersConfig.dataFilters.componentIris.some(
+      (componentIri) =>
+        !dashboardFilters?.dataFilters.componentIris.includes(componentIri)
+    );
   const chartFiltersState = useChartDataFiltersState({
     dataSource,
     chartConfig,
+    dashboardFilters,
   });
   return (
     <Box
@@ -87,6 +96,7 @@ export const ChartControls = ({
         <MetadataPanel
           dataSource={dataSource}
           chartConfig={chartConfig}
+          dashboardFilters={dashboardFilters}
           {...metadataPanelProps}
         />
       </Box>

--- a/app/components/chart-with-filters.tsx
+++ b/app/components/chart-with-filters.tsx
@@ -86,6 +86,7 @@ const GenericChart = (props: GenericChartProps) => {
     dashboardFilters,
     componentIris,
   });
+
   const commonProps = {
     dataSource,
     observationQueryFilters,

--- a/app/components/chart-with-filters.tsx
+++ b/app/components/chart-with-filters.tsx
@@ -5,7 +5,11 @@ import { forwardRef } from "react";
 import { useQueryFilters } from "@/charts/shared/chart-helpers";
 import { Observer } from "@/charts/shared/use-size";
 import useSyncInteractiveFilters from "@/charts/shared/use-sync-interactive-filters";
-import { ChartConfig, DataSource } from "@/configurator";
+import {
+  ChartConfig,
+  DashboardFiltersConfig,
+  DataSource,
+} from "@/configurator";
 
 const ChartAreasVisualization = dynamic(
   import("@/charts/area/chart-area").then(
@@ -72,12 +76,14 @@ type GenericChartProps = {
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: ChartConfig;
+  dashboardFilters: DashboardFiltersConfig | undefined;
 };
 
 const GenericChart = (props: GenericChartProps) => {
-  const { dataSource, componentIris, chartConfig } = props;
+  const { dataSource, componentIris, chartConfig, dashboardFilters } = props;
   const observationQueryFilters = useQueryFilters({
     chartConfig,
+    dashboardFilters,
     componentIris,
   });
   const commonProps = {
@@ -150,6 +156,7 @@ type ChartWithFiltersProps = {
   dataSource: DataSource;
   componentIris: string[] | undefined;
   chartConfig: ChartConfig;
+  dashboardFilters: DashboardFiltersConfig | undefined;
 };
 
 const useStyles = makeStyles(() => ({

--- a/app/components/chart-with-filters.tsx
+++ b/app/components/chart-with-filters.tsx
@@ -170,9 +170,8 @@ export const ChartWithFilters = forwardRef<
   HTMLDivElement,
   ChartWithFiltersProps
 >((props, ref) => {
-  useSyncInteractiveFilters(props.chartConfig);
+  useSyncInteractiveFilters(props.chartConfig, props.dashboardFilters);
   const classes = useStyles();
-
   return (
     <div className={classes.chartWithFilters} ref={ref}>
       <Observer>

--- a/app/components/dashboard-interactive-filters.spec.tsx
+++ b/app/components/dashboard-interactive-filters.spec.tsx
@@ -1,6 +1,9 @@
 import { saveDataFiltersSnapshot } from "@/components/dashboard-interactive-filters";
 import { ChartConfig } from "@/configurator";
-import { InteractiveFiltersContextValue } from "@/stores/interactive-filters";
+import {
+  InteractiveFiltersContextValue,
+  setDataFilter,
+} from "@/stores/interactive-filters";
 
 class MockState<T = unknown> {
   private _state: any;
@@ -54,19 +57,6 @@ test("Save snapshot, modify the store manually, then restore and check result", 
     stores,
     "component1"
   );
-
-  const setDataFilter = (
-    store: InteractiveFiltersContextValue["2"],
-    key: string,
-    value: string
-  ) => {
-    store.setState({
-      dataFilters: {
-        ...store.getState().dataFilters,
-        [key]: { type: "single", value },
-      },
-    });
-  };
 
   // Manually modify the store
   setDataFilter(stores.chart1[2], "component1", "modified filter");

--- a/app/components/dashboard-interactive-filters.spec.tsx
+++ b/app/components/dashboard-interactive-filters.spec.tsx
@@ -1,0 +1,112 @@
+import { saveDataFiltersSnapshot } from "@/components/dashboard-interactive-filters";
+import { ChartConfig } from "@/configurator";
+import { InteractiveFiltersContextValue } from "@/stores/interactive-filters";
+
+class MockState<T = unknown> {
+  private _state: any;
+
+  constructor(state: T) {
+    this._state = state;
+  }
+
+  getState() {
+    return this._state;
+  }
+
+  setState(newState: any) {
+    Object.assign(this._state, newState);
+  }
+}
+const mockDashboardInteractiveFiltersContextValue = <T extends unknown>(
+  state: T
+) => {
+  return [
+    null,
+    null,
+    new MockState(state),
+  ] as unknown as InteractiveFiltersContextValue;
+};
+test("Save snapshot, modify the store manually, then restore and check result", () => {
+  // Mock chartConfigs
+  const chartConfigs: ChartConfig[] = [
+    { key: "chart1" } as ChartConfig,
+    { key: "chart2" } as ChartConfig,
+    { key: "chart3" } as ChartConfig,
+  ];
+
+  // Mock stores
+  const stores = {
+    chart1: mockDashboardInteractiveFiltersContextValue({
+      unrelated: 1,
+      dataFilters: { component1: { type: "single", value: "filter1" } },
+    }),
+    chart2: mockDashboardInteractiveFiltersContextValue({
+      dataFilters: { component2: { type: "single", value: "filter2" } },
+    }),
+    chart3: mockDashboardInteractiveFiltersContextValue({
+      dataFilters: { component3: { type: "single", value: "filter3" } },
+    }),
+  };
+
+  // Save the snapshot
+  const restoreComponent1 = saveDataFiltersSnapshot(
+    chartConfigs,
+    stores,
+    "component1"
+  );
+
+  const setDataFilter = (
+    store: InteractiveFiltersContextValue["2"],
+    key: string,
+    value: string
+  ) => {
+    store.setState({
+      dataFilters: {
+        ...store.getState().dataFilters,
+        [key]: { type: "single", value },
+      },
+    });
+  };
+
+  // Manually modify the store
+  setDataFilter(stores.chart1[2], "component1", "modified filter");
+  setDataFilter(stores.chart1[2], "component2", "modified filter 2");
+
+  const restoreComponent3 = saveDataFiltersSnapshot(
+    chartConfigs,
+    stores,
+    "component3"
+  );
+
+  setDataFilter(stores.chart1[2], "component3", "modified filter 3");
+
+  // Restore the snapshot
+  restoreComponent1();
+
+  // Check if the store is restored correctly
+  expect(stores.chart1[2].getState()).toEqual({
+    unrelated: 1,
+    dataFilters: {
+      // Filter 1 is restored
+      component1: { type: "single", value: "filter1" },
+      // Filter 2 is not restored
+      component2: { type: "single", value: "modified filter 2" },
+      // Filter 3 is not yet restored
+      component3: { type: "single", value: "modified filter 3" },
+    },
+  });
+
+  restoreComponent3();
+
+  // Check if the store is restored correctly
+  expect(stores.chart1[2].getState()).toEqual({
+    unrelated: 1,
+    dataFilters: {
+      // Filter 1 is restored
+      component1: { type: "single", value: "filter1" },
+      // Filter 2 is not restored
+      component2: { type: "single", value: "modified filter 2" },
+      // Filter 3 is not there anymore
+    },
+  });
+});

--- a/app/components/dashboard-interactive-filters.tsx
+++ b/app/components/dashboard-interactive-filters.tsx
@@ -1,8 +1,21 @@
-import { Slider, sliderClasses, useEventCallback } from "@mui/material";
+import {
+  Box,
+  BoxProps,
+  SelectChangeEvent,
+  Slider,
+  sliderClasses,
+  useEventCallback,
+} from "@mui/material";
 import { Theme } from "@mui/material/styles";
 import { makeStyles } from "@mui/styles";
-import { useEffect, useMemo, useState } from "react";
+import uniq from "lodash/uniq";
+import { ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
 
+import {
+  DataFilterGenericDimension,
+  DataFilterHierarchyDimension,
+  DataFilterTemporalDimension,
+} from "@/charts/shared/chart-data-filters";
 import {
   DashboardTimeRangeFilter,
   hasChartConfigs,
@@ -13,18 +26,44 @@ import {
   timeUnitToFormatter,
   timeUnitToParser,
 } from "@/configurator/components/ui-helpers";
+import { isTemporalDimension } from "@/domain/data";
+import { useDataCubesComponentsQuery } from "@/graphql/hooks";
 import { TimeUnit } from "@/graphql/query-hooks";
-import { useDashboardInteractiveFilters } from "@/stores/interactive-filters";
+import { useLocale } from "@/locales/use-locale";
+import {
+  InteractiveFiltersState,
+  useDashboardInteractiveFilters,
+} from "@/stores/interactive-filters";
 import { useTransitionStore } from "@/stores/transition";
 import { assert } from "@/utils/assert";
+import useEvent from "@/utils/use-event";
 
 import { useTimeout } from "../hooks/use-timeout";
 
-const useStyles = makeStyles((theme: Theme) => ({
+export const DashboardInteractiveFilters = (props: BoxProps) => {
+  const [state] = useConfiguratorState(hasChartConfigs);
+  const { dashboardFilters } = state;
+  return (
+    <Box {...props}>
+      {dashboardFilters?.timeRange.active ? (
+        <DashboardTimeRangeSlider
+          filter={dashboardFilters.timeRange}
+          mounted={dashboardFilters.timeRange.active}
+        />
+      ) : null}
+      {dashboardFilters?.dataFilters.componentIris.length ? (
+        <DashboardDataFilters
+          componentIris={dashboardFilters.dataFilters.componentIris}
+        />
+      ) : null}
+    </Box>
+  );
+};
+
+const useTimeRangeRangeStyles = makeStyles((theme: Theme) => ({
   slider: {
     maxWidth: 800,
     margin: theme.spacing(6, 4, 2),
-
     [`& .${sliderClasses.track}`]: {
       height: 1,
     },
@@ -75,7 +114,7 @@ const DashboardTimeRangeSlider = ({
   filter: DashboardTimeRangeFilter;
   mounted: boolean;
 }) => {
-  const classes = useStyles();
+  const classes = useTimeRangeRangeStyles();
   const dashboardInteractiveFilters = useDashboardInteractiveFilters();
   const setEnableTransition = useTransitionStore((state) => state.setEnable);
   const presets = filter.presets;
@@ -177,20 +216,6 @@ const DashboardTimeRangeSlider = ({
   );
 };
 
-export const DashboardInteractiveFilters = () => {
-  const [{ dashboardFilters }] = useConfiguratorState(hasChartConfigs);
-  return (
-    <div>
-      {dashboardFilters?.timeRange.active ? (
-        <DashboardTimeRangeSlider
-          filter={dashboardFilters.timeRange}
-          mounted={dashboardFilters.timeRange.active}
-        />
-      ) : null}
-    </div>
-  );
-};
-
 function stepFromTimeUnit(timeUnit: TimeUnit | undefined) {
   if (!timeUnit) {
     return 0;
@@ -213,3 +238,180 @@ function stepFromTimeUnit(timeUnit: TimeUnit | undefined) {
       return 1;
   }
 }
+
+const useDataFilterStyles = makeStyles((theme: Theme) => ({
+  wrapper: {
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
+    gap: theme.spacing(2),
+  },
+  filter: {
+    display: "flex",
+    flex: "1 1 100%",
+    width: "100%",
+    marginRight: theme.spacing(3),
+    "&:last-of-type": {
+      marginRight: 0,
+    },
+    "& > div": {
+      width: "100%",
+    },
+  },
+}));
+
+const DashboardDataFilters = ({
+  componentIris,
+}: {
+  componentIris: string[];
+}) => {
+  const classes = useDataFilterStyles();
+  return (
+    <div className={classes.wrapper}>
+      {componentIris.map((componentIri) => (
+        <DataFilter key={componentIri} componentIri={componentIri} />
+      ))}
+    </div>
+  );
+};
+
+const DataFilter = ({ componentIri }: { componentIri: string }) => {
+  const locale = useLocale();
+  const classes = useDataFilterStyles();
+  const [state] = useConfiguratorState(hasChartConfigs);
+  const dashboardInteractiveFilters = useDashboardInteractiveFilters();
+  const chartConfigs = state.chartConfigs.filter((config) =>
+    config.cubes.some((cube) =>
+      Object.keys(cube.filters).includes(componentIri)
+    )
+  );
+  const cubeIris = uniq(
+    state.chartConfigs.flatMap((config) =>
+      config.cubes
+        .filter((cube) => Object.keys(cube.filters).includes(componentIri))
+        .map((cube) => cube.iri)
+    )
+  );
+
+  if (cubeIris.length > 1) {
+    console.error(
+      `Data filter ${componentIri} is used in multiple cubes: ${cubeIris.join(", ")}`
+    );
+  }
+
+  const cubeIri = cubeIris[0];
+
+  const [{ data }] = useDataCubesComponentsQuery({
+    variables: {
+      sourceType: state.dataSource.type,
+      sourceUrl: state.dataSource.url,
+      locale,
+      cubeFilters: [
+        { iri: cubeIri, componentIris: [componentIri], loadValues: true },
+      ],
+    },
+    keepPreviousData: true,
+  });
+
+  const dimension = data?.dataCubesComponents.dimensions[0];
+
+  const [value, setValue] = useState<string>();
+  const handleChange = useEvent(
+    (
+      e:
+        | SelectChangeEvent<unknown>
+        | ChangeEvent<HTMLSelectElement>
+        | { target: { value: string } }
+    ) => {
+      const newValue = e.target.value as string;
+      setValue(newValue);
+
+      for (const [chartKey, [_getState, _useStore, store]] of Object.entries(
+        dashboardInteractiveFilters.stores
+      )) {
+        if (chartConfigs.map((config) => config.key).includes(chartKey)) {
+          store.setState({
+            dataFilters: {
+              ...store.getState().dataFilters,
+              [componentIri]: {
+                type: "single",
+                value: newValue,
+              },
+            },
+          });
+        }
+      }
+    }
+  );
+
+  // Store the state of the stores to restore it when the component is unmounted
+  const storesRef = useRef<{ [chartKey: string]: InteractiveFiltersState }>();
+  useEffect(() => {
+    storesRef.current = Object.fromEntries(
+      Object.entries(dashboardInteractiveFilters.stores).map(
+        ([key, [_getState, _useStore, store]]) => {
+          return [key, store.getState()];
+        }
+      )
+    );
+
+    if (dimension?.values.length) {
+      handleChange({
+        target: { value: dimension.values[0].value as string },
+      } as ChangeEvent<HTMLSelectElement>);
+    }
+
+    const storesRefCurrent = storesRef.current;
+
+    return () => {
+      for (const [chartKey, [_getState, _useStore, store]] of Object.entries(
+        dashboardInteractiveFilters.stores
+      )) {
+        if (chartConfigs.map((config) => config.key).includes(chartKey)) {
+          const dataFilters = store.getState().dataFilters;
+          const refStore = storesRefCurrent[chartKey];
+          if (refStore) {
+            const refDataFilters = refStore.dataFilters;
+            if (refDataFilters[componentIri]) {
+              dataFilters[componentIri] = refDataFilters[componentIri];
+              store.setState({ dataFilters });
+            } else {
+              delete dataFilters[componentIri];
+              store.setState({ dataFilters });
+            }
+          }
+        }
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dimension]);
+  const disabled = !dimension?.values.length;
+  const hierarchy = dimension?.hierarchy;
+
+  return dimension && value ? (
+    <div className={classes.filter}>
+      {isTemporalDimension(dimension) ? (
+        <DataFilterTemporalDimension
+          value={value}
+          dimension={dimension}
+          onChange={handleChange}
+          disabled={disabled}
+        />
+      ) : hierarchy ? (
+        <DataFilterHierarchyDimension
+          value={value}
+          dimension={dimension}
+          onChange={handleChange}
+          hierarchy={hierarchy}
+          disabled={disabled}
+        />
+      ) : (
+        <DataFilterGenericDimension
+          value={value}
+          dimension={dimension}
+          onChange={handleChange}
+          disabled={disabled}
+        />
+      )}
+    </div>
+  ) : null;
+};

--- a/app/components/dashboard-interactive-filters.tsx
+++ b/app/components/dashboard-interactive-filters.tsx
@@ -1,16 +1,13 @@
-import {
-  Collapse,
-  Slider,
-  sliderClasses,
-  useEventCallback,
-} from "@mui/material";
+import { Slider, sliderClasses, useEventCallback } from "@mui/material";
 import { Theme } from "@mui/material/styles";
 import { makeStyles } from "@mui/styles";
 import { useEffect, useMemo, useState } from "react";
 
 import {
   DashboardTimeRangeFilter,
+  hasChartConfigs,
   InteractiveFiltersTimeRange,
+  useConfiguratorState,
 } from "@/configurator";
 import {
   timeUnitToFormatter,
@@ -181,17 +178,17 @@ const DashboardTimeRangeSlider = ({
 };
 
 export const DashboardInteractiveFilters = () => {
-  const { timeRange } = useDashboardInteractiveFilters();
-  return timeRange?.active ? (
-    <Collapse in={timeRange.active}>
-      <div>
+  const [{ dashboardFilters }] = useConfiguratorState(hasChartConfigs);
+  return (
+    <div>
+      {dashboardFilters?.timeRange.active ? (
         <DashboardTimeRangeSlider
-          filter={timeRange}
-          mounted={timeRange.active}
+          filter={dashboardFilters.timeRange}
+          mounted={dashboardFilters.timeRange.active}
         />
-      </div>
-    </Collapse>
-  ) : null;
+      ) : null}
+    </div>
+  );
 };
 
 function stepFromTimeUnit(timeUnit: TimeUnit | undefined) {

--- a/app/components/dashboard-interactive-filters.tsx
+++ b/app/components/dashboard-interactive-filters.tsx
@@ -375,7 +375,7 @@ const DataFilter = ({ componentIri }: { componentIri: string }) => {
     }
   );
 
-  // Sync the interactive filter value with the config value
+  // Syncs the interactive filter value with the config value
   useEffect(() => {
     const value = dashboardFilters?.dataFilters.filters[componentIri].value as
       | string

--- a/app/components/dashboard-interactive-filters.tsx
+++ b/app/components/dashboard-interactive-filters.tsx
@@ -383,7 +383,7 @@ const DataFilter = ({ componentIri }: { componentIri: string }) => {
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dimension]);
+  }, [dimension?.values]);
   const disabled = !dimension?.values.length;
   const hierarchy = dimension?.hierarchy;
 

--- a/app/components/dashboard-interactive-filters.tsx
+++ b/app/components/dashboard-interactive-filters.tsx
@@ -257,9 +257,11 @@ const useDataFilterStyles = makeStyles((theme: Theme) => ({
   },
 }));
 
-type Stores = ReturnType<typeof useDashboardInteractiveFilters>["stores"];
+export type Stores = ReturnType<
+  typeof useDashboardInteractiveFilters
+>["stores"];
 
-const saveDataFiltersSnapshot = (
+export const saveDataFiltersSnapshot = (
   chartConfigs: ChartConfig[],
   stores: Stores,
   componentIri: string

--- a/app/components/dashboard-interactive-filters.tsx
+++ b/app/components/dashboard-interactive-filters.tsx
@@ -31,7 +31,10 @@ import { isTemporalDimension } from "@/domain/data";
 import { useDataCubesComponentsQuery } from "@/graphql/hooks";
 import { TimeUnit } from "@/graphql/query-hooks";
 import { useLocale } from "@/locales/use-locale";
-import { useDashboardInteractiveFilters } from "@/stores/interactive-filters";
+import {
+  setDataFilter,
+  useDashboardInteractiveFilters,
+} from "@/stores/interactive-filters";
 import { useTransitionStore } from "@/stores/transition";
 import { assert } from "@/utils/assert";
 import useEvent from "@/utils/use-event";
@@ -366,15 +369,7 @@ const DataFilter = ({ componentIri }: { componentIri: string }) => {
         if (
           relevantChartConfigs.map((config) => config.key).includes(chartKey)
         ) {
-          store.setState({
-            dataFilters: {
-              ...store.getState().dataFilters,
-              [componentIri]: {
-                type: "single",
-                value: newValue,
-              },
-            },
-          });
+          setDataFilter(store, componentIri, newValue);
         }
       }
     }

--- a/app/components/metadata-panel.tsx
+++ b/app/components/metadata-panel.tsx
@@ -45,7 +45,12 @@ import {
   useMetadataPanelStoreActions,
 } from "@/components/metadata-panel-store";
 import { MotionBox } from "@/components/presence";
-import { BackButton, ChartConfig, DataSource } from "@/configurator";
+import {
+  BackButton,
+  ChartConfig,
+  DashboardFiltersConfig,
+  DataSource,
+} from "@/configurator";
 import { DRAWER_WIDTH } from "@/configurator/components/drawer";
 import {
   getComponentDescription,
@@ -229,6 +234,7 @@ export const OpenMetadataPanelWrapper = ({
 
 export const MetadataPanel = ({
   chartConfig,
+  dashboardFilters,
   dataSource,
   components,
   container,
@@ -237,6 +243,7 @@ export const MetadataPanel = ({
   renderToggle = true,
 }: {
   chartConfig: ChartConfig;
+  dashboardFilters: DashboardFiltersConfig | undefined;
   dataSource: DataSource;
   components: Component[];
   container?: HTMLDivElement | null;
@@ -327,7 +334,11 @@ export const MetadataPanel = ({
           <AnimatePresence>
             {activeSection === "general" ? (
               <MotionBox key="cubes-panel" {...animationProps}>
-                <CubesPanel dataSource={dataSource} chartConfig={chartConfig} />
+                <CubesPanel
+                  dataSource={dataSource}
+                  chartConfig={chartConfig}
+                  dashboardFilters={dashboardFilters}
+                />
               </MotionBox>
             ) : activeSection === "data" ? (
               <MotionBox key="data-panel" {...animationProps}>
@@ -380,9 +391,11 @@ const Header = ({ onClose }: { onClose: () => void }) => {
 const CubesPanel = ({
   dataSource,
   chartConfig,
+  dashboardFilters,
 }: {
   dataSource: DataSource;
   chartConfig: ChartConfig;
+  dashboardFilters: DashboardFiltersConfig | undefined;
 }) => {
   const classes = useOtherStyles();
   const locale = useLocale();
@@ -404,6 +417,7 @@ const CubesPanel = ({
   const cubesMetadata = dataCubesMetadataData?.dataCubesMetadata;
   const queryFilters = useQueryFilters({
     chartConfig,
+    dashboardFilters,
     componentIris: extractChartConfigComponentIris({ chartConfig }),
   });
   const [

--- a/app/components/select-tree.tsx
+++ b/app/components/select-tree.tsx
@@ -269,7 +269,7 @@ export type SelectTreeProps = {
   value: NodeId | undefined;
   topControls?: React.ReactNode;
   sideControls?: React.ReactNode;
-  onChange: (ev: { target: { value: NodeId } }) => void;
+  onChange: (e: { target: { value: NodeId } }) => void;
   disabled?: boolean;
   label?: React.ReactNode;
   onOpen?: () => void;

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -1168,6 +1168,12 @@ const DashboardFiltersConfig = t.type({
 });
 export type DashboardFiltersConfig = t.TypeOf<typeof DashboardFiltersConfig>;
 
+export const areDataFiltersActive = (
+  dashboardFilters: DashboardFiltersConfig | undefined
+) => {
+  return dashboardFilters?.dataFilters.componentIris.length;
+};
+
 const Config = t.intersection([
   t.type(
     {

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -1155,7 +1155,6 @@ export type DashboardTimeRangeFilter = t.TypeOf<
 >;
 
 const DashboardDataFiltersConfig = t.type({
-  active: t.boolean,
   componentIris: t.array(t.string),
 });
 export type DashboardDataFiltersConfig = t.TypeOf<

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -1150,13 +1150,21 @@ const DashboardTimeRangeFilter = t.type({
     to: t.string,
   }),
 });
-
 export type DashboardTimeRangeFilter = t.TypeOf<
   typeof DashboardTimeRangeFilter
 >;
 
+const DashboardDataFiltersConfig = t.type({
+  active: t.boolean,
+  componentIris: t.array(t.string),
+});
+export type DashboardDataFiltersConfig = t.TypeOf<
+  typeof DashboardDataFiltersConfig
+>;
+
 const DashboardFiltersConfig = t.type({
   timeRange: DashboardTimeRangeFilter,
+  dataFilters: DashboardDataFiltersConfig,
 });
 export type DashboardFiltersConfig = t.TypeOf<typeof DashboardFiltersConfig>;
 

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -1156,6 +1156,7 @@ export type DashboardTimeRangeFilter = t.TypeOf<
 
 const DashboardDataFiltersConfig = t.type({
   componentIris: t.array(t.string),
+  filters: SingleFilters,
 });
 export type DashboardDataFiltersConfig = t.TypeOf<
   typeof DashboardDataFiltersConfig

--- a/app/configurator/components/add-dataset-dialog.mock.ts
+++ b/app/configurator/components/add-dataset-dialog.mock.ts
@@ -111,6 +111,7 @@ export const photovoltaikChartStateMock: ConfiguratorStateConfiguringChart = {
     },
     dataFilters: {
       componentIris: [],
+      filters: {},
     },
   },
 };

--- a/app/configurator/components/add-dataset-dialog.mock.ts
+++ b/app/configurator/components/add-dataset-dialog.mock.ts
@@ -109,5 +109,9 @@ export const photovoltaikChartStateMock: ConfiguratorStateConfiguringChart = {
         to: "",
       },
     },
+    dataFilters: {
+      active: false,
+      componentIris: [],
+    },
   },
 };

--- a/app/configurator/components/add-dataset-dialog.mock.ts
+++ b/app/configurator/components/add-dataset-dialog.mock.ts
@@ -110,7 +110,6 @@ export const photovoltaikChartStateMock: ConfiguratorStateConfiguringChart = {
       },
     },
     dataFilters: {
-      active: false,
       componentIris: [],
     },
   },

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -40,6 +40,7 @@ import {
   ChartConfig,
   ConfiguratorStateConfiguringChart,
   ConfiguratorStatePublishing,
+  DashboardFiltersConfig,
   DataSource,
   Filters,
   getChartConfig,
@@ -629,6 +630,7 @@ export const ChartConfigurator = ({
           <ChartFields
             dataSource={state.dataSource}
             chartConfig={chartConfig}
+            dashboardFilters={state.dashboardFilters}
             dimensions={dimensions}
             measures={measures}
           />
@@ -755,6 +757,7 @@ export const ChartConfigurator = ({
       <MetadataPanel
         dataSource={state.dataSource}
         chartConfig={chartConfig}
+        dashboardFilters={state.dashboardFilters}
         components={components}
         top={HEADER_HEIGHT}
         renderToggle={false}
@@ -766,14 +769,16 @@ export const ChartConfigurator = ({
 type ChartFieldsProps = {
   dataSource: DataSource;
   chartConfig: ChartConfig;
+  dashboardFilters: DashboardFiltersConfig | undefined;
   dimensions?: Dimension[];
   measures?: Measure[];
 };
 
 const ChartFields = (props: ChartFieldsProps) => {
-  const { dataSource, chartConfig, dimensions, measures } = props;
+  const { dataSource, chartConfig, dashboardFilters, dimensions, measures } =
+    props;
   const components = [...(dimensions ?? []), ...(measures ?? [])];
-  const queryFilters = useQueryFilters({ chartConfig });
+  const queryFilters = useQueryFilters({ chartConfig, dashboardFilters });
   const locale = useLocale();
   const [{ data: observationsData }] = useDataCubesObservationsQuery({
     variables: {

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -99,24 +99,23 @@ import useEvent from "@/utils/use-event";
 import { FiltersBadge } from "./badges";
 import { DatasetsControlSection } from "./dataset-control-section";
 
-type DataFilterSelectGenericProps = {
+export const DataFilterSelectGeneric = ({
+  rawDimension,
+  filterDimensionIris,
+  index,
+  disabled,
+  onRemove,
+  sideControls,
+  disableLabel,
+}: {
   rawDimension: Dimension;
   filterDimensionIris: string[];
   index: number;
   disabled?: boolean;
-  onRemove: () => void;
+  onRemove?: () => void;
   sideControls?: React.ReactNode;
-};
-
-const DataFilterSelectGeneric = (props: DataFilterSelectGenericProps) => {
-  const {
-    rawDimension,
-    filterDimensionIris,
-    index,
-    disabled,
-    onRemove,
-    sideControls,
-  } = props;
+  disableLabel?: boolean;
+}) => {
   const locale = useLocale();
   const [state] = useConfiguratorState();
   const chartConfig = getChartConfig(state);
@@ -157,7 +156,7 @@ const DataFilterSelectGeneric = (props: DataFilterSelectGenericProps) => {
 
   const sharedProps = {
     dimension,
-    label: (
+    label: disableLabel ? null : (
       <OpenMetadataPanelWrapper component={dimension}>
         <span>{`${index + 1}. ${dimension.label}`}</span>
       </OpenMetadataPanelWrapper>
@@ -423,7 +422,7 @@ const useFilterReorder = ({
     onAddDimensionFilter?.();
     const filterValue = dimension.values[0];
     dispatch({
-      type: "CHART_CONFIG_FILTER_SET_SINGLE",
+      type: "FILTER_SET_SINGLE",
       value: {
         filters: dimensionToFieldProps(dimension),
         value: `${filterValue.value}`,
@@ -433,7 +432,7 @@ const useFilterReorder = ({
 
   const handleRemoveDimensionFilter = useEvent((dimension: Dimension) => {
     dispatch({
-      type: "CHART_CONFIG_FILTER_REMOVE_SINGLE",
+      type: "FILTER_REMOVE_SINGLE",
       value: {
         filters: dimensionToFieldProps(dimension),
       },

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -121,7 +121,10 @@ export const ChartOptionsSelector = ({
     });
   const dimensions = componentsData?.dataCubesComponents.dimensions;
   const measures = componentsData?.dataCubesComponents.measures;
-  const queryFilters = useQueryFilters({ chartConfig });
+  const queryFilters = useQueryFilters({
+    chartConfig,
+    dashboardFilters: state.dashboardFilters,
+  });
   const [{ data: observationsData, fetching: fetchingObservations }] =
     useDataCubesObservationsQuery({
       variables: {

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -335,16 +335,6 @@ export const MostRecentDateSwitch = (props: MostRecentDateSwitchProps) => {
   );
 };
 
-type DataFilterTemporalProps = {
-  label: React.ReactNode;
-  dimension: TemporalDimension;
-  timeUnit: DatePickerTimeUnit;
-  disabled?: boolean;
-  isOptional?: boolean;
-  topControls?: React.ReactNode;
-  sideControls?: React.ReactNode;
-};
-
 export const dimensionToFieldProps = (dim: Component) => {
   return isJoinByComponent(dim)
     ? dim.originalIris.map((o) => pick(o, ["cubeIri", "dimensionIri"]))
@@ -356,16 +346,23 @@ export const dimensionToFieldProps = (dim: Component) => {
       ];
 };
 
-export const DataFilterTemporal = (props: DataFilterTemporalProps) => {
-  const {
-    label: _label,
-    dimension,
-    timeUnit,
-    disabled,
-    isOptional,
-    topControls,
-    sideControls,
-  } = props;
+export const DataFilterTemporal = ({
+  label: _label,
+  dimension,
+  timeUnit,
+  disabled,
+  isOptional,
+  topControls,
+  sideControls,
+}: {
+  label: React.ReactNode;
+  dimension: TemporalDimension;
+  timeUnit: DatePickerTimeUnit;
+  disabled?: boolean;
+  isOptional?: boolean;
+  topControls?: React.ReactNode;
+  sideControls?: React.ReactNode;
+}) => {
   const { values, timeFormat } = dimension;
   const formatLocale = useTimeFormatLocale();
   const formatDate = formatLocale.format(timeFormat);

--- a/app/configurator/components/layout-configurator.tsx
+++ b/app/configurator/components/layout-configurator.tsx
@@ -194,7 +194,7 @@ const LayoutSharedFiltersConfigurator = () => {
           timeFormatUnit,
         });
 
-        const from = options.sortedOptions[0].date;
+        const from = options.sortedOptions[0]?.date;
         const to = options.sortedOptions.at(-1)?.date;
         const formatDate = timeUnitToFormatter[combinedDimension.timeUnit];
 
@@ -266,7 +266,8 @@ const LayoutSharedFiltersConfigurator = () => {
           </SubsectionTitle>
           <ControlSectionContent>
             <Stack gap="0.5rem">
-              {timeRange ? (
+              {/* TODO: allow TemporalOrdinalDimensions to work here */}
+              {timeRange && combinedDimension.values.length ? (
                 <>
                   <Box
                     sx={{

--- a/app/configurator/components/layout-configurator.tsx
+++ b/app/configurator/components/layout-configurator.tsx
@@ -115,12 +115,9 @@ const LayoutLayoutConfigurator = () => {
 const LayoutSharedFiltersConfigurator = () => {
   const [state, dispatch] = useConfiguratorState(isLayouting);
   const { layout } = state;
-  const {
-    timeRange,
-    potentialTimeRangeFilterIris,
-    dataFilters,
-    potentialDataFilterIris,
-  } = useDashboardInteractiveFilters();
+  const { potentialTimeRangeFilterIris, potentialDataFilterIris } =
+    useDashboardInteractiveFilters();
+  const { timeRange, dataFilters } = state.dashboardFilters ?? {};
 
   const locale = useLocale();
   const [{ data }] = useConfigsCubeComponents({

--- a/app/configurator/components/layout-configurator.tsx
+++ b/app/configurator/components/layout-configurator.tsx
@@ -116,8 +116,12 @@ const LayoutLayoutConfigurator = () => {
 const LayoutSharedFiltersConfigurator = () => {
   const [state, dispatch] = useConfiguratorState(isLayouting);
   const { layout } = state;
-  const { timeRange, potentialTimeRangeFilterIris } =
-    useDashboardInteractiveFilters();
+  const {
+    timeRange,
+    potentialTimeRangeFilterIris,
+    dataFilters,
+    potentialDataFilterIris,
+  } = useDashboardInteractiveFilters();
 
   const locale = useLocale();
   const [{ data }] = useConfigsCubeComponents({
@@ -224,7 +228,11 @@ const LayoutSharedFiltersConfigurator = () => {
   switch (layout.type) {
     case "tab":
     case "dashboard":
-      if (!timeRange || potentialTimeRangeFilterIris.length === 0) {
+      if (
+        !timeRange ||
+        (potentialTimeRangeFilterIris.length === 0 &&
+          (!dataFilters || potentialDataFilterIris.length === 0))
+      ) {
         return null;
       }
 

--- a/app/configurator/components/layout-configurator.tsx
+++ b/app/configurator/components/layout-configurator.tsx
@@ -225,9 +225,22 @@ const LayoutSharedFiltersConfigurator = () => {
     (checked: boolean, componentIri: string) => {
       if (checked) {
         dispatch({
-          type: "DASHBOARD_DATA_FILTER_ADD",
+          type: "DASHBOARD_DATA_FILTERS_SET",
           value: {
-            dimensionIri: componentIri,
+            componentIris: dataFilters?.componentIris
+              ? [...dataFilters.componentIris, componentIri].sort((a, b) => {
+                  const dimensions = data?.dataCubesComponents.dimensions ?? [];
+                  const aIndex =
+                    dimensions.find((d) => d.iri === a)?.order ??
+                    dimensions.findIndex((d) => d.iri === a) ??
+                    0;
+                  const bIndex =
+                    dimensions.find((d) => d.iri === b)?.order ??
+                    dimensions.findIndex((d) => d.iri === b) ??
+                    0;
+                  return aIndex - bIndex;
+                })
+              : [componentIri],
           },
         });
       } else {

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -451,7 +451,7 @@ export const useAddOrEditChartType = (
 
 // Used in the configurator filters
 export const useSingleFilterSelect = (
-  filters: GetConfiguratorStateAction<"CHART_CONFIG_FILTER_SET_SINGLE">["value"]["filters"]
+  filters: GetConfiguratorStateAction<"FILTER_SET_SINGLE">["value"]["filters"]
 ) => {
   const [state, dispatch] = useConfiguratorState();
   const onChange = useCallback<
@@ -466,14 +466,14 @@ export const useSingleFilterSelect = (
 
       if (value === FIELD_VALUE_NONE) {
         dispatch({
-          type: "CHART_CONFIG_FILTER_REMOVE_SINGLE",
+          type: "FILTER_REMOVE_SINGLE",
           value: {
             filters,
           },
         });
       } else {
         dispatch({
-          type: "CHART_CONFIG_FILTER_SET_SINGLE",
+          type: "FILTER_SET_SINGLE",
           value: {
             filters,
             value: value === "" ? FIELD_VALUE_NONE : value,
@@ -496,6 +496,12 @@ export const useSingleFilterSelect = (
         value = get(cube, ["filters", dimensionIri, "value"], FIELD_VALUE_NONE);
       }
     }
+  } else if (isLayouting(state)) {
+    value = get(
+      state.dashboardFilters,
+      ["dataFilters", "filters", filters[0].dimensionIri, "value"],
+      FIELD_VALUE_NONE
+    ) as string;
   }
 
   return {
@@ -509,14 +515,14 @@ export const useSingleFilterField = ({
   filters,
   value,
 }: {
-  filters: GetConfiguratorStateAction<"CHART_CONFIG_FILTER_SET_SINGLE">["value"]["filters"];
+  filters: GetConfiguratorStateAction<"FILTER_SET_SINGLE">["value"]["filters"];
   value: string;
 }): FieldProps => {
   const [state, dispatch] = useConfiguratorState();
   const onChange = useCallback<(e: ChangeEvent<HTMLInputElement>) => void>(
     (e) => {
       dispatch({
-        type: "CHART_CONFIG_FILTER_SET_SINGLE",
+        type: "FILTER_SET_SINGLE",
         value: {
           filters: filters,
           value: e.currentTarget.value,

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -2,8 +2,8 @@ import { SelectChangeEvent, SelectProps } from "@mui/material";
 import get from "lodash/get";
 import React, {
   ChangeEvent,
-  InputHTMLAttributes,
   createContext,
+  InputHTMLAttributes,
   useCallback,
   useContext,
   useMemo,
@@ -20,8 +20,8 @@ import {
   isComboChartConfig,
 } from "@/config-types";
 import {
-  GetConfiguratorStateAction,
   getChartOptionField,
+  GetConfiguratorStateAction,
   getFilterValue,
   isConfiguring,
   isLayouting,
@@ -33,8 +33,8 @@ import {
   Dimension,
   DimensionValue,
   HierarchyValue,
-  Measure,
   isMeasure,
+  Measure,
 } from "@/domain/data";
 import { useLocale } from "@/locales/use-locale";
 import { bfs } from "@/utils/bfs";

--- a/app/configurator/configurator-state/actions.tsx
+++ b/app/configurator/configurator-state/actions.tsx
@@ -283,6 +283,12 @@ export type ConfiguratorStateAction =
       };
     }
   | {
+      type: "DASHBOARD_DATA_FILTERS_SET";
+      value: {
+        componentIris: string[];
+      };
+    }
+  | {
       type: "DASHBOARD_DATA_FILTER_REMOVE";
       value: {
         dimensionIri: string;

--- a/app/configurator/configurator-state/actions.tsx
+++ b/app/configurator/configurator-state/actions.tsx
@@ -139,7 +139,7 @@ export type ConfiguratorStateAction =
       };
     }
   | {
-      type: "CHART_CONFIG_FILTER_SET_SINGLE";
+      type: "FILTER_SET_SINGLE";
       value: {
         filters: {
           cubeIri: string;
@@ -149,7 +149,7 @@ export type ConfiguratorStateAction =
       };
     }
   | {
-      type: "CHART_CONFIG_FILTER_REMOVE_SINGLE";
+      type: "FILTER_REMOVE_SINGLE";
       value: {
         filters: {
           cubeIri: string;
@@ -284,9 +284,7 @@ export type ConfiguratorStateAction =
     }
   | {
       type: "DASHBOARD_DATA_FILTERS_SET";
-      value: {
-        componentIris: string[];
-      };
+      value: DashboardFiltersConfig["dataFilters"];
     }
   | {
       type: "DASHBOARD_DATA_FILTER_REMOVE";

--- a/app/configurator/configurator-state/actions.tsx
+++ b/app/configurator/configurator-state/actions.tsx
@@ -275,4 +275,16 @@ export type ConfiguratorStateAction =
     }
   | {
       type: "DASHBOARD_TIME_RANGE_FILTER_REMOVE";
+    }
+  | {
+      type: "DASHBOARD_DATA_FILTER_ADD";
+      value: {
+        dimensionIri: string;
+      };
+    }
+  | {
+      type: "DASHBOARD_DATA_FILTER_REMOVE";
+      value: {
+        dimensionIri: string;
+      };
     };

--- a/app/configurator/configurator-state/initial.tsx
+++ b/app/configurator/configurator-state/initial.tsx
@@ -47,7 +47,6 @@ export const getInitialConfiguringConfigBasedOnCube = (props: {
         },
       },
       dataFilters: {
-        active: false,
         componentIris: [],
       },
     },

--- a/app/configurator/configurator-state/initial.tsx
+++ b/app/configurator/configurator-state/initial.tsx
@@ -48,6 +48,7 @@ export const getInitialConfiguringConfigBasedOnCube = (props: {
       },
       dataFilters: {
         componentIris: [],
+        filters: {},
       },
     },
   };

--- a/app/configurator/configurator-state/initial.tsx
+++ b/app/configurator/configurator-state/initial.tsx
@@ -46,6 +46,10 @@ export const getInitialConfiguringConfigBasedOnCube = (props: {
           to: "",
         },
       },
+      dataFilters: {
+        active: false,
+        componentIris: [],
+      },
     },
   };
 };

--- a/app/configurator/configurator-state/mocks.ts
+++ b/app/configurator/configurator-state/mocks.ts
@@ -70,6 +70,10 @@ export const configStateMock = {
           to: "",
         },
       },
+      dataFilters: {
+        active: false,
+        componentIris: [],
+      },
     },
   },
   groupedColumnChart: {
@@ -212,6 +216,10 @@ export const configStateMock = {
           from: "",
           to: "",
         },
+      },
+      dataFilters: {
+        active: false,
+        componentIris: [],
       },
     },
   },

--- a/app/configurator/configurator-state/mocks.ts
+++ b/app/configurator/configurator-state/mocks.ts
@@ -72,6 +72,7 @@ export const configStateMock = {
       },
       dataFilters: {
         componentIris: [],
+        filters: {},
       },
     },
   },
@@ -218,6 +219,7 @@ export const configStateMock = {
       },
       dataFilters: {
         componentIris: [],
+        filters: {},
       },
     },
   },

--- a/app/configurator/configurator-state/mocks.ts
+++ b/app/configurator/configurator-state/mocks.ts
@@ -71,7 +71,6 @@ export const configStateMock = {
         },
       },
       dataFilters: {
-        active: false,
         componentIris: [],
       },
     },
@@ -218,7 +217,6 @@ export const configStateMock = {
         },
       },
       dataFilters: {
-        active: false,
         componentIris: [],
       },
     },

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -740,7 +740,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
 
       return draft;
 
-    case "CHART_CONFIG_FILTER_SET_SINGLE":
+    case "FILTER_SET_SINGLE":
       if (isConfiguring(draft)) {
         const { filters, value } = action.value;
         const chartConfig = getChartConfig(draft);
@@ -765,11 +765,20 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
             );
           }
         }
+      } else if (isLayouting(draft)) {
+        const { filters, value } = action.value;
+        const { dimensionIri } = filters[0];
+        if (draft.dashboardFilters) {
+          draft.dashboardFilters.dataFilters.filters[dimensionIri] = {
+            type: "single",
+            value,
+          };
+        }
       }
 
       return draft;
 
-    case "CHART_CONFIG_FILTER_REMOVE_SINGLE":
+    case "FILTER_REMOVE_SINGLE":
       if (isConfiguring(draft)) {
         const { filters } = action.value;
         const chartConfig = getChartConfig(draft);
@@ -787,6 +796,12 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
             );
             chartConfig.interactiveFiltersConfig = newIFConfig;
           }
+        }
+      } else if (isLayouting(draft)) {
+        const { filters } = action.value;
+        const { dimensionIri } = filters[0];
+        if (draft.dashboardFilters) {
+          delete draft.dashboardFilters.dataFilters.filters[dimensionIri];
         }
       }
 

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -1085,6 +1085,40 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       }
       return draft;
 
+    case "DASHBOARD_DATA_FILTER_ADD":
+      if (isLayouting(draft) && draft.dashboardFilters) {
+        const { dimensionIri } = action.value;
+        const newFilters = {
+          ...draft.dashboardFilters,
+          dataFilters: {
+            ...draft.dashboardFilters.dataFilters,
+            componentIris: [
+              ...draft.dashboardFilters.dataFilters.componentIris,
+              dimensionIri,
+            ],
+          },
+        };
+        draft.dashboardFilters = newFilters;
+      }
+      return draft;
+
+    case "DASHBOARD_DATA_FILTER_REMOVE":
+      if (isLayouting(draft) && draft.dashboardFilters) {
+        const { dimensionIri } = action.value;
+        const newFilters = {
+          ...draft.dashboardFilters,
+          dataFilters: {
+            ...draft.dashboardFilters.dataFilters,
+            componentIris:
+              draft.dashboardFilters.dataFilters.componentIris.filter(
+                (d) => d !== dimensionIri
+              ),
+          },
+        };
+        draft.dashboardFilters = newFilters;
+      }
+      return draft;
+
     default:
       throw unreachableError(action);
   }

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -1102,6 +1102,12 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       }
       return draft;
 
+    case "DASHBOARD_DATA_FILTERS_SET":
+      if (isLayouting(draft) && draft.dashboardFilters) {
+        draft.dashboardFilters.dataFilters = action.value;
+      }
+      return draft;
+
     case "DASHBOARD_DATA_FILTER_REMOVE":
       if (isLayouting(draft) && draft.dashboardFilters) {
         const { dimensionIri } = action.value;

--- a/app/configurator/interactive-filters/time-slider.tsx
+++ b/app/configurator/interactive-filters/time-slider.tsx
@@ -16,6 +16,7 @@ import { TableChartState } from "@/charts/table/table-state";
 import { Slider as GenericSlider } from "@/components/form";
 import { AnimationField, Filters, SortingField } from "@/config-types";
 import { parseDate } from "@/configurator/components/ui-helpers";
+import { hasChartConfigs } from "@/configurator/configurator-state";
 import {
   Dimension,
   isTemporalDimension,
@@ -25,10 +26,8 @@ import {
 import { truthy } from "@/domain/types";
 import { useTimeFormatUnit } from "@/formatters";
 import { Icon } from "@/icons";
-import {
-  useChartInteractiveFilters,
-  useDashboardInteractiveFilters,
-} from "@/stores/interactive-filters";
+import { useConfiguratorState } from "@/src";
+import { useChartInteractiveFilters } from "@/stores/interactive-filters";
 import { Timeline, TimelineProps } from "@/utils/observables";
 import {
   getSortingOrders,
@@ -67,14 +66,13 @@ export const TimeSlider = (props: TimeSliderProps) => {
     dimensions,
   } = props;
 
+  const [state] = useConfiguratorState(hasChartConfigs);
   const dimension = useMemo(() => {
     return dimensions.find((d) => d.iri === componentIri);
   }, [componentIri, dimensions]);
   const temporal = isTemporalDimension(dimension);
   const temporalEntity = isTemporalEntityDimension(dimension);
   const temporalOrdinal = isTemporalOrdinalDimension(dimension);
-
-  const dashboardFilters = useDashboardInteractiveFilters();
 
   if (!(temporal || temporalEntity || temporalOrdinal)) {
     throw new Error("You can only use TimeSlider with temporal dimensions!");
@@ -144,7 +142,7 @@ export const TimeSlider = (props: TimeSliderProps) => {
     return new Timeline(timelineProps);
   }, [timelineProps]);
 
-  if (dashboardFilters.timeRange?.active) {
+  if (state.dashboardFilters?.timeRange.active) {
     return null;
   }
 

--- a/app/docs/charts.stories.tsx
+++ b/app/docs/charts.stories.tsx
@@ -78,7 +78,6 @@ const ColumnsStory = {
             },
           },
           dataFilters: {
-            active: false,
             componentIris: [],
           },
         },
@@ -141,7 +140,6 @@ const ScatterplotStory = {
             },
           },
           dataFilters: {
-            active: false,
             componentIris: [],
           },
         },

--- a/app/docs/charts.stories.tsx
+++ b/app/docs/charts.stories.tsx
@@ -79,6 +79,7 @@ const ColumnsStory = {
           },
           dataFilters: {
             componentIris: [],
+            filters: {},
           },
         },
       }}
@@ -141,6 +142,7 @@ const ScatterplotStory = {
           },
           dataFilters: {
             componentIris: [],
+            filters: {},
           },
         },
       }}

--- a/app/docs/charts.stories.tsx
+++ b/app/docs/charts.stories.tsx
@@ -77,6 +77,10 @@ const ColumnsStory = {
               to: "",
             },
           },
+          dataFilters: {
+            active: false,
+            componentIris: [],
+          },
         },
       }}
     >
@@ -135,6 +139,10 @@ const ScatterplotStory = {
               from: "",
               to: "",
             },
+          },
+          dataFilters: {
+            active: false,
+            componentIris: [],
           },
         },
       }}

--- a/app/docs/fixtures.ts
+++ b/app/docs/fixtures.ts
@@ -99,6 +99,7 @@ export const states: ConfiguratorState[] = [
       },
       dataFilters: {
         componentIris: [],
+        filters: {},
       },
     },
   },

--- a/app/docs/fixtures.ts
+++ b/app/docs/fixtures.ts
@@ -98,7 +98,6 @@ export const states: ConfiguratorState[] = [
         },
       },
       dataFilters: {
-        active: false,
         componentIris: [],
       },
     },

--- a/app/docs/fixtures.ts
+++ b/app/docs/fixtures.ts
@@ -97,6 +97,10 @@ export const states: ConfiguratorState[] = [
           to: "",
         },
       },
+      dataFilters: {
+        active: false,
+        componentIris: [],
+      },
     },
   },
 ];

--- a/app/docs/lines.stories.tsx
+++ b/app/docs/lines.stories.tsx
@@ -56,7 +56,6 @@ const LineChartStory = () => (
           },
         },
         dataFilters: {
-          active: false,
           componentIris: [],
         },
       },

--- a/app/docs/lines.stories.tsx
+++ b/app/docs/lines.stories.tsx
@@ -55,6 +55,10 @@ const LineChartStory = () => (
             to: "",
           },
         },
+        dataFilters: {
+          active: false,
+          componentIris: [],
+        },
       },
     }}
   >

--- a/app/docs/lines.stories.tsx
+++ b/app/docs/lines.stories.tsx
@@ -57,6 +57,7 @@ const LineChartStory = () => (
         },
         dataFilters: {
           componentIris: [],
+          filters: {},
         },
       },
     }}

--- a/app/stores/interactive-filters.tsx
+++ b/app/stores/interactive-filters.tsx
@@ -5,6 +5,7 @@ import { getChartSpec } from "@/charts/chart-config-ui-options";
 import {
   CalculationType,
   ChartConfig,
+  DashboardDataFiltersConfig,
   DashboardTimeRangeFilter,
   FilterValueSingle,
   hasChartConfigs,
@@ -146,6 +147,8 @@ const InteractiveFiltersContext = createContext<
   | {
       potentialTimeRangeFilterIris: string[];
       timeRange: DashboardTimeRangeFilter | undefined;
+      potentialDataFilterIris: string[];
+      dataFilters: DashboardDataFiltersConfig | undefined;
       stores: Record<ChartConfig["key"], InteractiveFiltersContextValue>;
     }
   | undefined
@@ -222,9 +225,14 @@ export const InteractiveFiltersProvider = ({
 
   const ctxValue = useMemo(
     () => ({
-      stores,
       potentialTimeRangeFilterIris,
       timeRange,
+      potentialDataFilterIris: [],
+      dataFilters: {
+        active: false,
+        componentIris: [],
+      },
+      stores,
     }),
     [stores, potentialTimeRangeFilterIris, timeRange]
   );

--- a/app/stores/interactive-filters.tsx
+++ b/app/stores/interactive-filters.tsx
@@ -134,10 +134,11 @@ const interactiveFiltersStoreCreator: StateCreator<State> = (set) => {
   };
 };
 
+export type InteractiveFiltersStore = StoreApi<State>;
 export type InteractiveFiltersContextValue = [
   UseBoundStore<StoreApi<State>>["getState"],
   UseBoundStoreWithSelector<StoreApi<State>>,
-  StoreApi<State>,
+  InteractiveFiltersStore,
 ];
 
 const InteractiveFiltersContext = createContext<
@@ -314,4 +315,17 @@ export const useDashboardInteractiveFilters = () => {
   );
 
   return ctx;
+};
+
+export const setDataFilter = (
+  store: InteractiveFiltersStore,
+  key: string,
+  value: string
+) => {
+  store.setState({
+    dataFilters: {
+      ...store.getState().dataFilters,
+      [key]: { type: "single", value },
+    },
+  });
 };

--- a/app/stores/interactive-filters.tsx
+++ b/app/stores/interactive-filters.tsx
@@ -11,9 +11,9 @@ import {
 import { truthy } from "@/domain/types";
 import { getOriginalIris, isJoinById } from "@/graphql/join";
 import {
+  createBoundUseStoreWithSelector,
   ExtractState,
   UseBoundStoreWithSelector,
-  createBoundUseStoreWithSelector,
 } from "@/stores/utils";
 import { assert } from "@/utils/assert";
 
@@ -134,7 +134,7 @@ const interactiveFiltersStoreCreator: StateCreator<State> = (set) => {
   };
 };
 
-type InteractiveFiltersContextValue = [
+export type InteractiveFiltersContextValue = [
   UseBoundStore<StoreApi<State>>["getState"],
   UseBoundStoreWithSelector<StoreApi<State>>,
   StoreApi<State>,

--- a/app/stores/interactive-filters.tsx
+++ b/app/stores/interactive-filters.tsx
@@ -6,11 +6,7 @@ import { getChartSpec } from "@/charts/chart-config-ui-options";
 import {
   CalculationType,
   ChartConfig,
-  DashboardDataFiltersConfig,
-  DashboardTimeRangeFilter,
   FilterValueSingle,
-  hasChartConfigs,
-  useConfiguratorState,
 } from "@/configurator";
 import { truthy } from "@/domain/types";
 import { getOriginalIris, isJoinById } from "@/graphql/join";
@@ -147,9 +143,7 @@ type InteractiveFiltersContextValue = [
 const InteractiveFiltersContext = createContext<
   | {
       potentialTimeRangeFilterIris: string[];
-      timeRange: DashboardTimeRangeFilter | undefined;
       potentialDataFilterIris: string[];
-      dataFilters: DashboardDataFiltersConfig | undefined;
       stores: Record<ChartConfig["key"], InteractiveFiltersContextValue>;
     }
   | undefined
@@ -211,7 +205,6 @@ export const InteractiveFiltersProvider = ({
 }: React.PropsWithChildren<{
   chartConfigs: ChartConfig[];
 }>) => {
-  const [state] = useConfiguratorState(hasChartConfigs);
   const storeRefs = useRef<Record<ChartConfig["key"], StoreApi<State>>>({});
 
   const potentialTimeRangeFilterIris = useMemo(() => {
@@ -239,24 +232,13 @@ export const InteractiveFiltersProvider = ({
     );
   }, [chartConfigs]);
 
-  const timeRange = state.dashboardFilters?.timeRange;
-  const dataFilters = state.dashboardFilters?.dataFilters;
-
   const ctxValue = useMemo(
     () => ({
       potentialTimeRangeFilterIris,
-      timeRange,
       potentialDataFilterIris,
-      dataFilters,
       stores,
     }),
-    [
-      potentialTimeRangeFilterIris,
-      timeRange,
-      potentialDataFilterIris,
-      dataFilters,
-      stores,
-    ]
+    [potentialTimeRangeFilterIris, potentialDataFilterIris, stores]
   );
 
   return (

--- a/app/utils/chart-config/versioning.ts
+++ b/app/utils/chart-config/versioning.ts
@@ -1296,6 +1296,7 @@ export const configuratorStateMigrations: Migration[] = [
           ...config.dashboardFilters,
           dataFilters: {
             componentIris: [],
+            filters: {},
           },
         },
       };

--- a/app/utils/chart-config/versioning.ts
+++ b/app/utils/chart-config/versioning.ts
@@ -931,7 +931,7 @@ export const migrateChartConfig = makeMigrate<ChartConfig>(
   }
 );
 
-export const CONFIGURATOR_STATE_VERSION = "3.5.0";
+export const CONFIGURATOR_STATE_VERSION = "3.6.0";
 
 export const configuratorStateMigrations: Migration[] = [
   {
@@ -1279,6 +1279,35 @@ export const configuratorStateMigrations: Migration[] = [
               },
             },
           ],
+        },
+      };
+      return newConfig;
+    },
+  },
+  {
+    description: "ALL (modify dashboardFilters)",
+    from: "3.5.0",
+    to: "3.6.0",
+    up: (config) => {
+      const newConfig = {
+        ...config,
+        version: "3.6.0",
+        dashboardFilters: {
+          ...config.dashboardFilters,
+          dataFilters: {
+            active: false,
+            componentIris: [],
+          },
+        },
+      };
+      return newConfig;
+    },
+    down: (config) => {
+      const newConfig = {
+        ...config,
+        version: "3.5.0",
+        dashboardFilters: {
+          timeRange: config.dashboardFilters.timeRange,
         },
       };
       return newConfig;

--- a/app/utils/chart-config/versioning.ts
+++ b/app/utils/chart-config/versioning.ts
@@ -1295,7 +1295,6 @@ export const configuratorStateMigrations: Migration[] = [
         dashboardFilters: {
           ...config.dashboardFilters,
           dataFilters: {
-            active: false,
             componentIris: [],
           },
         },

--- a/app/utils/uniqueMapBy.ts
+++ b/app/utils/uniqueMapBy.ts
@@ -2,9 +2,7 @@ export const uniqueMapBy = <T, K>(arr: T[], keyFn: (t: T) => K) => {
   const res = new Map<K, T>();
   for (const item of arr) {
     const key = keyFn(item);
-    if (res.has(key)) {
-      console.log(`uniqueMapBy: duplicate detected ${key}, ignoring it`);
-    } else {
+    if (!res.has(key)) {
       res.set(key, item);
     }
   }


### PR DESCRIPTION
Closes #1669

This PR introduces categorical dashboard filters.
- Each categorical filter displays all available dimension values; there's no cascading filters behavior, as every chart can have a different combination of other filters, which makes it impossible to have a "global cascading filter logic"
- Global categorical filters take precedence over local, chart-defined interactive filters, whose UI is disabled when global filters are active
- Cascading interactive filters behavior for chart is disabled when global categorical filters are enabled – in this mode we want to see no data, when a given combination actually yields no data, instead of reloading the chart filters and being out-of-sync with global filters.

## How to test
1. Go to [this link](https://visualization-tool-git-feat-categorical-dashboard-filters-ixt1.vercel.app/en/create/new?cube=https://environment.ld.admin.ch/foen/ubd003701/5&dataSource=Prod).
2. Add two more charts, so that there are three in total.
3. Modify the filters of every chart in a way that there's a different set of filters for every chart.
4. Proceed to layout options.
5. Switch to dashboard / free canvas layout.
6. See that there are four shared filters to be selected.
7. Toggle the filters and see that the select elements appeared on top of the canvas.
8. Use the filters to see that every chart adheres to global filters.
9. Toggle the filters off to see that the chart reverts back to its original filters.
10. You can also experiment with adding interactive filters to charts and seeing that they would be overwritten by global filters and that the state is reverted back to individual interactive filter after disabling global filter.

## To do in the future
- Refactor interactive filters so that they are scoped per cube. Currently if there are dimensions with the same iris across different cubes, we'd combine them and filter as one.