### PR TITLE
fix: Do not completely fail if a chart cannot be loaded

### DIFF
--- a/e2e/varnish-cache-preload.spec.ts
+++ b/e2e/varnish-cache-preload.spec.ts
@@ -4,19 +4,71 @@ import { setup } from "./common";
 
 const { test } = setup();
 
+const atMost = async ({
+  timeout,
+  fn,
+  onTimeout,
+}: {
+  timeout: number;
+  fn: () => Promise<void>;
+  onTimeout: () => void;
+}) => {
+  let success = false;
+  await Promise.race([
+    fn().then((result) => {
+      success = true;
+      return result;
+    }),
+    new Promise((resolve, reject) =>
+      setTimeout(() => {
+        if (!success) {
+          onTimeout();
+        }
+        return resolve(void 0);
+      }, timeout)
+    ),
+  ]);
+  throw new Error("Timeout");
+};
+
+const fetchMetadata = ({
+  limit,
+  orderByViewCount,
+}: {
+  limit: 25;
+  orderByViewCount?: boolean;
+}) => {
+  const qp = new URLSearchParams();
+  if (limit !== undefined) {
+    qp.append("limit", `${limit}`);
+  }
+  if (orderByViewCount !== undefined) {
+    qp.append("orderByViewCount", orderByViewCount ? "true" : "false");
+  }
+  return fetch(`https://visualize.admin.ch/api/config/all-metadata?${qp}`).then(
+    (res) => res.json()
+  );
+};
+
 // @noci as it's a special test that's supposed to preload varnish cache
 // for most recent charts
 test("@noci it should preload most recent charts", async ({ page }) => {
-  const fetchedConfigs = await fetch(
-    "https://visualize.admin.ch/api/config/all-metadata?limit=25"
-  ).then((res) => res.json());
+  const fetchedConfigs = await fetchMetadata({ limit: 25 });
   const keys = fetchedConfigs.data.map((config) => config.key);
 
   for (const key of keys) {
     for (const locale of locales) {
-      await page.goto(`https://visualize.admin.ch/${locale}/v/${key}`);
-      // Wait for all the queries to finish
-      await page.waitForLoadState("networkidle");
+      await atMost({
+        timeout: 40_1000,
+        fn: async () => {
+          await page.goto(`https://visualize.admin.ch/${locale}/v/${key}`);
+          // Wait for all the queries to finish
+          await page.waitForLoadState("networkidle");
+        },
+        onTimeout: () => {
+          console.error(`Timeout for ${key}`);
+        },
+      });
     }
   }
 });
@@ -24,16 +76,25 @@ test("@noci it should preload most recent charts", async ({ page }) => {
 // @noci as it's a special test that's supposed to preload varnish cache
 // for most viewed charts
 test("@noci it should preload most viewed charts", async ({ page }) => {
-  const fetchedConfigs = await fetch(
-    "https://visualize.admin.ch/api/config/all-metadata?limit=25&orderByViewCount=true"
-  ).then((res) => res.json());
+  const fetchedConfigs = await fetchMetadata({
+    limit: 25,
+    orderByViewCount: true,
+  });
   const keys = fetchedConfigs.data.map((config) => config.key);
 
   for (const key of keys) {
     for (const locale of locales) {
-      await page.goto(`https://visualize.admin.ch/${locale}/v/${key}`);
-      // Wait for all the queries to finish
-      await page.waitForLoadState("networkidle");
+      await atMost({
+        timeout: 40_1000,
+        fn: async () => {
+          await page.goto(`https://visualize.admin.ch/${locale}/v/${key}`);
+          // Wait for all the queries to finish
+          await page.waitForLoadState("networkidle");
+        },
+        onTimeout: () => {
+          console.error(`Timeout for ${key}`);
+        },
+      });
     }
   }
 });


### PR DESCRIPTION
We do not want to fail if a chart takes a long time to load. It could be
due to factors that we do not control like the availability of the database.
Here, we put a limit of 40s for a chart to load, and if it does not we 
issue an error in the console, but the script does not crash.
