### PR TITLE
fix: Fixed tooltip for Mobile Area Charts

### DIFF
--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -1,10 +1,10 @@
 import { extent, group, rollup, sum } from "d3-array";
 import {
   ScaleLinear,
-  ScaleOrdinal,
-  ScaleTime,
   scaleLinear,
+  ScaleOrdinal,
   scaleOrdinal,
+  ScaleTime,
   scaleTime,
 } from "d3-scale";
 import { schemeCategory10 } from "d3-scale-chromatic";
@@ -40,7 +40,10 @@ import {
   InteractiveXTimeRangeState,
 } from "@/charts/shared/chart-state";
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
-import { getCenteredTooltipPlacement } from "@/charts/shared/interaction/tooltip-box";
+import {
+  getCenteredTooltipPlacement,
+  TooltipPlacement,
+} from "@/charts/shared/interaction/tooltip-box";
 import {
   getStackedTooltipValueFormatter,
   getStackedYScale,
@@ -379,17 +382,18 @@ const useAreasState = (
         ? yScale.range()[0] * 0.5
         : yScale(sum(yValues) * (fields.segment ? 0.5 : 1));
       const yAnchor = isMobile ? chartHeight : yDesktopAnchor;
+      const placement: TooltipPlacement = isMobile
+        ? { x: "center", y: "bottom" }
+        : getCenteredTooltipPlacement({
+            chartWidth,
+            xAnchor,
+            topAnchor: !fields.segment,
+          });
 
       return {
         xAnchor,
         yAnchor,
-        placement: isMobile
-          ? { x: "center", y: "bottom" }
-          : getCenteredTooltipPlacement({
-              chartWidth,
-              xAnchor,
-              topAnchor: !fields.segment,
-            }),
+        placement,
         xValue: timeFormatUnit(getX(datum), xDimension.timeUnit),
         datum: {
           label: fields.segment && getSegmentAbbreviationOrLabel(datum),

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -42,7 +42,7 @@ import {
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
 import {
   getCenteredTooltipPlacement,
-  TooltipPlacement,
+  MOBILE_TOOLTIP_PLACEMENT,
 } from "@/charts/shared/interaction/tooltip-box";
 import {
   getStackedTooltipValueFormatter,
@@ -382,8 +382,8 @@ const useAreasState = (
         ? yScale.range()[0] * 0.5
         : yScale(sum(yValues) * (fields.segment ? 0.5 : 1));
       const yAnchor = isMobile ? chartHeight : yDesktopAnchor;
-      const placement: TooltipPlacement = isMobile
-        ? { x: "center", y: "bottom" }
+      const placement = isMobile
+        ? MOBILE_TOOLTIP_PLACEMENT
         : getCenteredTooltipPlacement({
             chartWidth,
             xAnchor,

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -1,3 +1,4 @@
+import { useMediaQuery, useTheme } from "@mui/material";
 import { extent, group, rollup, sum } from "d3-array";
 import {
   ScaleLinear,
@@ -352,6 +353,9 @@ const useAreasState = (
   xScaleTimeRange.range([0, chartWidth]);
   yScale.range([chartHeight, 0]);
 
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+
   /** Tooltip */
   const getAnnotationInfo = useCallback(
     (datum: Observation): TooltipInfo => {
@@ -372,18 +376,21 @@ const useAreasState = (
         formatNumber,
       });
       const xAnchor = xScale(getX(datum));
-      const yAnchor = normalize
+      const yNormalized = normalize
         ? yScale.range()[0] * 0.5
         : yScale(sum(yValues) * (fields.segment ? 0.5 : 1));
+      const yAnchor = isMobile ? chartHeight : yNormalized;
 
       return {
         xAnchor,
         yAnchor,
-        placement: getCenteredTooltipPlacement({
-          chartWidth,
-          xAnchor,
-          topAnchor: !fields.segment,
-        }),
+        placement: isMobile
+          ? { x: "center", y: "bottom" }
+          : getCenteredTooltipPlacement({
+              chartWidth,
+              xAnchor,
+              topAnchor: !fields.segment,
+            }),
         xValue: timeFormatUnit(getX(datum), xDimension.timeUnit),
         datum: {
           label: fields.segment && getSegmentAbbreviationOrLabel(datum),
@@ -420,6 +427,8 @@ const useAreasState = (
       normalize,
       getIdentityY,
       chartWidth,
+      chartHeight,
+      isMobile,
     ]
   );
 

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -1,4 +1,3 @@
-import { useMediaQuery, useTheme } from "@mui/material";
 import { extent, group, rollup, sum } from "d3-array";
 import {
   ScaleLinear,
@@ -59,6 +58,7 @@ import {
   getSortingOrders,
   makeDimensionValueSorters,
 } from "@/utils/sorting-values";
+import { useIsMobile } from "@/utils/use-is-mobile";
 
 import { ChartProps } from "../shared/ChartProps";
 
@@ -353,8 +353,7 @@ const useAreasState = (
   xScaleTimeRange.range([0, chartWidth]);
   yScale.range([chartHeight, 0]);
 
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+  const isMobile = useIsMobile();
 
   /** Tooltip */
   const getAnnotationInfo = useCallback(
@@ -376,10 +375,10 @@ const useAreasState = (
         formatNumber,
       });
       const xAnchor = xScale(getX(datum));
-      const yNormalized = normalize
+      const yDesktopAnchor = normalize
         ? yScale.range()[0] * 0.5
         : yScale(sum(yValues) * (fields.segment ? 0.5 : 1));
-      const yAnchor = isMobile ? chartHeight : yNormalized;
+      const yAnchor = isMobile ? chartHeight : yDesktopAnchor;
 
       return {
         xAnchor,

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -1,10 +1,10 @@
 import { extent, group, max, rollup, sum } from "d3-array";
 import {
   ScaleBand,
-  ScaleLinear,
-  ScaleOrdinal,
   scaleBand,
+  ScaleLinear,
   scaleLinear,
+  ScaleOrdinal,
   scaleOrdinal,
   scaleTime,
 } from "d3-scale";
@@ -34,7 +34,10 @@ import {
   InteractiveXTimeRangeState,
 } from "@/charts/shared/chart-state";
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
-import { getCenteredTooltipPlacement } from "@/charts/shared/interaction/tooltip-box";
+import {
+  getCenteredTooltipPlacement,
+  TooltipPlacement,
+} from "@/charts/shared/interaction/tooltip-box";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useSize } from "@/charts/shared/use-size";
@@ -47,6 +50,7 @@ import {
   getSortingOrders,
   makeDimensionValueSorters,
 } from "@/utils/sorting-values";
+import { useIsMobile } from "@/utils/use-is-mobile";
 
 import { ChartProps } from "../shared/ChartProps";
 
@@ -359,6 +363,8 @@ const useColumnsGroupedState = (
   xScaleTimeRange.range([0, chartWidth]);
   yScale.range([chartHeight, 0]);
 
+  const isMobile = useIsMobile();
+
   // Tooltip
   const getAnnotationInfo = (datum: Observation): TooltipInfo => {
     const bw = xScale.bandwidth();
@@ -383,12 +389,14 @@ const useColumnsGroupedState = (
 
     const xAnchorRaw = (xScale(x) as number) + bw * 0.5;
     const [yMin, yMax] = extent(yValues, (d) => d ?? 0) as [number, number];
-    const yAnchor = yScale((yMin + yMax) * 0.5);
-    const placement = getCenteredTooltipPlacement({
-      chartWidth,
-      xAnchor: xAnchorRaw,
-      topAnchor: !fields.segment,
-    });
+    const yAnchor = isMobile ? chartHeight : yScale((yMin + yMax) * 0.5);
+    const placement: TooltipPlacement = isMobile
+      ? { x: "center", y: "bottom" }
+      : getCenteredTooltipPlacement({
+          chartWidth,
+          xAnchor: xAnchorRaw,
+          topAnchor: !fields.segment,
+        });
 
     const getError = (d: Observation) => {
       if (!showYStandardError || !getYError || getYError(d) == null) {

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -36,7 +36,7 @@ import {
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
 import {
   getCenteredTooltipPlacement,
-  TooltipPlacement,
+  MOBILE_TOOLTIP_PLACEMENT,
 } from "@/charts/shared/interaction/tooltip-box";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
@@ -390,8 +390,8 @@ const useColumnsGroupedState = (
     const xAnchorRaw = (xScale(x) as number) + bw * 0.5;
     const [yMin, yMax] = extent(yValues, (d) => d ?? 0) as [number, number];
     const yAnchor = isMobile ? chartHeight : yScale((yMin + yMax) * 0.5);
-    const placement: TooltipPlacement = isMobile
-      ? { x: "center", y: "bottom" }
+    const placement = isMobile
+      ? MOBILE_TOOLTIP_PLACEMENT
       : getCenteredTooltipPlacement({
           chartWidth,
           xAnchor: xAnchorRaw,

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -44,7 +44,7 @@ import {
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
 import {
   getCenteredTooltipPlacement,
-  TooltipPlacement,
+  MOBILE_TOOLTIP_PLACEMENT,
 } from "@/charts/shared/interaction/tooltip-box";
 import {
   getStackedTooltipValueFormatter,
@@ -447,8 +447,8 @@ const useColumnsStackedState = (
       const yAnchor = isMobile
         ? chartHeight
         : yScale(sum(yValues.map((d) => d ?? 0)) * 0.5);
-      const placement: TooltipPlacement = isMobile
-        ? { x: "center", y: "bottom" }
+      const placement = isMobile
+        ? MOBILE_TOOLTIP_PLACEMENT
         : getCenteredTooltipPlacement({
             chartWidth,
             xAnchor: xAnchorRaw,

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -1,10 +1,10 @@
 import { extent, group, rollup, sum } from "d3-array";
 import {
   ScaleBand,
-  ScaleLinear,
-  ScaleOrdinal,
   scaleBand,
+  ScaleLinear,
   scaleLinear,
+  ScaleOrdinal,
   scaleOrdinal,
   scaleTime,
 } from "d3-scale";
@@ -42,7 +42,10 @@ import {
   InteractiveXTimeRangeState,
 } from "@/charts/shared/chart-state";
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
-import { getCenteredTooltipPlacement } from "@/charts/shared/interaction/tooltip-box";
+import {
+  getCenteredTooltipPlacement,
+  TooltipPlacement,
+} from "@/charts/shared/interaction/tooltip-box";
 import {
   getStackedTooltipValueFormatter,
   getStackedYScale,
@@ -60,6 +63,7 @@ import {
   getSortingOrders,
   makeDimensionValueSorters,
 } from "@/utils/sorting-values";
+import { useIsMobile } from "@/utils/use-is-mobile";
 
 import { ChartProps } from "../shared/ChartProps";
 
@@ -415,6 +419,8 @@ const useColumnsStackedState = (
   xScaleTimeRange.range([0, chartWidth]);
   yScale.range([chartHeight, 0]);
 
+  const isMobile = useIsMobile();
+
   // Tooltips
   const getAnnotationInfo = useCallback(
     (datum: Observation): TooltipInfo => {
@@ -438,12 +444,16 @@ const useColumnsStackedState = (
       });
 
       const xAnchorRaw = (xScale(x) as number) + bw * 0.5;
-      const yAnchor = yScale(sum(yValues.map((d) => d ?? 0)) * 0.5);
-      const placement = getCenteredTooltipPlacement({
-        chartWidth,
-        xAnchor: xAnchorRaw,
-        topAnchor: !fields.segment,
-      });
+      const yAnchor = isMobile
+        ? chartHeight
+        : yScale(sum(yValues.map((d) => d ?? 0)) * 0.5);
+      const placement: TooltipPlacement = isMobile
+        ? { x: "center", y: "bottom" }
+        : getCenteredTooltipPlacement({
+            chartWidth,
+            xAnchor: xAnchorRaw,
+            topAnchor: !fields.segment,
+          });
 
       return {
         xAnchor: xAnchorRaw + (placement.x === "right" ? 0.5 : -0.5) * bw,
@@ -479,6 +489,8 @@ const useColumnsStackedState = (
       getIdentityY,
       colors,
       chartWidth,
+      chartHeight,
+      isMobile,
       normalize,
       yScale,
     ]

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -29,7 +29,7 @@ import {
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
 import {
   getCenteredTooltipPlacement,
-  TooltipPlacement,
+  MOBILE_TOOLTIP_PLACEMENT,
 } from "@/charts/shared/interaction/tooltip-box";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
@@ -229,8 +229,8 @@ const useColumnsState = (
     const yAnchor = isMobile
       ? chartHeight
       : yScale(Math.max(getY(d) ?? NaN, 0));
-    const placement: TooltipPlacement = isMobile
-      ? { x: "center", y: "bottom" }
+    const placement = isMobile
+      ? MOBILE_TOOLTIP_PLACEMENT
       : getCenteredTooltipPlacement({
           chartWidth,
           xAnchor,

--- a/app/charts/combo/combo-line-column-state.tsx
+++ b/app/charts/combo/combo-line-column-state.tsx
@@ -27,7 +27,10 @@ import {
   InteractiveXTimeRangeState,
 } from "@/charts/shared/chart-state";
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
-import { getCenteredTooltipPlacement } from "@/charts/shared/interaction/tooltip-box";
+import {
+  getCenteredTooltipPlacement,
+  TooltipPlacement,
+} from "@/charts/shared/interaction/tooltip-box";
 import { getTickNumber } from "@/charts/shared/ticks";
 import { TICK_FONT_SIZE } from "@/charts/shared/use-chart-theme";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
@@ -38,6 +41,7 @@ import { useFormatFullDateAuto } from "@/formatters";
 import { TimeUnit } from "@/graphql/resolver-types";
 import { getTimeInterval } from "@/intervals";
 import { getTextWidth } from "@/utils/get-text-width";
+import { useIsMobile } from "@/utils/use-is-mobile";
 
 import { ChartProps } from "../shared/ChartProps";
 
@@ -151,6 +155,8 @@ const useComboLineColumnState = (
   const yScales = [yScale, yScaleLeft, yScaleRight];
   adjustScales(xScales, yScales, { chartWidth, chartHeight });
 
+  const isMobile = useIsMobile();
+
   // Tooltip
   const getAnnotationInfo = (d: Observation): TooltipInfo => {
     const x = getX(d);
@@ -172,17 +178,21 @@ const useComboLineColumnState = (
         };
       })
       .filter(truthy);
-    const yAnchor = mean(values.map((d) => d.yPos));
+    const yAnchor = isMobile ? chartHeight : mean(values.map((d) => d.yPos));
+    const placement: TooltipPlacement = isMobile
+      ? { x: "center", y: "bottom" }
+      : getCenteredTooltipPlacement({
+          chartWidth,
+          xAnchor: xScaled,
+          topAnchor: false,
+        });
+
     return {
       datum: { label: "", value: "0", color: schemeCategory10[0] },
       xAnchor: xScaled,
       yAnchor,
       xValue: timeFormatUnit(x, variables.xTimeUnit as TimeUnit),
-      placement: getCenteredTooltipPlacement({
-        chartWidth,
-        xAnchor: xScaled,
-        topAnchor: false,
-      }),
+      placement,
       values,
     } as TooltipInfo;
   };

--- a/app/charts/combo/combo-line-column-state.tsx
+++ b/app/charts/combo/combo-line-column-state.tsx
@@ -29,7 +29,7 @@ import {
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
 import {
   getCenteredTooltipPlacement,
-  TooltipPlacement,
+  MOBILE_TOOLTIP_PLACEMENT,
 } from "@/charts/shared/interaction/tooltip-box";
 import { getTickNumber } from "@/charts/shared/ticks";
 import { TICK_FONT_SIZE } from "@/charts/shared/use-chart-theme";
@@ -179,8 +179,8 @@ const useComboLineColumnState = (
       })
       .filter(truthy);
     const yAnchor = isMobile ? chartHeight : mean(values.map((d) => d.yPos));
-    const placement: TooltipPlacement = isMobile
-      ? { x: "center", y: "bottom" }
+    const placement = isMobile
+      ? MOBILE_TOOLTIP_PLACEMENT
       : getCenteredTooltipPlacement({
           chartWidth,
           xAnchor: xScaled,

--- a/app/charts/combo/combo-line-dual-state.tsx
+++ b/app/charts/combo/combo-line-dual-state.tsx
@@ -28,7 +28,7 @@ import {
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
 import {
   getCenteredTooltipPlacement,
-  TooltipPlacement,
+  MOBILE_TOOLTIP_PLACEMENT,
 } from "@/charts/shared/interaction/tooltip-box";
 import { getTickNumber } from "@/charts/shared/ticks";
 import { TICK_FONT_SIZE, useChartTheme } from "@/charts/shared/use-chart-theme";
@@ -166,10 +166,10 @@ const useComboLineDualState = (
       })
       .filter(truthy);
     const yAnchor = isMobile
-      ? chartHeight + 32
+      ? chartHeight + margins.bottom
       : mean(values.map((d) => d.yPos));
-    const placement: TooltipPlacement = isMobile
-      ? { x: "center", y: "bottom" }
+    const placement = isMobile
+      ? MOBILE_TOOLTIP_PLACEMENT
       : getCenteredTooltipPlacement({
           chartWidth,
           xAnchor: xScaled,

--- a/app/charts/combo/combo-line-dual-state.tsx
+++ b/app/charts/combo/combo-line-dual-state.tsx
@@ -165,7 +165,9 @@ const useComboLineDualState = (
         };
       })
       .filter(truthy);
-    const yAnchor = isMobile ? chartHeight : mean(values.map((d) => d.yPos));
+    const yAnchor = isMobile
+      ? chartHeight + 32
+      : mean(values.map((d) => d.yPos));
     const placement: TooltipPlacement = isMobile
       ? { x: "center", y: "bottom" }
       : getCenteredTooltipPlacement({

--- a/app/charts/combo/combo-line-single-state.tsx
+++ b/app/charts/combo/combo-line-single-state.tsx
@@ -26,7 +26,7 @@ import {
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
 import {
   getCenteredTooltipPlacement,
-  TooltipPlacement,
+  MOBILE_TOOLTIP_PLACEMENT,
 } from "@/charts/shared/interaction/tooltip-box";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { ComboLineSingleConfig } from "@/configurator";
@@ -143,8 +143,8 @@ const useComboLineSingleState = (
       })
       .filter(truthy);
     const yAnchor = isMobile ? chartHeight : mean(values.map((d) => d.yPos));
-    const placement: TooltipPlacement = isMobile
-      ? { x: "center", y: "bottom" }
+    const placement = isMobile
+      ? MOBILE_TOOLTIP_PLACEMENT
       : getCenteredTooltipPlacement({
           chartWidth,
           xAnchor: xScaled,

--- a/app/charts/combo/combo-line-single-state.tsx
+++ b/app/charts/combo/combo-line-single-state.tsx
@@ -24,11 +24,15 @@ import {
   InteractiveXTimeRangeState,
 } from "@/charts/shared/chart-state";
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
-import { getCenteredTooltipPlacement } from "@/charts/shared/interaction/tooltip-box";
+import {
+  getCenteredTooltipPlacement,
+  TooltipPlacement,
+} from "@/charts/shared/interaction/tooltip-box";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { ComboLineSingleConfig } from "@/configurator";
 import { Observation } from "@/domain/data";
 import { truthy } from "@/domain/types";
+import { useIsMobile } from "@/utils/use-is-mobile";
 
 import { ChartProps } from "../shared/ChartProps";
 
@@ -115,6 +119,8 @@ const useComboLineSingleState = (
   const yScales = [yScale];
   adjustScales(xScales, yScales, { chartWidth, chartHeight });
 
+  const isMobile = useIsMobile();
+
   // Tooltip
   const getAnnotationInfo = (d: Observation): TooltipInfo => {
     const x = getX(d);
@@ -136,18 +142,21 @@ const useComboLineSingleState = (
         };
       })
       .filter(truthy);
-    const yAnchor = mean(values.map((d) => d.yPos));
+    const yAnchor = isMobile ? chartHeight : mean(values.map((d) => d.yPos));
+    const placement: TooltipPlacement = isMobile
+      ? { x: "center", y: "bottom" }
+      : getCenteredTooltipPlacement({
+          chartWidth,
+          xAnchor: xScaled,
+          topAnchor: false,
+        });
 
     return {
       datum: { label: "", value: "0", color: schemeCategory10[0] },
       xAnchor: xScaled,
       yAnchor: yAnchor,
       xValue: timeFormatUnit(x, xDimension.timeUnit),
-      placement: getCenteredTooltipPlacement({
-        chartWidth,
-        xAnchor: xScaled,
-        topAnchor: false,
-      }),
+      placement,
       values,
     } as TooltipInfo;
   };

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -31,7 +31,7 @@ import {
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
 import {
   getCenteredTooltipPlacement,
-  TooltipPlacement,
+  MOBILE_TOOLTIP_PLACEMENT,
 } from "@/charts/shared/interaction/tooltip-box";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
@@ -264,8 +264,8 @@ const useLinesState = (
     const yValues = tooltipValues.map(getY);
     const [yMin, yMax] = extent(yValues, (d) => d ?? 0) as [number, number];
     const yAnchor = isMobile ? chartHeight : yScale((yMin + yMax) * 0.5);
-    const placement: TooltipPlacement = isMobile
-      ? { x: "center", y: "bottom" }
+    const placement = isMobile
+      ? MOBILE_TOOLTIP_PLACEMENT
       : getCenteredTooltipPlacement({
           chartWidth,
           xAnchor,

--- a/app/charts/pie/pie.tsx
+++ b/app/charts/pie/pie.tsx
@@ -1,5 +1,5 @@
 import { arc, PieArcDatum } from "d3-shape";
-import React, { useMemo, useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 
 import { PieState } from "@/charts/pie/pie-state";
 import { RenderDatum, renderPies } from "@/charts/pie/rendering-utils";

--- a/app/charts/pie/rendering-utils.ts
+++ b/app/charts/pie/rendering-utils.ts
@@ -47,8 +47,8 @@ export const renderPies = (
               (s: Selection<SVGPathElement, RenderDatum, BaseType, unknown>) =>
                 maybeTransition(s, {
                   transition,
-                  s: (g) => g.attr("stroke-width", 2),
-                  t: (g) => g.attr("stroke-width", 2),
+                  s: (g) => g.attr("stroke-width", 1),
+                  t: (g) => g.attr("stroke-width", 1),
                 })
             );
           })

--- a/app/charts/pie/rendering-utils.ts
+++ b/app/charts/pie/rendering-utils.ts
@@ -1,5 +1,5 @@
 import { interpolate } from "d3-interpolate";
-import { Selection } from "d3-selection";
+import { select } from "d3-selection";
 import { PieArcDatum } from "d3-shape";
 import { Transition } from "d3-transition";
 
@@ -8,6 +8,8 @@ import {
   maybeTransition,
 } from "@/charts/shared/rendering-utils";
 import { Observation } from "@/domain/data";
+
+import type { BaseType, Selection } from "d3-selection";
 
 export type RenderDatum = {
   key: string;
@@ -26,7 +28,7 @@ export const renderPies = (
   renderData: RenderDatum[],
   options: RenderPieOptions
 ) => {
-  const { arcGenerator, handleMouseEnter, handleMouseLeave, transition } =
+  const { arcGenerator, transition, handleMouseEnter, handleMouseLeave } =
     options;
 
   g.selectAll<SVGPathElement, RenderDatum>("path")
@@ -37,8 +39,30 @@ export const renderPies = (
           .append("path")
           .attr("data-index", (_, i) => i)
           .attr("fill", (d) => d.color)
-          .on("mouseenter", (_, d) => handleMouseEnter(d.arcDatum))
-          .on("mouseleave", handleMouseLeave)
+          .attr("stroke", "black")
+          .attr("stroke-width", 0)
+          .on("mouseenter", function (_, d) {
+            handleMouseEnter(d.arcDatum);
+            select<SVGPathElement, RenderDatum>(this).call(
+              (s: Selection<SVGPathElement, RenderDatum, BaseType, unknown>) =>
+                maybeTransition(s, {
+                  transition,
+                  s: (g) => g.attr("stroke-width", 2),
+                  t: (g) => g.attr("stroke-width", 2),
+                })
+            );
+          })
+          .on("mouseleave", function () {
+            handleMouseLeave();
+            select<SVGPathElement, RenderDatum>(this).call(
+              (s: Selection<SVGPathElement, RenderDatum, BaseType, unknown>) =>
+                maybeTransition(s, {
+                  transition,
+                  s: (g) => g.attr("stroke-width", 0),
+                  t: (g) => g.attr("stroke-width", 0),
+                })
+            );
+          })
           .call((enter) =>
             maybeTransition(enter, {
               transition,

--- a/app/charts/scatterplot/chart-scatterplot.tsx
+++ b/app/charts/scatterplot/chart-scatterplot.tsx
@@ -23,6 +23,7 @@ import { ScatterPlotConfig, useChartConfigFilters } from "@/config-types";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 
 import { ChartProps, VisualizationProps } from "../shared/ChartProps";
+import { Ruler } from "../shared/interaction/ruler";
 
 export const ChartScatterplotVisualization = (
   props: VisualizationProps<ScatterPlotConfig>
@@ -45,6 +46,7 @@ const ChartScatterplot = memo((props: ChartProps<ScatterPlotConfig>) => {
           <Scatterplot />
           <InteractionVoronoi />
         </ChartSvg>
+        <Ruler />
         <Tooltip type="single" />
       </ChartContainer>
       {(fields.animation || fields.segment) && (

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -19,7 +19,10 @@ import {
   ChartStateData,
   CommonChartState,
 } from "@/charts/shared/chart-state";
-import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
+import {
+  TooltipInfo,
+  TooltipPlacement,
+} from "@/charts/shared/interaction/tooltip";
 import { TooltipScatterplot } from "@/charts/shared/interaction/tooltip-content";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useSize } from "@/charts/shared/use-size";
@@ -31,6 +34,7 @@ import {
   getSortingOrders,
   makeDimensionValueSorters,
 } from "@/utils/sorting-values";
+import { useIsMobile } from "@/utils/use-is-mobile";
 
 import { ChartProps } from "../shared/ChartProps";
 
@@ -178,12 +182,14 @@ const useScatterplotState = (
   xScale.range([0, chartWidth]);
   yScale.range([chartHeight, 0]);
 
+  const isMobile = useIsMobile();
+
   // Tooltip
   const getAnnotationInfo = (datum: Observation): TooltipInfo => {
     const xRef = xScale(getX(datum) ?? NaN);
     const yRef = yScale(getY(datum) ?? NaN);
     const xAnchor = xRef;
-    const yAnchor = yRef;
+    const yAnchor = isMobile ? chartHeight : yRef;
 
     const xPlacement =
       xAnchor < chartWidth * 0.33
@@ -199,10 +205,14 @@ const useScatterplotState = (
           ? "bottom"
           : "middle";
 
+    const placement: TooltipPlacement = isMobile
+      ? { x: "center", y: "bottom" }
+      : { x: xPlacement, y: yPlacement };
+
     return {
       xAnchor,
       yAnchor,
-      placement: { x: xPlacement, y: yPlacement },
+      placement,
       xValue: formatNumber(getX(datum)),
       tooltipContent: (
         <TooltipScatterplot

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -19,10 +19,7 @@ import {
   ChartStateData,
   CommonChartState,
 } from "@/charts/shared/chart-state";
-import {
-  TooltipInfo,
-  TooltipPlacement,
-} from "@/charts/shared/interaction/tooltip";
+import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
 import { TooltipScatterplot } from "@/charts/shared/interaction/tooltip-content";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useSize } from "@/charts/shared/use-size";
@@ -37,6 +34,10 @@ import {
 import { useIsMobile } from "@/utils/use-is-mobile";
 
 import { ChartProps } from "../shared/ChartProps";
+import {
+  MOBILE_TOOLTIP_PLACEMENT,
+  TooltipPlacement,
+} from "../shared/interaction/tooltip-box";
 
 export type ScatterplotState = CommonChartState &
   ScatterplotStateVariables & {
@@ -206,7 +207,7 @@ const useScatterplotState = (
           : "middle";
 
     const placement: TooltipPlacement = isMobile
-      ? { x: "center", y: "bottom" }
+      ? MOBILE_TOOLTIP_PLACEMENT
       : { x: xPlacement, y: yPlacement };
 
     return {

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -34,10 +34,7 @@ import {
 import { useIsMobile } from "@/utils/use-is-mobile";
 
 import { ChartProps } from "../shared/ChartProps";
-import {
-  MOBILE_TOOLTIP_PLACEMENT,
-  TooltipPlacement,
-} from "../shared/interaction/tooltip-box";
+import { TooltipPlacement } from "../shared/interaction/tooltip-box";
 
 export type ScatterplotState = CommonChartState &
   ScatterplotStateVariables & {
@@ -190,7 +187,7 @@ const useScatterplotState = (
     const xRef = xScale(getX(datum) ?? NaN);
     const yRef = yScale(getY(datum) ?? NaN);
     const xAnchor = xRef;
-    const yAnchor = isMobile ? chartHeight : yRef;
+    const yAnchor = isMobile ? 0 : yRef;
 
     const xPlacement =
       xAnchor < chartWidth * 0.33
@@ -207,7 +204,7 @@ const useScatterplotState = (
           : "middle";
 
     const placement: TooltipPlacement = isMobile
-      ? MOBILE_TOOLTIP_PLACEMENT
+      ? { x: "center", y: "top" }
       : { x: xPlacement, y: yPlacement };
 
     return {

--- a/app/charts/shared/interaction/ruler.tsx
+++ b/app/charts/shared/interaction/ruler.tsx
@@ -1,4 +1,4 @@
-import { Box, Theme, useMediaQuery, useTheme } from "@mui/material";
+import { Box, Theme } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 
 import { ComboLineColumnState } from "@/charts/combo/combo-line-column-state";
@@ -13,6 +13,7 @@ import {
 import { useInteraction } from "@/charts/shared/use-interaction";
 import { Margins } from "@/charts/shared/use-size";
 import { Observation } from "@/domain/data";
+import { useIsMobile } from "@/utils/use-is-mobile";
 
 type RulerProps = {
   rotate?: boolean;
@@ -95,8 +96,7 @@ export const RulerContent = (props: RulerContentProps) => {
   const { rotate, xValue, chartHeight, margins, xAnchor } = props;
   const classes = useStyles({ rotate });
 
-  const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+  const isMobile = useIsMobile();
 
   return (
     <>

--- a/app/charts/shared/interaction/ruler.tsx
+++ b/app/charts/shared/interaction/ruler.tsx
@@ -1,4 +1,4 @@
-import { Box, Theme } from "@mui/material";
+import { Box, Theme, useMediaQuery, useTheme } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 
 import { ComboLineColumnState } from "@/charts/combo/combo-line-column-state";
@@ -63,6 +63,7 @@ type RulerContentProps = {
   xAnchor: number;
   datum: TooltipValue;
   placement: TooltipPlacement;
+  showXValue?: boolean;
 };
 
 const useStyles = makeStyles<Theme, { rotate: boolean }>((theme: Theme) => ({
@@ -94,6 +95,9 @@ export const RulerContent = (props: RulerContentProps) => {
   const { rotate, xValue, chartHeight, margins, xAnchor } = props;
   const classes = useStyles({ rotate });
 
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+
   return (
     <>
       <Box
@@ -104,15 +108,17 @@ export const RulerContent = (props: RulerContentProps) => {
           top: margins.top,
         }}
       />
-      <Box
-        className={classes.right}
-        style={{
-          left: xAnchor + margins.left,
-          top: chartHeight + margins.top + 6,
-        }}
-      >
-        {xValue}
-      </Box>
+      {!isMobile && (
+        <Box
+          className={classes.right}
+          style={{
+            left: xAnchor + margins.left,
+            top: chartHeight + margins.top + 6,
+          }}
+        >
+          {xValue}
+        </Box>
+      )}
     </>
   );
 };

--- a/app/charts/shared/interaction/tooltip-box.tsx
+++ b/app/charts/shared/interaction/tooltip-box.tsx
@@ -17,6 +17,10 @@ import { useChartBounds } from "../chart-dimensions";
 
 const TRIANGLE_SIZE = 8;
 const TOOLTIP_OFFSET = 4;
+export const MOBILE_TOOLTIP_PLACEMENT: TooltipPlacement = {
+  x: "center",
+  y: "bottom",
+};
 
 export type Xplacement = "left" | "center" | "right";
 export type Yplacement = "top" | "middle" | "bottom";
@@ -134,10 +138,10 @@ export const TooltipBox = ({
   const { width, height } = useSize();
   const { chartWidth } = useChartBounds(width, margins, height);
 
-  const tooltipX = isMobile
-    ? toolTipXBoundary(x!, tooltipWidth, chartWidth)
+  const tooltipXBoundary = isMobile
+    ? getTooltipXBoundary(x!, tooltipWidth, chartWidth)
     : x!;
-  const triangleX = triangleXPos(x!, tooltipWidth, chartWidth);
+  const triangleX = getTriangleXPos(x!, tooltipWidth, chartWidth);
 
   return (
     <>
@@ -149,7 +153,7 @@ export const TooltipBox = ({
           style={{
             zIndex: 1301,
             position: "absolute",
-            left: tooltipX! + margins.left + pos.left,
+            left: tooltipXBoundary! + margins.left + pos.left,
             top: mxYOffset(y!, placement) + margins.top + pos.top,
             transform: mkTranslation(placement),
             pointerEvents: "none",
@@ -367,41 +371,41 @@ const mkTriangle = (p: TooltipPlacement) => {
   }
 };
 
-const toolTipXBoundary = (
-  value: number,
+const getTooltipXBoundary = (
+  x: number,
   tooltipWidth: number,
   chartWidth: number
 ) => {
   return Math.max(
     tooltipWidth / 2 - TRIANGLE_SIZE,
-    Math.min(chartWidth - tooltipWidth / 2 + TRIANGLE_SIZE, value)
+    Math.min(chartWidth - tooltipWidth / 2 + TRIANGLE_SIZE, x)
   );
 };
 
-const triangleXPos = (
-  value: number,
+const getTriangleXPos = (
+  x: number,
   tooltipWidth: number,
   chartWidth: number
 ): number => {
   if (chartWidth < tooltipWidth) {
-    const maxPosition = chartWidth + TRIANGLE_SIZE;
+    const xMax = chartWidth + TRIANGLE_SIZE;
 
     return Math.min(
       Math.max(
-        value,
+        x,
         Math.min(
           tooltipWidth / 2 - TRIANGLE_SIZE,
-          Math.min(chartWidth - tooltipWidth / 2 + TRIANGLE_SIZE, value)
+          Math.min(chartWidth - tooltipWidth / 2 + TRIANGLE_SIZE, x)
         )
       ),
-      maxPosition
+      xMax
     );
   }
 
-  const condition = chartWidth - tooltipWidth / 2 + TRIANGLE_SIZE < value;
+  const hasReachedMax = chartWidth - tooltipWidth / 2 + TRIANGLE_SIZE < x;
 
-  if (condition) {
-    const overflow = value - (chartWidth - tooltipWidth / 2 + TRIANGLE_SIZE);
+  if (hasReachedMax) {
+    const overflow = x - (chartWidth - tooltipWidth / 2 + TRIANGLE_SIZE);
     const maxOverflow = tooltipWidth / 2 - TRIANGLE_SIZE;
 
     const proportion = Math.min(overflow / maxOverflow, 1);
@@ -412,7 +416,7 @@ const triangleXPos = (
   } else {
     return Math.min(
       tooltipWidth / 2 - TRIANGLE_SIZE,
-      Math.min(chartWidth - tooltipWidth / 2 + TRIANGLE_SIZE, value)
+      Math.min(chartWidth - tooltipWidth / 2 + TRIANGLE_SIZE, x)
     );
   }
 };

--- a/app/charts/shared/interaction/tooltip-box.tsx
+++ b/app/charts/shared/interaction/tooltip-box.tsx
@@ -383,6 +383,21 @@ const triangleXPos = (
   tooltipWidth: number,
   chartWidth: number
 ): number => {
+  if (chartWidth < tooltipWidth) {
+    const maxPosition = chartWidth + TRIANGLE_SIZE;
+
+    return Math.min(
+      Math.max(
+        value,
+        Math.min(
+          tooltipWidth / 2 - TRIANGLE_SIZE,
+          Math.min(chartWidth - tooltipWidth / 2 + TRIANGLE_SIZE, value)
+        )
+      ),
+      maxPosition
+    );
+  }
+
   const condition = chartWidth - tooltipWidth / 2 + TRIANGLE_SIZE < value;
 
   if (condition) {

--- a/app/charts/shared/interaction/tooltip-box.tsx
+++ b/app/charts/shared/interaction/tooltip-box.tsx
@@ -141,7 +141,17 @@ export const TooltipBox = ({
   const tooltipXBoundary = isMobile
     ? getTooltipXBoundary(x!, tooltipWidth, chartWidth)
     : x!;
-  const triangleX = getTriangleXPos(x!, tooltipWidth, chartWidth);
+
+  const mobileTriangleXPosition = getTriangleXPos(x!, tooltipWidth, chartWidth);
+
+  const desktopTriangleXPosition = {
+    left: triangle.left,
+    right: triangle.right,
+  };
+
+  const triangleXPosition = isMobile
+    ? { left: mobileTriangleXPosition }
+    : desktopTriangleXPosition;
 
   return (
     <>
@@ -180,8 +190,7 @@ export const TooltipBox = ({
                 borderStyle: "solid",
                 top: triangle.top,
                 bottom: triangle.bottom,
-                left: isMobile ? triangleX : triangle.left,
-                right: !isMobile ? triangle.right : undefined,
+                ...triangleXPosition,
                 borderWidth: triangle.borderWidth,
                 borderTopColor: triangle.borderTopColor,
                 borderRightColor: triangle.borderRightColor,

--- a/app/utils/use-is-mobile.ts
+++ b/app/utils/use-is-mobile.ts
@@ -1,0 +1,7 @@
+import { useMediaQuery, useTheme } from "@mui/material";
+
+export const useIsMobile = () => {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
+  return isMobile;
+};


### PR DESCRIPTION
@bprusinowski please check if this is the correct approach, if so I will continue implementing this for all charts and for tooltips that are larger the arrow will have to be more dynamic of course.

This PR: 
- Fixes Mobile Tooltip for all Chart except (Pie Charts, Scatterplot Charts, Map Charts)
- The exceptions still need design criteria, @KerstinFaye 
- This PR also uncovered a new Issue [#110](https://github.com/visualize-admin/visualization-tool-private/issues/110)
- This PR is the start to fix Issue [#94](https://github.com/visualize-admin/visualization-tool-private/issues/94)

This PR will resolve #94

---
### How to Test
1. Go to this [Visit Preview](https://vercel.live/open-feedback/visualization-tool-git-fix-mobile-tooltip-positioning-ixt1.vercel.app?via=pr-comment-visit-preview-link&passThrough=1)
2. Use the Einmalvergütung für Photovoltaikanlagen Dataset (you can test almost all Chart types w/ this)

3. Select Bar Chart -> Publish -> See how the tooltip is at the bottom with adjusting arrow ✅
4. Select Line Chart -> Publish -> See how the tooltip is at the bottom with adjusting arrow ✅
5. Select Area Chart -> Publish -> See how the tooltip is at the bottom with adjusting arrow ✅
6. Select Scatter Chart -> Publish -> See how the tooltip is at the bottom with adjusting arrow, but not optimal design ✅
7. Select Pie Chart -> Publish -> See how the tooltip is not placed correctly on mobile (potential separate issue), but is highlighted correctly ✅
8. Select Dual Axis Line Chart -> Publish -> See how the tooltip is at the bottom with adjusting arrow, but not optimal design ✅
9. Select Column Line Chart -> Publish -> See how the tooltip is at the bottom with adjusting arrow ✅

---

CC: @KerstinFaye , @sosiology 