### PR TITLE
feat: General improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ You can also check the
   - Shared time slider now works correctly in cases of applied to charts from
     different cubes, where one cube has a temporal dimension and the other does
     not
+  - Adding a new chart when the free canvas layout has already been initialized
+    is not breaking the application anymore
+  - Axis titles now wrap
 
 # [4.8.0] - 2024-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ You can also check the
   - Adding a new chart when the free canvas layout has already been initialized
     is not breaking the application anymore
   - Axis titles now wrap
+  - Metadata panel is not longer shared between separate charts in a dashboard
 
 # [4.8.0] - 2024-09-11
 

--- a/app/browser/dataset-browse.tsx
+++ b/app/browser/dataset-browse.tsx
@@ -43,7 +43,6 @@ import Tag from "@/components/tag";
 import useDisclosure from "@/components/use-disclosure";
 import { SearchCube } from "@/domain/data";
 import { truthy } from "@/domain/types";
-import { useFlag } from "@/flags";
 import { useFormatDate } from "@/formatters";
 import {
   DataCubeOrganization,
@@ -869,9 +868,8 @@ export const SearchFilters = ({
       />
     ) : null;
 
-  const termsetFlag = useFlag("search.termsets");
   const termsetNav =
-    termsets.length === 0 || !termsetFlag ? null : (
+    termsets.length === 0 ? null : (
       <NavSection
         key="termsets"
         items={displayedTermsets}

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -23,7 +23,7 @@ import {
   useAreasStateVariables,
 } from "@/charts/area/areas-state-props";
 import {
-  useAxisLabelHeight,
+  useAxisLabelHeightOffset,
   useChartBounds,
   useChartPadding,
 } from "@/charts/shared/chart-dimensions";
@@ -332,14 +332,14 @@ const useAreasState = (
     normalize,
   });
   const right = 40;
-  const yAxisLabelMargin = useAxisLabelHeight({
+  const { offset: yAxisLabelMargin } = useAxisLabelHeightOffset({
     label: yMeasure.label,
     width,
     marginLeft: left,
     marginRight: right,
   });
   const margins = {
-    top: 40 + yAxisLabelMargin,
+    top: 50 + yAxisLabelMargin,
     right,
     bottom,
     left,

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -23,6 +23,7 @@ import {
   useAreasStateVariables,
 } from "@/charts/area/areas-state-props";
 import {
+  useAxisLabelHeight,
   useChartBounds,
   useChartPadding,
 } from "@/charts/shared/chart-dimensions";
@@ -330,9 +331,16 @@ const useAreasState = (
     formatNumber,
     normalize,
   });
+  const right = 40;
+  const yAxisLabelMargin = useAxisLabelHeight({
+    label: yMeasure.label,
+    width,
+    marginLeft: left,
+    marginRight: right,
+  });
   const margins = {
-    top: 50,
-    right: 40,
+    top: 40 + yAxisLabelMargin,
+    right,
     bottom,
     left,
   };

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -23,7 +23,7 @@ import {
   PADDING_WITHIN,
 } from "@/charts/column/constants";
 import {
-  useAxisLabelHeight,
+  useAxisLabelHeightOffset,
   useChartBounds,
   useChartPadding,
 } from "@/charts/shared/chart-dimensions";
@@ -335,14 +335,14 @@ const useColumnsGroupedState = (
     bandDomain: xTimeRangeDomainLabels,
   });
   const right = 40;
-  const yAxisLabelMargin = useAxisLabelHeight({
+  const { offset: yAxisLabelMargin } = useAxisLabelHeightOffset({
     label: yMeasure.label,
     width,
     marginLeft: left,
     marginRight: right,
   });
   const margins = {
-    top: 40 + yAxisLabelMargin,
+    top: 50 + yAxisLabelMargin,
     right,
     bottom,
     left,

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -23,6 +23,7 @@ import {
   PADDING_WITHIN,
 } from "@/charts/column/constants";
 import {
+  useAxisLabelHeight,
   useChartBounds,
   useChartPadding,
 } from "@/charts/shared/chart-dimensions";
@@ -333,9 +334,16 @@ const useColumnsGroupedState = (
     formatNumber,
     bandDomain: xTimeRangeDomainLabels,
   });
+  const right = 40;
+  const yAxisLabelMargin = useAxisLabelHeight({
+    label: yMeasure.label,
+    width,
+    marginLeft: left,
+    marginRight: right,
+  });
   const margins = {
-    top: 50,
-    right: 40,
+    top: 40 + yAxisLabelMargin,
+    right,
     bottom,
     left,
   };

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/charts/column/columns-stacked-state-props";
 import { PADDING_INNER, PADDING_OUTER } from "@/charts/column/constants";
 import {
+  useAxisLabelHeight,
   useChartBounds,
   useChartPadding,
 } from "@/charts/shared/chart-dimensions";
@@ -391,9 +392,16 @@ const useColumnsStackedState = (
     bandDomain: xTimeRangeDomainLabels,
     normalize,
   });
+  const right = 40;
+  const yAxisLabelMargin = useAxisLabelHeight({
+    label: yMeasure.label,
+    width,
+    marginLeft: left,
+    marginRight: right,
+  });
   const margins = {
-    top: 50,
-    right: 40,
+    top: 40 + yAxisLabelMargin,
+    right,
     bottom,
     left,
   };

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -27,7 +27,7 @@ import {
 } from "@/charts/column/columns-stacked-state-props";
 import { PADDING_INNER, PADDING_OUTER } from "@/charts/column/constants";
 import {
-  useAxisLabelHeight,
+  useAxisLabelHeightOffset,
   useChartBounds,
   useChartPadding,
 } from "@/charts/shared/chart-dimensions";
@@ -393,14 +393,14 @@ const useColumnsStackedState = (
     normalize,
   });
   const right = 40;
-  const yAxisLabelMargin = useAxisLabelHeight({
+  const { offset: yAxisLabelMargin } = useAxisLabelHeightOffset({
     label: yMeasure.label,
     width,
     marginLeft: left,
     marginRight: right,
   });
   const margins = {
-    top: 40 + yAxisLabelMargin,
+    top: 50 + yAxisLabelMargin,
     right,
     bottom,
     left,

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/charts/column/columns-state-props";
 import { PADDING_INNER, PADDING_OUTER } from "@/charts/column/constants";
 import {
-  useAxisLabelHeight,
+  useAxisLabelHeightOffset,
   useChartBounds,
   useChartPadding,
 } from "@/charts/shared/chart-dimensions";
@@ -194,14 +194,14 @@ const useColumnsState = (
     bandDomain: xTimeRangeDomainLabels,
   });
   const right = 40;
-  const yAxisLabelMargin = useAxisLabelHeight({
+  const { offset: yAxisLabelMargin } = useAxisLabelHeightOffset({
     label: yMeasure.label,
     width,
     marginLeft: left,
     marginRight: right,
   });
   const margins = {
-    top: 40 + yAxisLabelMargin,
+    top: 50 + yAxisLabelMargin,
     right,
     bottom,
     left,

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/charts/column/columns-state-props";
 import { PADDING_INNER, PADDING_OUTER } from "@/charts/column/constants";
 import {
+  useAxisLabelHeight,
   useChartBounds,
   useChartPadding,
 } from "@/charts/shared/chart-dimensions";
@@ -192,9 +193,16 @@ const useColumnsState = (
     formatNumber,
     bandDomain: xTimeRangeDomainLabels,
   });
+  const right = 40;
+  const yAxisLabelMargin = useAxisLabelHeight({
+    label: yMeasure.label,
+    width,
+    marginLeft: left,
+    marginRight: right,
+  });
   const margins = {
-    top: 50,
-    right: 40,
+    top: 40 + yAxisLabelMargin,
+    right,
     bottom,
     left,
   };

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -17,7 +17,7 @@ import {
   useLinesStateVariables,
 } from "@/charts/line/lines-state-props";
 import {
-  useAxisLabelHeight,
+  useAxisLabelHeightOffset,
   useChartBounds,
   useChartPadding,
 } from "@/charts/shared/chart-dimensions";
@@ -222,14 +222,14 @@ const useLinesState = (
     formatNumber,
   });
   const right = 40;
-  const yAxisLabelMargin = useAxisLabelHeight({
+  const { offset: yAxisLabelMargin } = useAxisLabelHeightOffset({
     label: yMeasure.label,
     width,
     marginLeft: left,
     marginRight: right,
   });
   const margins = {
-    top: 40 + yAxisLabelMargin,
+    top: 50 + yAxisLabelMargin,
     right,
     bottom,
     left,

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -17,6 +17,7 @@ import {
   useLinesStateVariables,
 } from "@/charts/line/lines-state-props";
 import {
+  useAxisLabelHeight,
   useChartBounds,
   useChartPadding,
 } from "@/charts/shared/chart-dimensions";
@@ -220,9 +221,16 @@ const useLinesState = (
     interactiveFiltersConfig,
     formatNumber,
   });
+  const right = 40;
+  const yAxisLabelMargin = useAxisLabelHeight({
+    label: yMeasure.label,
+    width,
+    marginLeft: left,
+    marginRight: right,
+  });
   const margins = {
-    top: 50,
-    right: 40,
+    top: 40 + yAxisLabelMargin,
+    right,
     bottom,
     left,
   };

--- a/app/charts/map/map-legend.tsx
+++ b/app/charts/map/map-legend.tsx
@@ -34,7 +34,7 @@ const HEIGHT = 40;
 const COLOR_RAMP_HEIGHT = 10;
 const MARGIN = { top: 6, right: 4, bottom: 0, left: 4 };
 const AXIS_TICK_ROTATE_ANGLE = 45;
-const LABELFONTSIZE = 10
+const AXIS_LABEL_FONT_SIZE = 10;
 
 const useLegendWidth = () => Math.min(useSize().width, MAX_WIDTH);
 
@@ -42,18 +42,18 @@ const makeAxis = (
   g: Selection<SVGGElement, unknown, null, undefined>,
   {
     axisLabelColor,
+    axisLabelFontSize,
     fontFamily,
     formatNumber,
     labelColor,
-    LABELFONTSIZE,
     scale,
     thresholds,
   }: {
     axisLabelColor: string;
+    axisLabelFontSize: number;
     fontFamily: string;
     formatNumber: (x: NumberValue | undefined | null) => string;
     labelColor: string;
-    LABELFONTSIZE: number;
     scale: ScaleLinear<number, number, number>;
     thresholds: number[];
   }
@@ -67,7 +67,7 @@ const makeAxis = (
   g.select("path.domain").remove();
   g.selectAll(".tick line").attr("stroke", axisLabelColor);
   g.selectAll(".tick text")
-    .attr("font-size", LABELFONTSIZE)
+    .attr("font-size", axisLabelFontSize)
     .attr("font-family", fontFamily)
     .attr("fill", labelColor)
     .attr("transform", `rotate(${AXIS_TICK_ROTATE_ANGLE})`)
@@ -350,7 +350,7 @@ const CircleLegend = ({
                 stroke={axisLabelColor}
                 radius={radius}
                 maxRadius={maxRadius}
-                fontSize={LABELFONTSIZE}
+                fontSize={AXIS_LABEL_FONT_SIZE}
                 showLine={!interaction.visible}
               />
             );
@@ -370,7 +370,7 @@ const CircleLegend = ({
               stroke={axisLabelColor}
               radius={radius}
               maxRadius={maxRadius}
-              fontSize={LABELFONTSIZE}
+              fontSize={AXIS_LABEL_FONT_SIZE}
             />
           )}
       </g>
@@ -394,16 +394,16 @@ const getMaxRotatedAxisLabelHeight = (
   values: number[],
   options: {
     formatNumber: (d: number) => string;
-    LABELFONTSIZE: number;
+    fontSize: number;
   }
 ) => {
-  const { formatNumber, LABELFONTSIZE } = options;
+  const { formatNumber, fontSize } = options;
 
   return Math.max(
     ...values.map((d) => {
       return getRotatedAxisLabelHeight(d, {
         formatNumber,
-        fontSize: LABELFONTSIZE,
+        fontSize,
       });
     })
   );
@@ -413,16 +413,16 @@ const useLegendWithRotatedAxisLabelsHeight = (
   values: number[],
   options: {
     formatNumber: (d: number) => string;
-    LABELFONTSIZE: number;
+    fontSize: number;
   }
 ) => {
-  const { formatNumber, LABELFONTSIZE } = options;
+  const { formatNumber, fontSize } = options;
   const maxLabelHeight = useMemo(() => {
     return getMaxRotatedAxisLabelHeight(values, {
       formatNumber,
-      LABELFONTSIZE,
+      fontSize,
     });
-  }, [values, formatNumber, LABELFONTSIZE]);
+  }, [values, formatNumber, fontSize]);
 
   return Math.max(HEIGHT, HEIGHT * 0.4 + maxLabelHeight);
 };
@@ -438,8 +438,7 @@ const JenksColorLegend = ({
 }) => {
   const width = useLegendWidth();
   const legendAxisRef = useRef<SVGGElement>(null);
-  const { axisLabelColor, labelColor, fontFamily } =
-    useChartTheme();
+  const { axisLabelColor, labelColor, fontFamily } = useChartTheme();
   const formatNumber = useFormatInteger();
   const thresholds = useMemo(() => colorScale.domain(), [colorScale]);
   const [min, max] = domain;
@@ -460,27 +459,19 @@ const JenksColorLegend = ({
     () =>
       makeAxis(select(legendAxisRef.current) as any, {
         axisLabelColor,
+        axisLabelFontSize: AXIS_LABEL_FONT_SIZE,
         fontFamily,
         formatNumber,
         labelColor,
-        LABELFONTSIZE,
         scale,
         thresholds: tickValues,
       }),
-    [
-      axisLabelColor,
-      fontFamily,
-      formatNumber,
-      labelColor,
-      LABELFONTSIZE,
-      scale,
-      tickValues,
-    ]
+    [axisLabelColor, fontFamily, formatNumber, labelColor, scale, tickValues]
   );
 
   const height = useLegendWithRotatedAxisLabelsHeight(thresholdsScale.range(), {
     formatNumber,
-    LABELFONTSIZE,
+    fontSize: AXIS_LABEL_FONT_SIZE,
   });
 
   return (
@@ -523,8 +514,7 @@ const QuantileColorLegend = ({
   const width = useLegendWidth();
   const legendAxisRef = useRef<SVGGElement>(null);
 
-  const { axisLabelColor, labelColor, fontFamily } =
-    useChartTheme();
+  const { axisLabelColor, labelColor, fontFamily } = useChartTheme();
   const formatNumber = useFormatInteger();
 
   const thresholds = useMemo(
@@ -549,27 +539,19 @@ const QuantileColorLegend = ({
     () =>
       makeAxis(select(legendAxisRef.current) as any, {
         axisLabelColor,
+        axisLabelFontSize: AXIS_LABEL_FONT_SIZE,
         fontFamily,
         formatNumber,
         labelColor,
-        LABELFONTSIZE,
         scale,
         thresholds,
       }),
-    [
-      axisLabelColor,
-      fontFamily,
-      formatNumber,
-      labelColor,
-      LABELFONTSIZE,
-      scale,
-      thresholds,
-    ]
+    [axisLabelColor, fontFamily, formatNumber, labelColor, scale, thresholds]
   );
 
   const height = useLegendWithRotatedAxisLabelsHeight(thresholdsScale.range(), {
     formatNumber,
-    LABELFONTSIZE,
+    fontSize: AXIS_LABEL_FONT_SIZE,
   });
 
   return (
@@ -612,8 +594,7 @@ const QuantizeColorLegend = ({
   const width = useLegendWidth();
   const legendAxisRef = useRef<SVGGElement>(null);
 
-  const { axisLabelColor, labelColor, fontFamily } =
-    useChartTheme();
+  const { axisLabelColor, labelColor, fontFamily } = useChartTheme();
   const formatNumber = useFormatInteger();
 
   const classesScale = scaleLinear()
@@ -634,27 +615,19 @@ const QuantizeColorLegend = ({
     () =>
       makeAxis(select(legendAxisRef.current) as any, {
         axisLabelColor,
+        axisLabelFontSize: AXIS_LABEL_FONT_SIZE,
         fontFamily,
         formatNumber,
         labelColor,
-        LABELFONTSIZE,
         scale,
         thresholds,
       }),
-    [
-      axisLabelColor,
-      fontFamily,
-      formatNumber,
-      labelColor,
-      LABELFONTSIZE,
-      scale,
-      thresholds,
-    ]
+    [axisLabelColor, fontFamily, formatNumber, labelColor, scale, thresholds]
   );
 
   const height = useLegendWithRotatedAxisLabelsHeight(thresholds, {
     formatNumber,
-    LABELFONTSIZE,
+    fontSize: AXIS_LABEL_FONT_SIZE,
   });
 
   return (
@@ -726,10 +699,10 @@ const ContinuousColorLegend = ({
           MARGIN.top + COLOR_RAMP_HEIGHT + 14
         })`}
         fontFamily={fontFamily}
-        fontSize={LABELFONTSIZE}
+        fontSize={AXIS_LABEL_FONT_SIZE}
         fill={legendLabelColor}
       >
-        <text textAnchor="start" fontSize={LABELFONTSIZE}>
+        <text textAnchor="start" fontSize={AXIS_LABEL_FONT_SIZE}>
           {valueFormatter(min)}
         </text>
         <text x={width - MARGIN.right - MARGIN.left} textAnchor="end">

--- a/app/charts/pie/pie-state.tsx
+++ b/app/charts/pie/pie-state.tsx
@@ -10,7 +10,10 @@ import {
   usePieStateData,
   usePieStateVariables,
 } from "@/charts/pie/pie-state-props";
-import { useChartBounds } from "@/charts/shared/chart-dimensions";
+import {
+  useAxisLabelHeight,
+  useChartBounds,
+} from "@/charts/shared/chart-dimensions";
 import {
   ChartContext,
   ChartStateData,
@@ -141,11 +144,19 @@ const usePieState = (
   ]);
 
   // Dimensions
+  const left = 40;
+  const right = 40;
+  const yAxisLabelMargin = useAxisLabelHeight({
+    label: yMeasure.label,
+    width,
+    marginLeft: left,
+    marginRight: right,
+  });
   const margins = {
-    top: 40,
-    right: 40,
+    top: 40 + yAxisLabelMargin,
+    right,
     bottom: 40,
-    left: 40,
+    left,
   };
   const bounds = useChartBounds(width, margins, height);
   const { chartWidth, chartHeight } = bounds;

--- a/app/charts/pie/pie-state.tsx
+++ b/app/charts/pie/pie-state.tsx
@@ -11,7 +11,7 @@ import {
   usePieStateVariables,
 } from "@/charts/pie/pie-state-props";
 import {
-  useAxisLabelHeight,
+  useAxisLabelHeightOffset,
   useChartBounds,
 } from "@/charts/shared/chart-dimensions";
 import {
@@ -146,14 +146,14 @@ const usePieState = (
   // Dimensions
   const left = 40;
   const right = 40;
-  const yAxisLabelMargin = useAxisLabelHeight({
+  const { offset: yAxisLabelMargin } = useAxisLabelHeightOffset({
     label: yMeasure.label,
     width,
     marginLeft: left,
     marginRight: right,
   });
   const margins = {
-    top: 40 + yAxisLabelMargin,
+    top: 50 + yAxisLabelMargin,
     right,
     bottom: 40,
     left,

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -10,6 +10,7 @@ import {
   useScatterplotStateVariables,
 } from "@/charts/scatterplot//scatterplot-state-props";
 import {
+  useAxisLabelHeight,
   useChartBounds,
   useChartPadding,
 } from "@/charts/shared/chart-dimensions";
@@ -152,10 +153,23 @@ const useScatterplotState = (
     animationPresent: !!fields.animation,
     formatNumber,
   });
+  const right = 40;
+  const xAxisLabelMargin = useAxisLabelHeight({
+    label: xAxisLabel,
+    width,
+    marginLeft: left,
+    marginRight: right,
+  });
+  const yAxisLabelMargin = useAxisLabelHeight({
+    label: yAxisLabel,
+    width,
+    marginLeft: left,
+    marginRight: right,
+  });
   const margins = {
-    top: 50,
-    right: 40,
-    bottom,
+    top: 40 + yAxisLabelMargin,
+    right,
+    bottom: bottom + xAxisLabelMargin,
     left,
   };
   const bounds = useChartBounds(width, margins, height);

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -10,7 +10,7 @@ import {
   useScatterplotStateVariables,
 } from "@/charts/scatterplot//scatterplot-state-props";
 import {
-  useAxisLabelHeight,
+  useAxisLabelHeightOffset,
   useChartBounds,
   useChartPadding,
 } from "@/charts/shared/chart-dimensions";
@@ -154,20 +154,20 @@ const useScatterplotState = (
     formatNumber,
   });
   const right = 40;
-  const xAxisLabelMargin = useAxisLabelHeight({
+  const { offset: xAxisLabelMargin } = useAxisLabelHeightOffset({
     label: xAxisLabel,
     width,
     marginLeft: left,
     marginRight: right,
   });
-  const yAxisLabelMargin = useAxisLabelHeight({
+  const { offset: yAxisLabelMargin } = useAxisLabelHeightOffset({
     label: yAxisLabel,
     width,
     marginLeft: left,
     marginRight: right,
   });
   const margins = {
-    top: 40 + yAxisLabelMargin,
+    top: 50 + yAxisLabelMargin,
     right,
     bottom: bottom + xAxisLabelMargin,
     left,

--- a/app/charts/shared/axis-height-linear.tsx
+++ b/app/charts/shared/axis-height-linear.tsx
@@ -9,7 +9,7 @@ import type { ColumnsState } from "@/charts/column/columns-state";
 import { ComboLineSingleState } from "@/charts/combo/combo-line-single-state";
 import type { LinesState } from "@/charts/line/lines-state";
 import type { ScatterplotState } from "@/charts/scatterplot/scatterplot-state";
-import { useAxisLabelHeight } from "@/charts/shared/chart-dimensions";
+import { useAxisLabelHeightOffset } from "@/charts/shared/chart-dimensions";
 import { useChartState } from "@/charts/shared/chart-state";
 import {
   maybeTransition,
@@ -52,7 +52,7 @@ export const AxisHeightLinear = () => {
     textColor: labelColor,
   });
 
-  const height = useAxisLabelHeight({
+  const { height } = useAxisLabelHeightOffset({
     label: state.yAxisLabel,
     width: state.bounds.chartWidth,
     marginLeft: state.bounds.margins.left,

--- a/app/charts/shared/axis-height-linear.tsx
+++ b/app/charts/shared/axis-height-linear.tsx
@@ -9,6 +9,7 @@ import type { ColumnsState } from "@/charts/column/columns-state";
 import { ComboLineSingleState } from "@/charts/combo/combo-line-single-state";
 import type { LinesState } from "@/charts/line/lines-state";
 import type { ScatterplotState } from "@/charts/scatterplot/scatterplot-state";
+import { useAxisLabelHeight } from "@/charts/shared/chart-dimensions";
 import { useChartState } from "@/charts/shared/chart-state";
 import {
   maybeTransition,
@@ -51,8 +52,12 @@ export const AxisHeightLinear = () => {
     textColor: labelColor,
   });
 
-  const textIsOverlapping = axisTitleWidth > state.bounds.chartWidth;
-  const overlappingAmount = Math.ceil(axisTitleWidth / state.bounds.chartWidth);
+  const height = useAxisLabelHeight({
+    label: state.yAxisLabel,
+    width: state.bounds.chartWidth,
+    marginLeft: state.bounds.margins.left,
+    marginRight: state.bounds.margins.right,
+  });
 
   return (
     <>
@@ -65,8 +70,8 @@ export const AxisHeightLinear = () => {
         </text>
       ) : (
         <foreignObject
-          width={textIsOverlapping ? state.bounds.chartWidth : axisTitleWidth}
-          height={(axisLabelFontSize + TICK_PADDING) * overlappingAmount * 2}
+          width={Math.min(axisTitleWidth, state.bounds.chartWidth)}
+          height={height}
         >
           <OpenMetadataPanelWrapper component={state.yMeasure}>
             <span style={{ fontSize: axisLabelFontSize }}>

--- a/app/charts/shared/axis-width-linear.tsx
+++ b/app/charts/shared/axis-width-linear.tsx
@@ -2,6 +2,7 @@ import { axisBottom } from "d3-axis";
 import { useEffect, useRef } from "react";
 
 import { ScatterplotState } from "@/charts/scatterplot/scatterplot-state";
+import { useAxisLabelHeight } from "@/charts/shared/chart-dimensions";
 import { useChartState } from "@/charts/shared/chart-state";
 import {
   maybeTransition,
@@ -79,13 +80,20 @@ export const AxisWidthLinear = () => {
     xScale,
   ]);
 
+  const height = useAxisLabelHeight({
+    label: xAxisLabel,
+    width: chartWidth,
+    marginLeft: margins.left,
+    marginRight: margins.right,
+  });
+
   return (
     <>
       <foreignObject
         x={margins.left}
         y={margins.top + chartHeight + 24}
         width={chartWidth}
-        height={axisLabelFontSize * 2}
+        height={height}
         style={{ textAlign: "right" }}
       >
         <OpenMetadataPanelWrapper component={xMeasure}>

--- a/app/charts/shared/axis-width-linear.tsx
+++ b/app/charts/shared/axis-width-linear.tsx
@@ -2,7 +2,7 @@ import { axisBottom } from "d3-axis";
 import { useEffect, useRef } from "react";
 
 import { ScatterplotState } from "@/charts/scatterplot/scatterplot-state";
-import { useAxisLabelHeight } from "@/charts/shared/chart-dimensions";
+import { useAxisLabelHeightOffset } from "@/charts/shared/chart-dimensions";
 import { useChartState } from "@/charts/shared/chart-state";
 import {
   maybeTransition,
@@ -80,7 +80,7 @@ export const AxisWidthLinear = () => {
     xScale,
   ]);
 
-  const height = useAxisLabelHeight({
+  const { height } = useAxisLabelHeightOffset({
     label: xAxisLabel,
     width: chartWidth,
     marginLeft: margins.left,

--- a/app/charts/shared/chart-dimensions.tsx
+++ b/app/charts/shared/chart-dimensions.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { TICK_PADDING } from "@/charts/shared/axis-height-linear";
 import { BRUSH_BOTTOM_SPACE } from "@/charts/shared/brush/constants";
 import { getTickNumber } from "@/charts/shared/ticks";
-import { TICK_FONT_SIZE } from "@/charts/shared/use-chart-theme";
+import { TICK_FONT_SIZE, useChartTheme } from "@/charts/shared/use-chart-theme";
 import { Bounds, Margins } from "@/charts/shared/use-size";
 import { CHART_GRID_MIN_HEIGHT } from "@/components/react-grid";
 import {
@@ -136,4 +136,23 @@ export const useChartBounds = (
     chartWidth,
     chartHeight,
   };
+};
+
+const LINE_HEIGHT = 1.25;
+
+export const useAxisLabelHeight = ({
+  label,
+  width,
+  marginLeft,
+  marginRight,
+}: {
+  label: string;
+  width: number;
+  marginLeft: number;
+  marginRight: number;
+}) => {
+  const { axisLabelFontSize: fontSize } = useChartTheme();
+  const labelWidth = getTextWidth(label, { fontSize });
+  const lines = Math.ceil(labelWidth / (width - marginLeft - marginRight));
+  return fontSize * LINE_HEIGHT * lines;
 };

--- a/app/charts/shared/chart-dimensions.tsx
+++ b/app/charts/shared/chart-dimensions.tsx
@@ -143,7 +143,7 @@ export const useChartBounds = (
 
 const LINE_HEIGHT = 1.25;
 
-export const useAxisLabelHeight = ({
+export const useAxisLabelHeightOffset = ({
   label,
   width,
   marginLeft,
@@ -157,5 +157,8 @@ export const useAxisLabelHeight = ({
   const { axisLabelFontSize: fontSize } = useChartTheme();
   const labelWidth = getTextWidth(label, { fontSize });
   const lines = Math.ceil(labelWidth / (width - marginLeft - marginRight));
-  return fontSize * LINE_HEIGHT * lines;
+  return {
+    height: fontSize * LINE_HEIGHT * lines,
+    offset: fontSize * LINE_HEIGHT * (lines - 1),
+  };
 };

--- a/app/charts/shared/chart-dimensions.tsx
+++ b/app/charts/shared/chart-dimensions.tsx
@@ -125,7 +125,10 @@ export const useChartBounds = (
 
   const chartWidth = width - left - right;
   const chartHeight = isLayoutingFreeCanvas(state)
-    ? Math.max(CHART_GRID_MIN_HEIGHT, height - top - bottom)
+    ? Math.max(
+        Math.max(40, CHART_GRID_MIN_HEIGHT - top - bottom),
+        height - top - bottom
+      )
     : chartWidth * ASPECT_RATIO;
 
   return {

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -56,25 +56,18 @@ import {
 } from "@/stores/interactive-filters";
 import { useResizeObserver } from "@/utils/use-resize-observer";
 
-type ChartPublishedIndividualChartProps = ChartPublishInnerProps;
+type ChartPublishedIndividualChartProps = Omit<
+  ChartPublishInnerProps,
+  "metadataPanelStore"
+>;
 
 const ChartPublishedIndividualChart = forwardRef<
   HTMLDivElement,
   ChartPublishedIndividualChartProps
->(
-  (
-    {
-      dataSource,
-      state,
-      chartConfig,
-      configKey,
-      metadataPanelStore,
-      children,
-      ...rest
-    },
-    ref
-  ) => {
-    return (
+>(({ dataSource, state, chartConfig, configKey, children, ...rest }, ref) => {
+  const metadataPanelStore = useMemo(() => createMetadataPanelStore(), []);
+  return (
+    <MetadataPanelStoreContext.Provider value={metadataPanelStore}>
       <ChartTablePreviewProvider key={chartConfig.key}>
         <ChartWrapper
           key={chartConfig.key}
@@ -95,9 +88,9 @@ const ChartPublishedIndividualChart = forwardRef<
           </ChartPublishedInner>
         </ChartWrapper>
       </ChartTablePreviewProvider>
-    );
-  }
-);
+    </MetadataPanelStoreContext.Provider>
+  );
+});
 
 export const ChartPublished = ({
   configKey,
@@ -121,10 +114,9 @@ export const ChartPublished = ({
         state={state}
         chartConfig={chartConfig}
         configKey={configKey}
-        metadataPanelStore={metadataPanelStore}
       />
     ),
-    [configKey, dataSource, metadataPanelStore, state]
+    [configKey, dataSource, state]
   );
   // Sends out the height of the chart, so the iframe can be resized accordingly.
   const handleHeightChange = useCallback(

--- a/app/components/chart-selection-tabs.tsx
+++ b/app/components/chart-selection-tabs.tsx
@@ -35,7 +35,6 @@ import {
 import { useSearchDatasetPanelStore } from "@/configurator/components/add-new-dataset-panel";
 import { ChartTypeSelector } from "@/configurator/components/chart-type-selector";
 import { getIconName } from "@/configurator/components/ui-helpers";
-import { useFlag } from "@/flags";
 import { Icon, IconName } from "@/icons";
 import { useLocale } from "@/locales";
 import useEvent from "@/utils/use-event";
@@ -143,8 +142,6 @@ const TabsEditable = (props: TabsEditableProps) => {
 
   const { open: openAddDatasetPanel } = useSearchDatasetPanelStore();
 
-  const addNewDatasetFlag = useFlag("configurator.add-dataset.new");
-
   const switchChart = (key: string) => {
     dispatch({
       type: "SWITCH_ACTIVE_CHART",
@@ -209,18 +206,16 @@ const TabsEditable = (props: TabsEditableProps) => {
             direction="column"
           >
             <Stack direction="column" gap="0.5rem" m="1rem">
-              {addNewDatasetFlag ? (
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  textAlign="center"
-                  gutterBottom
-                >
-                  <Trans id="chart-selection-tabs.add-chart-same-dataset.caption">
-                    Add chart based on the same dataset
-                  </Trans>
-                </Typography>
-              ) : null}
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                textAlign="center"
+                gutterBottom
+              >
+                <Trans id="chart-selection-tabs.add-chart-same-dataset.caption">
+                  Add chart based on the same dataset
+                </Trans>
+              </Typography>
               <ChartTypeSelector
                 state={state}
                 type="add"
@@ -230,32 +225,30 @@ const TabsEditable = (props: TabsEditableProps) => {
                 sx={{ pb: 3 }}
               />
             </Stack>
-            {addNewDatasetFlag ? (
-              <Stack direction="column" gap="0.5rem" mx="1.5rem" my="1rem">
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  textAlign="center"
-                  gutterBottom
-                >
-                  <Trans id="chart-selection-tabs.add-chart-different-dataset.caption">
-                    Add chart based on a different dataset
-                  </Trans>
-                </Typography>
-                <Button
-                  fullWidth
-                  sx={{ justifyContent: "center" }}
-                  onClick={() => {
-                    setTabsState({ ...tabsState, popoverOpen: false });
-                    openAddDatasetPanel();
-                  }}
-                >
-                  <Trans id="chart-selection-tabs.add-chart-different-dataset.button">
-                    Select dataset
-                  </Trans>
-                </Button>
-              </Stack>
-            ) : null}
+            <Stack direction="column" gap="0.5rem" mx="1.5rem" my="1rem">
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                textAlign="center"
+                gutterBottom
+              >
+                <Trans id="chart-selection-tabs.add-chart-different-dataset.caption">
+                  Add chart based on a different dataset
+                </Trans>
+              </Typography>
+              <Button
+                fullWidth
+                sx={{ justifyContent: "center" }}
+                onClick={() => {
+                  setTabsState({ ...tabsState, popoverOpen: false });
+                  openAddDatasetPanel();
+                }}
+              >
+                <Trans id="chart-selection-tabs.add-chart-different-dataset.button">
+                  Select dataset
+                </Trans>
+              </Button>
+            </Stack>
           </Stack>
         </ArrowMenuTopCenter>
       ) : null}

--- a/app/components/chart-shared.tsx
+++ b/app/components/chart-shared.tsx
@@ -125,8 +125,12 @@ export const ChartMoreButton = ({
   useEffect(() => {
     setIsTableRaw(false);
   }, [chartConfig.chartType, setIsTableRaw]);
+  const disableButton =
+    isPublished(state) &&
+    state.layout.type === "dashboard" &&
+    chartConfig.chartType === "table";
 
-  return (
+  return disableButton ? null : (
     <>
       <IconButton
         color="secondary"

--- a/app/components/copy-to-clipboard-text-input.tsx
+++ b/app/components/copy-to-clipboard-text-input.tsx
@@ -120,7 +120,7 @@ export const CopyToClipboardTextInput = ({ content }: { content: string }) => {
   const classes = useCopyToClipboardTextInputStyles();
 
   return (
-    <Flex sx={{ alignItems: "stretch", height: 48, mt: 1, mb: 2 }}>
+    <Flex sx={{ alignItems: "stretch", height: 48, mt: 1 }}>
       <Input className={classes.input} type="text" value={content} readOnly />
       <Button
         variant="text"

--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -88,10 +88,12 @@ export const Radio = ({
   disabled,
   onChange,
   warnMessage,
+  formLabelProps,
 }: {
   label: string;
   disabled?: boolean;
   warnMessage?: string;
+  formLabelProps?: Partial<FormControlLabelProps>;
 } & FieldProps) => {
   const color = checked
     ? disabled
@@ -128,6 +130,7 @@ export const Radio = ({
           />
         }
         disabled={disabled}
+        {...formLabelProps}
       />
     </MaybeTooltip>
   );

--- a/app/components/publish-actions.tsx
+++ b/app/components/publish-actions.tsx
@@ -6,6 +6,7 @@ import {
   Popover,
   PopoverProps,
   Stack,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import { ChangeEvent, ReactNode, RefObject, useEffect, useState } from "react";
@@ -13,12 +14,11 @@ import { ChangeEvent, ReactNode, RefObject, useEffect, useState } from "react";
 import { CHART_RESIZE_EVENT_TYPE } from "@/charts/shared/use-size";
 import { CopyToClipboardTextInput } from "@/components/copy-to-clipboard-text-input";
 import Flex from "@/components/flex";
+import { Radio } from "@/components/form";
 import { IconLink } from "@/components/links";
 import { Icon } from "@/icons";
 import useEvent from "@/utils/use-event";
 import { useI18n } from "@/utils/use-i18n";
-
-import { Radio } from "./form";
 
 type PublishActionProps = {
   chartWrapperRef: RefObject<HTMLDivElement>;
@@ -110,7 +110,7 @@ const Embed = ({ chartWrapperRef, configKey, locale }: PublishActionProps) => {
         </Button>
       )}
     >
-      <Box m={4} sx={{ "& > * + *": { mt: 4 } }}>
+      <Flex sx={{ flexDirection: "column", gap: 4, p: 4 }}>
         <div>
           <Typography component="div" variant="h5">
             <Trans id="publication.embed.iframe">Iframe Embed Code</Trans>
@@ -120,35 +120,33 @@ const Embed = ({ chartWrapperRef, configKey, locale }: PublishActionProps) => {
               Use this link to embed the chart into other webpages.
             </Trans>
           </Typography>
-          <Flex sx={{ justifyContent: "flex-start", flexWrap: "wrap" }} mt={3}>
-            <Radio
-              checked={isResponsive}
+          <Flex sx={{ alignItems: "center", gap: 4, mt: 3, mb: 2 }}>
+            <EmbedRadio
               value="responsive"
-              name="iframe-type"
+              checked={isResponsive}
               onChange={handleChange}
               label={t({
                 id: "publication.embed.iframe.responsive",
                 message: "Responsive iframe",
               })}
-              warnMessage={t({
+              infoMessage={t({
                 id: "publication.embed.iframe.responsive.warn",
                 message:
                   "For embedding visualizations in web pages without CMS support. The iframe will be responsive. The JavaScript part of the embed code ensures that the iframe always maintains the correct size.",
               })}
             />
-            <Radio
-              checked={!isResponsive}
+            <EmbedRadio
               value="static"
-              name="iframe-type"
+              checked={!isResponsive}
               onChange={handleChange}
               label={t({
                 id: "publication.embed.iframe.static",
                 message: "Static iframe",
               })}
-              warnMessage={t({
+              infoMessage={t({
                 id: "publication.embed.iframe.static.warn",
                 message:
-                  "For embedding visualizations in systems without Web Components or JavaScript support. (e.g. WordPress)",
+                  "For embedding visualizations in systems without JavaScript support (e.g. WordPress).",
               })}
             />
           </Flex>
@@ -169,8 +167,39 @@ const Embed = ({ chartWrapperRef, configKey, locale }: PublishActionProps) => {
           </Typography>
           <CopyToClipboardTextInput content={embedAEMUrl} />
         </div>
-      </Box>
+      </Flex>
     </TriggeredPopover>
+  );
+};
+
+const EmbedRadio = ({
+  infoMessage,
+  ...rest
+}: {
+  value: string;
+  checked: boolean;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  label: string;
+  infoMessage?: string;
+}) => {
+  return (
+    <Flex sx={{ alignItems: "center", gap: 1 }}>
+      <Radio {...rest} formLabelProps={{ sx: { m: 0 } }} />
+      {infoMessage && (
+        <Tooltip
+          arrow
+          title={<Typography variant="body2">{infoMessage}</Typography>}
+          PopperProps={{ sx: { width: 190, p: 0 } }}
+          componentsProps={{
+            tooltip: { sx: { color: "secondary.active", px: 4, py: 3 } },
+          }}
+        >
+          <Box sx={{ color: "secondary.active" }}>
+            <Icon name="infoOutline" size={16} />
+          </Box>
+        </Tooltip>
+      )}
+    </Flex>
   );
 };
 

--- a/app/components/react-grid.tsx
+++ b/app/components/react-grid.tsx
@@ -268,7 +268,7 @@ export const ChartGridLayout = ({
         return [
           breakpoint,
           chartLayouts.map((chartLayout) => {
-            if (configLayout.layoutsMetadata[chartLayout.i].initialized) {
+            if (configLayout.layoutsMetadata[chartLayout.i]?.initialized) {
               return chartLayout;
             }
 
@@ -318,11 +318,10 @@ export const ChartGridLayout = ({
           ...configLayout,
           layouts: newLayouts,
           layoutsMetadata: Object.fromEntries(
-            Object.entries(configLayout.layoutsMetadata).map(
-              ([chartId, metadata]) => {
-                return [chartId, { ...metadata, initialized: true }];
-              }
-            )
+            state.chartConfigs.map(({ key }) => {
+              const layoutMetadata = configLayout.layoutsMetadata[key];
+              return [key, { ...layoutMetadata, initialized: true }];
+            })
           ),
         },
       });
@@ -335,6 +334,7 @@ export const ChartGridLayout = ({
     mountedForSomeTime,
     resize,
     configLayout,
+    state.chartConfigs,
   ]);
 
   return (

--- a/app/components/react-grid.tsx
+++ b/app/components/react-grid.tsx
@@ -40,8 +40,9 @@ export const availableHandles: ResizeHandle[] = [
 
 /** In grid unit */
 const MAX_H = 10;
+
 const INITIAL_H = 7;
-export const MIN_H = 1;
+const MIN_H = 1;
 
 /** In grid unit */
 const MAX_W = 4;

--- a/app/configurator/components/add-dataset-dialog.tsx
+++ b/app/configurator/components/add-dataset-dialog.tsx
@@ -569,23 +569,35 @@ const PreviewDataTable = ({
                     </TableBody>
                   </Table>
                 </Box>
-                <FirstTenRowsCaption />
               </Box>
             ) : null}
           </>
         ) : null}
       </DialogContent>
-      <DialogActions>
-        <Button variant="outlined" onClick={onClickBack}>
-          <Trans id="button.back">Back</Trans>
-        </Button>
-        <LoadingButton
-          loading={addingDataset}
-          variant="contained"
-          onClick={onConfirm}
-        >
-          <Trans id="button.confirm">Confirm</Trans>
-        </LoadingButton>
+      <DialogActions
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "flex-end",
+          gap: 1,
+          px: 4,
+          pt: "0 !important",
+          pb: "2rem !important",
+        }}
+      >
+        <FirstTenRowsCaption />
+        <Box sx={{ display: "flex", gap: 2 }}>
+          <Button variant="outlined" onClick={onClickBack}>
+            <Trans id="button.back">Back</Trans>
+          </Button>
+          <LoadingButton
+            loading={addingDataset}
+            variant="contained"
+            onClick={onConfirm}
+          >
+            <Trans id="button.confirm">Confirm</Trans>
+          </LoadingButton>
+        </Box>
       </DialogActions>
     </>
   );

--- a/app/configurator/components/chart-type-selector.tsx
+++ b/app/configurator/components/chart-type-selector.tsx
@@ -200,6 +200,7 @@ const ChartTypeSelectorMenu = (props: ChartTypeSelectorMenuProps) => {
         sx={{
           display: "grid",
           gridTemplateColumns: ["1fr 1fr", "1fr 1fr", "1fr 1fr 1fr"],
+          justifyItems: "center",
           gridGap: "0.75rem",
           mx: 2,
         }}

--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -539,6 +539,7 @@ const LayoutingStep = () => {
           type: "LAYOUT_CHANGED",
           value: {
             ...layoutRef.current,
+            meta: state.layout.meta,
             activeField: undefined,
           },
         });
@@ -548,7 +549,7 @@ const LayoutingStep = () => {
 
       setPreviewBreakpoint(null);
     },
-    [dispatch, setPreviewBreakpoint, state.layout.type]
+    [dispatch, setPreviewBreakpoint, state.layout.meta, state.layout.type]
   );
 
   if (state.state !== "LAYOUTING") {

--- a/app/configurator/components/layout-configurator.tsx
+++ b/app/configurator/components/layout-configurator.tsx
@@ -73,7 +73,6 @@ export const LayoutConfigurator = () => {
 const LayoutLayoutConfigurator = () => {
   const [state] = useConfiguratorState(isLayouting);
   const { layout } = state;
-  const freeCanvasFlag = useFlag("layouter.dashboard.free-canvas");
   switch (layout.type) {
     case "dashboard":
       return (
@@ -99,9 +98,7 @@ const LayoutLayoutConfigurator = () => {
             >
               <DashboardLayoutButton type="tall" layout={layout} />
               <DashboardLayoutButton type="vertical" layout={layout} />
-              {freeCanvasFlag ? (
-                <DashboardLayoutButton type="canvas" layout={layout} />
-              ) : null}
+              <DashboardLayoutButton type="canvas" layout={layout} />
             </Box>
           </ControlSectionContent>
         </ControlSection>

--- a/app/configurator/configurator-state/reducer.spec.tsx
+++ b/app/configurator/configurator-state/reducer.spec.tsx
@@ -26,7 +26,7 @@ import {
   applyNonTableDimensionToFilters,
   applyTableDimensionToFilters,
   deriveFiltersFromFields,
-  ensureDashboardLayoutAreCorrect,
+  ensureDashboardLayoutIsCorrect,
   handleChartFieldChanged,
   handleChartOptionChanged,
   reducer,
@@ -1127,7 +1127,7 @@ describe("handleChartOptionChanged", () => {
   });
 });
 
-describe("ensureDashboardLayoutAreCorrect", () => {
+describe("ensureDashboardLayoutIsCorrect", () => {
   const state = configStateMock.map;
   const newState = produce(state, (state: ConfiguratorState) => {
     assert(
@@ -1141,12 +1141,12 @@ describe("ensureDashboardLayoutAreCorrect", () => {
     );
     state.layout.layout = "canvas";
     assert(state.layout.layout === "canvas", "Layout type should be canvas");
-    state.layout.layouts = { lg: [] };
+    state.layout.layouts = { xl: [], lg: [], md: [], sm: [] };
     state.chartConfigs.push({
       ...state.chartConfigs[0],
       key: "newKey",
     });
-    ensureDashboardLayoutAreCorrect(state);
+    ensureDashboardLayoutIsCorrect(state);
     return state;
   });
   expect((newState as any).layout.layouts.lg.length).toBe(2);

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -973,7 +973,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
           iris,
           dimensions,
           measures,
-          meta: chartConfig.meta,
+          meta: current(chartConfig.meta), // Cast proxy to object
         });
         const newChartConfig = deriveFiltersFromFields(initialConfig, {
           dimensions,

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -915,7 +915,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
           draft.activeChartKey = action.value.chartConfig.key;
         }
 
-        ensureDashboardLayoutAreCorrect(draft);
+        ensureDashboardLayoutIsCorrect(draft);
       }
 
       return draft;
@@ -1013,7 +1013,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
         console.log(current(draft));
       }
 
-      ensureDashboardLayoutAreCorrect(draft);
+      ensureDashboardLayoutIsCorrect(draft);
 
       return draft;
 
@@ -1167,7 +1167,7 @@ const withLogging = <TState, TAction extends { type: unknown }>(
 };
 export const reducer = reducerLogging ? withLogging(reducer_) : reducer_;
 
-export function ensureDashboardLayoutAreCorrect(
+export function ensureDashboardLayoutIsCorrect(
   draft: WritableDraft<ConfiguratorState>
 ) {
   if (

--- a/app/flags/flag.tsx
+++ b/app/flags/flag.tsx
@@ -91,11 +91,8 @@ const initFromHost = (host: string) => {
     host.includes("test.visualize.admin.ch") ||
     isVercelPreviewHost(host)
   ) {
-    setDefaultFlag("configurator.add-dataset.new", true);
     setDefaultFlag("configurator.add-dataset.shared", true);
-    setDefaultFlag("layouter.dashboard.free-canvas", true);
     setDefaultFlag("layouter.dashboard.shared-filters", true);
-    setDefaultFlag("search.termsets", true);
   }
 };
 

--- a/app/flags/types.ts
+++ b/app/flags/types.ts
@@ -3,14 +3,8 @@ export type FlagValue = any;
 export type FlagName =
   /** Whether debug UI like the configurator debug panel is shown */
   | "debug"
-  /** Whether we can search by termsets */
-  | "search.termsets"
   /** Whether we can add dataset from shared dimensions */
   | "configurator.add-dataset.shared"
-  /** Whether we can add a new dataset */
-  | "configurator.add-dataset.new"
-  /** Whether we can use the free canvas dashboard layout */
-  | "layouter.dashboard.free-canvas"
   /** Whether we can use shared filters on dashboard layout */
   | "layouter.dashboard.shared-filters"
   /** Whether server side cache is disabled */

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -1398,10 +1398,6 @@ msgid "login.chart.rename"
 msgstr ""
 
 #: app/login/components/profile-tables.tsx
-msgid "login.chart.share"
-msgstr "Teilen"
-
-#: app/login/components/profile-tables.tsx
 msgid "login.chart.view"
 msgstr ""
 

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -174,7 +174,7 @@ msgstr "Bearbeiten"
 
 #: app/components/chart-selection-tabs.tsx
 msgid "chart-controls.edit-tab-label"
-msgstr "Tab titel editieren"
+msgstr "Tab-Titel editieren"
 
 #: app/components/dataset-metadata.tsx
 msgid "chart-controls.sparql-query"
@@ -202,7 +202,7 @@ msgstr "Fügen Sie ein Diagramm basierend auf demselben Datensatz hinzu"
 
 #: app/components/chart-selection-tabs.tsx
 msgid "chart-selection-tabs.no-label"
-msgstr ""
+msgstr "Kein Tab-Titel"
 
 #: app/configurator/components/dataset-control-section.tsx
 msgid "chart.datasets.add"
@@ -303,7 +303,7 @@ msgstr "Fügen Sie eine Beschreibung hinzu"
 
 #: app/configurator/components/annotators.tsx
 msgid "controls.annotator.add-tab-label-warning"
-msgstr "Please add a tab label"
+msgstr "Bitte fügen Sie eine Tab-Titel hinzu"
 
 #: app/configurator/components/annotators.tsx
 #: app/configurator/components/annotators.tsx
@@ -959,7 +959,7 @@ msgstr "Messwert auswählen"
 #: app/configurator/components/field.tsx
 #: app/configurator/components/field.tsx
 msgid "controls.select.optional"
-msgstr ""
+msgstr "optional"
 
 #: app/configurator/components/filters.tsx
 #: app/configurator/components/filters.tsx
@@ -1274,11 +1274,11 @@ msgstr "Tutorials"
 
 #: app/components/hint.tsx
 msgid "hint.chartunexpected.message"
-msgstr ""
+msgstr "Beim Anzeigen dieses Diagramms ist ein unerwarteter Fehler aufgetreten."
 
 #: app/components/hint.tsx
 msgid "hint.chartunexpected.title"
-msgstr ""
+msgstr "Unerwarteter Fehler"
 
 #: app/components/hint.tsx
 msgid "hint.coordinatesloadingerror.message"
@@ -1395,11 +1395,11 @@ msgstr "Vorschau"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.chart.rename"
-msgstr ""
+msgstr "Umbenennen"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.chart.view"
-msgstr ""
+msgstr "Anzeigen"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.create-chart"
@@ -1463,7 +1463,7 @@ msgstr "Datensatz"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.multiple-datasets"
-msgstr ""
+msgstr "Mehrere Datensätze"
 
 #: app/login/components/login-menu.tsx
 msgid "login.sign-in"
@@ -1501,7 +1501,7 @@ msgstr "Einbett-Code für «Externe Applikation»"
 
 #: app/components/publish-actions.tsx
 msgid "publication.embed.external-application.caption"
-msgstr ""
+msgstr "Verwenden Sie diesen Link, um das Diagramm ohne Iframe-Tags einzubetten."
 
 #: app/components/publish-actions.tsx
 msgid "publication.embed.iframe"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -1398,10 +1398,6 @@ msgid "login.chart.rename"
 msgstr "Rename"
 
 #: app/login/components/profile-tables.tsx
-msgid "login.chart.share"
-msgstr "Share"
-
-#: app/login/components/profile-tables.tsx
 msgid "login.chart.view"
 msgstr "View"
 

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -1398,10 +1398,6 @@ msgid "login.chart.rename"
 msgstr "Renommer"
 
 #: app/login/components/profile-tables.tsx
-msgid "login.chart.share"
-msgstr "Partager"
-
-#: app/login/components/profile-tables.tsx
 msgid "login.chart.view"
 msgstr "Voir"
 

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -186,7 +186,7 @@ msgstr "Vue en tableau"
 
 #: app/components/chart-selection-tabs.tsx
 msgid "chart-selection-tabs.add-chart"
-msgstr ""
+msgstr "Ajouter un graphique"
 
 #: app/components/chart-selection-tabs.tsx
 msgid "chart-selection-tabs.add-chart-different-dataset.button"
@@ -252,11 +252,11 @@ msgstr "Nombre total de lignes:"
 
 #: app/components/chart-selection-tabs.tsx
 msgid "chat-preview.delete.confirmation"
-msgstr ""
+msgstr "Etes-vous sûr de vouloir supprimer ce graphique ?"
 
 #: app/components/chart-selection-tabs.tsx
 msgid "chat-preview.delete.title"
-msgstr ""
+msgstr "Supprimer le graphique ?"
 
 #: app/configurator/table/table-chart-options.tsx
 msgid "columnStyle.bar"
@@ -600,7 +600,7 @@ msgstr "Zéros"
 
 #: app/configurator/components/field-i18n.ts
 msgid "controls.label"
-msgstr ""
+msgstr "Étiquette de l'onglet"
 
 #: app/components/rename-dialog.tsx
 #: app/configurator/components/field-i18n.ts
@@ -628,7 +628,7 @@ msgstr "Mise en page libre"
 
 #: app/login/components/profile-tables.tsx
 msgid "controls.layout.chart"
-msgstr ""
+msgstr "Graphique"
 
 #: app/configurator/components/field-i18n.ts
 #: app/login/components/profile-tables.tsx
@@ -959,7 +959,7 @@ msgstr "Sélectionner une variable"
 #: app/configurator/components/field.tsx
 #: app/configurator/components/field.tsx
 msgid "controls.select.optional"
-msgstr "Optionnel"
+msgstr "optionnel"
 
 #: app/configurator/components/filters.tsx
 #: app/configurator/components/filters.tsx
@@ -1109,7 +1109,7 @@ msgstr "Dimensions partagées"
 
 #: app/components/chart-footnotes.tsx
 msgid "dataset.footnotes.dataset"
-msgstr ""
+msgstr "Ensemble de données"
 
 #: app/components/chart-footnotes.tsx
 msgid "dataset.footnotes.updated"
@@ -1274,11 +1274,11 @@ msgstr "Tutoriels"
 
 #: app/components/hint.tsx
 msgid "hint.chartunexpected.message"
-msgstr ""
+msgstr "Une erreur inattendue s'est produite lors de l'affichage de ce graphique."
 
 #: app/components/hint.tsx
 msgid "hint.chartunexpected.title"
-msgstr ""
+msgstr "Erreur inattendue"
 
 #: app/components/hint.tsx
 msgid "hint.coordinatesloadingerror.message"
@@ -1374,7 +1374,7 @@ msgstr "Supprimer"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.chart.delete-draft.confirmation"
-msgstr ""
+msgstr "Etes-vous sûr de vouloir supprimer ce brouillon ?"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.chart.delete.confirmation"
@@ -1415,7 +1415,7 @@ msgstr "Êtes-vous sûr de vouloir effectuer cette action ?"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.chart.delete-draft.warning"
-msgstr ""
+msgstr "Cette action ne peut pas être annulée."
 
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.chart.delete.warning"
@@ -1439,7 +1439,7 @@ msgstr "Mes visualisations publiées"
 
 #: app/login/components/login-menu.tsx
 msgid "login.profile.my-visualizations"
-msgstr ""
+msgstr "Mes visualisations"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.chart-actions"
@@ -1463,16 +1463,16 @@ msgstr "Ensemble de données"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.multiple-datasets"
-msgstr ""
+msgstr "Plusieurs ensembles de données"
 
 #: app/login/components/login-menu.tsx
 msgid "login.sign-in"
-msgstr ""
+msgstr "Se connecter"
 
 #: app/login/components/login-menu.tsx
 #: app/login/components/profile-header.tsx
 msgid "login.sign-out"
-msgstr ""
+msgstr "Se déconnecter"
 
 #: app/components/header.tsx
 #: app/components/header.tsx
@@ -1501,7 +1501,7 @@ msgstr "Code pour intégrer sur comme \"External Application\""
 
 #: app/components/publish-actions.tsx
 msgid "publication.embed.external-application.caption"
-msgstr ""
+msgstr "Utilisez ce lien pour intégrer le graphique sans balises iframe."
 
 #: app/components/publish-actions.tsx
 msgid "publication.embed.iframe"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -1398,10 +1398,6 @@ msgid "login.chart.rename"
 msgstr ""
 
 #: app/login/components/profile-tables.tsx
-msgid "login.chart.share"
-msgstr "Condividi"
-
-#: app/login/components/profile-tables.tsx
 msgid "login.chart.view"
 msgstr ""
 

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -186,7 +186,7 @@ msgstr "Visualizzazione tabella"
 
 #: app/components/chart-selection-tabs.tsx
 msgid "chart-selection-tabs.add-chart"
-msgstr ""
+msgstr "Aggiungere grafico"
 
 #: app/components/chart-selection-tabs.tsx
 msgid "chart-selection-tabs.add-chart-different-dataset.button"
@@ -600,7 +600,7 @@ msgstr "Zeri"
 
 #: app/configurator/components/field-i18n.ts
 msgid "controls.label"
-msgstr ""
+msgstr "Etichetta della scheda"
 
 #: app/components/rename-dialog.tsx
 #: app/configurator/components/field-i18n.ts
@@ -628,7 +628,7 @@ msgstr "Layout libero"
 
 #: app/login/components/profile-tables.tsx
 msgid "controls.layout.chart"
-msgstr ""
+msgstr "Grafico"
 
 #: app/configurator/components/field-i18n.ts
 #: app/login/components/profile-tables.tsx
@@ -959,7 +959,7 @@ msgstr "Seleziona una misura"
 #: app/configurator/components/field.tsx
 #: app/configurator/components/field.tsx
 msgid "controls.select.optional"
-msgstr ""
+msgstr "opzionale"
 
 #: app/configurator/components/filters.tsx
 #: app/configurator/components/filters.tsx
@@ -1109,7 +1109,7 @@ msgstr "Dimensioni condivise"
 
 #: app/components/chart-footnotes.tsx
 msgid "dataset.footnotes.dataset"
-msgstr ""
+msgstr "Insieme di dati"
 
 #: app/components/chart-footnotes.tsx
 msgid "dataset.footnotes.updated"
@@ -1274,11 +1274,11 @@ msgstr "Tutorials"
 
 #: app/components/hint.tsx
 msgid "hint.chartunexpected.message"
-msgstr ""
+msgstr "Si è verificato un errore imprevisto durante la visualizzazione di questo grafico."
 
 #: app/components/hint.tsx
 msgid "hint.chartunexpected.title"
-msgstr ""
+msgstr "Errore imprevisto"
 
 #: app/components/hint.tsx
 msgid "hint.coordinatesloadingerror.message"
@@ -1374,7 +1374,7 @@ msgstr "Cancellare"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.chart.delete-draft.confirmation"
-msgstr ""
+msgstr "Sei sicuro di voler eliminare questa bozza?"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.chart.delete.confirmation"
@@ -1395,11 +1395,11 @@ msgstr "Anteprima"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.chart.rename"
-msgstr ""
+msgstr "Rinominare"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.chart.view"
-msgstr ""
+msgstr "Mostra"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.create-chart"
@@ -1415,7 +1415,7 @@ msgstr "Siete sicuri di voler eseguire questa azione?"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.chart.delete-draft.warning"
-msgstr ""
+msgstr "Questa azione non può essere annullata."
 
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.chart.delete.warning"
@@ -1439,7 +1439,7 @@ msgstr "Le mie visualizzazioni"
 
 #: app/login/components/login-menu.tsx
 msgid "login.profile.my-visualizations"
-msgstr ""
+msgstr "Le mie visualizzazioni"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.chart-actions"
@@ -1455,7 +1455,7 @@ msgstr "Tipo"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.chart-updated-date"
-msgstr ""
+msgstr "Aggiornato"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.dataset-name"
@@ -1463,16 +1463,16 @@ msgstr "Set di dati"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.multiple-datasets"
-msgstr ""
+msgstr "Più set di dati"
 
 #: app/login/components/login-menu.tsx
 msgid "login.sign-in"
-msgstr ""
+msgstr "Accedi"
 
 #: app/login/components/login-menu.tsx
 #: app/login/components/profile-header.tsx
 msgid "login.sign-out"
-msgstr ""
+msgstr "Disconnessione"
 
 #: app/components/header.tsx
 #: app/components/header.tsx
@@ -1489,11 +1489,11 @@ msgstr "No"
 
 #: app/components/rename-dialog.tsx
 msgid "profile.chart.rename-dialog.description"
-msgstr ""
+msgstr "Rendi più chiaro il grafico con un titolo chiaro: un buon titolo aiuta a comprenderne il contenuto."
 
 #: app/components/rename-dialog.tsx
 msgid "profile.chart.rename-dialog.title"
-msgstr ""
+msgstr "Rinomina la visualizzazione"
 
 #: app/components/publish-actions.tsx
 msgid "publication.embed.external-application"
@@ -1501,7 +1501,7 @@ msgstr "Codice da incorporare su come \"External Application\""
 
 #: app/components/publish-actions.tsx
 msgid "publication.embed.external-application.caption"
-msgstr ""
+msgstr "Utilizza questo link per incorporare il grafico senza tag iframe."
 
 #: app/components/publish-actions.tsx
 msgid "publication.embed.iframe"

--- a/app/utils/use-resize-observer.ts
+++ b/app/utils/use-resize-observer.ts
@@ -1,5 +1,6 @@
 import { ResizeObserver } from "@juggle/resize-observer";
 import { useEventCallback } from "@mui/material";
+import isEqual from "lodash/isEqual";
 import throttle from "lodash/throttle";
 import { useEffect, useRef, useState } from "react";
 
@@ -28,18 +29,21 @@ export const useResizeObserver = <T extends Element>(
 
         const entry = entries[0];
 
+        const { width, height } = size;
         const { inlineSize: newWidth, blockSize: newHeight } =
           entry.contentBoxSize[0];
         // Prevent flickering when scrollbars appear and triggers another resize
         // by only resizing when difference to current measurement is above a certain threshold
         const newSize =
-          (Math.abs(newHeight - size.height) > 16 && newHeight > 0) ||
-          (Math.abs(newWidth - size.width) > 16 && newWidth > 0)
-            ? {
-                height: newHeight,
-                width: newWidth,
-              }
+          (Math.abs(newHeight - height) > 16 && newHeight > 0) ||
+          (Math.abs(newWidth - width) > 16 && newWidth > 0)
+            ? { height: newHeight, width: newWidth }
             : size;
+
+        if (isEqual(newSize, size)) {
+          return;
+        }
+
         changeSize(newSize);
         cb?.(newSize);
       }, 16);


### PR DESCRIPTION
Closes #1735
Closes #1763
Closes #1765

This PR introduces some overall improvements to the application:
- fixes not keeping the dashboard title when set in a given mode, after switching to another mode (e.g. from tab to dashboard),
- aligns embed styles with the design,
- fixes initialization of free canvas layout charts when adding a new chart to existing canvas,
- wraps axis titles of regular charts (building upon @noahonyejese approach ✨) and makes sure the chart height and margins are extended as needed,
- removes `ChartMoreButton` in case of published table chart in a dashboard (as there are no possible actions to take then),
- decreases a chance that column chart X axis labels will be cut when initializing chart height in free canvas layout,
- metadata panels no longer open all at once when opening one in a published free canvas layout dashboard,
- all missing translations have been added,
- improves add dataset dialog styles and fixes removing of datasets.