### PR TITLE
fix: Table height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Fixes
+  - Last table row is no longer cut
 
 # [4.9.2] - 2024-10-04
 

--- a/app/charts/table/table-content.tsx
+++ b/app/charts/table/table-content.tsx
@@ -61,6 +61,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     minHeight: SORTING_ARROW_WIDTH,
     alignItems: "center",
     justifyContent: "flex-start",
+    whiteSpace: "nowrap",
   },
   headerGroupMeasure: {
     justifyContent: "flex-end",

--- a/app/charts/table/table-state.tsx
+++ b/app/charts/table/table-state.tsx
@@ -25,7 +25,7 @@ import {
 } from "@/charts/shared/chart-state";
 import { useSize } from "@/charts/shared/use-size";
 import { BAR_CELL_PADDING, TABLE_HEIGHT } from "@/charts/table/constants";
-import { shouldShowCompactMobileView } from "@/charts/table/table";
+import { getTableUIElementsOffset } from "@/charts/table/table";
 import {
   TableStateVariables,
   useTableStateData,
@@ -139,8 +139,7 @@ const useTableState = (
     chartHeight +
     margins.top +
     margins.bottom +
-    (settings.showSearch ? 48 : 0) +
-    (shouldShowCompactMobileView(width) ? 48 : 0);
+    getTableUIElementsOffset({ showSearch: settings.showSearch, width });
   const bounds = {
     width,
     height,

--- a/app/charts/table/table-state.tsx
+++ b/app/charts/table/table-state.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/charts/shared/chart-state";
 import { useSize } from "@/charts/shared/use-size";
 import { BAR_CELL_PADDING, TABLE_HEIGHT } from "@/charts/table/constants";
+import { shouldShowCompactMobileView } from "@/charts/table/table";
 import {
   TableStateVariables,
   useTableStateData,
@@ -128,9 +129,18 @@ const useTableState = (
     left: 10,
   };
   const chartWidth = width - margins.left - margins.right; // We probably don't need this
-  const chartHeight = Math.min(TABLE_HEIGHT, chartData.length * rowHeight);
+  const chartHeight = Math.min(
+    TABLE_HEIGHT,
+    // + 1 for the header row
+    (chartData.length + 1) * rowHeight
+  );
 
-  const height = chartHeight + margins.top + margins.bottom;
+  const height =
+    chartHeight +
+    margins.top +
+    margins.bottom +
+    (settings.showSearch ? 48 : 0) +
+    (shouldShowCompactMobileView(width) ? 48 : 0);
   const bounds = {
     width,
     height,

--- a/app/charts/table/table.tsx
+++ b/app/charts/table/table.tsx
@@ -62,8 +62,21 @@ const useStyles = makeStyles(() => {
   };
 });
 
-export const shouldShowCompactMobileView = (width: number) => {
+const shouldShowCompactMobileView = (width: number) => {
   return width < MOBILE_VIEW_THRESHOLD;
+};
+
+/** Use to make sure we don't cut the table off by having other UI elements enabled */
+export const getTableUIElementsOffset = ({
+  showSearch,
+  width,
+}: {
+  showSearch: boolean;
+  width: number;
+}) => {
+  return (
+    (showSearch ? 48 : 0) + (shouldShowCompactMobileView(width) ? 48 : 0) + 4
+  );
 };
 
 export const Table = () => {
@@ -284,9 +297,10 @@ export const Table = () => {
       tableColumnsMeta,
     ]
   );
-  // Make sure we don't cut the table off by having other UI elements enabled
-  const defaultListHeightOffset =
-    (showSearch ? 48 : 0) + (showCompactMobileView ? 48 : 0) + 4;
+  const defaultListHeightOffset = getTableUIElementsOffset({
+    showSearch,
+    width: bounds.width,
+  });
 
   return (
     <>

--- a/app/charts/table/table.tsx
+++ b/app/charts/table/table.tsx
@@ -62,6 +62,10 @@ const useStyles = makeStyles(() => {
   };
 });
 
+export const shouldShowCompactMobileView = (width: number) => {
+  return width < MOBILE_VIEW_THRESHOLD;
+};
+
 export const Table = () => {
   const {
     bounds,
@@ -78,8 +82,7 @@ export const Table = () => {
 
   const [compactMobileViewEnabled, setCompactMobileView] = useState(false);
 
-  const showCompactMobileView =
-    bounds.width < MOBILE_VIEW_THRESHOLD && compactMobileViewEnabled;
+  const showCompactMobileView = shouldShowCompactMobileView(bounds.width);
 
   // Search & filter data
   const [searchTerm, setSearchTerm] = useState("");
@@ -281,6 +284,9 @@ export const Table = () => {
       tableColumnsMeta,
     ]
   );
+  // Make sure we don't cut the table off by having other UI elements enabled
+  const defaultListHeightOffset =
+    (showSearch ? 48 : 0) + (showCompactMobileView ? 48 : 0) + 4;
 
   return (
     <>
@@ -311,7 +317,7 @@ export const Table = () => {
         />
       </Box>
 
-      {showCompactMobileView ? (
+      {showCompactMobileView && compactMobileViewEnabled ? (
         /* Compact Mobile View */
         <Box
           sx={{
@@ -327,7 +333,7 @@ export const Table = () => {
             {({ width, height }: { width: number; height: number }) => (
               <VariableSizeList
                 key={rows.length} // Reset when groups are toggled because itemSize remains cached per index
-                height={height}
+                height={height - defaultListHeightOffset}
                 itemCount={rows.length}
                 itemSize={getMobileItemSize}
                 width={width}
@@ -359,7 +365,8 @@ export const Table = () => {
                 {({ height }: { height: number }) => (
                   <FixedSizeList
                     outerElementType={TableContentWrapper}
-                    height={height}
+                    // row height = header row height
+                    height={height - defaultListHeightOffset - rowHeight}
                     itemCount={rows.length}
                     itemSize={rowHeight} // depends on whether a column has bars (40px or 56px)
                     width="100%"

--- a/app/charts/table/table.tsx
+++ b/app/charts/table/table.tsx
@@ -211,7 +211,7 @@ export const Table = () => {
               style: {
                 ...style,
                 flexDirection: "column",
-                width: "max-content",
+                width: "100%",
               },
             })}
           >


### PR DESCRIPTION
Fixes #1792
Fixes #1790 

## How to test
1. Go to [this link](https://visualization-tool-git-fix-table-height-ixt1.vercel.app/en/create/new?cube=https://health.ld.admin.ch/fsvo/BT_table/17&dataSource=Prod).
2. Switch to a table chart.
3. ✅ See that the content is not cut.
4. Publish the chart.
5. ✅ See that the table is not cut there either.
6. Reduce the browser window width to activate the compact view option.
7. ✅ Enable the compact view option, scroll down and see that the content is not cut.
8. Repeat the above steps for another cube, e.g. Photovoltaikanlagen, to see that long tables are also not cut. You can also disable the search box from table settings to see that this doesn't make the table cut as well.