### PR TITLE
feat: Improve chart sizes preview

### DIFF
--- a/app/components/chart-panel-layout-tall.module.css
+++ b/app/components/chart-panel-layout-tall.module.css
@@ -1,0 +1,13 @@
+.root {
+  display: grid;
+  grid-auto-rows: min-content;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+/* sm + 1px */
+@container (min-width: 769px) {
+  .root {
+    grid-template-columns: 1fr 1fr;
+  }
+}

--- a/app/components/chart-panel-layout-tall.tsx
+++ b/app/components/chart-panel-layout-tall.tsx
@@ -1,6 +1,7 @@
 import { Box, useMediaQuery } from "@mui/material";
 import { useMemo } from "react";
 
+import classes from "@/components/chart-panel-layout-tall.module.css";
 import { ChartConfig } from "@/config-types";
 import { useTheme } from "@/themes";
 
@@ -41,17 +42,7 @@ const ChartPanelLayoutTallRow = (props: ChartPanelLayoutTallRowProps) => {
       }
 
       return (
-        <Box
-          sx={{
-            display: "grid",
-            gridTemplateColumns: {
-              xs: "1fr",
-              md: "calc(50% - 8px) calc(50% - 8px)",
-            },
-            gridAutoRows: "min-content",
-            columnGap: 4,
-          }}
-        >
+        <Box className={classes.root}>
           {row.chartConfigs.map(row.renderChart)}
         </Box>
       );

--- a/app/components/chart-panel.tsx
+++ b/app/components/chart-panel.tsx
@@ -16,6 +16,7 @@ import { useConfiguratorState } from "@/src";
 
 const useStyles = makeStyles((theme: Theme) => ({
   panelLayout: {
+    containerType: "inline-size",
     display: "flex",
     flexDirection: "column",
     gap: theme.spacing(4),

--- a/app/components/chart-panel.tsx
+++ b/app/components/chart-panel.tsx
@@ -21,6 +21,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     gap: theme.spacing(4),
   },
   chartWrapper: {
+    display: "flex",
+    flexDirection: "column",
     overflow: "hidden",
     [`.${chartPanelLayoutGridClasses.root} &`]: {
       transition: theme.transitions.create(["box-shadow"], {

--- a/app/components/chart-shared.tsx
+++ b/app/components/chart-shared.tsx
@@ -31,11 +31,11 @@ import { createChartId } from "@/utils/create-chart-id";
 /** Generic styles shared between `ChartPreview` and `ChartPublished`. */
 export const useChartStyles = makeStyles<Theme>((theme) => ({
   root: {
+    flexGrow: 1,
     display: "grid",
     gridTemplateRows: "subgrid",
     /** Should stay in sync with the number of rows contained in a chart */
     gridRow: "span 7",
-    height: "100%",
     padding: theme.spacing(6),
     backgroundColor: theme.palette.background.paper,
     border: "1px solid",

--- a/app/configurator/components/preview-breakpoint.tsx
+++ b/app/configurator/components/preview-breakpoint.tsx
@@ -56,7 +56,7 @@ export const PreviewContainer = ({
         case "lg":
           return `calc(100% - ${PREVIEW_CONTAINER_PADDING}px)`;
         case "md":
-          return breakpoints.values[breakpoint];
+          return `min(calc(100% - ${PREVIEW_CONTAINER_PADDING}px), ${breakpoints.values.md}px)`;
         case "sm":
           return 480;
         default:

--- a/app/configurator/components/preview-breakpoint.tsx
+++ b/app/configurator/components/preview-breakpoint.tsx
@@ -151,7 +151,6 @@ const useStyles = makeStyles<Theme>((theme) => ({
   container: {
     width: "100%",
     margin: "0 auto",
-    containerType: "inline-size",
   },
   toggleButtonGroup: {
     float: "right",

--- a/app/configurator/components/preview-breakpoint.tsx
+++ b/app/configurator/components/preview-breakpoint.tsx
@@ -145,6 +145,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
   container: {
     width: "100%",
     margin: "0 auto",
+    containerType: "inline-size",
   },
   toggleButtonGroup: {
     float: "right",

--- a/app/configurator/components/preview-breakpoint.tsx
+++ b/app/configurator/components/preview-breakpoint.tsx
@@ -52,10 +52,16 @@ export const PreviewContainer = ({
   const { breakpoints } = useTheme();
   const maxWidth = useMemo(() => {
     if (breakpoint) {
-      if (breakpoint === "lg") {
-        return `calc(100% - ${PREVIEW_CONTAINER_PADDING}px)`;
-      } else {
-        return breakpoints.values[breakpoint];
+      switch (breakpoint) {
+        case "lg":
+          return `calc(100% - ${PREVIEW_CONTAINER_PADDING}px)`;
+        case "md":
+          return breakpoints.values[breakpoint];
+        case "sm":
+          return 480;
+        default:
+          const _exhaustiveCheck: never = breakpoint;
+          return _exhaustiveCheck;
       }
     }
     return singleColumn ? SINGLE_COLUMN_MAX_WIDTH : "100%";

--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -9,8 +9,8 @@ const config = {
     },
   },
   moduleNameMapper: {
-    "^@/(.*)$": "<rootDir>/$1",
     "\\.(css)$": "<rootDir>/test/style-mock.js",
+    "^@/(.*)$": "<rootDir>/$1",
   },
   transform: {
     "node_modules/@rdf*": "ts-jest",


### PR DESCRIPTION
This PR:
- fixes https://github.com/visualize-admin/visualization-tool/pull/1724#issuecomment-2334360578 by using container queries,
- adjusts width of smallest preview breakpoint from `sm` (768px) to 480px,
- fixes an overflowing issue with previewing / resizing the window in the Tall layout.