### PR TITLE
feat: General improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ You can also check the
 
 # Unreleased
 
+- Features
+  - It's now possible to label individual chart tabs
 - Fixes
   - Map is now correctly centered after copying a chart or switching to layout
     mode
@@ -20,6 +22,7 @@ You can also check the
   - Renaming of charts through user profile now works correctly
   - Manually entering dates in date pickers works correctly again
   - Improved scrolling behavior in the chart tabs
+- Style
   - Aligned editor and layouting page layouts
 
 # [4.7.4] - 2024-07-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ You can also check the
 
 - Features
   - It's now possible to label individual chart tabs
+  - Time is now displayed in addition to date in `Last edit` column in user
+    profile
+  - Free canvas layout option now includes a 3-column layout, depending on the
+    screen width
+  - Added a new popover login menu
 - Fixes
   - Map is now correctly centered after copying a chart or switching to layout
     mode
@@ -24,6 +29,8 @@ You can also check the
   - Improved scrolling behavior in the chart tabs
 - Style
   - Aligned editor and layouting page layouts
+  - Removed dimension selection from modal when merging cubes
+  - Updated styles of confirmation dialog
 
 # [4.7.4] - 2024-07-23
 

--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -7,6 +7,7 @@ import { useMemo } from "react";
 import { extractChartConfigComponentIris } from "@/charts/shared/chart-helpers";
 import { LegendItem } from "@/charts/shared/legend-color";
 import { ChartFiltersList } from "@/components/chart-filters-list";
