### PR TITLE
bump cube-hierarchy-query to v3.0.0

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -46,7 +46,7 @@
     "@urql/devtools": "^2.0.3",
     "@visx/group": "^2.10.0",
     "@visx/text": "^2.12.2",
-    "@zazuko/cube-hierarchy-query": "^2.2.2",
+    "@zazuko/cube-hierarchy-query": "^3.0.0",
     "apollo-server-micro": "^3.0.0",
     "autosuggest-highlight": "^3.3.4",
     "catalog": "^4.0.1-canary.2",


### PR DESCRIPTION
v3.0.0 has the same functionality
- fixes a specific issue with some SPARQL query engines
- performs equally

see perf results at https://rdataflow.github.io/speedtest-cubehierarchy/

@bprusinowski thanks for your review & merge