### PR TITLE
feat: Add most popular charts to Statistics page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ You can also check the
 
 # Unreleased
 
+- Features
+  - Added most recent charts (all time and last 30 days) to the the Statistics
+    page
 - Fixes
   - Fixed inconsistent text style behavior in title and description fields
 

--- a/app/pages/statistics.tsx
+++ b/app/pages/statistics.tsx
@@ -282,12 +282,20 @@ const BaseStatsCard = ({
                 </Typography>
                 <Typography variant="caption">
                   Last 30 days daily average:{" "}
-                  <b>{trend.lastMonthDailyAverage.toFixed(2)}</b>
+                  <b>
+                    {trend.lastMonthDailyAverage >= 10
+                      ? formatInteger(trend.lastMonthDailyAverage)
+                      : trend.lastMonthDailyAverage.toFixed(2)}
+                  </b>
                 </Typography>
                 <br />
                 <Typography variant="caption">
                   Last 90 days daily average:{" "}
-                  <b>{trend.previousThreeMonthsDailyAverage.toFixed(2)}</b>
+                  <b>
+                    {trend.previousThreeMonthsDailyAverage >= 10
+                      ? formatInteger(trend.previousThreeMonthsDailyAverage)
+                      : trend.previousThreeMonthsDailyAverage.toFixed(2)}
+                  </b>
                 </Typography>
               </>
             }
@@ -453,7 +461,7 @@ const Bar = ({
 };
 
 const StatsCard = (
-  props: PageProps["charts"] & {
+  props: StatProps & {
     title: (total: number) => string;
     subtitle: (total: number, avgMonthlyCount: number) => string;
   }

--- a/app/pages/statistics.tsx
+++ b/app/pages/statistics.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable visualize-admin/no-large-sx */
-import { Box, Card, Tooltip, Typography } from "@mui/material";
+import { Box, Card, Link, Tooltip, Typography } from "@mui/material";
 import { max, rollups, sum } from "d3-array";
 import { formatLocale } from "d3-format";
 import { motion } from "framer-motion";
 import uniq from "lodash/uniq";
 import { GetServerSideProps } from "next";
-import { ComponentProps, useMemo } from "react";
+import { ComponentProps, ReactNode, useMemo } from "react";
 
 import { AppLayout } from "@/components/layout";
 import { BANNER_MARGIN_TOP } from "@/components/presence";
@@ -215,7 +215,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async () => {
 
 const Statistics = (props: Serialized<PageProps>) => {
   const { charts, views } = deserializeProps(props);
-  console.log("month", charts.mostPopularThisMonth);
+  const locale = useLocale();
 
   return (
     <AppLayout>
@@ -267,7 +267,18 @@ const Statistics = (props: Serialized<PageProps>) => {
               subtitle="Top 10 charts by view count"
               data={charts.mostPopularAllTime.map((chart) => [
                 chart.key,
-                { count: chart.viewCount, label: chart.key },
+                {
+                  count: chart.viewCount,
+                  label: (
+                    <Link
+                      href={`/${locale}/v/${chart.key}`}
+                      target="_blank"
+                      color="primary"
+                    >
+                      {chart.key}
+                    </Link>
+                  ),
+                },
               ])}
               columnName="Chart"
             />
@@ -278,7 +289,18 @@ const Statistics = (props: Serialized<PageProps>) => {
               subtitle="Top 10 charts by view count"
               data={charts.mostPopularThisMonth.map((chart) => [
                 chart.key,
-                { count: chart.viewCount, label: chart.key },
+                {
+                  count: chart.viewCount,
+                  label: (
+                    <Link
+                      href={`/${locale}/v/${chart.key}`}
+                      target="_blank"
+                      color="primary"
+                    >
+                      {chart.key}
+                    </Link>
+                  ),
+                },
               ])}
               columnName="Chart"
             />
@@ -343,7 +365,7 @@ const BaseStatsCard = ({
 }: {
   title: string;
   subtitle: string;
-  data: [string, { count: number; label: string }][];
+  data: [string, { count: number; label: ReactNode }][];
   columnName?: string;
   trend?: {
     direction: "up" | "down";
@@ -484,7 +506,7 @@ const Bar = ({
   count,
   maxCount,
 }: ComponentProps<typeof BaseStatsCard>["data"][number][1] & {
-  label: string;
+  label: ReactNode;
   maxCount: number;
 }) => {
   const easterEgg = useFlag("easter-eggs");

--- a/app/pages/statistics.tsx
+++ b/app/pages/statistics.tsx
@@ -12,6 +12,7 @@ import { BANNER_MARGIN_TOP } from "@/components/presence";
 import prisma from "@/db/client";
 import { Serialized, deserializeProps, serializeProps } from "@/db/serialize";
 import { useFlag } from "@/flags";
+import { Icon } from "@/icons";
 import { Locale } from "@/locales/locales";
 import { useLocale } from "@/src";
 
@@ -63,7 +64,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async () => {
             _count: "desc",
           },
         },
-        take: 10,
+        take: 25,
       })
       .then((rows) =>
         rows.map((row) => {
@@ -80,7 +81,7 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async () => {
       WHERE viewed_at > CURRENT_DATE - INTERVAL '30 days'
       GROUP BY config_key
       ORDER BY view_count DESC
-      LIMIT 10;
+      LIMIT 25;
     `.then((rows) => {
       return (
         rows as {
@@ -264,20 +265,12 @@ const Statistics = (props: Serialized<PageProps>) => {
           {charts.mostPopularAllTime.length > 0 && (
             <BaseStatsCard
               title="Most popular charts (all time)"
-              subtitle="Top 10 charts by view count"
+              subtitle="Top 25 charts by view count"
               data={charts.mostPopularAllTime.map((chart) => [
                 chart.key,
                 {
                   count: chart.viewCount,
-                  label: (
-                    <Link
-                      href={`/${locale}/v/${chart.key}`}
-                      target="_blank"
-                      color="primary"
-                    >
-                      {chart.key}
-                    </Link>
-                  ),
+                  label: <ChartLink locale={locale} chartKey={chart.key} />,
                 },
               ])}
               columnName="Chart"
@@ -286,20 +279,12 @@ const Statistics = (props: Serialized<PageProps>) => {
           {charts.mostPopularThisMonth.length > 0 && (
             <BaseStatsCard
               title="Most popular charts (last 30 days)"
-              subtitle="Top 10 charts by view count"
+              subtitle="Top 25 charts by view count"
               data={charts.mostPopularThisMonth.map((chart) => [
                 chart.key,
                 {
                   count: chart.viewCount,
-                  label: (
-                    <Link
-                      href={`/${locale}/v/${chart.key}`}
-                      target="_blank"
-                      color="primary"
-                    >
-                      {chart.key}
-                    </Link>
-                  ),
+                  label: <ChartLink locale={locale} chartKey={chart.key} />,
                 },
               ])}
               columnName="Chart"
@@ -308,6 +293,30 @@ const Statistics = (props: Serialized<PageProps>) => {
         </Box>
       </Box>
     </AppLayout>
+  );
+};
+
+const ChartLink = ({
+  locale,
+  chartKey,
+}: {
+  locale: Locale;
+  chartKey: string;
+}) => {
+  return (
+    <Link
+      href={`/${locale}/v/${chartKey}`}
+      target="_blank"
+      color="primary"
+      sx={{
+        display: "flex",
+        gap: 2,
+        justifyContent: "space-between",
+      }}
+    >
+      {chartKey}
+      <Icon name="linkExternal" size={16} />
+    </Link>
   );
 };
 


### PR DESCRIPTION
This PR adds:
- most popular charts (all time),
- most popular charts (last 30 days),

to the `Statistics` page.

## How to test
1. Go to [this link](https://visualization-tool-git-feat-improve-statistics-page-ixt1.vercel.app/statistics).
2. ✅ See that there are two new cards, showcasing most popular charts (all time and in last 30 days).