### PR TITLE
fix: Deleting saved charts

### DIFF
--- a/app/db/config.ts
+++ b/app/db/config.ts
@@ -83,11 +83,19 @@ export const updateConfig = async ({
  * @param key Key of the config to be updated
  */
 export const removeConfig = async ({ key }: { key: string }) => {
-  return await prisma.config.delete({
-    where: {
-      key,
-    },
-  });
+  await prisma.configView
+    .deleteMany({
+      where: {
+        config_key: key,
+      },
+    })
+    .then(() => {
+      return prisma.config.delete({
+        where: {
+          key,
+        },
+      });
+    });
 };
 
 const migrateCubeIri = (iri: string): string => {


### PR DESCRIPTION
Fixes #1686

In order to be able to delete a chart config, we need to first remove all related entries from the `config_view` table, to avoid foreign key constraint errors.

## How to test
It will be possible to test the change on TEST once the PR is merged by logging in, creating a chart and removing it using the user profile table.