### PR TITLE
perf: Add pragmas to SPARQL query button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Performance
+  - Added pragmas to the SPARQL query button
 
 # [4.9.0] - 2024-10-01
 

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -755,9 +755,11 @@ async function fetchViewObservations({
   }
 
   const fullQuery = observationsView.observationsQuery({ disableDistinct });
-  const query = (
-    preview && limit ? fullQuery.previewQuery({ limit }) : fullQuery.query
-  ).toString();
+  const query = pragmas
+    .concat(
+      preview && limit ? fullQuery.previewQuery({ limit }) : fullQuery.query
+    )
+    .toString();
 
   let observationsRaw: PromiseValue<ObservationRaw[]> | undefined;
 


### PR DESCRIPTION
Closes #1775

This PR adds pragmas to SPARQL query button. They were used in the application, as they are appended automatically through `sparqlClient`, but here we needed to explicitly add them.

## How to reproduce
1. Go to [this link](https://test.visualize.admin.ch/en/v/sR3dVqbrEZHE?dataSource=Prod).
2. Open Details panel.
3. Click on SPARQL query button.
4. ❌ See that the query fails to fetch the data.

## How to test
1. Go to [this link](https://visualization-tool-git-perf-sparql-query-button-pragmas-ixt1.vercel.app/en/v/5P82vNyimdaa?dataSource=Prod).
2. Open Details panel.
3. Click on SPARQL query button.
4. ✅ See that the query successfully fetches the data.