### PR TITLE
fix: Server-side eIAM session termination

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ yarn dev:ssl # If you are working with the login process
 > experience an SSL error when the authentication provider redirects you back to
 > the app after login. You can either remove the trailing s in the URL after the
 > redirection, or use the `yarn dev:ssl` command to use HTTPs for the
-> development server.
+> development server. Also, make sure to set the `NEXTAUTH_URL` environment
+> variable to `https://localhost:3000` in your `.env.local` file.
 
 > 👉 In [Visual Studio Code](https://code.visualstudio.com/), you also can run
 > the **default build task** (CMD-SHIFT-B) to start the dev server, database
@@ -350,6 +351,9 @@ We use Next-auth to integrate our application with it, through a
 You can use the ref eIAM. ADFS environment variables should be configured in
 your `.env.local` file. You'll find those secret variables in our shared
 1Password in the "Visualize.admin .env.local" entry.
+
+Make sure to set the `NEXTAUTH_URL` environment variable to
+`http://localhost:3000` and run the dev server with `yarn dev:ssl`.
 
 ## 10. <a name='Translations'></a>Translations
 

--- a/app/.env.development
+++ b/app/.env.development
@@ -7,3 +7,4 @@ SENTRY_IGNORE_API_RESOLUTION_ERROR=1
 NEXT_PUBLIC_VECTOR_TILE_URL=https://world.vectortiles.geo.admin.ch
 NEXT_PUBLIC_MAPTILER_STYLE_KEY=123
 ADFS_PROFILE_URL=https://www.myaccount-r.eiam.admin.ch/
+NEXTAUTH_URL=https://localhost:3000

--- a/app/login/components/login-menu.tsx
+++ b/app/login/components/login-menu.tsx
@@ -60,7 +60,9 @@ export const LoginMenu = () => {
                 id: "login.sign-out",
                 message: "Sign out",
               })}
-              onClick={async () => await signOut()}
+              onClick={async () =>
+                await signOut({ callbackUrl: "/api/auth/signout" })
+              }
             />
           </ArrowMenuTopCenter>
         </>

--- a/app/pages/api/auth/[...nextauth].ts
+++ b/app/pages/api/auth/[...nextauth].ts
@@ -28,6 +28,21 @@ const providers = [
 export const nextAuthOptions = {
   providers,
   callbacks: {
+    /** Necessary otherwise we cannot sign out */
+    jwt: async ({ token }) => {
+      return token;
+    },
+    redirect: async ({ url, baseUrl }) => {
+      if (url.startsWith("/")) {
+        if (url === "/api/auth/signout") {
+          return `${ADFS_ISSUER}/protocol/openid-connect/logout?redirect_url=${baseUrl}`;
+        }
+        return `${baseUrl}${url}`;
+      } else if (new URL(url).origin === baseUrl) {
+        return url;
+      }
+      return baseUrl;
+    },
     /**
      * When the user is logged in, ensures it creates on our side and save its id
      * on the session.
@@ -39,10 +54,6 @@ export const nextAuthOptions = {
         session.user.id = user.id;
       }
       return session;
-    },
-    /** Necessary otherwise we cannot sign out */
-    jwt: async ({ token }) => {
-      return token;
     },
   },
   debug: false,

--- a/app/pages/api/auth/[...nextauth].ts
+++ b/app/pages/api/auth/[...nextauth].ts
@@ -35,7 +35,7 @@ export const nextAuthOptions = {
     redirect: async ({ url, baseUrl }) => {
       if (url.startsWith("/")) {
         if (url === "/api/auth/signout") {
-          return `${ADFS_ISSUER}/protocol/openid-connect/logout?redirect_url=${baseUrl}`;
+          return `${ADFS_ISSUER}/protocol/openid-connect/logout?redirect_uri=${baseUrl}`;
         }
         return `${baseUrl}${url}`;
       } else if (new URL(url).origin === baseUrl) {


### PR DESCRIPTION
Fixes #1691

This PR fires a request to eIAM servers when user signs out, to also terminate the session on their side.

As we can't connect to eIAM infrastructure from localhost, I wasn't able to test out if this works – we would be able to do so when the change is deployed to TEST.

It would be extremely helpful to be able to connect to e.g. TEST eIAM auth server to work on such issues. @adintegra @ptbrowne do you know if we have such access, maybe I missed this? If not, could we potentially request it?