### PR TITLE
fix: [ No title ] single charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ You can also check the
     mode
   - Table single filters now correctly display selected state
   - Drag handles are now centered in table configurator
+  - Single chart titles are now correctly displayed in user profile
+  - Renaming of charts through user profile now works correctly
 
 # [4.7.4] - 2024-07-23
 

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -609,7 +609,12 @@ msgstr "Italienisch"
 msgid "controls.layout.canvas"
 msgstr "Freies Layout"
 
+#: app/login/components/profile-tables.tsx
+msgid "controls.layout.chart"
+msgstr ""
+
 #: app/configurator/components/field-i18n.ts
+#: app/login/components/profile-tables.tsx
 msgid "controls.layout.dashboard"
 msgstr "Dashboard"
 
@@ -817,10 +822,6 @@ msgstr "Geteilte Filter"
 #: app/configurator/components/layout-configurator.tsx
 msgid "controls.section.shared-filters.date"
 msgstr "Datum"
-
-#: app/configurator/components/layout-configurator.tsx
-msgid "controls.section.shared-filters.shared-switch"
-msgstr "Geteilt"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.section.show-standard-error"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -609,7 +609,12 @@ msgstr "Italian"
 msgid "controls.layout.canvas"
 msgstr "Free canvas"
 
+#: app/login/components/profile-tables.tsx
+msgid "controls.layout.chart"
+msgstr "Chart"
+
 #: app/configurator/components/field-i18n.ts
+#: app/login/components/profile-tables.tsx
 msgid "controls.layout.dashboard"
 msgstr "Dashboard"
 
@@ -817,10 +822,6 @@ msgstr "Shared filters"
 #: app/configurator/components/layout-configurator.tsx
 msgid "controls.section.shared-filters.date"
 msgstr "Date"
-
-#: app/configurator/components/layout-configurator.tsx
-msgid "controls.section.shared-filters.shared-switch"
-msgstr "Shared"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.section.show-standard-error"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -609,7 +609,12 @@ msgstr "Italien"
 msgid "controls.layout.canvas"
 msgstr "Mise en page libre"
 
+#: app/login/components/profile-tables.tsx
+msgid "controls.layout.chart"
+msgstr ""
+
 #: app/configurator/components/field-i18n.ts
+#: app/login/components/profile-tables.tsx
 msgid "controls.layout.dashboard"
 msgstr "Dashboard"
 
@@ -817,10 +822,6 @@ msgstr "Filtres partagés"
 #: app/configurator/components/layout-configurator.tsx
 msgid "controls.section.shared-filters.date"
 msgstr "Date"
-
-#: app/configurator/components/layout-configurator.tsx
-msgid "controls.section.shared-filters.shared-switch"
-msgstr "Partagé"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.section.show-standard-error"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -609,7 +609,12 @@ msgstr "Italiano"
 msgid "controls.layout.canvas"
 msgstr "Layout libero"
 
+#: app/login/components/profile-tables.tsx
+msgid "controls.layout.chart"
+msgstr ""
+
 #: app/configurator/components/field-i18n.ts
+#: app/login/components/profile-tables.tsx
 msgid "controls.layout.dashboard"
 msgstr "Dashboard"
 
@@ -817,10 +822,6 @@ msgstr "Filtri condivisi"
 #: app/configurator/components/layout-configurator.tsx
 msgid "controls.section.shared-filters.date"
 msgstr "Data"
-
-#: app/configurator/components/layout-configurator.tsx
-msgid "controls.section.shared-filters.shared-switch"
-msgstr "Condiviso"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.section.show-standard-error"

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -301,9 +301,9 @@ const ProfileVisualizationsRow = (props: {
 
   const chartTitle = useMemo(() => {
     const title =
-      config.data.layout.meta.title?.[locale] ??
+      config.data.layout.meta.title?.[locale] ||
       config.data.chartConfigs
-        .map((d) => d.meta.title?.[locale] ?? false)
+        .map((chartConfig) => chartConfig.meta.title?.[locale] ?? false)
         .filter(truthy)
         .join(", ");
 

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -163,12 +163,10 @@ export const ProfileVisualizationsTable = (
   );
 };
 
-type ProfileVisualizationsRowProps = {
+const ProfileVisualizationsRow = (props: {
   userId: number;
   config: ParsedConfig;
-};
-
-const ProfileVisualizationsRow = (props: ProfileVisualizationsRowProps) => {
+}) => {
   const { userId, config } = props;
   const { dataSource } = config.data;
   const dataSets = Array.from(

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -301,17 +301,16 @@ const ProfileVisualizationsRow = (props: {
 
   const isSingleChart = config.data.chartConfigs.length === 1;
   const chartTitle = useMemo(() => {
-    const title =
-      config.data.layout.meta.title?.[locale] ||
-      config.data.chartConfigs
-        .map((chartConfig) => chartConfig.meta.title?.[locale] ?? false)
-        .filter(truthy)
-        .join(", ");
-
-    return title
-      ? title
-      : t({ id: "annotation.add.title", message: "[ No Title ]" });
-  }, [config.data.chartConfigs, config.data.layout.meta.title, locale]);
+    const title = isSingleChart
+      ? config.data.chartConfigs[0].meta.title[locale]
+      : config.data.layout.meta.title[locale];
+    return title || t({ id: "annotation.add.title", message: "[ No Title ]" });
+  }, [
+    config.data.chartConfigs,
+    config.data.layout.meta.title,
+    isSingleChart,
+    locale,
+  ]);
 
   return (
     <TableRow>

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -299,6 +299,7 @@ const ProfileVisualizationsRow = (props: {
     updateConfigMut,
   ]);
 
+  const isSingleChart = config.data.chartConfigs.length === 1;
   const chartTitle = useMemo(() => {
     const title =
       config.data.layout.meta.title?.[locale] ||
@@ -316,7 +317,9 @@ const ProfileVisualizationsRow = (props: {
     <TableRow>
       <TableCell width="10%">
         <Typography variant="body2">
-          {config.data.chartConfigs.length > 1 ? "dashboard" : "single"}
+          {isSingleChart
+            ? t({ id: "controls.layout.chart", message: "Chart" })
+            : t({ id: "controls.layout.dashboard", message: "Dashboard" })}
         </Typography>
       </TableCell>
       <TableCell width="30%">


### PR DESCRIPTION
Fixes #1634

This PR fixes a problem with chart titles not being retrieved in the user profile for single charts. The problem was that we used a nullish coalescing operator operator (`??`) instead of a regular or (`||`), when layout title was an empty string by default. This led to actual chart title not being even considered to be displayed.

I've also added new transition strings for "single" and "dashboard" texts in user profile, and fixed rename dialog in a way that now it:
- updates chart title in case of single charts,
- updates layout title in case of multi-charts.

## How to test
This PR can be tested once merged and deployed to TEST by renaming a single chart.