+import { OpenMetadataPanelWrapper } from "@/components/metadata-panel";
 import {
   ChartConfig,
   ComboLineColumnConfig,
@@ -96,8 +97,16 @@ export const ChartFootnotes = ({
             components={components}
             cubeIri={metadata.iri}
           />
+          <Typography component="span" variant="caption" color="grey.600">
+            <OpenMetadataPanelWrapper>
+              <Trans id="dataset.footnotes.dataset">Dataset</Trans>
+            </OpenMetadataPanelWrapper>
+            <Trans id="typography.colon">: </Trans>
+            {metadata.title}
+          </Typography>
           {metadata.dateModified ? (
             <Typography component="span" variant="caption" color="grey.600">
+              {", "}
               <Trans id="dataset.footnotes.updated">Latest data update</Trans>
               <Trans id="typography.colon">: </Trans>
               {formatLocale.format("%d.%m.%Y %H:%M")(

--- a/app/components/chart-selection-tabs.tsx
+++ b/app/components/chart-selection-tabs.tsx
@@ -544,6 +544,7 @@ export const useIconStyles = makeStyles<
     flexWrap: "nowrap",
     whiteSpace: "nowrap",
     minWidth: 0,
+    maxWidth: 400,
     overflow: "hidden",
     minHeight: "100%",
     position: "relative",

--- a/app/components/confirmation-dialog.tsx
+++ b/app/components/confirmation-dialog.tsx
@@ -27,11 +27,8 @@ const ConfirmationDialog = ({
   onClose: NonNullable<DialogProps["onClose"]>;
 }) => {
   const [loading, setLoading] = useState(false);
-
   return (
     <Dialog
-      // To prevent the click away listener from closing the dialog.
-      onClick={(e) => e.stopPropagation()}
       maxWidth="xs"
       {...props}
     >

--- a/app/components/confirmation-dialog.tsx
+++ b/app/components/confirmation-dialog.tsx
@@ -9,7 +9,7 @@ import {
   DialogProps,
   DialogTitle,
 } from "@mui/material";
-import React, { useState } from "react";
+import { useState } from "react";
 
 const ConfirmationDialog = ({
   title,
@@ -30,36 +30,42 @@ const ConfirmationDialog = ({
   return (
     <Dialog
       maxWidth="xs"
+      PaperProps={{ sx: { gap: 4, width: "100%", p: 6 } }}
       {...props}
     >
-      <DialogTitle sx={{ typography: "h3" }}>
-        {title ??
+      <DialogTitle sx={{ p: 0, typography: "h4" }}>
+        {title ||
           t({
             id: "login.profile.chart.confirmation.default",
             message: "Are you sure you want to perform this action?",
           })}
       </DialogTitle>
       {text && (
-        <DialogContent>
-          <DialogContentText>{text}</DialogContentText>
+        <DialogContent sx={{ p: 0 }}>
+          <DialogContentText sx={{ typography: "body2" }}>
+            {text}
+          </DialogContentText>
         </DialogContent>
       )}
       <DialogActions
         sx={{
+          p: 0,
           "& > .MuiButton-root": {
             justifyContent: "center",
+            minWidth: 76,
+            minHeight: "fit-content",
             pointerEvents: loading ? "none" : "auto",
           },
         }}
       >
         <Button
-          variant="text"
+          variant="outlined"
           onClick={() => props.onClose({}, "escapeKeyDown")}
         >
           <Trans id="no">No</Trans>
         </Button>
         <Button
-          variant="text"
+          variant="contained"
           onClick={async (e) => {
             e.stopPropagation();
             setLoading(true);

--- a/app/components/menu-action-item.tsx
+++ b/app/components/menu-action-item.tsx
@@ -18,7 +18,7 @@ const StyledMenuItem = styled(MenuItem)(({ theme, color }) => ({
 
 export type MenuActionProps = {
   label: string | NonNullable<React.ReactNode>;
-  iconName: IconName;
+  iconName?: IconName;
   priority?: number;
   stayOpen?: boolean;
   color?: "primary" | "error";
@@ -60,7 +60,7 @@ export const MenuActionItem = (
     label,
     color = "primary",
   }: {
-    icon: IconName;
+    icon?: IconName;
     label: string | NonNullable<React.ReactNode>;
     color?: MenuActionProps["color"];
   }) => {
@@ -105,7 +105,9 @@ export const MenuActionItem = (
             {...forwardedProps}
             sx={{ minHeight: 0 }}
           >
-            <Icon size={16} name={icon} style={{ marginTop: "0.25rem" }} />
+            {icon && (
+              <Icon size={16} name={icon} style={{ marginTop: "0.25rem" }} />
+            )}
             {label}
           </StyledMenuItem>
           <Divider sx={{ mx: 1, "&:last-of-type": { display: "none" } }} />

--- a/app/components/metadata-panel-store.tsx
+++ b/app/components/metadata-panel-store.tsx
@@ -9,14 +9,14 @@ type MetadataPanelSection = "general" | "data";
 type MetadataPanelState = {
   open: boolean;
   activeSection: MetadataPanelSection;
-  selectedDimension: Component | undefined;
+  selectedComponent: Component | undefined;
   actions: {
-    setOpen: (d: boolean) => void;
+    setOpen: (open: boolean) => void;
     toggle: () => void;
-    setActiveSection: (d: MetadataPanelSection) => void;
-    setSelectedDimension: (d: Component) => void;
-    clearSelectedDimension: () => void;
-    openDimension: (d: Component) => void;
+    setActiveSection: (activeSection: MetadataPanelSection) => void;
+    setSelectedComponent: (component: Component) => void;
+    clearSelectedComponent: () => void;
+    openComponent: (component: Component) => void;
     reset: () => void;
   };
 };
@@ -25,28 +25,32 @@ export const createMetadataPanelStore = () =>
   createStore<MetadataPanelState>((set, get) => ({
     open: false,
     activeSection: "general",
-    selectedDimension: undefined,
+    selectedComponent: undefined,
     actions: {
-      setOpen: (d: boolean) => {
-        set({ open: d });
+      setOpen: (open: boolean) => {
+        set({ open });
       },
       toggle: () => {
         set({ open: !get().open });
       },
-      setActiveSection: (d: MetadataPanelSection) => {
-        set({ activeSection: d });
+      setActiveSection: (section: MetadataPanelSection) => {
+        set({ activeSection: section });
       },
-      setSelectedDimension: (d: Component) => {
-        set({ selectedDimension: d });
+      setSelectedComponent: (component: Component) => {
+        set({ selectedComponent: component });
       },
-      clearSelectedDimension: () => {
-        set({ selectedDimension: undefined });
+      clearSelectedComponent: () => {
+        set({ selectedComponent: undefined });
       },
-      openDimension: (d: Component) => {
-        set({ open: true, activeSection: "data", selectedDimension: d });
+      openComponent: (component: Component) => {
+        set({
+          open: true,
+          activeSection: "data",
+          selectedComponent: component,
+        });
       },
       reset: () => {
-        set({ activeSection: "general", selectedDimension: undefined });
+        set({ activeSection: "general", selectedComponent: undefined });
       },
     },
   }));

--- a/app/components/metadata-panel.tsx
+++ b/app/components/metadata-panel.tsx
@@ -175,7 +175,7 @@ const useOtherStyles = makeStyles<Theme>((theme) => {
         borderBottom: "none",
       },
     },
-    openDimension: {
+    openComponent: {
       minHeight: 0,
       verticalAlign: "baseline",
       padding: 0,
@@ -214,11 +214,11 @@ export const OpenMetadataPanelWrapper = ({
   component?: Component;
 }) => {
   const classes = useOtherStyles();
-  const { openDimension, setOpen } = useMetadataPanelStoreActions();
+  const { openComponent, setOpen } = useMetadataPanelStoreActions();
   const handleClick = useEvent((e: React.MouseEvent) => {
     e.stopPropagation();
     if (component) {
-      openDimension(component);
+      openComponent(component);
     } else {
       setOpen(true);
     }
@@ -226,7 +226,7 @@ export const OpenMetadataPanelWrapper = ({
 
   return (
     <Button
-      className={classes.openDimension}
+      className={classes.openComponent}
       variant="text"
       size="small"
       onClick={handleClick}
@@ -477,9 +477,9 @@ const DataPanel = ({
   const locale = useLocale();
   const classes = useOtherStyles();
   const selectedDimension = useMetadataPanelStore(
-    (state) => state.selectedDimension
+    (state) => state.selectedComponent
   );
-  const { setSelectedDimension, clearSelectedDimension } =
+  const { setSelectedComponent, clearSelectedComponent } =
     useMetadataPanelStoreActions();
   const [inputValue, setInputValue] = useState("");
   const { options, groupedComponents } = useMemo(() => {
@@ -556,7 +556,7 @@ const DataPanel = ({
         {selectedDimension ? (
           <MotionBox key="dimension-selected" {...animationProps}>
             <BackButton
-              onClick={() => clearSelectedDimension()}
+              onClick={() => clearSelectedComponent()}
               sx={{ color: "primary.main" }}
             >
               <Trans id="button.back">Back</Trans>
@@ -578,7 +578,7 @@ const DataPanel = ({
             <Autocomplete
               className={classes.search}
               disablePortal
-              onChange={(_, v) => v && setSelectedDimension(v.value)}
+              onChange={(_, v) => v && setSelectedComponent(v.value)}
               inputValue={inputValue}
               onInputChange={(_, v) => setInputValue(v.toLowerCase())}
               options={sortedOptions}
@@ -690,7 +690,7 @@ const ComponentTabPanel = ({
   cubeIri?: string;
 }) => {
   const classes = useOtherStyles();
-  const { setSelectedDimension } = useMetadataPanelStoreActions();
+  const { setSelectedComponent } = useMetadataPanelStoreActions();
   const label = useMemo(
     () => getComponentLabel(component, { cubeIri }),
     [cubeIri, component]
@@ -749,9 +749,9 @@ const ComponentTabPanel = ({
 
   const handleClick = useCallback(() => {
     if (!expanded) {
-      setSelectedDimension(component);
+      setSelectedComponent(component);
     }
-  }, [expanded, component, setSelectedDimension]);
+  }, [expanded, component, setSelectedComponent]);
 
   return (
     <div>

--- a/app/components/metadata-panel.tsx
+++ b/app/components/metadata-panel.tsx
@@ -211,13 +211,17 @@ export const OpenMetadataPanelWrapper = ({
   component,
 }: {
   children: ReactNode;
-  component: Component;
+  component?: Component;
 }) => {
   const classes = useOtherStyles();
-  const { openDimension } = useMetadataPanelStoreActions();
+  const { openDimension, setOpen } = useMetadataPanelStoreActions();
   const handleClick = useEvent((e: React.MouseEvent) => {
     e.stopPropagation();
-    openDimension(component);
+    if (component) {
+      openDimension(component);
+    } else {
+      setOpen(true);
+    }
   });
 
   return (

--- a/app/components/metadata-panel.tsx
+++ b/app/components/metadata-panel.tsx
@@ -214,12 +214,14 @@ export const OpenMetadataPanelWrapper = ({
   component?: Component;
 }) => {
   const classes = useOtherStyles();
-  const { openComponent, setOpen } = useMetadataPanelStoreActions();
+  const { openComponent, setOpen, setActiveSection } =
+    useMetadataPanelStoreActions();
   const handleClick = useEvent((e: React.MouseEvent) => {
     e.stopPropagation();
     if (component) {
       openComponent(component);
     } else {
+      setActiveSection("general");
       setOpen(true);
     }
   });

--- a/app/components/react-grid.tsx
+++ b/app/components/react-grid.tsx
@@ -36,7 +36,7 @@ export const MIN_H = 1;
 /** In grid unit */
 const MAX_W = 4;
 
-export const COLS = { lg: 4, md: 2, sm: 1, xs: 1, xxs: 1 };
+export const COLS = { lg: 4, md: 3, sm: 2, xs: 1, xxs: 1 };
 const ROW_HEIGHT = 100;
 
 const useStyles = makeStyles((theme: Theme) => ({

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -508,12 +508,10 @@ msgstr "Kein Filter"
 msgid "controls.filter.nb-elements"
 msgstr "{0} von {1}"
 
-#: app/configurator/components/add-dataset-dialog.tsx
 #: app/configurator/components/filters.tsx
 msgid "controls.filter.select.all"
 msgstr "Alle auswählen"
 
-#: app/configurator/components/add-dataset-dialog.tsx
 #: app/configurator/components/filters.tsx
 msgid "controls.filter.select.none"
 msgstr "Alle abwählen"
@@ -1186,14 +1184,6 @@ msgid "dataset.search.preview.description"
 msgstr "Überprüfen Sie alle verfügbaren Dimensionen, bevor Sie mit der Bearbeitung Ihrer Visualisierung fortfahren."
 
 #: app/configurator/components/add-dataset-dialog.tsx
-msgid "dataset.search.preview.dimensions"
-msgstr "Dimensionen"
-
-#: app/configurator/components/add-dataset-dialog.tsx
-msgid "dataset.search.preview.dimensions-shown"
-msgstr "{0} angezeigt in dieser Ansicht"
-
-#: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.preview.new-dimension"
 msgstr "Neu"
 
@@ -1437,6 +1427,10 @@ msgstr "Datensatz"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.multiple-datasets"
+msgstr ""
+
+#: app/login/components/login-menu.tsx
+msgid "login.sign-in"
 msgstr ""
 
 #: app/components/header.tsx

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -1405,6 +1405,10 @@ msgstr "Meine Entwürfe"
 msgid "login.profile.my-published-visualizations"
 msgstr "Meine Visualisierungen"
 
+#: app/login/components/login-menu.tsx
+msgid "login.profile.my-visualizations"
+msgstr ""
+
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.chart-actions"
 msgstr "Aktionen"
@@ -1431,6 +1435,10 @@ msgstr ""
 
 #: app/login/components/login-menu.tsx
 msgid "login.sign-in"
+msgstr ""
+
+#: app/login/components/login-menu.tsx
+msgid "login.sign-out"
 msgstr ""
 
 #: app/components/header.tsx

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -1084,6 +1084,10 @@ msgid "dataset-result.shared-dimensions"
 msgstr "Geteilte Dimensionen"
 
 #: app/components/chart-footnotes.tsx
+msgid "dataset.footnotes.dataset"
+msgstr ""
+
+#: app/components/chart-footnotes.tsx
 msgid "dataset.footnotes.updated"
 msgstr "Neuestes Datenupdate"
 
@@ -1552,6 +1556,7 @@ msgstr "Woche"
 msgid "time-units.Year"
 msgstr "Jahr"
 
+#: app/components/chart-footnotes.tsx
 #: app/components/chart-footnotes.tsx
 msgid "typography.colon"
 msgstr ": "

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -508,12 +508,10 @@ msgstr "No Filter"
 msgid "controls.filter.nb-elements"
 msgstr "{0} of {1}"
 
-#: app/configurator/components/add-dataset-dialog.tsx
 #: app/configurator/components/filters.tsx
 msgid "controls.filter.select.all"
 msgstr "Select all"
 
-#: app/configurator/components/add-dataset-dialog.tsx
 #: app/configurator/components/filters.tsx
 msgid "controls.filter.select.none"
 msgstr "Select none"
@@ -1186,14 +1184,6 @@ msgid "dataset.search.preview.description"
 msgstr "Review data preview of new available dimensions and continue to edit visualization."
 
 #: app/configurator/components/add-dataset-dialog.tsx
-msgid "dataset.search.preview.dimensions"
-msgstr "Dimensions"
-
-#: app/configurator/components/add-dataset-dialog.tsx
-msgid "dataset.search.preview.dimensions-shown"
-msgstr "{0} shown in this view"
-
-#: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.preview.new-dimension"
 msgstr "New"
 
@@ -1438,6 +1428,10 @@ msgstr "Dataset"
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.multiple-datasets"
 msgstr "Multiple datasets"
+
+#: app/login/components/login-menu.tsx
+msgid "login.sign-in"
+msgstr "Sign in"
 
 #: app/components/header.tsx
 #: app/components/header.tsx

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -1084,6 +1084,10 @@ msgid "dataset-result.shared-dimensions"
 msgstr "Shared dimensions:"
 
 #: app/components/chart-footnotes.tsx
+msgid "dataset.footnotes.dataset"
+msgstr "Dataset"
+
+#: app/components/chart-footnotes.tsx
 msgid "dataset.footnotes.updated"
 msgstr "Latest data update"
 
@@ -1552,6 +1556,7 @@ msgstr "Week"
 msgid "time-units.Year"
 msgstr "Year"
 
+#: app/components/chart-footnotes.tsx
 #: app/components/chart-footnotes.tsx
 msgid "typography.colon"
 msgstr ":"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -1405,6 +1405,10 @@ msgstr "My drafts"
 msgid "login.profile.my-published-visualizations"
 msgstr "My published visualizations"
 
+#: app/login/components/login-menu.tsx
+msgid "login.profile.my-visualizations"
+msgstr "My visualizations"
+
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.chart-actions"
 msgstr "Actions"
@@ -1432,6 +1436,10 @@ msgstr "Multiple datasets"
 #: app/login/components/login-menu.tsx
 msgid "login.sign-in"
 msgstr "Sign in"
+
+#: app/login/components/login-menu.tsx
+msgid "login.sign-out"
+msgstr "Sign out"
 
 #: app/components/header.tsx
 #: app/components/header.tsx

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -1405,6 +1405,10 @@ msgstr "Mes visualisations en brouillon"
 msgid "login.profile.my-published-visualizations"
 msgstr "Mes visualisations publiées"
 
+#: app/login/components/login-menu.tsx
+msgid "login.profile.my-visualizations"
+msgstr ""
+
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.chart-actions"
 msgstr "Actions"
@@ -1431,6 +1435,10 @@ msgstr ""
 
 #: app/login/components/login-menu.tsx
 msgid "login.sign-in"
+msgstr ""
+
+#: app/login/components/login-menu.tsx
+msgid "login.sign-out"
 msgstr ""
 
 #: app/components/header.tsx

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -1084,6 +1084,10 @@ msgid "dataset-result.shared-dimensions"
 msgstr "Dimensions partagées"
 
 #: app/components/chart-footnotes.tsx
+msgid "dataset.footnotes.dataset"
+msgstr ""
+
+#: app/components/chart-footnotes.tsx
 msgid "dataset.footnotes.updated"
 msgstr "Mise à jour des données"
 
@@ -1552,6 +1556,7 @@ msgstr "Semaine"
 msgid "time-units.Year"
 msgstr "Année"
 
+#: app/components/chart-footnotes.tsx
 #: app/components/chart-footnotes.tsx
 msgid "typography.colon"
 msgstr " : "

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -508,12 +508,10 @@ msgstr "Aucune filtre"
 msgid "controls.filter.nb-elements"
 msgstr "{0} sur {1}"
 
-#: app/configurator/components/add-dataset-dialog.tsx
 #: app/configurator/components/filters.tsx
 msgid "controls.filter.select.all"
 msgstr "Tout sélectionner"
 
-#: app/configurator/components/add-dataset-dialog.tsx
 #: app/configurator/components/filters.tsx
 msgid "controls.filter.select.none"
 msgstr "Tout déselectionner"
@@ -1186,14 +1184,6 @@ msgid "dataset.search.preview.description"
 msgstr "Vérifiez les nouvelles dimensions disponibles puis continuez à modifier la visualisation."
 
 #: app/configurator/components/add-dataset-dialog.tsx
-msgid "dataset.search.preview.dimensions"
-msgstr "Dimensions"
-
-#: app/configurator/components/add-dataset-dialog.tsx
-msgid "dataset.search.preview.dimensions-shown"
-msgstr "{0} affichée(s) dans cette vue"
-
-#: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.preview.new-dimension"
 msgstr "Nouveau"
 
@@ -1437,6 +1427,10 @@ msgstr "Ensemble de données"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.multiple-datasets"
+msgstr ""
+
+#: app/login/components/login-menu.tsx
+msgid "login.sign-in"
 msgstr ""
 
 #: app/components/header.tsx

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -1084,6 +1084,10 @@ msgid "dataset-result.shared-dimensions"
 msgstr "Dimensioni condivise"
 
 #: app/components/chart-footnotes.tsx
+msgid "dataset.footnotes.dataset"
+msgstr ""
+
+#: app/components/chart-footnotes.tsx
 msgid "dataset.footnotes.updated"
 msgstr "Ultimo aggiornamento dei dati"
 
@@ -1552,6 +1556,7 @@ msgstr "Settimana"
 msgid "time-units.Year"
 msgstr "Anno"
 
+#: app/components/chart-footnotes.tsx
 #: app/components/chart-footnotes.tsx
 msgid "typography.colon"
 msgstr ": "

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -508,12 +508,10 @@ msgstr "Nessun filtro"
 msgid "controls.filter.nb-elements"
 msgstr "{0} di {1}"
 
-#: app/configurator/components/add-dataset-dialog.tsx
 #: app/configurator/components/filters.tsx
 msgid "controls.filter.select.all"
 msgstr "Seleziona tutti"
 
-#: app/configurator/components/add-dataset-dialog.tsx
 #: app/configurator/components/filters.tsx
 msgid "controls.filter.select.none"
 msgstr "Deseleziona tutto"
@@ -1186,14 +1184,6 @@ msgid "dataset.search.preview.description"
 msgstr "Esamina tutte le dimensioni disponibili prima di continuare a modificare la visualizzazione."
 
 #: app/configurator/components/add-dataset-dialog.tsx
-msgid "dataset.search.preview.dimensions"
-msgstr "Dimensioni"
-
-#: app/configurator/components/add-dataset-dialog.tsx
-msgid "dataset.search.preview.dimensions-shown"
-msgstr "{0} mostrate in questa vista"
-
-#: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.preview.new-dimension"
 msgstr "Nuovo"
 
@@ -1437,6 +1427,10 @@ msgstr "Set di dati"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.multiple-datasets"
+msgstr ""
+
+#: app/login/components/login-menu.tsx
+msgid "login.sign-in"
 msgstr ""
 
 #: app/components/header.tsx

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -1405,6 +1405,10 @@ msgstr "Le mie bozze"
 msgid "login.profile.my-published-visualizations"
 msgstr "Le mie visualizzazioni"
 
+#: app/login/components/login-menu.tsx
+msgid "login.profile.my-visualizations"
+msgstr ""
+
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.chart-actions"
 msgstr "Azioni"
@@ -1431,6 +1435,10 @@ msgstr ""
 
 #: app/login/components/login-menu.tsx
 msgid "login.sign-in"
+msgstr ""
+
+#: app/login/components/login-menu.tsx
+msgid "login.sign-out"
 msgstr ""
 
 #: app/components/header.tsx

--- a/app/login/components/login-menu.tsx
+++ b/app/login/components/login-menu.tsx
@@ -1,23 +1,62 @@
-import { Trans } from "@lingui/macro";
-import { Box, Button, Link, Typography } from "@mui/material";
-import { signIn } from "next-auth/react";
-import NextLink from "next/link";
+import { t, Trans } from "@lingui/macro";
+import { Button, Typography } from "@mui/material";
+import { signIn, signOut } from "next-auth/react";
+import { useState } from "react";
 
+import { ArrowMenuTopCenter } from "@/components/arrow-menu";
+import { MenuActionItem } from "@/components/menu-action-item";
+import { ADFS_PROFILE_URL } from "@/domain/env";
 import { useUser } from "@/login/utils";
 
 export const LoginMenu = () => {
   const user = useUser();
-
+  const [anchorEl, setAnchorEl] = useState<null | HTMLButtonElement>(null);
   return (
-    <Box sx={{ alignItems: "center", display: "flex" }}>
+    <div>
       {user ? (
-        <Typography variant="body2">
-          <NextLink href="/profile" passHref legacyBehavior>
-            <Link sx={{ textDecoration: "none", color: "primary.main" }}>
-              {user.name}
-            </Link>
-          </NextLink>
-        </Typography>
+        <>
+          <Button
+            variant="text"
+            onClick={(e) => setAnchorEl(e.currentTarget)}
+            style={{ minWidth: 0 }}
+          >
+            <Typography variant="body2">{user.name}</Typography>
+          </Button>
+          <ArrowMenuTopCenter
+            anchorEl={anchorEl}
+            anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+            transformOrigin={{ vertical: "top", horizontal: "center" }}
+            open={!!anchorEl}
+            onClose={() => setAnchorEl(null)}
+          >
+            <MenuActionItem
+              type="link"
+              as="menuitem"
+              label={t({
+                id: "login.profile.my-visualizations",
+                message: "My visualizations",
+              })}
+              href="/profile"
+            />
+            {ADFS_PROFILE_URL && (
+              <MenuActionItem
+                type="link"
+                as="menuitem"
+                label="eIAM MyAccount"
+                href={ADFS_PROFILE_URL}
+              />
+            )}
+            <MenuActionItem
+              type="button"
+              as="menuitem"
+              label={t({
+                id: "login.sign-out",
+                message: "Sign out",
+              })}
+              onClick={async () => await signOut()}
+            />
+          </ArrowMenuTopCenter>
+        </>
       ) : (
         <Button
           variant="text"
@@ -28,6 +67,6 @@ export const LoginMenu = () => {
           <Trans id="login.sign-in">Sign in</Trans>
         </Button>
       )}
-    </Box>
+    </div>
   );
 };

--- a/app/login/components/login-menu.tsx
+++ b/app/login/components/login-menu.tsx
@@ -1,3 +1,4 @@
+import { Trans } from "@lingui/macro";
 import { Box, Button, Link, Typography } from "@mui/material";
 import { signIn } from "next-auth/react";
 import NextLink from "next/link";
@@ -24,7 +25,7 @@ export const LoginMenu = () => {
           size="small"
           onClick={() => signIn("adfs")}
         >
-          Sign in
+          <Trans id="login.sign-in">Sign in</Trans>
         </Button>
       )}
     </Box>

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -354,7 +354,7 @@ const ProfileVisualizationsRow = (props: {
       </TableCell>
       <TableCell width="10%">
         <Typography width="auto" variant="body2">
-          {config.updated_at.toLocaleDateString("de")}
+          {config.updated_at.toLocaleString("de")}
         </Typography>
       </TableCell>
       <TableCell width="20%" align="right">

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "locales:compile": "lingui compile --verbose",
     "locales:push": "dotenv -- accent sync --add-translations",
     "locales:pull": "dotenv -- accent export; yarn locales:extract # putting back file location comments",
+    "locales:sync": "yarn locales:push && yarn locales:pull",
     "locales:browse": "open 'https://accent.interactivethings.io/app/projects/584e1dfa-ff1f-4b26-8cac-07004c465134'",
     "graphql:codegen": "graphql-codegen --config codegen.yml",
     "graphql:codegen:dev": "graphql-codegen --config codegen.yml --watch",


### PR DESCRIPTION
This PR:
- (merging of cubes) removes dimension selection from merging of cubes modal,
- (login) adds time to last edit date in user profile,
- (login) adds a new login popover menu when clicking on logged user name,
- (dashboard) adds a new, 3-column layout to free canvas dashboard,
- (general) updates styles and closing behavior of confirmation dialog.


## How to test
Changes marked with (login) can only be tested on TEST after merging the PR.

To test other changes, go to [this link](https://visualization-tool-git-feat-improvements-2-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10&dataSource=Prod&flag__debug=true) and try to:
- add a chart and remove it to see new dialog design,
- add a new dataset to see removed dimension selector in the last step of the process,
- add two new charts and go to layouting step, change the layout to dashboard / free canvas and resize the window to see that there's an intermediary layout with 3 columns.