### PR TITLE
fix: Allow duplication of charts in layouting step

### DIFF
--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -158,12 +158,16 @@ const DashboardPreview = ({
 
   if (layoutType === "canvas") {
     return (
-      <ChartPanelLayout
-        chartConfigs={state.chartConfigs}
-        renderChart={renderChart}
-        layoutType={layoutType}
-        className={classes.canvasChartPanelLayout}
-      />
+      // Force re-rendering of the canvas layout when the chart configs change
+      // to properly initialize the height of the new charts
+      <div key={state.chartConfigs.map((c) => c.key).join(",")}>
+        <ChartPanelLayout
+          chartConfigs={state.chartConfigs}
+          renderChart={renderChart}
+          layoutType={layoutType}
+          className={classes.canvasChartPanelLayout}
+        />
+      </div>
     );
   }
 

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -889,7 +889,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       return draft;
 
     case "CHART_CONFIG_ADD":
-      if (isConfiguring(draft)) {
+      if (isConfiguring(draft) || isLayouting(draft)) {
         const chartConfig =
           createDraft(action.value.chartConfig) ?? getChartConfig(draft);
         const dataCubesComponents = getCachedComponents({

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -1175,20 +1175,21 @@ export function ensureDashboardLayoutIsCorrect(
     draft.layout.type === "dashboard" &&
     draft.layout.layout === "canvas"
   ) {
+    const layouts = draft.layout.layouts;
     const chartConfigKeys = draft.chartConfigs.map((c) => c.key).sort();
 
     const breakpoints = Object.keys(FREE_CANVAS_BREAKPOINTS);
-    const xlCanvasLayouts = draft.layout.layouts[breakpoints[0]];
-    const xlLayoutConfigKeys = xlCanvasLayouts.map((c) => c.i).sort();
+    const layoutConfigKeys = Array.from(
+      new Set(breakpoints.flatMap((bp) => layouts[bp].map((c) => c.i)))
+    ).sort();
 
     const newConfigs = draft.chartConfigs.filter(
-      (x) => !xlLayoutConfigKeys.includes(x.key)
+      (x) => !layoutConfigKeys.includes(x.key)
     );
 
-    if (!isEqual(chartConfigKeys, xlLayoutConfigKeys)) {
+    if (!isEqual(chartConfigKeys, layoutConfigKeys)) {
       for (const bp of breakpoints) {
-        const canvasLayouts = draft.layout.layouts[bp];
-        draft.layout.layouts[bp] = canvasLayouts.filter((c) =>
+        const canvasLayouts = draft.layout.layouts[bp].filter((c) =>
           chartConfigKeys.includes(c.i)
         );
 
@@ -1216,6 +1217,7 @@ export function ensureDashboardLayoutIsCorrect(
             curY += chartH;
           }
         }
+
         draft.layout.layouts[bp] = canvasLayouts;
       }
     }


### PR DESCRIPTION
Closes #1769

This PR allows duplication of charts in the layouting step. What still could be improved is to maintain the size of the duplicated chart in the layout mode, now it initializes in "initial" size and adjusts the height like a new chart.

## How to reproduce
See #1769

## How to test
1. Go to [this link](https://visualization-tool-git-fix-duplicating-charts-in-la-b0c5bf-ixt1.vercel.app/en/create/new?copy=4WaHLAUCWEq-).
2. Proceed to layout options.
3. ✅ See that it's possible to duplicate charts using any layout.