### PR TITLE
fix: Constrain single interactive filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ You can also check the
   - Improved scrolling behavior in the chart tabs
   - Shared time range filter now correctly positions the marks in the time
     slider
+  - Single interactive filters are now constrained by config filters
 - Style
   - Aligned editor and layouting page layouts
   - Removed dimension selection from modal when merging cubes

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -267,7 +267,9 @@ const DataFilter = ({
     );
     return otherKeys.length > 0
       ? interactiveFilters
-      : Object.fromEntries(
+      : // In case of only one filter, we want to constrain the values
+        // by config filters.
+        Object.fromEntries(
           Object.entries(filters).filter(([key]) => key !== dimensionIri)
         );
   }, [filters, interactiveFilters, dimensionIri]);

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -261,9 +261,16 @@ const DataFilter = ({
   const updateDataFilter = useChartInteractiveFilters(
     (d) => d.updateDataFilter
   );
-  const otherKeys = Object.keys(interactiveFilters).filter(
-    (key) => key !== dimensionIri
-  );
+  const queryFilters = useMemo(() => {
+    const otherKeys = Object.keys(interactiveFilters).filter(
+      (key) => key !== dimensionIri
+    );
+    return otherKeys.length > 0
+      ? interactiveFilters
+      : Object.fromEntries(
+          Object.entries(filters).filter(([key]) => key !== dimensionIri)
+        );
+  }, [filters, interactiveFilters, dimensionIri]);
   const [{ data, fetching }] = useDataCubesComponentsQuery({
     variables: {
       sourceType: dataSource.type,
@@ -273,7 +280,7 @@ const DataFilter = ({
         {
           iri: cubeIri,
           componentIris: [dimensionIri],
-          filters: otherKeys.length > 0 ? interactiveFilters : undefined,
+          filters: queryFilters,
           loadValues: true,
         },
       ],
@@ -282,7 +289,7 @@ const DataFilter = ({
       // If this is not present, we'll have outdated dimension
       // values after we change the filter order.
       // @ts-ignore
-      filterKeys: otherKeys.join(", "),
+      filterKeys: Object.keys(queryFilters).join(", "),
     },
     keepPreviousData: true,
   });


### PR DESCRIPTION
Fixes #1736

This PR constrains a solitary interactive filter by config filters, to eliminate the possibility of selecting values that result in no observations.

## How to test
1. Go to this link.

## How to reproduce
See #1736 