### PR TITLE
fix: Shared time slider in case of multiple cubes with and without temporal dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ You can also check the
     title is truncated
   - Concepts navigation on the browse page now shows the correct number of
     results
+  - Shared time slider now works correctly in cases of applied to charts from
+    different cubes, where one cube has a temporal dimension and the other does
+    not
 
 # [4.8.0] - 2024-09-11
 

--- a/app/charts/area/areas-state-props.ts
+++ b/app/charts/area/areas-state-props.ts
@@ -77,6 +77,7 @@ export const useAreasStateData = (
   const { chartConfig, observations } = chartProps;
   const {
     sortData,
+    xDimension,
     getX,
     getY,
     getSegmentAbbreviationOrLabel,
@@ -91,6 +92,7 @@ export const useAreasStateData = (
   }, [sortData, plottableData]);
   const data = useChartData(sortedPlottableData, {
     chartConfig,
+    timeRangeDimensionIri: xDimension.iri,
     getXAsDate: getX,
     getSegmentAbbreviationOrLabel,
     getTimeRangeDate,

--- a/app/charts/column/columns-grouped-state-props.ts
+++ b/app/charts/column/columns-grouped-state-props.ts
@@ -130,6 +130,7 @@ export const useColumnsGroupedStateData = (
   const { chartConfig, observations } = chartProps;
   const {
     sortData,
+    xDimension,
     getXAsDate,
     getY,
     getSegmentAbbreviationOrLabel,
@@ -143,6 +144,7 @@ export const useColumnsGroupedStateData = (
   }, [sortData, plottableData]);
   const data = useChartData(sortedPlottableData, {
     chartConfig,
+    timeRangeDimensionIri: xDimension.iri,
     getXAsDate,
     getSegmentAbbreviationOrLabel,
     getTimeRangeDate,

--- a/app/charts/column/columns-stacked-state-props.ts
+++ b/app/charts/column/columns-stacked-state-props.ts
@@ -125,6 +125,7 @@ export const useColumnsStackedStateData = (
   const { x } = fields;
   const {
     sortData,
+    xDimension,
     getX,
     getXAsDate,
     getY,
@@ -153,6 +154,7 @@ export const useColumnsStackedStateData = (
   }, [plottableData, getX, x.componentIri, getY, getSegment, sortData]);
   const data = useChartData(sortedPlottableData, {
     chartConfig,
+    timeRangeDimensionIri: xDimension.iri,
     getXAsDate,
     getSegmentAbbreviationOrLabel,
     getTimeRangeDate,

--- a/app/charts/column/columns-state-props.ts
+++ b/app/charts/column/columns-state-props.ts
@@ -114,7 +114,8 @@ export const useColumnsStateData = (
   variables: ColumnsStateVariables
 ): ChartStateData => {
   const { chartConfig, observations } = chartProps;
-  const { sortData, getXAsDate, getY, getTimeRangeDate } = variables;
+  const { sortData, xDimension, getXAsDate, getY, getTimeRangeDate } =
+    variables;
   const plottableData = usePlottableData(observations, {
     getY,
   });
@@ -123,6 +124,7 @@ export const useColumnsStateData = (
   }, [sortData, plottableData]);
   const data = useChartData(sortedPlottableData, {
     chartConfig,
+    timeRangeDimensionIri: xDimension.iri,
     getXAsDate,
     getTimeRangeDate,
   });

--- a/app/charts/combo/combo-line-column-state-props.ts
+++ b/app/charts/combo/combo-line-column-state-props.ts
@@ -152,7 +152,8 @@ export const useComboLineColumnStateData = (
   variables: ComboLineColumnStateVariables
 ): ChartStateData => {
   const { chartConfig, observations } = chartProps;
-  const { sortData, getX, getXAsDate, y, getTimeRangeDate } = variables;
+  const { sortData, xDimension, getX, getXAsDate, y, getTimeRangeDate } =
+    variables;
   const plottableData = usePlottableData(observations, {
     getX,
     getY: (d) => {
@@ -170,6 +171,7 @@ export const useComboLineColumnStateData = (
   }, [sortData, plottableData]);
   const data = useChartData(sortedPlottableData, {
     chartConfig,
+    timeRangeDimensionIri: xDimension.iri,
     getXAsDate,
     getTimeRangeDate,
   });

--- a/app/charts/combo/combo-line-dual-state-props.ts
+++ b/app/charts/combo/combo-line-dual-state-props.ts
@@ -118,7 +118,7 @@ export const useComboLineDualStateData = (
   variables: ComboLineDualStateVariables
 ): ChartStateData => {
   const { chartConfig, observations } = chartProps;
-  const { sortData, getX, y, getTimeRangeDate } = variables;
+  const { sortData, xDimension, getX, y, getTimeRangeDate } = variables;
   const plottableData = usePlottableData(observations, {
     getX,
     getY: (d) => {
@@ -136,6 +136,7 @@ export const useComboLineDualStateData = (
   }, [sortData, plottableData]);
   const data = useChartData(sortedPlottableData, {
     chartConfig,
+    timeRangeDimensionIri: xDimension.iri,
     getXAsDate: getX,
     getTimeRangeDate,
   });

--- a/app/charts/combo/combo-line-single-state-props.ts
+++ b/app/charts/combo/combo-line-single-state-props.ts
@@ -90,7 +90,7 @@ export const useComboLineSingleStateData = (
   variables: ComboLineSingleStateVariables
 ): ChartStateData => {
   const { chartConfig, observations } = chartProps;
-  const { sortData, getX, y, getTimeRangeDate } = variables;
+  const { sortData, xDimension, getX, y, getTimeRangeDate } = variables;
   const plottableData = usePlottableData(observations, {
     getX,
     getY: (d) => {
@@ -108,6 +108,7 @@ export const useComboLineSingleStateData = (
   }, [sortData, plottableData]);
   const data = useChartData(sortedPlottableData, {
     chartConfig,
+    timeRangeDimensionIri: xDimension.iri,
     getXAsDate: getX,
     getTimeRangeDate,
   });

--- a/app/charts/line/lines-state-props.ts
+++ b/app/charts/line/lines-state-props.ts
@@ -96,6 +96,7 @@ export const useLinesStateData = (
   const { chartConfig, observations } = chartProps;
   const {
     sortData,
+    xDimension,
     getX,
     getY,
     getSegmentAbbreviationOrLabel,
@@ -109,6 +110,7 @@ export const useLinesStateData = (
   }, [sortData, plottableData]);
   const data = useChartData(sortedPlottableData, {
     chartConfig,
+    timeRangeDimensionIri: xDimension.iri,
     getXAsDate: getX,
     getSegmentAbbreviationOrLabel,
     getTimeRangeDate,

--- a/app/charts/map/map-state-props.ts
+++ b/app/charts/map/map-state-props.ts
@@ -96,6 +96,7 @@ export const useMapStateData = (
   const plottableData = usePlottableData(observations, {});
   const data = useChartData(plottableData, {
     chartConfig,
+    timeRangeDimensionIri: undefined,
   });
 
   const areaLayer = useMemo(() => {

--- a/app/charts/pie/pie-state-props.ts
+++ b/app/charts/pie/pie-state-props.ts
@@ -70,6 +70,7 @@ export const usePieStateData = (
   });
   const data = useChartData(plottableData, {
     chartConfig,
+    timeRangeDimensionIri: undefined,
     getSegmentAbbreviationOrLabel,
   });
 

--- a/app/charts/scatterplot/scatterplot-state-props.ts
+++ b/app/charts/scatterplot/scatterplot-state-props.ts
@@ -78,6 +78,7 @@ export const useScatterplotStateData = (
   });
   const data = useChartData(plottableData, {
     chartConfig,
+    timeRangeDimensionIri: undefined,
     getSegmentAbbreviationOrLabel,
   });
 

--- a/app/charts/table/table-state-props.ts
+++ b/app/charts/table/table-state-props.ts
@@ -29,6 +29,7 @@ export const useTableStateData = (
   const plottableData = usePlottableData(observations, {});
   const data = useChartData(plottableData, {
     chartConfig,
+    timeRangeDimensionIri: undefined,
   });
 
   return {


### PR DESCRIPTION
Fixes https://github.com/visualize-admin/visualization-tool/issues/1669#issuecomment-2373370535

## How to reproduce
1. Go to [this link](https://test.visualize.admin.ch/en/v/46J-ffwMimrI?dataSource=Prod).
2. ❌ See that using a shared time filter breaks the first chart.

## How to test
1. Go to [this link](https://visualization-tool-git-fix-shared-time-filters-data-c8c019-ixt1.vercel.app/en/v/_FWl8l-02fkr?dataSource=Prod).
2. ✅ See that using a shared time filter doesn't break the first chart.