### PR TITLE
fix: Search bots behavior

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /usr/src/app
 
 # build with
 # docker build \
+#   --build-arg PREVENT_SEARCH_BOTS=<true/false> \
 #   --build-arg COMMIT=$(git rev-parse HEAD) \
 #   --build-arg VECTOR_TILE_URL=<url of the vector service> \
 #   --build-arg MAPTILER_STYLE_KEY=<maptiler style key> \
@@ -15,6 +16,7 @@ WORKDIR /usr/src/app
 #   --build-arg NEXTAUTH_URL=<nextauth url>
 
 # Supplied by build pipeline
+ARG PREVENT_SEARCH_BOTS
 ARG COMMIT
 ARG VECTOR_TILE_URL
 ARG MAPTILER_STYLE_KEY
@@ -35,6 +37,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 ENV STORYBOOK_DISABLE_TELEMETRY=1
 ENV PORT 3000
 
+ENV PREVENT_SEARCH_BOTS=$PREVENT_SEARCH_BOTS
 ENV NEXT_PUBLIC_COMMIT=$COMMIT
 ENV NEXT_PUBLIC_BASE_VECTOR_TILE_URL=$VECTOR_TILE_URL
 ENV NEXT_PUBLIC_MAPTILER_STYLE_KEY=$MAPTILER_STYLE_KEY

--- a/app/domain/env.ts
+++ b/app/domain/env.ts
@@ -52,6 +52,7 @@ export const ADFS_PROFILE_URL =
  * Server-side-only **RUNTIME** variables (not exposed through window)
  */
 
+export const PREVENT_SEARCH_BOTS = process.env.PREVENT_SEARCH_BOTS === "true";
 export const DATABASE_URL = process.env.DATABASE_URL;
 export const ADFS_ID = process.env.ADFS_ID;
 export const ADFS_ISSUER = process.env.ADFS_ISSUER;

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -26,6 +26,7 @@ console.log("Commit", process.env.NEXT_PUBLIC_COMMIT);
 console.log("GitHub Repo", process.env.NEXT_PUBLIC_GITHUB_REPO);
 
 console.log("Extra Certs", process.env.NODE_EXTRA_CA_CERTS);
+console.log("Prevent search bots", process.env.PREVENT_SEARCH_BOTS);
 
 module.exports = withPreconstruct(
   withBundleAnalyzer(
@@ -39,7 +40,7 @@ module.exports = withPreconstruct(
       headers: async () => {
         const headers = [];
 
-        if (process.env.ALLOW_SEARCH_BOTS !== "true") {
+        if (process.env.PREVENT_SEARCH_BOTS === "true") {
           headers.push({
             source: "/:path*",
             headers: [


### PR DESCRIPTION
Fixes #1676

It looks like we had a legacy variable – `ALLOW_SEARCH_BOTS` – that was not passed via the Dockerfile and couldn't be picked up during build. The exact rule we had in the code was "if ALLOW_SEARCH_BOTS is not 'true'", then disable the indexing, which resulted in the problem described in #1676.

I think it makes more sense to enable indexing by default, and disable it conditionally; that's why there's a new, `PREVENT_SEARCH_BOTS` variable to disable this behavior where needed.

## Todo
- [ ] Add `PREVENT_SEARCH_BOTS=true` env variable to Vercel
- [ ] Add `PREVENT_SEARCH_BOTS=true` env variable to GitLab TEST pipeline
- [ ] Reach out to VSHN to add `PREVENT_SEARCH_BOTS=true` variable to INT pipeline
- [ ] PROD doesn't need a variable at all, once we deploy the behavior should be right due to reversed condition

cc @adintegra