### PR TITLE
feat: Smaller login improvements

### DIFF
--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -1369,10 +1369,6 @@ msgid "login.chart.actions.unpublish"
 msgstr "Veröffentlichung aufheben"
 
 #: app/login/components/profile-tables.tsx
-msgid "login.chart.copy"
-msgstr "Kopieren"
-
-#: app/login/components/profile-tables.tsx
 msgid "login.chart.delete"
 msgstr "Löschen"
 
@@ -1383,6 +1379,10 @@ msgstr "Möchten Sie diesen Entwurf wirklich löschen?"
 #: app/login/components/profile-tables.tsx
 msgid "login.chart.delete.confirmation"
 msgstr "Sind Sie sicher, dass Sie diese Grafik löschen wollen?"
+
+#: app/login/components/profile-tables.tsx
+msgid "login.chart.duplicate"
+msgstr "Duplizieren"
 
 #: app/login/components/profile-tables.tsx
 #: app/pages/v/[chartId].tsx

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -1369,10 +1369,6 @@ msgid "login.chart.actions.unpublish"
 msgstr "Unpublish"
 
 #: app/login/components/profile-tables.tsx
-msgid "login.chart.copy"
-msgstr "Copy"
-
-#: app/login/components/profile-tables.tsx
 msgid "login.chart.delete"
 msgstr "Delete"
 
@@ -1383,6 +1379,10 @@ msgstr "Are you sure you want to delete this draft?"
 #: app/login/components/profile-tables.tsx
 msgid "login.chart.delete.confirmation"
 msgstr "Are you sure you want to delete this chart?"
+
+#: app/login/components/profile-tables.tsx
+msgid "login.chart.duplicate"
+msgstr "Duplicate"
 
 #: app/login/components/profile-tables.tsx
 #: app/pages/v/[chartId].tsx

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -1369,10 +1369,6 @@ msgid "login.chart.actions.unpublish"
 msgstr "Dépublier"
 
 #: app/login/components/profile-tables.tsx
-msgid "login.chart.copy"
-msgstr "Copie"
-
-#: app/login/components/profile-tables.tsx
 msgid "login.chart.delete"
 msgstr "Supprimer"
 
@@ -1383,6 +1379,10 @@ msgstr ""
 #: app/login/components/profile-tables.tsx
 msgid "login.chart.delete.confirmation"
 msgstr "Êtes-vous sûr de vouloir supprimer cette carte ?"
+
+#: app/login/components/profile-tables.tsx
+msgid "login.chart.duplicate"
+msgstr "Dupliquer"
 
 #: app/login/components/profile-tables.tsx
 #: app/pages/v/[chartId].tsx

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -1369,10 +1369,6 @@ msgid "login.chart.actions.unpublish"
 msgstr "Annullare la pubblicazione"
 
 #: app/login/components/profile-tables.tsx
-msgid "login.chart.copy"
-msgstr "Copia"
-
-#: app/login/components/profile-tables.tsx
 msgid "login.chart.delete"
 msgstr "Cancellare"
 
@@ -1383,6 +1379,10 @@ msgstr ""
 #: app/login/components/profile-tables.tsx
 msgid "login.chart.delete.confirmation"
 msgstr "Sei sicuro di voler cancellare questo grafico?"
+
+#: app/login/components/profile-tables.tsx
+msgid "login.chart.duplicate"
+msgstr "Duplicare"
 
 #: app/login/components/profile-tables.tsx
 #: app/pages/v/[chartId].tsx

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -214,7 +214,7 @@ const ProfileVisualizationsRow = (props: {
       {
         type: "link",
         href: `/${locale}/create/new?copy=${config.key}`,
-        label: t({ id: "login.chart.copy", message: "Copy" }),
+        label: t({ id: "login.chart.duplicate", message: "Duplicate" }),
         iconName: "copy",
       },
       {

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -224,12 +224,6 @@ const ProfileVisualizationsRow = (props: {
         iconName: "edit",
         priority: !isPublished ? 0 : undefined,
       },
-      {
-        type: "link",
-        href: publishLink,
-        label: t({ id: "login.chart.share", message: "Share" }),
-        iconName: "linkExternal",
-      },
       isPublished
         ? {
             type: "button",


### PR DESCRIPTION
- `Copy` -> `Duplicate`
- Removed `Share` button, as it's the same as primary, "View" action, until we clarify the behavior proposed in #1758.

cc @sosiology