### PR TITLE
fix: DashboardTimeRangeSlider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ You can also check the
   - Renaming of charts through user profile now works correctly
   - Manually entering dates in date pickers works correctly again
   - Improved scrolling behavior in the chart tabs
+  - Shared time range filter now correctly positions the marks in the time
+    slider
 - Style
   - Aligned editor and layouting page layouts
   - Removed dimension selection from modal when merging cubes

--- a/app/charts/shared/use-combined-temporal-dimension.ts
+++ b/app/charts/shared/use-combined-temporal-dimension.ts
@@ -1,0 +1,87 @@
+import { t } from "@lingui/macro";
+import { ascending, descending } from "d3-array";
+import uniqBy from "lodash/uniqBy";
+import { useMemo } from "react";
+
+import {
+  hasChartConfigs,
+  useConfiguratorState,
+} from "@/configurator/configurator-state";
+import {
+  isTemporalDimensionWithTimeUnit,
+  TemporalDimension,
+  TemporalEntityDimension,
+} from "@/domain/data";
+import { useTimeFormatLocale } from "@/formatters";
+import { useConfigsCubeComponents } from "@/graphql/hooks";
+import { TimeUnit } from "@/graphql/query-hooks";
+import { useLocale } from "@/locales/use-locale";
+import { timeUnitFormats, timeUnitOrder } from "@/rdf/mappings";
+import { useDashboardInteractiveFilters } from "@/stores/interactive-filters";
+
+/** Hook to get combined temporal dimension. Useful for shared dashboard filters. */
+export const useCombinedTemporalDimension = () => {
+  const locale = useLocale();
+  const formatLocale = useTimeFormatLocale();
+  const [state] = useConfiguratorState(hasChartConfigs);
+  const { potentialTimeRangeFilterIris } = useDashboardInteractiveFilters();
+  const [{ data }] = useConfigsCubeComponents({
+    variables: {
+      state,
+      locale,
+    },
+  });
+  const dimensions = useMemo(
+    () => data?.dataCubesComponents.dimensions ?? [],
+    [data?.dataCubesComponents.dimensions]
+  );
+
+  return useMemo(() => {
+    const timeUnitDimensions = dimensions.filter(
+      (dimension) =>
+        isTemporalDimensionWithTimeUnit(dimension) &&
+        potentialTimeRangeFilterIris.includes(dimension.iri)
+    ) as (TemporalDimension | TemporalEntityDimension)[];
+    // We want to use lowest time unit for combined dimension filtering,
+    // so in case we have year and day, we'd filter both by day
+    const timeUnit = timeUnitDimensions.sort((a, b) =>
+      descending(
+        timeUnitOrder.get(a.timeUnit) ?? 0,
+        timeUnitOrder.get(b.timeUnit) ?? 0
+      )
+    )[0]?.timeUnit as TimeUnit;
+    const timeFormat = timeUnitFormats.get(timeUnit) as string;
+    const values = timeUnitDimensions.flatMap((dimension) => {
+      const formatDate = formatLocale.format(timeFormat);
+      const parseDate = formatLocale.parse(dimension.timeFormat);
+      // Standardize values to have same date format
+      return dimension.values.map((dimensionValue) => {
+        const date = parseDate(`${dimensionValue.value}`) as Date;
+        const dateString = formatDate(date);
+        return {
+          ...dimensionValue,
+          value: dateString,
+          label: dateString,
+        };
+      });
+    });
+    const combinedDimension: TemporalDimension = {
+      __typename: "TemporalDimension",
+      cubeIri: "all",
+      iri: "combined-date-filter",
+      label: t({
+        id: "controls.section.shared-filters.date",
+        message: "Date",
+      }),
+      isKeyDimension: true,
+      isNumerical: false,
+      values: uniqBy(values, "value").sort((a, b) =>
+        ascending(a.value, b.value)
+      ),
+      timeUnit,
+      timeFormat,
+    };
+
+    return combinedDimension;
+  }, [dimensions, formatLocale, potentialTimeRangeFilterIris]);
+};

--- a/app/charts/shared/use-combined-temporal-dimension.ts
+++ b/app/charts/shared/use-combined-temporal-dimension.ts
@@ -31,13 +31,10 @@ export const useCombinedTemporalDimension = () => {
       locale,
     },
   });
-  const dimensions = useMemo(
-    () => data?.dataCubesComponents.dimensions ?? [],
-    [data?.dataCubesComponents.dimensions]
-  );
-
   return useMemo(() => {
-    const timeUnitDimensions = dimensions.filter(
+    const timeUnitDimensions = (
+      data?.dataCubesComponents.dimensions ?? []
+    ).filter(
       (dimension) =>
         isTemporalDimensionWithTimeUnit(dimension) &&
         potentialTimeRangeFilterIris.includes(dimension.iri)
@@ -83,5 +80,9 @@ export const useCombinedTemporalDimension = () => {
     };
 
     return combinedDimension;
-  }, [dimensions, formatLocale, potentialTimeRangeFilterIris]);
+  }, [
+    data?.dataCubesComponents.dimensions,
+    formatLocale,
+    potentialTimeRangeFilterIris,
+  ]);
 };


### PR DESCRIPTION
Fixes #1617

This PR fixes a problem of wrong positioning of marks in `DashboardTimeRangeSlider`. Due to the conversion of dates to milliseconds, and interpolation of values between min and max dates, there were some non-obvious issues with marks positioning. To see one such issue, see [this link](https://test.visualize.admin.ch/en/v/ZJSPzC4KHBvM?dataSource=Prod) from TEST and slide through the slider values – see that 2022 and 2023 and extra-close to each other, while they should have the same spacing as previous years.

To fix this issue, I changed the Slider's behavior from continuous to discrete, passing the values that actually appear in the data. It also makes sure that we use combined values from merged date dimension.

## How to test
1. Go to [this link](https://visualization-tool-git-fix-time-range-dashboard-slider-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10&dataSource=Prod).
2. Add a line chart.
3. Proceed to layout options.
4. Enable shared date filter.
5. ✅ Scroll through the values and see that 2022 and 2023 have equal spacing, as between other years.