### PR TITLE
feat: Preview of charts in different screen sizes

### DIFF
--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -120,11 +120,6 @@ const snapCornerToCursor = createSnapCornerToCursor({
   xOffset: -DRAG_OVERLAY_WIDTH,
 });
 
-type DashboardPreviewProps = ChartPreviewProps & {
-  layoutType: Extract<Layout, { type: "dashboard" }>["layout"];
-  editing?: boolean;
-};
-
 const useStyles = makeStyles(() => ({
   canvasChartPanelLayout: {
     // Provide some space at the bottom of the canvas layout to make it possible
@@ -133,7 +128,12 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-const DashboardPreview = (props: DashboardPreviewProps) => {
+const DashboardPreview = (
+  props: ChartPreviewProps & {
+    layoutType: Extract<Layout, { type: "dashboard" }>["layout"];
+    editing?: boolean;
+  }
+) => {
   const { dataSource, layoutType, editing } = props;
   const [state, dispatch] = useConfiguratorState(hasChartConfigs);
   const theme = useTheme();

--- a/app/components/react-grid.tsx
+++ b/app/components/react-grid.tsx
@@ -237,7 +237,7 @@ export const ChartGridLayout = ({
     setMounted(true);
   }, []);
 
-  const hasBeenConstrained = useRef(false);
+  const hasBeenConstrained = useRef(!initialize);
   useEffect(() => {
     if (!mountedForSomeTime || hasBeenConstrained.current) {
       return;

--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -641,11 +641,19 @@ const LayoutingStep = () => {
           <PublishChartButton chartId={chartId} />
         </PanelHeaderWrapper>
       </PanelHeaderLayout>
-      {!isSingleURLs && (
-        <PanelBodyWrapper type="L">
-          <LayoutConfigurator />
-        </PanelBodyWrapper>
-      )}
+      <PanelBodyWrapper
+        type="L"
+        sx={{
+          position: "absolute",
+          left: isSingleURLs ? -DRAWER_WIDTH : 0,
+          top: isSingleURLs ? LAYOUT_HEADER_HEIGHT : 0,
+          width: DRAWER_WIDTH,
+          height: "100%",
+          transition: "left 0.3s",
+        }}
+      >
+        <LayoutConfigurator />
+      </PanelBodyWrapper>
       <PanelBodyWrapper type="M">
         <Box
           sx={

--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -794,6 +794,9 @@ const useShowDrawerButtonStyles = makeStyles<Theme>((theme) => ({
     width: 42,
     height: 32,
     background: theme.palette.background.paper,
+    "&:hover": {
+      background: theme.palette.background.paper,
+    },
   },
 }));
 
@@ -817,17 +820,26 @@ const PreviewWidthButtons = ({
     {
       breakpoint: "lg",
       iconName: "desktop",
-      title: "Preview using available width",
+      title: t({
+        id: "controls.layout.preview-lg",
+        message: "Preview using available width",
+      }),
     },
     {
       breakpoint: "md",
       iconName: "tabletPortrait",
-      title: "Preview using tablet width",
+      title: t({
+        id: "controls.layout.preview-md",
+        message: "Preview using medium width",
+      }),
     },
     {
       breakpoint: "sm",
       iconName: "mobilePortrait",
-      title: "Preview using mobile width",
+      title: t({
+        id: "controls.layout.preview-sm",
+        message: "Preview using small width",
+      }),
     },
   ] as const;
 

--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -15,7 +15,7 @@ import { PUBLISHED_STATE } from "@prisma/client";
 import { useSession } from "next-auth/react";
 import NextLink from "next/link";
 import { useRouter } from "next/router";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import { useClient } from "urql";
 import { useDebounce } from "use-debounce";
 
@@ -62,6 +62,7 @@ import {
   PanelLayout,
 } from "@/configurator/components/layout";
 import { LayoutConfigurator } from "@/configurator/components/layout-configurator";
+import { usePreviewBreakpoint } from "@/configurator/components/preview-breakpoint";
 import { ShowDrawerButton } from "@/configurator/components/show-drawer-button";
 import { ChartConfiguratorTable } from "@/configurator/table/table-chart-configurator";
 import { useUserConfig } from "@/domain/user-configs";
@@ -519,14 +520,8 @@ const LayoutingStep = () => {
     }
   }, [state.layout]);
 
-  const [previewBreakpoint, setPreviewBreakpoint] =
-    useState<PreviewBreakpoint | null>(null);
-  const maxWidthLayoutRef = useRef(state.layout);
-  useEffect(() => {
-    if (!previewBreakpoint) {
-      maxWidthLayoutRef.current = state.layout;
-    }
-  }, [previewBreakpoint, state.layout]);
+  const { previewBreakpoint, setPreviewBreakpoint, previewBreakpointLayout } =
+    usePreviewBreakpoint();
 
   if (state.state !== "LAYOUTING") {
     return null;
@@ -685,7 +680,7 @@ const LayoutingStep = () => {
               dispatch({
                 type: "LAYOUT_CHANGED",
                 value: {
-                  ...maxWidthLayoutRef.current,
+                  ...previewBreakpointLayout,
                   activeField: undefined,
                 },
               });

--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -61,6 +61,7 @@ import {
 import { LayoutConfigurator } from "@/configurator/components/layout-configurator";
 import {
   PreviewBreakpointToggleMenu,
+  PreviewContainer,
   usePreviewBreakpoint,
 } from "@/configurator/components/preview-breakpoint";
 import { ShowDrawerButton } from "@/configurator/components/show-drawer-button";
@@ -563,7 +564,6 @@ const LayoutingStep = () => {
                 return;
               }
 
-              setPreviewBreakpoint(null);
               if (layoutRef.current?.type === "tab") {
                 dispatch({
                   type: "LAYOUT_CHANGED",
@@ -579,6 +579,8 @@ const LayoutingStep = () => {
                   },
                 });
               }
+
+              setPreviewBreakpoint(null);
             }}
           />
           <IconButton
@@ -589,7 +591,6 @@ const LayoutingStep = () => {
                 return;
               }
 
-              setPreviewBreakpoint(null);
               if (layoutRef.current?.type === "dashboard") {
                 dispatch({
                   type: "LAYOUT_CHANGED",
@@ -606,6 +607,8 @@ const LayoutingStep = () => {
                   },
                 });
               }
+
+              setPreviewBreakpoint(null);
             }}
           />
           <IconButton
@@ -616,7 +619,6 @@ const LayoutingStep = () => {
                 return;
               }
 
-              setPreviewBreakpoint(null);
               if (layoutRef.current?.type === "singleURLs") {
                 dispatch({
                   type: "LAYOUT_CHANGED",
@@ -637,6 +639,8 @@ const LayoutingStep = () => {
                   },
                 });
               }
+
+              setPreviewBreakpoint(null);
             }}
           />
         </PanelHeaderWrapper>
@@ -686,17 +690,9 @@ const LayoutingStep = () => {
             setPreviewBreakpoint(previewBreakpoint === value ? null : value);
           }}
         />
-        <Box
-          sx={{
-            width: "100%",
-            maxWidth: previewBreakpoint
-              ? (t) =>
-                  `calc(${previewBreakpoint !== "lg" ? `${t.breakpoints.values[previewBreakpoint]}px` : isSingleURLs ? 1280 : "100%"} - 216px)`
-              : isSingleURLs
-                ? 1280
-                : "100%",
-            mx: "auto",
-          }}
+        <PreviewContainer
+          breakpoint={previewBreakpoint}
+          singleColumn={isSingleURLs}
         >
           <Box
             sx={{
@@ -747,7 +743,7 @@ const LayoutingStep = () => {
           </Box>
           {/* We need to reset the key to prevent overwriting of the layout */}
           <ChartPreview key={previewBreakpoint} dataSource={state.dataSource} />
-        </Box>
+        </PreviewContainer>
       </PanelBodyWrapper>
       <ConfiguratorDrawer
         anchor="left"

--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -1,11 +1,8 @@
 import { t, Trans } from "@lingui/macro";
 import {
   Box,
-  Divider,
   Grow,
   SxProps,
-  ToggleButton,
-  ToggleButtonGroup,
   Tooltip,
   Typography,
   useEventCallback,
@@ -62,7 +59,10 @@ import {
   PanelLayout,
 } from "@/configurator/components/layout";
 import { LayoutConfigurator } from "@/configurator/components/layout-configurator";
-import { usePreviewBreakpoint } from "@/configurator/components/preview-breakpoint";
+import {
+  PreviewBreakpointToggleMenu,
+  usePreviewBreakpoint,
+} from "@/configurator/components/preview-breakpoint";
 import { ShowDrawerButton } from "@/configurator/components/show-drawer-button";
 import { ChartConfiguratorTable } from "@/configurator/table/table-chart-configurator";
 import { useUserConfig } from "@/domain/user-configs";
@@ -495,8 +495,6 @@ const ConfigureChartStep = () => {
   );
 };
 
-type PreviewBreakpoint = "lg" | "md" | "sm";
-
 const LayoutingStep = () => {
   const locale = useLocale();
   const [state, dispatch] = useConfiguratorState(isLayouting);
@@ -673,31 +671,21 @@ const LayoutingStep = () => {
         {!isSingleURLs && previewBreakpoint && (
           <ShowDrawerButton onClick={() => setPreviewBreakpoint(null)} />
         )}
-        <PreviewWidthButtons
+        <PreviewBreakpointToggleMenu
           value={previewBreakpoint}
           onChange={(value) => {
-            if (previewBreakpoint === value) {
-              dispatch({
-                type: "LAYOUT_CHANGED",
-                value: {
-                  ...previewBreakpointLayout,
-                  activeField: undefined,
-                },
-              });
-              setPreviewBreakpoint(null);
-            } else {
-              dispatch({
-                type: "LAYOUT_CHANGED",
-                value: {
-                  ...state.layout,
-                  activeField: undefined,
-                },
-              });
-              setPreviewBreakpoint(value);
-            }
+            dispatch({
+              type: "LAYOUT_CHANGED",
+              value: {
+                ...(previewBreakpoint === value
+                  ? previewBreakpointLayout
+                  : state.layout),
+                activeField: undefined,
+              },
+            });
+            setPreviewBreakpoint(previewBreakpoint === value ? null : value);
           }}
         />
-
         <Box
           sx={{
             width: "100%",
@@ -775,82 +763,6 @@ const LayoutingStep = () => {
         </div>
       </ConfiguratorDrawer>
     </PanelLayout>
-  );
-};
-
-const PreviewWidthButtons = ({
-  value,
-  onChange,
-}: {
-  value: PreviewBreakpoint | null;
-  onChange: (value: PreviewBreakpoint | null) => void;
-}) => {
-  const options = [
-    {
-      breakpoint: "lg",
-      iconName: "desktop",
-      title: t({
-        id: "controls.layout.preview-lg",
-        message: "Preview using available width",
-      }),
-    },
-    {
-      breakpoint: "md",
-      iconName: "tabletPortrait",
-      title: t({
-        id: "controls.layout.preview-md",
-        message: "Preview using medium width",
-      }),
-    },
-    {
-      breakpoint: "sm",
-      iconName: "mobilePortrait",
-      title: t({
-        id: "controls.layout.preview-sm",
-        message: "Preview using small width",
-      }),
-    },
-  ] as const;
-
-  return (
-    <ToggleButtonGroup
-      value={value}
-      exclusive
-      color="primary"
-      sx={{ float: "right", backgroundColor: "background.paper" }}
-    >
-      {options.map(({ breakpoint, iconName, title }) => {
-        return (
-          <>
-            <Tooltip title={title} arrow enterDelay={1000}>
-              <ToggleButton
-                key={value}
-                value={breakpoint}
-                onClick={() => onChange(breakpoint)}
-                sx={{
-                  border: "none",
-                  backgroundColor: "background.paper",
-                  color: breakpoint === value ? "primary.main" : "text.primary",
-                  "&:hover": {
-                    backgroundColor: "background.paper",
-                    color: "primary.main",
-                  },
-                }}
-              >
-                <Icon name={iconName} size={16} />
-              </ToggleButton>
-            </Tooltip>
-            {breakpoint !== "sm" && (
-              <Divider
-                orientation="vertical"
-                flexItem
-                sx={{ alignSelf: "center", height: 16 }}
-              />
-            )}
-          </>
-        );
-      })}
-    </ToggleButtonGroup>
   );
 };
 

--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -4,7 +4,6 @@ import {
   Divider,
   Grow,
   SxProps,
-  Theme,
   ToggleButton,
   ToggleButtonGroup,
   Tooltip,
@@ -12,7 +11,6 @@ import {
   useEventCallback,
 } from "@mui/material";
 import Button, { ButtonProps } from "@mui/material/Button";
-import { makeStyles } from "@mui/styles";
 import { PUBLISHED_STATE } from "@prisma/client";
 import { useSession } from "next-auth/react";
 import NextLink from "next/link";
@@ -64,6 +62,7 @@ import {
   PanelLayout,
 } from "@/configurator/components/layout";
 import { LayoutConfigurator } from "@/configurator/components/layout-configurator";
+import { ShowDrawerButton } from "@/configurator/components/show-drawer-button";
 import { ChartConfiguratorTable } from "@/configurator/table/table-chart-configurator";
 import { useUserConfig } from "@/domain/user-configs";
 import { useDataCubesComponentsQuery } from "@/graphql/hooks";
@@ -781,31 +780,6 @@ const LayoutingStep = () => {
         </div>
       </ConfiguratorDrawer>
     </PanelLayout>
-  );
-};
-
-const useShowDrawerButtonStyles = makeStyles<Theme>((theme) => ({
-  root: {
-    zIndex: 1,
-    float: "left",
-    display: "flex",
-    justifyContent: "center",
-    alignItems: "center",
-    width: 42,
-    height: 32,
-    background: theme.palette.background.paper,
-    "&:hover": {
-      background: theme.palette.background.paper,
-    },
-  },
-}));
-
-const ShowDrawerButton = ({ onClick }: { onClick: () => void }) => {
-  const classes = useShowDrawerButtonStyles();
-  return (
-    <Button className={classes.root} variant="text" onClick={onClick}>
-      <Icon name="doubleArrow" />
-    </Button>
   );
 };
 

--- a/app/configurator/components/layout.tsx
+++ b/app/configurator/components/layout.tsx
@@ -45,7 +45,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
   panelHeaderLayout: {
     gridArea: "header",
     background: theme.palette.background.paper,
-    height: LAYOUT_HEADER_HEIGHT
+    height: LAYOUT_HEADER_HEIGHT,
   },
   LMRPanelHeaderLayout: {
     width: "100%",
@@ -164,11 +164,11 @@ export const PanelLayout = (props: PanelLayoutProps) => {
   );
 };
 
-type PanelBodyWrapperProps = BoxProps & {
-  type: "L" | "M" | "R";
-};
-
-export const PanelBodyWrapper = (props: PanelBodyWrapperProps) => {
+export const PanelBodyWrapper = (
+  props: BoxProps & {
+    type: "L" | "M" | "R";
+  }
+) => {
   const { children, type, ...rest } = props;
   const classes = useStyles();
 

--- a/app/configurator/components/layout.tsx
+++ b/app/configurator/components/layout.tsx
@@ -50,7 +50,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
   LMRPanelHeaderLayout: {
     width: "100%",
     display: "grid",
-    gridTemplateColumns: `${DRAWER_WIDTH}px minmax(22rem, 1fr) auto`,
+    gridTemplateColumns: `${DRAWER_WIDTH}px minmax(22rem, 1fr) minmax(${DRAWER_WIDTH}px, auto)`,
     gridTemplateAreas: `
     "left middle right"
     `,

--- a/app/configurator/components/preview-breakpoint.tsx
+++ b/app/configurator/components/preview-breakpoint.tsx
@@ -5,10 +5,11 @@ import {
   ToggleButton,
   ToggleButtonGroup,
   Tooltip,
+  useTheme,
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import clsx from "clsx";
-import { Fragment, useEffect, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   isLayouting,
@@ -33,6 +34,37 @@ export const usePreviewBreakpoint = () => {
     setPreviewBreakpoint: setBreakpoint,
     previewBreakpointLayout: layoutRef.current,
   };
+};
+
+const SINGLE_COLUMN_MAX_WIDTH = 1280;
+const PREVIEW_CONTAINER_PADDING = 216;
+
+export const PreviewContainer = ({
+  children,
+  breakpoint,
+  singleColumn,
+}: {
+  children: React.ReactNode;
+  breakpoint: PreviewBreakpoint | null;
+  singleColumn?: boolean;
+}) => {
+  const classes = useStyles();
+  const { breakpoints } = useTheme();
+  const maxWidth = useMemo(() => {
+    if (breakpoint) {
+      if (breakpoint === "lg") {
+        return `calc(${singleColumn ? `${SINGLE_COLUMN_MAX_WIDTH}px` : "100%"} - ${PREVIEW_CONTAINER_PADDING}px)`;
+      } else {
+        return breakpoints.values[breakpoint];
+      }
+    }
+    return singleColumn ? SINGLE_COLUMN_MAX_WIDTH : "100%";
+  }, [breakpoint, breakpoints, singleColumn]);
+  return (
+    <div className={classes.container} style={{ maxWidth }}>
+      {children}
+    </div>
+  );
 };
 
 export const PreviewBreakpointToggleMenu = ({
@@ -110,6 +142,10 @@ const PREVIEW_BREAKPOINT_OPTIONS: {
 ];
 
 const useStyles = makeStyles<Theme>((theme) => ({
+  container: {
+    width: "100%",
+    margin: "0 auto",
+  },
   toggleButtonGroup: {
     float: "right",
     backgroundColor: theme.palette.background.paper,

--- a/app/configurator/components/preview-breakpoint.tsx
+++ b/app/configurator/components/preview-breakpoint.tsx
@@ -1,9 +1,20 @@
-import { useEffect, useRef, useState } from "react";
+import { t } from "@lingui/macro";
+import {
+  Divider,
+  Theme,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+} from "@mui/material";
+import { makeStyles } from "@mui/styles";
+import clsx from "clsx";
+import { Fragment, useEffect, useRef, useState } from "react";
 
 import {
   isLayouting,
   useConfiguratorState,
 } from "@/configurator/configurator-state";
+import { Icon, IconName } from "@/icons";
 
 type PreviewBreakpoint = "lg" | "md" | "sm";
 
@@ -23,3 +34,100 @@ export const usePreviewBreakpoint = () => {
     previewBreakpointLayout: layoutRef.current,
   };
 };
+
+export const PreviewBreakpointToggleMenu = ({
+  value,
+  onChange,
+}: {
+  value: PreviewBreakpoint | null;
+  onChange: (value: PreviewBreakpoint | null) => void;
+}) => {
+  const classes = useStyles();
+  return (
+    <ToggleButtonGroup
+      className={classes.toggleButtonGroup}
+      color="primary"
+      value={value}
+      exclusive
+    >
+      {PREVIEW_BREAKPOINT_OPTIONS.map(({ breakpoint, iconName, title }) => {
+        return (
+          <Fragment key={breakpoint}>
+            <Tooltip title={title} arrow enterDelay={1000}>
+              <ToggleButton
+                className={clsx(classes.toggleButton, {
+                  [classes.toggleButtonSelected]: value === breakpoint,
+                })}
+                value={breakpoint}
+                onClick={() => onChange(breakpoint)}
+              >
+                <Icon name={iconName} size={16} />
+              </ToggleButton>
+            </Tooltip>
+            {breakpoint !== "sm" && (
+              <Divider
+                className={classes.divider}
+                orientation="vertical"
+                flexItem
+              />
+            )}
+          </Fragment>
+        );
+      })}
+    </ToggleButtonGroup>
+  );
+};
+
+const PREVIEW_BREAKPOINT_OPTIONS: {
+  breakpoint: PreviewBreakpoint;
+  iconName: IconName;
+  title: string;
+}[] = [
+  {
+    breakpoint: "lg",
+    iconName: "desktop",
+    title: t({
+      id: "controls.layout.preview-lg",
+      message: "Preview using available width",
+    }),
+  },
+  {
+    breakpoint: "md",
+    iconName: "tabletPortrait",
+    title: t({
+      id: "controls.layout.preview-md",
+      message: "Preview using medium width",
+    }),
+  },
+  {
+    breakpoint: "sm",
+    iconName: "mobilePortrait",
+    title: t({
+      id: "controls.layout.preview-sm",
+      message: "Preview using small width",
+    }),
+  },
+];
+
+const useStyles = makeStyles<Theme>((theme) => ({
+  toggleButtonGroup: {
+    float: "right",
+    backgroundColor: theme.palette.background.paper,
+  },
+  toggleButton: {
+    border: "none",
+    backgroundColor: theme.palette.background.paper,
+    color: theme.palette.text.primary,
+    "&:hover": {
+      backgroundColor: theme.palette.background.paper,
+      color: theme.palette.primary.main,
+    },
+  },
+  toggleButtonSelected: {
+    color: theme.palette.primary.main,
+  },
+  divider: {
+    alignSelf: "center",
+    height: 16,
+  },
+}));

--- a/app/configurator/components/preview-breakpoint.tsx
+++ b/app/configurator/components/preview-breakpoint.tsx
@@ -1,0 +1,25 @@
+import { useEffect, useRef, useState } from "react";
+
+import {
+  isLayouting,
+  useConfiguratorState,
+} from "@/configurator/configurator-state";
+
+type PreviewBreakpoint = "lg" | "md" | "sm";
+
+export const usePreviewBreakpoint = () => {
+  const [state] = useConfiguratorState(isLayouting);
+  const [breakpoint, setBreakpoint] = useState<PreviewBreakpoint | null>(null);
+  const layoutRef = useRef(state.layout);
+  useEffect(() => {
+    if (!breakpoint) {
+      layoutRef.current = state.layout;
+    }
+  }, [breakpoint, state.layout]);
+
+  return {
+    previewBreakpoint: breakpoint,
+    setPreviewBreakpoint: setBreakpoint,
+    previewBreakpointLayout: layoutRef.current,
+  };
+};

--- a/app/configurator/components/show-drawer-button.tsx
+++ b/app/configurator/components/show-drawer-button.tsx
@@ -1,0 +1,31 @@
+import { Button, ButtonProps, Theme } from "@mui/material";
+import { makeStyles } from "@mui/styles";
+import clsx from "clsx";
+
+import { Icon } from "@/icons";
+
+const useStyles = makeStyles<Theme>((theme) => ({
+  root: {
+    float: "left",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    width: 42,
+    height: 32,
+    background: theme.palette.background.paper,
+    color: theme.palette.primary.main,
+    "&:hover": {
+      background: theme.palette.background.paper,
+    },
+  },
+}));
+
+export const ShowDrawerButton = (props: ButtonProps) => {
+  const { className, variant = "text", ...rest } = props;
+  const classes = useStyles();
+  return (
+    <Button className={clsx(classes.root, className)} {...rest}>
+      <Icon name="doubleArrow" />
+    </Button>
+  );
+};

--- a/app/icons/components/IcDoubleArrow.tsx
+++ b/app/icons/components/IcDoubleArrow.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+function SvgIcDoubleArrow(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      width="1em"
+      height="1em"
+      {...props}
+    >
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M10.293 12L5 17.5 6.5 19l6.5-7-6.5-7L5 6.5l5.293 5.5z"
+      />
+      <path
+        fill="currentColor"
+        fillRule="evenodd"
+        d="M16.293 12L11 17.5l1.5 1.5 6.5-7-6.5-7L11 6.5l5.293 5.5z"
+      />
+    </svg>
+  );
+}
+export default SvgIcDoubleArrow;

--- a/app/icons/components/index.tsx
+++ b/app/icons/components/index.tsx
@@ -46,6 +46,7 @@ import { default as DatasetError } from "@/icons/components/IcDatasetError";
 import { default as DatasetSuccess } from "@/icons/components/IcDatasetSuccess";
 import { default as Description } from "@/icons/components/IcDescription";
 import { default as Desktop } from "@/icons/components/IcDesktop";
+import { default as DoubleArrow } from "@/icons/components/IcDoubleArrow";
 import { default as Download } from "@/icons/components/IcDownload";
 import { default as Drag } from "@/icons/components/IcDrag";
 import { default as DragHandle } from "@/icons/components/IcDragHandle";
@@ -201,6 +202,7 @@ export const Icons = {
   datasetSuccess: DatasetSuccess,
   description: Description,
   desktop: Desktop,
+  doubleArrow: DoubleArrow,
   download: Download,
   dragHandle: DragHandle,
   drag: Drag,

--- a/app/icons/svg/ic_double-arrow.svg
+++ b/app/icons/svg/ic_double-arrow.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path
+    fill-rule="evenodd"
+    d="M10.2929 12L5 17.5L6.5 19L13 12L6.5 5L5 6.5L10.2929 12Z"
+    fill="#454545"
+  />
+  <path
+    fill-rule="evenodd"
+    d="M16.2929 12L11 17.5L12.5 19L19 12L12.5 5L11 6.5L16.2929 12Z"
+    fill="#454545"
+  />
+</svg>

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -627,6 +627,18 @@ msgstr ""
 msgid "controls.layout.dashboard"
 msgstr "Dashboard"
 
+#: app/configurator/components/configurator.tsx
+msgid "controls.layout.preview-lg"
+msgstr ""
+
+#: app/configurator/components/configurator.tsx
+msgid "controls.layout.preview-md"
+msgstr ""
+
+#: app/configurator/components/configurator.tsx
+msgid "controls.layout.preview-sm"
+msgstr ""
+
 #: app/configurator/components/field-i18n.ts
 msgid "controls.layout.singleURLs"
 msgstr "Separate URLs"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -627,6 +627,18 @@ msgstr "Chart"
 msgid "controls.layout.dashboard"
 msgstr "Dashboard"
 
+#: app/configurator/components/configurator.tsx
+msgid "controls.layout.preview-lg"
+msgstr "Preview using available width"
+
+#: app/configurator/components/configurator.tsx
+msgid "controls.layout.preview-md"
+msgstr "Preview using medium width"
+
+#: app/configurator/components/configurator.tsx
+msgid "controls.layout.preview-sm"
+msgstr "Preview using small width"
+
 #: app/configurator/components/field-i18n.ts
 msgid "controls.layout.singleURLs"
 msgstr "Separate URLs"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -627,6 +627,18 @@ msgstr ""
 msgid "controls.layout.dashboard"
 msgstr "Dashboard"
 
+#: app/configurator/components/configurator.tsx
+msgid "controls.layout.preview-lg"
+msgstr ""
+
+#: app/configurator/components/configurator.tsx
+msgid "controls.layout.preview-md"
+msgstr ""
+
+#: app/configurator/components/configurator.tsx
+msgid "controls.layout.preview-sm"
+msgstr ""
+
 #: app/configurator/components/field-i18n.ts
 msgid "controls.layout.singleURLs"
 msgstr "URL distincts"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -627,6 +627,18 @@ msgstr ""
 msgid "controls.layout.dashboard"
 msgstr "Dashboard"
 
+#: app/configurator/components/configurator.tsx
+msgid "controls.layout.preview-lg"
+msgstr ""
+
+#: app/configurator/components/configurator.tsx
+msgid "controls.layout.preview-md"
+msgstr ""
+
+#: app/configurator/components/configurator.tsx
+msgid "controls.layout.preview-sm"
+msgstr ""
+
 #: app/configurator/components/field-i18n.ts
 msgid "controls.layout.singleURLs"
 msgstr "URL separati"


### PR DESCRIPTION
Closes #1710.

This PR adds an option to preview every layout (tab, dashboard and single URLs) in three modes:
- full available window width,
- tablet width (`md` breakpoint),
- mobile width (`sm` breakpoint).

## How to test
1. Go to this link.
2. Add a few more charts.
3. Proceed to layout options.
4. ✅ See that there's a new toggle menu in the right top corner with device icons.
5. ✅ Click through them to see that the chart area adjusts accordingly – you can toggle off the preview by clicking on a currently select preview mode, or by `>>` button in the left top corner.
6. Switch to dashboard / free canvas layout and modify it.
7. Preview different viewport sizes and exit the preview mode.
8. ✅  See that the original layout was persisted.

## Next steps
We should probably persist the changes made in the preview mode, so that users can not only modify largest viewport layout (`lg`), but rather also smaller ones. Currently they are just preview, without an option to be saved.