### PR TITLE
debug: Annotate GQL queries

### DIFF
--- a/app/browser/dataset-preview.tsx
+++ b/app/browser/dataset-preview.tsx
@@ -12,6 +12,7 @@ import Flex from "@/components/flex";
 import { HintRed, Loading, LoadingDataError } from "@/components/hint";
 import { DataSource } from "@/config-types";
 import { sourceToLabel } from "@/domain/datasource";
+import { getQueryRequestContext } from "@/graphql/hooks";
 import {
   useDataCubeMetadataQuery,
   useDataCubePreviewQuery,
@@ -86,6 +87,11 @@ export interface Preview {
   label: string;
 }
 
+const DATA_CUBE_PREVIEW_QUERY_REQUEST_CONTEXT = getQueryRequestContext({
+  querySource: "DataSetPreview / dataset-preview.tsx",
+  queryReason: "Needed to display a dataset preview in the /browse page.",
+});
+
 export const DataSetPreview = ({
   dataSetIri,
   dataSource,
@@ -110,7 +116,10 @@ export const DataSetPreview = ({
     useDataCubeMetadataQuery({ variables });
   const [
     { data: previewData, fetching: fetchingPreview, error: previewError },
-  ] = useDataCubePreviewQuery({ variables });
+  ] = useDataCubePreviewQuery({
+    variables,
+    context: DATA_CUBE_PREVIEW_QUERY_REQUEST_CONTEXT,
+  });
   const classes = useStyles({
     descriptionPresent: !!metadata?.dataCubeMetadata.description,
   });

--- a/app/gql-flamegraph/devtool.tsx
+++ b/app/gql-flamegraph/devtool.tsx
@@ -330,14 +330,29 @@ const Queries = ({ queries }: { queries: RequestQueryMeta[] }) => {
         return (
           <div key={i} style={{ overflowX: "auto" }}>
             <div>
+              {q.source && (
+                <>
+                  <Typography variant="caption" sx={{ fontWeight: "bold" }}>
+                    {q.source}
+                  </Typography>
+                  {" – "}
+                </>
+              )}
               <Typography variant="caption">
                 {q.endTime - q.startTime}ms
               </Typography>{" "}
-              -{" "}
+              –{" "}
               <CopyLink toCopy={q.text} sx={{ fontSize: "small" }}>
                 Copy
               </CopyLink>
             </div>
+            {q.reason && (
+              <div style={{ marginBottom: "0.25rem" }}>
+                <Typography variant="caption" sx={{ fontStyle: "italic" }}>
+                  ℹ️ {q.reason}
+                </Typography>
+              </div>
+            )}
             <Box
               cols={100}
               rows={10}

--- a/app/graphql/client.tsx
+++ b/app/graphql/client.tsx
@@ -6,23 +6,38 @@ import { flag } from "@/flags/flag";
 import { devtoolsExchanges } from "@/graphql/devtools";
 
 const graphqlEndpointFlag = flag("graphql.endpoint");
+
 if (graphqlEndpointFlag) {
   console.log("ℹ️ Using custom GraphQL endpoint:", graphqlEndpointFlag);
 }
-export const client = createClient({
-  url: graphqlEndpointFlag ?? GRAPHQL_ENDPOINT,
-  exchanges: [...devtoolsExchanges, ...defaultExchanges],
-  fetchOptions: {
-    headers: getHeaders(),
-  },
-});
 
-function getHeaders() {
+export const GQL_DEBUG_HEADER = "x-visualize-debug";
+export const GQL_CACHE_CONTROL_HEADER = "x-visualize-cache-control";
+export const GQL_QUERY_SOURCE_HEADER = "x-visualize-query-source";
+export const GQL_QUERY_REASON_HEADER = "x-visualize-query-reason";
+
+export const getGraphqlHeaders = ({
+  querySource,
+  queryReason,
+}: {
+  querySource?: string;
+  queryReason?: string;
+} = {}) => {
   const debug = flag("debug");
   const disableCache = flag("server-side-cache.disable");
 
   return {
-    "x-visualize-debug": debug ? "true" : "",
-    "x-visualize-cache-control": disableCache ? "no-cache" : "",
+    [GQL_DEBUG_HEADER]: debug ? "true" : "",
+    [GQL_CACHE_CONTROL_HEADER]: disableCache ? "no-cache" : "",
+    [GQL_QUERY_SOURCE_HEADER]: querySource ?? "",
+    [GQL_QUERY_REASON_HEADER]: queryReason ?? "",
   };
-}
+};
+
+export const client = createClient({
+  url: graphqlEndpointFlag ?? GRAPHQL_ENDPOINT,
+  exchanges: [...devtoolsExchanges, ...defaultExchanges],
+  fetchOptions: {
+    headers: getGraphqlHeaders(),
+  },
+});

--- a/app/graphql/hooks.ts
+++ b/app/graphql/hooks.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Client, useClient } from "urql";
+import { Client, OperationContext, useClient } from "urql";
 
 import { ConfiguratorState, hasChartConfigs } from "@/configurator";
 import {
@@ -7,10 +7,8 @@ import {
   DataCubeMetadata,
   DataCubesObservations,
 } from "@/domain/data";
-import { Locale } from "@/locales/locales";
-import { assert } from "@/utils/assert";
-
-import { joinDimensions, mergeObservations } from "./join";
+import { getGraphqlHeaders } from "@/graphql/client";
+import { joinDimensions, mergeObservations } from "@/graphql/join";
 import {
   DataCubeComponentFilter,
   DataCubeComponentsDocument,
@@ -24,7 +22,24 @@ import {
   DataCubeObservationsDocument,
   DataCubeObservationsQuery,
   DataCubeObservationsQueryVariables,
-} from "./query-hooks";
+} from "@/graphql/query-hooks";
+import { Locale } from "@/locales/locales";
+import { assert } from "@/utils/assert";
+
+export const getQueryRequestContext = (options: {
+  querySource?: string;
+  queryReason?: string;
+}): Partial<OperationContext> => {
+  if (!options) {
+    return {};
+  }
+
+  return {
+    fetchOptions: {
+      headers: getGraphqlHeaders(options),
+    },
+  };
+};
 
 const useQueryKey = (options: object) => {
   return useMemo(() => {

--- a/app/graphql/query-meta.ts
+++ b/app/graphql/query-meta.ts
@@ -2,5 +2,6 @@ export type RequestQueryMeta = {
   text: string;
   startTime: number;
   endTime: number;
-  label?: string;
+  source?: string;
+  reason?: string;
 };


### PR DESCRIPTION
Closes #1715

This PR adds a way to annotate GQL queries by passing a specific headers with `querySource` and `queryReason`, which are then displayed in the DebugPanel.

This should help understand which parts of the application require which data at which time, to be able to better optimize performance (or see which queries are e.g. not needed).

## How to test
1. Go to this link.
2. Open a `DebugPanel` by clicking on a 🛠️ emoji in the right bottom corner.
3. Click on `DataCubePreview` entry.
4. ✅ See that there's a title and description on the right side, which informs about the origin of the query and why it was fired.