### PR TITLE
feat: Add chart and dashboard labels

### DIFF
--- a/app/charts/index.spec.ts
+++ b/app/charts/index.spec.ts
@@ -240,6 +240,12 @@ describe("chart type switch", () => {
           fr: "",
           it: "",
         },
+        label: {
+          en: "",
+          de: "",
+          fr: "",
+          it: "",
+        },
       },
       fields: {
         x: {

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -330,6 +330,12 @@ export const META: Meta = {
     fr: "",
     it: "",
   },
+  label: {
+    en: "",
+    de: "",
+    fr: "",
+    it: "",
+  },
 };
 
 type GetInitialConfigOptions = {

--- a/app/components/chart-selection-tabs.tsx
+++ b/app/components/chart-selection-tabs.tsx
@@ -618,7 +618,7 @@ const TabContent = (props: {
   } = props;
   const classes = useIconStyles({ active, dragging });
   const [_, dispatch] = useConfiguratorState();
-  const allowEditingLabel = editable && !label;
+  const showAddLabel = editable && !label;
   const addLabel = t({
     id: "chart-selection-tabs.add-label",
     message: "Add label",
@@ -632,14 +632,14 @@ const TabContent = (props: {
       >
         <Icon name={iconName} />
       </Button>
-      {label || allowEditingLabel ? (
+      {label || showAddLabel ? (
         <Tooltip title={label || addLabel} enterDelay={750}>
           <Button
             variant="text"
             className={classes.label}
             onClick={() => {
               onSwitchClick?.();
-              if (allowEditingLabel) {
+              if (editable) {
                 dispatch({
                   type: "CHART_ACTIVE_FIELD_CHANGED",
                   value: "label",

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -112,7 +112,6 @@ export const extractSingleFilters = (filters: Filters): SingleFilters => {
   ) as SingleFilters;
 };
 
-// Meta
 const Title = t.type({
   de: t.string,
   fr: t.string,
@@ -126,7 +125,19 @@ const Description = t.type({
   it: t.string,
   en: t.string,
 });
-const Meta = t.type({ title: Title, description: Description });
+export type Description = t.TypeOf<typeof Description>;
+const Label = t.type({
+  de: t.string,
+  fr: t.string,
+  it: t.string,
+  en: t.string,
+});
+export type Label = t.TypeOf<typeof Label>;
+const Meta = t.type({
+  title: Title,
+  description: Description,
+  label: Label,
+});
 export type Meta = t.TypeOf<typeof Meta>;
 export type MetaKey = keyof Meta;
 

--- a/app/configurator/components/add-dataset-dialog.mock.ts
+++ b/app/configurator/components/add-dataset-dialog.mock.ts
@@ -23,6 +23,12 @@ export const photovoltaikChartStateMock: ConfiguratorStateConfiguringChart = {
         fr: "",
         it: "",
       },
+      label: {
+        de: "",
+        en: "",
+        fr: "",
+        it: "",
+      },
     },
   },
   chartConfigs: [
@@ -38,6 +44,12 @@ export const photovoltaikChartStateMock: ConfiguratorStateConfiguringChart = {
           it: "",
         },
         description: {
+          en: "",
+          de: "",
+          fr: "",
+          it: "",
+        },
+        label: {
           en: "",
           de: "",
           fr: "",

--- a/app/configurator/components/annotation-options.tsx
+++ b/app/configurator/components/annotation-options.tsx
@@ -85,7 +85,7 @@ const AnnotationOptions = (props: AnnotationOptionsProps) => {
       tabIndex={-1}
       sx={{ overflowX: "hidden", overflowY: "auto" }}
     >
-      <ControlSection>
+      <ControlSection hideTopBorder>
         <SectionTitle>{getFieldLabel(activeField)}</SectionTitle>
         <ControlSectionContent gap="none">
           {orderedLocales.map((locale) => (

--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -34,6 +34,7 @@ import {
   hasChartConfigs,
   initChartStateFromChartEdit,
   isConfiguring,
+  MetaKey,
   saveChartLocally,
   useConfiguratorState,
 } from "@/configurator";
@@ -115,8 +116,8 @@ export const BackButton = ({
 
 export const isAnnotationField = (
   field: string | undefined
-): field is "title" | "description" => {
-  return field === "title" || field === "description";
+): field is MetaKey => {
+  return field === "title" || field === "description" || field === "label";
 };
 
 const useAssureCorrectDataSource = (stateGuard: ConfiguratorState["state"]) => {

--- a/app/configurator/components/field-i18n.ts
+++ b/app/configurator/components/field-i18n.ts
@@ -28,6 +28,7 @@ const fieldLabels = {
     id: "controls.description",
     message: "Description",
   }),
+  "controls.label": defineMessage({ id: "controls.label", message: "Label" }),
   "controls.column.stacked": defineMessage({
     id: "controls.column.stacked",
     message: "Stacked",
@@ -262,6 +263,8 @@ export function getFieldLabel(field: string): string {
       return i18n._(fieldLabels["controls.title"]);
     case "description":
       return i18n._(fieldLabels["controls.description"]);
+    case "label":
+      return i18n._(fieldLabels["controls.label"]);
 
     // Encoding Options
     case "stacked":

--- a/app/configurator/configurator-state/initial.tsx
+++ b/app/configurator/configurator-state/initial.tsx
@@ -32,6 +32,12 @@ export const getInitialConfiguringConfigBasedOnCube = (props: {
           fr: "",
           it: "",
         },
+        label: {
+          de: "",
+          en: "",
+          fr: "",
+          it: "",
+        },
       },
       activeField: undefined,
     },

--- a/app/configurator/configurator-state/mocks.ts
+++ b/app/configurator/configurator-state/mocks.ts
@@ -99,6 +99,12 @@ export const configStateMock = {
           fr: "",
           it: "",
         },
+        label: {
+          de: "",
+          en: "",
+          fr: "",
+          it: "",
+        },
       },
     },
     chartConfigs: [
@@ -113,6 +119,12 @@ export const configStateMock = {
             it: "",
           },
           description: {
+            en: "",
+            de: "",
+            fr: "",
+            it: "",
+          },
+          label: {
             en: "",
             de: "",
             fr: "",
@@ -1116,6 +1128,7 @@ export const configJoinedCubes: Partial<
     meta: {
       title: { en: "", de: "", fr: "", it: "" },
       description: { en: "", de: "", fr: "", it: "" },
+      label: { en: "", de: "", fr: "", it: "" },
     },
     cubes: [
       {
@@ -1371,6 +1384,7 @@ export const configJoinedCubes: Partial<
     meta: {
       title: { en: "", de: "", fr: "", it: "" },
       description: { en: "", de: "", fr: "", it: "" },
+      label: { en: "", de: "", fr: "", it: "" },
     },
     cubes: [
       {

--- a/app/configurator/configurator-state/reducer.spec.tsx
+++ b/app/configurator/configurator-state/reducer.spec.tsx
@@ -560,6 +560,12 @@ describe("deriveFiltersFromFields", () => {
             "fr": "",
             "it": "",
           },
+          "label": Object {
+            "de": "",
+            "en": "",
+            "fr": "",
+            "it": "",
+          },
           "title": Object {
             "de": "",
             "en": "",

--- a/app/docs/charts.stories.tsx
+++ b/app/docs/charts.stories.tsx
@@ -63,6 +63,7 @@ const ColumnsStory = {
           meta: {
             title: { en: "", de: "", fr: "", it: "" },
             description: { en: "", de: "", fr: "", it: "" },
+            label: { en: "", de: "", fr: "", it: "" },
           },
           activeField: undefined,
         },
@@ -126,6 +127,7 @@ const ScatterplotStory = {
           meta: {
             title: { en: "", de: "", fr: "", it: "" },
             description: { en: "", de: "", fr: "", it: "" },
+            label: { en: "", de: "", fr: "", it: "" },
           },
           activeField: undefined,
         },

--- a/app/docs/columns.mock.ts
+++ b/app/docs/columns.mock.ts
@@ -30,6 +30,12 @@ export const chartConfig: ColumnConfig = {
       fr: "",
       it: "",
     },
+    label: {
+      en: "",
+      de: "",
+      fr: "",
+      it: "",
+    },
   },
   cubes: [
     {

--- a/app/docs/fixtures.ts
+++ b/app/docs/fixtures.ts
@@ -23,6 +23,7 @@ export const states: ConfiguratorState[] = [
       meta: {
         title: { en: "", de: "", fr: "", it: "" },
         description: { en: "", de: "", fr: "", it: "" },
+        label: { en: "", de: "", fr: "", it: "" },
       },
       activeField: undefined,
     },
@@ -38,6 +39,12 @@ export const states: ConfiguratorState[] = [
             it: "",
           },
           description: {
+            en: "",
+            de: "",
+            fr: "",
+            it: "",
+          },
+          label: {
             en: "",
             de: "",
             fr: "",
@@ -888,6 +895,12 @@ export const tableConfig: TableConfig = {
       it: "",
     },
     description: {
+      en: "",
+      de: "",
+      fr: "",
+      it: "",
+    },
+    label: {
       en: "",
       de: "",
       fr: "",

--- a/app/docs/lines.mock.tsx
+++ b/app/docs/lines.mock.tsx
@@ -79,6 +79,12 @@ export const chartConfig: LineConfig = {
       fr: "",
       it: "",
     },
+    label: {
+      en: "",
+      de: "",
+      fr: "",
+      it: "",
+    },
   },
   cubes: [
     {

--- a/app/docs/lines.stories.tsx
+++ b/app/docs/lines.stories.tsx
@@ -41,6 +41,7 @@ const LineChartStory = () => (
         meta: {
           title: { en: "", de: "", fr: "", it: "" },
           description: { en: "", de: "", fr: "", it: "" },
+          label: { en: "", de: "", fr: "", it: "" },
         },
         activeField: undefined,
       },

--- a/app/docs/scatterplot.mock.ts
+++ b/app/docs/scatterplot.mock.ts
@@ -72,6 +72,12 @@ export const chartConfig: ScatterPlotConfig = {
       fr: "",
       it: "",
     },
+    label: {
+      en: "",
+      de: "",
+      fr: "",
+      it: "",
+    },
   },
   cubes: [
     {

--- a/app/docs/tooltip.stories.tsx
+++ b/app/docs/tooltip.stories.tsx
@@ -83,6 +83,12 @@ const TooltipBoxStory = () => (
               fr: "",
               it: "",
             },
+            label: {
+              en: "",
+              de: "",
+              fr: "",
+              it: "",
+            },
           },
           cubes: [
             {
@@ -248,6 +254,12 @@ const TooltipContentStory = {
               fr: "",
               it: "",
             },
+            label: {
+              en: "",
+              de: "",
+              fr: "",
+              it: "",
+            },
           },
           cubes: [
             {
@@ -311,6 +323,12 @@ export const TooltipContentStory2 = {
               it: "",
             },
             description: {
+              en: "",
+              de: "",
+              fr: "",
+              it: "",
+            },
+            label: {
               en: "",
               de: "",
               fr: "",

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -196,6 +196,10 @@ msgstr "Fügen Sie ein Diagramm basierend auf einem anderen Datensatz hinzu"
 msgid "chart-selection-tabs.add-chart-same-dataset.caption"
 msgstr "Fügen Sie ein Diagramm basierend auf demselben Datensatz hinzu"
 
+#: app/components/chart-selection-tabs.tsx
+msgid "chart-selection-tabs.add-label"
+msgstr ""
+
 #: app/configurator/components/dataset-control-section.tsx
 msgid "chart.datasets.add"
 msgstr "Hinzufügen"
@@ -587,6 +591,10 @@ msgstr "-"
 #: app/configurator/components/field-i18n.ts
 msgid "controls.imputation.type.zeros"
 msgstr "Nullen"
+
+#: app/configurator/components/field-i18n.ts
+msgid "controls.label"
+msgstr ""
 
 #: app/components/rename-dialog.tsx
 #: app/configurator/components/field-i18n.ts

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -196,6 +196,10 @@ msgstr "Add chart based on a different dataset"
 msgid "chart-selection-tabs.add-chart-same-dataset.caption"
 msgstr "Add chart based on the same dataset"
 
+#: app/components/chart-selection-tabs.tsx
+msgid "chart-selection-tabs.add-label"
+msgstr "Add label"
+
 #: app/configurator/components/dataset-control-section.tsx
 msgid "chart.datasets.add"
 msgstr "Add dataset"
@@ -587,6 +591,10 @@ msgstr "-"
 #: app/configurator/components/field-i18n.ts
 msgid "controls.imputation.type.zeros"
 msgstr "Zeros"
+
+#: app/configurator/components/field-i18n.ts
+msgid "controls.label"
+msgstr "Label"
 
 #: app/components/rename-dialog.tsx
 #: app/configurator/components/field-i18n.ts

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -196,6 +196,10 @@ msgstr "Ajouter un graphique basé sur un ensemble de données différent"
 msgid "chart-selection-tabs.add-chart-same-dataset.caption"
 msgstr "Ajouter un graphique basé sur le même ensemble de données"
 
+#: app/components/chart-selection-tabs.tsx
+msgid "chart-selection-tabs.add-label"
+msgstr ""
+
 #: app/configurator/components/dataset-control-section.tsx
 msgid "chart.datasets.add"
 msgstr "Ajouter"
@@ -587,6 +591,10 @@ msgstr "-"
 #: app/configurator/components/field-i18n.ts
 msgid "controls.imputation.type.zeros"
 msgstr "Zéros"
+
+#: app/configurator/components/field-i18n.ts
+msgid "controls.label"
+msgstr ""
 
 #: app/components/rename-dialog.tsx
 #: app/configurator/components/field-i18n.ts

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -196,6 +196,10 @@ msgstr "Aggiungi grafico basato su un set di dati diverso"
 msgid "chart-selection-tabs.add-chart-same-dataset.caption"
 msgstr "Aggiungi grafico basato sullo stesso set di dati"
 
+#: app/components/chart-selection-tabs.tsx
+msgid "chart-selection-tabs.add-label"
+msgstr ""
+
 #: app/configurator/components/dataset-control-section.tsx
 msgid "chart.datasets.add"
 msgstr "Aggiungere"
@@ -587,6 +591,10 @@ msgstr "-"
 #: app/configurator/components/field-i18n.ts
 msgid "controls.imputation.type.zeros"
 msgstr "Zeri"
+
+#: app/configurator/components/field-i18n.ts
+msgid "controls.label"
+msgstr ""
 
 #: app/components/rename-dialog.tsx
 #: app/configurator/components/field-i18n.ts

--- a/app/utils/chart-config/versioning.ts
+++ b/app/utils/chart-config/versioning.ts
@@ -18,7 +18,7 @@ type Migration = {
   down: (config: any, migrationProps?: any) => any;
 };
 
-export const CHART_CONFIG_VERSION = "3.3.0";
+export const CHART_CONFIG_VERSION = "3.4.0";
 
 export const chartConfigMigrations: Migration[] = [
   {
@@ -922,6 +922,34 @@ export const chartConfigMigrations: Migration[] = [
       });
     },
   },
+  {
+    description: `ALL {
+      meta {
+        + label
+      }
+    }`,
+    from: "3.3.0",
+    to: "3.4.0",
+    up: (config) => {
+      const newConfig = { ...config, version: "3.4.0" };
+
+      return produce(newConfig, (draft: any) => {
+        draft.meta.label = {
+          de: "",
+          fr: "",
+          it: "",
+          en: "",
+        };
+      });
+    },
+    down: (config) => {
+      const newConfig = { ...config, version: "3.3.0" };
+
+      return produce(newConfig, (draft: any) => {
+        delete draft.meta.label;
+      });
+    },
+  },
 ];
 
 export const migrateChartConfig = makeMigrate<ChartConfig>(
@@ -931,7 +959,7 @@ export const migrateChartConfig = makeMigrate<ChartConfig>(
   }
 );
 
-export const CONFIGURATOR_STATE_VERSION = "3.6.0";
+export const CONFIGURATOR_STATE_VERSION = "3.7.0";
 
 export const configuratorStateMigrations: Migration[] = [
   {
@@ -1311,6 +1339,76 @@ export const configuratorStateMigrations: Migration[] = [
         },
       };
       return newConfig;
+    },
+  },
+  {
+    description: `ALL {
+      meta {
+        + label
+      }
+    } & bump ChartConfig version`,
+    from: "3.6.0",
+    to: "3.7.0",
+    up: (config) => {
+      const { layout, ...rest } = config;
+      const { meta, ...restLayout } = layout;
+      const newConfig = {
+        ...rest,
+        version: "3.7.0",
+        layout: {
+          ...restLayout,
+          meta: {
+            ...meta,
+            label: {
+              de: "",
+              fr: "",
+              it: "",
+              en: "",
+            },
+          },
+        },
+      };
+
+      return produce(newConfig, (draft: any) => {
+        const chartConfigs: any[] = [];
+
+        for (const chartConfig of draft.chartConfigs) {
+          const migratedChartConfig = migrateChartConfig(chartConfig, {
+            migrationProps: draft,
+            toVersion: "3.4.0",
+          });
+          chartConfigs.push(migratedChartConfig);
+        }
+
+        draft.chartConfigs = chartConfigs;
+      });
+    },
+    down: (config) => {
+      const { layout, ...rest } = config;
+      const { meta, ...restLayout } = layout.meta;
+      const { label, ...restMeta } = meta;
+      const newConfig = {
+        ...rest,
+        version: "3.6.0",
+        layout: {
+          ...restLayout,
+          meta: restMeta,
+        },
+      };
+
+      return produce(newConfig, (draft: any) => {
+        const chartConfigs: any[] = [];
+
+        for (const chartConfig of draft.chartConfigs) {
+          const migratedChartConfig = migrateChartConfig(chartConfig, {
+            migrationProps: draft,
+            toVersion: "3.3.0",
+          });
+          chartConfigs.push(migratedChartConfig);
+        }
+
+        draft.chartConfigs = chartConfigs;
+      });
     },
   },
 ];


### PR DESCRIPTION
This PR introduces a `label` property to the `Meta` object both in chart configs and layout definitions. For now, it's only used in chart config to label chart tabs, but in the future could be extended to e.g.:
- label dashboard charts in the left panel in layouts different than tab layout,
- label dashboards to keep a "working name", instead of showing the full title in user profile.

## How to test
1. Go to [this link](https://visualization-tool-git-feat-tab-labels-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10&dataSource=Prod).
2. ✅ See that there's an `Add label` button in chart tab.
3. ✅ Click on it and see that you can edit the label.
4. Add a new chart.
5. Proceed to layout options.
6. ✅ See that it's no longer possible to edit the labels.
7. Publish the chart.
8. ✅ See that `[ Add label ]` is not displayed and that tabs can't be edited.