### PR TITLE
fix: Misaligned Menu in login profile table on smaller screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ You can also check the
     page
 - Fixes
   - Fixed inconsistent text style behavior in title and description fields
+  - Fixed positioning of Menu Popover in the login profile row actions on small
+    screens
 
 # [4.9.1] - 2024-10-03
 

--- a/app/components/arrow-menu.tsx
+++ b/app/components/arrow-menu.tsx
@@ -23,6 +23,18 @@ export const ArrowMenuTopCenter = styled(Menu)({
   },
 });
 
+export const ArrowMenuBottomCenter = styled(Menu)({
+  [`& .${paperClasses.root}`]: {
+    overflow: "visible",
+    "&:before": {
+      ...commonBeforeStyles,
+      bottom: -5,
+      left: "0%",
+      right: 0,
+    },
+  },
+});
+
 export const ArrowMenuTopBottom = styled(Menu)({
   [`& .${paperClasses.root}`]: {
     overflow: "visible",

--- a/app/components/row-actions.tsx
+++ b/app/components/row-actions.tsx
@@ -1,54 +1,52 @@
 import { Box, IconButton } from "@mui/material";
-import { useRef } from "react";
 
-import { ArrowMenuTopCenter } from "@/components/arrow-menu";
 import { MenuActionItem, MenuActionProps } from "@/components/menu-action-item";
-import useDisclosure from "@/components/use-disclosure";
+import { useFlipMenu } from "@/components/use-flip-menu";
 import { Icon } from "@/icons";
 
-type ActionsProps = {
-  actions: MenuActionProps[];
-};
-
-export const RowActions = (props: ActionsProps) => {
+export const RowActions = (props: { actions: MenuActionProps[] }) => {
   const { actions } = props;
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const menuDisclosure = useDisclosure();
-  const { isOpen, open, close } = menuDisclosure;
+  const [primaryAction, ...otherActions] = actions;
+  const {
+    buttonRef,
+    handleOpenElClick,
+    handleClose,
+    anchorEl,
+    anchorOrigin,
+    transformOrigin,
+    Wrapper,
+  } = useFlipMenu({ itemsCount: actions.length });
+  const additionalProps =
+    primaryAction.type === "button" ? { onDialogClose: handleClose } : {};
 
-  const [primaryAction, ...rest] = actions;
   return (
     <Box gap="0.5rem" display="flex" alignItems="center">
-      <MenuActionItem
-        as="button"
-        {...primaryAction}
-        {...(primaryAction.type === "button" ? { onDialogClose: close } : {})}
-      />
-      <IconButton ref={buttonRef} onClick={isOpen ? close : open}>
+      <MenuActionItem as="button" {...primaryAction} {...additionalProps} />
+      <IconButton ref={buttonRef} onClick={handleOpenElClick}>
         <Icon name="more" size={16} />
       </IconButton>
-      <ArrowMenuTopCenter
-        onClose={close}
-        open={isOpen}
-        anchorEl={buttonRef.current}
-        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
-        transformOrigin={{ horizontal: "center", vertical: "top" }}
+      <Wrapper
+        onClose={handleClose}
+        open={!!anchorEl}
+        anchorEl={anchorEl}
+        anchorOrigin={anchorOrigin}
+        transformOrigin={transformOrigin}
       >
-        {rest.map((props, i) => (
+        {otherActions.map((actionProps, i) => (
           <MenuActionItem
-            as="menuitem"
             key={i}
-            {...props}
+            as="menuitem"
+            {...actionProps}
             onClick={() => {
-              if (!props.stayOpen) {
-                menuDisclosure.close();
+              if (!actionProps.stayOpen) {
+                handleClose();
               }
-              return props.onClick?.();
+              actionProps.onClick?.();
             }}
-            {...(props.type === "button" ? { onDialogClose: close } : {})}
+            {...additionalProps}
           />
         ))}
-      </ArrowMenuTopCenter>
+      </Wrapper>
     </Box>
   );
 };

--- a/app/components/use-flip-menu.tsx
+++ b/app/components/use-flip-menu.tsx
@@ -1,0 +1,76 @@
+import { useMemo, useRef, useState } from "react";
+
+import {
+  ArrowMenuBottomCenter,
+  ArrowMenuTopCenter,
+} from "@/components/arrow-menu";
+import useEvent from "@/utils/use-event";
+
+const MENU_ITEM_HEIGHT = 40;
+
+type FlipMenuOrigin = {
+  vertical: "top" | "bottom";
+  horizontal: "center";
+};
+
+export const useFlipMenu = ({ itemsCount }: { itemsCount: number }) => {
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>();
+  const [anchorOrigin, setAnchorOrigin] = useState<FlipMenuOrigin>({
+    vertical: "bottom",
+    horizontal: "center",
+  });
+  const [transformOrigin, setTransformOrigin] = useState<FlipMenuOrigin>({
+    vertical: "top",
+    horizontal: "center",
+  });
+
+  const handleOpenElClick = useEvent(() => {
+    const openEl = buttonRef.current;
+
+    if (!openEl) {
+      return;
+    }
+
+    setAnchorEl(openEl);
+
+    const { top, bottom } = openEl.getBoundingClientRect();
+    const windowHeight = window.innerHeight;
+    const spaceBelow = windowHeight - bottom;
+    const spaceAbove = top;
+    const threshold = MENU_ITEM_HEIGHT * itemsCount + 16;
+
+    if (spaceBelow < threshold && spaceAbove > spaceBelow) {
+      setAnchorOrigin({ vertical: "top", horizontal: "center" });
+      setTransformOrigin({ vertical: "bottom", horizontal: "center" });
+    } else {
+      setAnchorOrigin({ vertical: "bottom", horizontal: "center" });
+      setTransformOrigin({ vertical: "top", horizontal: "center" });
+    }
+  });
+
+  const handleClose = useEvent(() => {
+    setAnchorEl(null);
+  });
+
+  const Wrapper = useMemo(() => {
+    switch (anchorOrigin.vertical) {
+      case "bottom":
+        return ArrowMenuTopCenter;
+      case "top":
+        return ArrowMenuBottomCenter;
+      default:
+        return ArrowMenuTopCenter;
+    }
+  }, [anchorOrigin.vertical]);
+
+  return {
+    handleOpenElClick,
+    handleClose,
+    Wrapper,
+    anchorEl,
+    buttonRef,
+    anchorOrigin,
+    transformOrigin,
+  };
+};


### PR DESCRIPTION
Fixes #1773

This PR adds a `useFlipMenu` hook with logic to automatically position `Menu` component, depending on its top / bottom position on the screen.

## How to reproduce
1. Go to [this link](https://test.visualize.admin.ch/en).
2. Log in.
3. Go to `My visualizations`.
4. Click on an action button close to the bottom of the screen.
5. ❌ See that it's rendered in the middle, overlapping the button, with arrow not being correctly positioned (in the screenshot below, I clicked on the last row's button).

<img width="1328" alt="Screenshot 2024-10-04 at 14 06 00" src="https://github.com/user-attachments/assets/c10359d9-3a04-4b1d-8721-142c1336033f">

## How to test
Once the PR is deployed to TEST, it will be possible to test using the above instructions, and the result should look like below. Clicking on top items should still display the component in its default, top-to-bottom state.

<img width="1394" alt="Screenshot 2024-10-04 at 14 07 15" src="https://github.com/user-attachments/assets/2f3c35aa-960a-40b3-94d8-21a7f85fd316">
