### PR TITLE
automated pr to maintain dependencies for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
dependabot will create PR once new versions of GH actions become available, so no need for manual updates anymore ;-)

see dependabot docs at https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide

See also: https://github.com/visualize-admin/visualization-tool/issues/1820