### PR TITLE
feat: Improve layouting step

### DIFF
--- a/app/components/dashboard-interactive-filters.tsx
+++ b/app/components/dashboard-interactive-filters.tsx
@@ -9,7 +9,7 @@ import {
 import { Theme } from "@mui/material/styles";
 import { makeStyles } from "@mui/styles";
 import uniq from "lodash/uniq";
-import { ChangeEvent, useEffect, useMemo, useState } from "react";
+import { ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   DataFilterGenericDimension,
@@ -21,6 +21,7 @@ import {
   DashboardTimeRangeFilter,
   hasChartConfigs,
   InteractiveFiltersTimeRange,
+  isLayouting,
   useConfiguratorState,
 } from "@/configurator";
 import {
@@ -42,22 +43,33 @@ import useEvent from "@/utils/use-event";
 
 export const DashboardInteractiveFilters = (props: BoxProps) => {
   const { sx, ...rest } = props;
+  const ref = useRef<HTMLDivElement>(null);
   const [state] = useConfiguratorState(hasChartConfigs);
+  const layouting = isLayouting(state);
   const { dashboardFilters } = state;
   const { timeRange, dataFilters } = dashboardFilters ?? {
     timeRange: undefined,
     dataFilters: undefined,
   };
-  const show = !!(timeRange?.active || dataFilters?.componentIris.length);
-  return show ? (
-    <Box {...rest} sx={{ ...sx, mb: 4 }}>
-      {timeRange?.active ? (
+  const showTimeRange = !!timeRange?.active;
+  const showDataFilters = !!dataFilters?.componentIris.length;
+  useEffect(() => {
+    if (layouting && (showTimeRange || showDataFilters)) {
+      ref.current?.scrollIntoView({
+        block: "nearest",
+        behavior: "smooth",
+      });
+    }
+  }, [layouting, showDataFilters, showTimeRange]);
+  return showTimeRange || showDataFilters ? (
+    <Box ref={ref} {...rest} sx={{ ...sx, mb: 4 }}>
+      {showTimeRange ? (
         <DashboardTimeRangeSlider
           filter={timeRange}
           mounted={timeRange.active}
         />
       ) : null}
-      {dataFilters?.componentIris.length ? (
+      {showDataFilters ? (
         <DashboardDataFilters componentIris={dataFilters.componentIris} />
       ) : null}
     </Box>


### PR DESCRIPTION
This PR:
- makes the page scroll to a shared filter when adding or removing the filters in the layouting step, so that users won't miss the fact that they were added at the top of the viewport,
- makes the application remember past layouts when switching between them in the layouting step.

The latter could technically still be improved in a way that a previous layout is also kept when switching to editing step and back to layouting, but as I was unsure if this scenario of:
1. Spending a lot of time doing free canvas layout.
2. Switching to a tab layout.
3. Going back to editing mode.
4. Switching the layout back to free canvas layout.
would be very common, so I went with less complex implementation for now.

## How to test
1. Go to this link.
2. Add a new chart.
3. Proceed to layout options.
4. Make the window small, and scroll to the bottom of the page.
5. Activate a shared filter.
6. ✅ See that the page was scrolled to the top.
7. Switch to a dashboard / free canvas layout.
8. Change the positions of charts.
9. Toggle through dashboard sub-layouts (vertical, tall and free canvas).
10. ✅ See that the layout was persisted.
11. Switch to a tab layout, single URLs and dashboard layout again.
12. ✅ See that the layout was persisted.