### PR TITLE
feat: Allow editing free canvas in preview mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,14 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Features
+  - Added a new preview option (xl) in the layouting step
+  - Changes made in the preview mode are now persisted in the free canvas
+    layout, so that the user can tailor the dashboard's layout in every
+    breakpoint size
+  - Preview mode now takes the real size of the breakpoint, making the area
+    horizontally scrollable in case the screen size is smaller than the
+    breakpoint
 
 # [4.8.0] - 2024-09-11
 

--- a/app/components/chart-panel-layout-grid.tsx
+++ b/app/components/chart-panel-layout-grid.tsx
@@ -5,7 +5,9 @@ import { useState } from "react";
 import { Layouts } from "react-grid-layout";
 
 import { ChartPanelLayoutTypeProps } from "@/components/chart-panel";
-import ChartGridLayout from "@/components/react-grid";
+import ChartGridLayout, {
+  FREE_CANVAS_BREAKPOINTS,
+} from "@/components/react-grid";
 import { ReactGridLayoutsType, hasChartConfigs } from "@/configurator";
 import { useConfiguratorState } from "@/src";
 import { assert } from "@/utils/assert";
@@ -72,6 +74,7 @@ const ChartPanelLayoutCanvas = (props: ChartPanelLayoutTypeProps) => {
       resize={state.state === "LAYOUTING"}
       draggableHandle={`.${chartPanelLayoutGridClasses.dragHandle}`}
       onLayoutChange={(_l, allLayouts) => handleChangeLayouts(allLayouts)}
+      breakpoints={FREE_CANVAS_BREAKPOINTS}
     >
       {chartConfigs.map((chartConfig) => props.renderChart(chartConfig))}
     </ChartGridLayout>

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -113,7 +113,7 @@ const useStyles = makeStyles(() => ({
   canvasChartPanelLayout: {
     // Provide some space at the bottom of the canvas layout to make it possible
     // to resize vertically the last charts
-    marginBottom: "10rem",
+    paddingBottom: "10rem",
   },
 }));
 

--- a/app/components/react-grid.tsx
+++ b/app/components/react-grid.tsx
@@ -11,7 +11,11 @@ import { match } from "ts-pattern";
 
 import { useStyles as useChartContainerStyles } from "@/charts/shared/containers";
 import { getChartWrapperId } from "@/components/chart-panel";
-import { hasChartConfigs, isLayouting } from "@/configurator";
+import {
+  hasChartConfigs,
+  isLayouting,
+  ReactGridLayoutType,
+} from "@/configurator";
 import { useTimeout } from "@/hooks/use-timeout";
 import { useConfiguratorState } from "@/src";
 
@@ -328,7 +332,7 @@ export const generateLayout = function ({
   maxHeight?: number;
   layout: "horizontal" | "vertical" | "wide" | "tall" | "tiles";
   resizeHandles?: ResizeHandle[];
-}) {
+}): ReactGridLayoutType[] {
   return map(range(0, count), (_item, i) => {
     return match(layout)
       .with("horizontal", () => {

--- a/app/components/react-grid.tsx
+++ b/app/components/react-grid.tsx
@@ -39,7 +39,13 @@ export const MIN_H = 1;
 /** In grid unit */
 const MAX_W = 4;
 
-export const COLS = { lg: 4, md: 3, sm: 2, xs: 1, xxs: 1 };
+export const COLS = { xl: 4, lg: 3, md: 2, sm: 1 };
+export const FREE_CANVAS_BREAKPOINTS = {
+  xl: theme.breakpoints.values.md,
+  lg: theme.breakpoints.values.sm,
+  md: 480,
+  sm: 0,
+};
 const ROW_HEIGHT = 100;
 
 const useStyles = makeStyles((theme: Theme) => ({

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -1125,6 +1125,20 @@ export const ReactGridLayoutsType = t.record(
   t.string,
   t.array(ReactGridLayoutType)
 );
+export type ReactGridLayoutsType = t.TypeOf<typeof ReactGridLayoutsType>;
+
+const ReactGridLayoutMetadata = t.type({
+  initialized: t.boolean,
+});
+export type ReactGridLayoutMetadata = t.TypeOf<typeof ReactGridLayoutMetadata>;
+
+const ReactGridLayoutsMetadataType = t.record(
+  t.string,
+  ReactGridLayoutMetadata
+);
+export type ReactGridLayoutsMetadataType = t.TypeOf<
+  typeof ReactGridLayoutsMetadataType
+>;
 
 const Layout = t.intersection([
   t.type({
@@ -1143,6 +1157,7 @@ const Layout = t.intersection([
       type: t.literal("dashboard"),
       layout: t.literal("canvas"),
       layouts: ReactGridLayoutsType,
+      layoutsMetadata: ReactGridLayoutsMetadataType,
     }),
     t.type({
       type: t.literal("singleURLs"),
@@ -1153,6 +1168,10 @@ const Layout = t.intersection([
 export type Layout = t.TypeOf<typeof Layout>;
 export type LayoutType = Layout["type"];
 export type LayoutDashboard = Extract<Layout, { type: "dashboard" }>;
+export type LayoutDashboardFreeCanvas = Extract<
+  Layout,
+  { type: "dashboard"; layout: "canvas" }
+>;
 
 const DashboardTimeRangeFilter = t.type({
   active: t.boolean,

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -1119,6 +1119,7 @@ const ReactGridLayoutType = t.type({
   i: t.string,
   resizeHandles: t.union([t.array(ResizeHandle), t.undefined]),
 });
+export type ReactGridLayoutType = t.TypeOf<typeof ReactGridLayoutType>;
 
 export const ReactGridLayoutsType = t.record(
   t.string,

--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -456,7 +456,7 @@ const ConfigureChartStep = () => {
         </PanelHeaderLayout>
         <PanelBodyWrapper
           type="L"
-          sx={{
+          style={{
             flexGrow: 1,
             display: "flex",
             height: "100%",
@@ -474,7 +474,10 @@ const ConfigureChartStep = () => {
             />
           )}
         </PanelBodyWrapper>
-        <PanelBodyWrapper type="M">
+        <PanelBodyWrapper
+          type="M"
+          style={{ overflowX: "hidden", overflowY: "auto" }}
+        >
           <ChartPreview dataSource={state.dataSource} />
         </PanelBodyWrapper>
         <ConfiguratorDrawer
@@ -664,23 +667,28 @@ const LayoutingStep = () => {
       >
         <LayoutConfigurator />
       </PanelBodyWrapper>
-      <PanelBodyWrapper type="M">
-        {!isSingleURLs && previewBreakpoint && (
-          <ShowDrawerButton onClick={() => setPreviewBreakpoint(null)} />
-        )}
-        <PreviewBreakpointToggleMenu
-          value={previewBreakpoint}
-          onChange={(value) => {
-            dispatch({
-              type: "LAYOUT_CHANGED",
-              value: {
-                ...state.layout,
-                activeField: undefined,
-              },
-            });
-            setPreviewBreakpoint(previewBreakpoint === value ? null : value);
-          }}
-        />
+      <PanelBodyWrapper
+        type="M"
+        style={{ overflowY: "hidden", overflowX: "auto" }}
+      >
+        <Box sx={{ display: "flex", pb: 4 }}>
+          {!isSingleURLs && previewBreakpoint && (
+            <ShowDrawerButton onClick={() => setPreviewBreakpoint(null)} />
+          )}
+          <PreviewBreakpointToggleMenu
+            value={previewBreakpoint}
+            onChange={(value) => {
+              dispatch({
+                type: "LAYOUT_CHANGED",
+                value: {
+                  ...state.layout,
+                  activeField: undefined,
+                },
+              });
+              setPreviewBreakpoint(previewBreakpoint === value ? null : value);
+            }}
+          />
+        </Box>
         <PreviewContainer
           breakpoint={previewBreakpoint}
           singleColumn={isSingleURLs}

--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -520,8 +520,7 @@ const LayoutingStep = () => {
     }
   }, [state.layout]);
 
-  const { previewBreakpoint, setPreviewBreakpoint, previewBreakpointLayout } =
-    usePreviewBreakpoint();
+  const { previewBreakpoint, setPreviewBreakpoint } = usePreviewBreakpoint();
 
   const handleLayoutChange = useCallback(
     (
@@ -675,9 +674,7 @@ const LayoutingStep = () => {
             dispatch({
               type: "LAYOUT_CHANGED",
               value: {
-                ...(previewBreakpoint === value
-                  ? previewBreakpointLayout
-                  : state.layout),
+                ...state.layout,
                 activeField: undefined,
               },
             });

--- a/app/configurator/components/layout-configurator.tsx
+++ b/app/configurator/components/layout-configurator.tsx
@@ -576,6 +576,9 @@ const migrateLayout = (
       ...layout,
       layout: newLayoutType,
       layouts,
+      layoutsMetadata: Object.fromEntries(
+        chartConfigs.map(({ key }) => [key, { initialized: false }])
+      ),
     };
   } else {
     return {

--- a/app/configurator/components/layout-configurator.tsx
+++ b/app/configurator/components/layout-configurator.tsx
@@ -14,12 +14,16 @@ import { useCallback, useEffect, useMemo, useRef } from "react";
 import { DataFilterGenericDimensionProps } from "@/charts/shared/chart-data-filters";
 import { useCombinedTemporalDimension } from "@/charts/shared/use-combined-temporal-dimension";
 import { Select } from "@/components/form";
-import { generateLayout } from "@/components/react-grid";
+import {
+  FREE_CANVAS_BREAKPOINTS,
+  generateLayout,
+} from "@/components/react-grid";
 import {
   ChartConfig,
   DashboardTimeRangeFilter,
   getChartConfig,
   LayoutDashboard,
+  ReactGridLayoutType,
 } from "@/config-types";
 import { LayoutAnnotator } from "@/configurator/components/annotators";
 import { DataFilterSelectGeneric } from "@/configurator/components/chart-configurator";
@@ -552,21 +556,26 @@ const migrateLayout = (
   chartConfigs: ChartConfig[]
 ): LayoutDashboard => {
   if (newLayoutType === "canvas") {
-    const generated = generateLayout({
+    const defaultLayout = generateLayout({
       count: chartConfigs.length,
       layout: "tiles",
-    });
+    }).map((l, i) => ({
+      ...l,
+      i: chartConfigs[i].key,
+    }));
+    const layouts: Record<
+      keyof typeof FREE_CANVAS_BREAKPOINTS,
+      ReactGridLayoutType[]
+    > = {
+      xl: defaultLayout,
+      lg: defaultLayout,
+      md: defaultLayout,
+      sm: defaultLayout,
+    };
     return {
       ...layout,
       layout: newLayoutType,
-      layouts: {
-        lg: generated.map((l, i) => ({
-          ...l,
-          // We must pay attention to correctly change the i value to
-          // chart config key, as it is used to identify the layout
-          i: chartConfigs[i].key,
-        })),
-      },
+      layouts,
     };
   } else {
     return {

--- a/app/configurator/components/layout.tsx
+++ b/app/configurator/components/layout.tsx
@@ -81,8 +81,6 @@ const useStyles = makeStyles<Theme>((theme) => ({
     gridArea: "left",
   },
   MPanelBodyWrapper: {
-    overflowX: "hidden",
-    overflowY: "auto",
     padding: theme.spacing(5),
     gridArea: "middle",
   },

--- a/app/configurator/components/preview-breakpoint.tsx
+++ b/app/configurator/components/preview-breakpoint.tsx
@@ -9,15 +9,13 @@ import {
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import clsx from "clsx";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { ReactNode, useMemo, useState } from "react";
 
-import {
-  isLayouting,
-  useConfiguratorState,
-} from "@/configurator/configurator-state";
+import { FREE_CANVAS_BREAKPOINTS } from "@/components/react-grid";
 import { Icon, IconName } from "@/icons";
+import { theme } from "@/themes/federal";
 
-type PreviewBreakpoint = "lg" | "md" | "sm";
+type PreviewBreakpoint = keyof typeof FREE_CANVAS_BREAKPOINTS;
 
 export const usePreviewBreakpoint = () => {
   const [breakpoint, setBreakpoint] = useState<PreviewBreakpoint | null>(null);
@@ -32,7 +30,7 @@ export const PreviewContainer = ({
   breakpoint,
   singleColumn,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
   breakpoint: PreviewBreakpoint | null;
   singleColumn?: boolean;
 }) => {
@@ -41,18 +39,20 @@ export const PreviewContainer = ({
   const maxWidth = useMemo(() => {
     if (breakpoint) {
       switch (breakpoint) {
+        case "xl":
+          return breakpoints.values.lg - 1;
         case "lg":
-          return `calc(100% - ${PREVIEW_CONTAINER_PADDING}px)`;
+          return breakpoints.values.md - 1;
         case "md":
-          return `min(calc(100% - ${PREVIEW_CONTAINER_PADDING}px), ${breakpoints.values.md}px)`;
+          return breakpoints.values.sm - 1;
         case "sm":
-          return 480;
+          return FREE_CANVAS_BREAKPOINTS.md;
         default:
           const _exhaustiveCheck: never = breakpoint;
           return _exhaustiveCheck;
       }
     }
-    return singleColumn ? SINGLE_COLUMN_MAX_WIDTH : "100%";
+    return singleColumn ? theme.breakpoints.values.lg - 1 : "100%";
   }, [breakpoint, breakpoints, singleColumn]);
   return (
     <div className={classes.container} style={{ maxWidth }}>
@@ -75,11 +75,19 @@ export const PreviewBreakpointToggleMenu = ({
     title: string;
   }[] = [
     {
-      breakpoint: "lg",
+      breakpoint: "xl",
       iconName: "desktop",
       title: t({
+        id: "controls.layout.preview-xl",
+        message: "Preview using extra large width",
+      }),
+    },
+    {
+      breakpoint: "lg",
+      iconName: "laptop",
+      title: t({
         id: "controls.layout.preview-lg",
-        message: "Preview using available width",
+        message: "Preview using large width",
       }),
     },
     {

--- a/app/configurator/components/preview-breakpoint.tsx
+++ b/app/configurator/components/preview-breakpoint.tsx
@@ -20,23 +20,12 @@ import { Icon, IconName } from "@/icons";
 type PreviewBreakpoint = "lg" | "md" | "sm";
 
 export const usePreviewBreakpoint = () => {
-  const [state] = useConfiguratorState(isLayouting);
   const [breakpoint, setBreakpoint] = useState<PreviewBreakpoint | null>(null);
-  const layoutRef = useRef(state.layout);
-  useEffect(() => {
-    if (!breakpoint) {
-      layoutRef.current = state.layout;
-    }
-  }, [breakpoint, state.layout]);
   return {
     previewBreakpoint: breakpoint,
     setPreviewBreakpoint: setBreakpoint,
-    previewBreakpointLayout: layoutRef.current,
   };
 };
-
-const SINGLE_COLUMN_MAX_WIDTH = 1280;
-const PREVIEW_CONTAINER_PADDING = 216;
 
 export const PreviewContainer = ({
   children,

--- a/app/configurator/components/preview-breakpoint.tsx
+++ b/app/configurator/components/preview-breakpoint.tsx
@@ -36,7 +36,7 @@ export const PreviewContainer = ({
 }) => {
   const classes = useStyles();
   const { breakpoints } = useTheme();
-  const maxWidth = useMemo(() => {
+  const width = useMemo(() => {
     if (breakpoint) {
       switch (breakpoint) {
         case "xl":
@@ -55,8 +55,16 @@ export const PreviewContainer = ({
     return singleColumn ? theme.breakpoints.values.lg - 1 : "100%";
   }, [breakpoint, breakpoints, singleColumn]);
   return (
-    <div className={classes.container} style={{ maxWidth }}>
-      {children}
+    <div
+      className={classes.container}
+      style={{ marginTop: breakpoint ? "3rem" : 0 }}
+    >
+      <div
+        className={classes.chartContainer}
+        style={{ width, paddingTop: breakpoint ? "0.5rem" : 0 }}
+      >
+        {children}
+      </div>
     </div>
   );
 };
@@ -149,7 +157,14 @@ export const PreviewBreakpointToggleMenu = ({
 const useStyles = makeStyles<Theme>((theme) => ({
   container: {
     width: "100%",
+    overflowX: "auto",
+    // Show the scrollbar on top
+    transform: "rotateX(180deg)",
+  },
+  chartContainer: {
     margin: "0 auto",
+    // Show the scrollbar on top
+    transform: "rotateX(180deg)",
   },
   toggleButtonGroup: {
     float: "right",

--- a/app/configurator/components/preview-breakpoint.tsx
+++ b/app/configurator/components/preview-breakpoint.tsx
@@ -55,10 +55,7 @@ export const PreviewContainer = ({
     return singleColumn ? theme.breakpoints.values.lg - 1 : "100%";
   }, [breakpoint, breakpoints, singleColumn]);
   return (
-    <div
-      className={classes.container}
-      style={{ marginTop: breakpoint ? "3rem" : 0 }}
-    >
+    <div className={classes.container}>
       <div
         className={classes.chartContainer}
         style={{ width, paddingTop: breakpoint ? "0.5rem" : 0 }}
@@ -157,17 +154,15 @@ export const PreviewBreakpointToggleMenu = ({
 const useStyles = makeStyles<Theme>((theme) => ({
   container: {
     width: "100%",
-    overflowX: "auto",
-    // Show the scrollbar on top
-    transform: "rotateX(180deg)",
+    height: "calc(100% - 2rem)",
+    overflowY: "auto",
   },
   chartContainer: {
     margin: "0 auto",
-    // Show the scrollbar on top
-    transform: "rotateX(180deg)",
+    paddingBottom: "2rem",
   },
   toggleButtonGroup: {
-    float: "right",
+    marginLeft: "auto",
     backgroundColor: theme.palette.background.paper,
   },
   toggleButton: {

--- a/app/configurator/components/show-drawer-button.tsx
+++ b/app/configurator/components/show-drawer-button.tsx
@@ -6,7 +6,6 @@ import { Icon } from "@/icons";
 
 const useStyles = makeStyles<Theme>((theme) => ({
   root: {
-    float: "left",
     display: "flex",
     justifyContent: "center",
     alignItems: "center",

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -637,7 +637,7 @@ msgstr "Dashboard"
 
 #: app/configurator/components/preview-breakpoint.tsx
 msgid "controls.layout.preview-lg"
-msgstr "Vorschau mit verfügbarer Breite"
+msgstr "Vorschau in grosser Breite"
 
 #: app/configurator/components/preview-breakpoint.tsx
 msgid "controls.layout.preview-md"
@@ -646,6 +646,10 @@ msgstr "Vorschau in mittlerer Breite"
 #: app/configurator/components/preview-breakpoint.tsx
 msgid "controls.layout.preview-sm"
 msgstr "Vorschau in kleiner Breite"
+
+#: app/configurator/components/preview-breakpoint.tsx
+msgid "controls.layout.preview-xl"
+msgstr "Vorschau in extra grosser Breite"
 
 #: app/configurator/components/field-i18n.ts
 msgid "controls.layout.singleURLs"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -637,7 +637,7 @@ msgstr "Dashboard"
 
 #: app/configurator/components/preview-breakpoint.tsx
 msgid "controls.layout.preview-lg"
-msgstr "Preview using available width"
+msgstr "Preview using large width"
 
 #: app/configurator/components/preview-breakpoint.tsx
 msgid "controls.layout.preview-md"
@@ -646,6 +646,10 @@ msgstr "Preview using medium width"
 #: app/configurator/components/preview-breakpoint.tsx
 msgid "controls.layout.preview-sm"
 msgstr "Preview using small width"
+
+#: app/configurator/components/preview-breakpoint.tsx
+msgid "controls.layout.preview-xl"
+msgstr "Preview using extra large width"
 
 #: app/configurator/components/field-i18n.ts
 msgid "controls.layout.singleURLs"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -637,15 +637,19 @@ msgstr "Dashboard"
 
 #: app/configurator/components/preview-breakpoint.tsx
 msgid "controls.layout.preview-lg"
-msgstr ""
+msgstr "Aperçu en utilisant une grande largeur"
 
 #: app/configurator/components/preview-breakpoint.tsx
 msgid "controls.layout.preview-md"
-msgstr ""
+msgstr "Aperçu en utilisant une largeur moyenne"
 
 #: app/configurator/components/preview-breakpoint.tsx
 msgid "controls.layout.preview-sm"
-msgstr ""
+msgstr "Aperçu en utilisant une petite largeur"
+
+#: app/configurator/components/preview-breakpoint.tsx
+msgid "controls.layout.preview-xl"
+msgstr "Prévisualisation en utilisant une largeur extra large"
 
 #: app/configurator/components/field-i18n.ts
 msgid "controls.layout.singleURLs"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -637,15 +637,19 @@ msgstr "Dashboard"
 
 #: app/configurator/components/preview-breakpoint.tsx
 msgid "controls.layout.preview-lg"
-msgstr ""
+msgstr "Anteprima con larghezza elevata"
 
 #: app/configurator/components/preview-breakpoint.tsx
 msgid "controls.layout.preview-md"
-msgstr ""
+msgstr "Anteprima utilizzando la larghezza media"
 
 #: app/configurator/components/preview-breakpoint.tsx
 msgid "controls.layout.preview-sm"
-msgstr ""
+msgstr "Anteprima utilizzando una larghezza ridotta"
+
+#: app/configurator/components/preview-breakpoint.tsx
+msgid "controls.layout.preview-xl"
+msgstr "Anteprima utilizzando larghezza extra large"
 
 #: app/configurator/components/field-i18n.ts
 msgid "controls.layout.singleURLs"

--- a/app/utils/chart-config/versioning.ts
+++ b/app/utils/chart-config/versioning.ts
@@ -959,7 +959,7 @@ export const migrateChartConfig = makeMigrate<ChartConfig>(
   }
 );
 
-export const CONFIGURATOR_STATE_VERSION = "3.7.0";
+export const CONFIGURATOR_STATE_VERSION = "3.8.0";
 
 export const configuratorStateMigrations: Migration[] = [
   {
@@ -1408,6 +1408,49 @@ export const configuratorStateMigrations: Migration[] = [
         }
 
         draft.chartConfigs = chartConfigs;
+      });
+    },
+  },
+  {
+    description: "ALL (add layoutsMetadata to free canvas layout)",
+    from: "3.7.0",
+    to: "3.8.0",
+    up: (config) => {
+      const newConfig = {
+        ...config,
+        version: "3.8.0",
+      };
+
+      return produce(newConfig, (draft: any) => {
+        if (
+          draft.layout.type === "dashboard" &&
+          draft.layout.layout === "canvas"
+        ) {
+          draft.layout.layoutsMetadata = draft.chartConfigs.reduce(
+            (acc: any, chartConfig: any) => {
+              acc[chartConfig.key] = {
+                initialized: true,
+              };
+              return acc;
+            },
+            {}
+          );
+        }
+      });
+    },
+    down: (config) => {
+      const newConfig = {
+        ...config,
+        version: "3.7.0",
+      };
+
+      return produce(newConfig, (draft: any) => {
+        if (
+          draft.layout.type === "dashboard" &&
+          draft.layout.layout === "canvas"
+        ) {
+          delete draft.layout.layoutsMetadata;
+        }
       });
     },
   },


### PR DESCRIPTION
Closes #1739

This PR:
- saves the changes made while previewing free canvas layout in different breakpoints, and keeps the layouts separate for each breakpoint (`xl`, `lg`, `md`, `sm`),
- makes the preview mode size reflect the true size of the breakpoint, making the area horizontally scrollable when the screen size if lower than the breakpoint that's being previewed,
- adds a new preview breakpoint (`xl`) and aligns all of them with free canvas layout breakpoints.

## How to test
1. Go to [this link](https://visualization-tool-git-feat-allow-editing-free-canv-12397f-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10&dataSource=Prod).
2. Add two new charts.
3. Proceed to layout options.
4. ✅ See that there are four options in the preview menu (up from three).
5. Switch to a dashboard / free canvas layout.
6. ✅ Enable preview mode and see that the first one shows 4 columns, the next one 3, then 2 and 1.
7. ✅ Edit the dashboard in different preview modes and see that the changes are persisted between switches.
8. Make your browser window smaller.
9. Enable first (`xl`) preview mode.
10. ✅ See that the area still shows 4 columns and is horizontally scrollable, which allows users with smaller screens prepare their dashboards for larger ones when they're embedded.