### PR TITLE
feat: Restricted Toggle to single Charts only

### DIFF
--- a/app/components/publish-actions.tsx
+++ b/app/components/publish-actions.tsx
@@ -17,6 +17,7 @@ import { CopyToClipboardTextInput } from "@/components/copy-to-clipboard-text-in
 import Flex from "@/components/flex";
 import { Radio } from "@/components/form";
 import { IconLink } from "@/components/links";
+import { ConfiguratorStatePublished } from "@/configurator";
 import { Icon } from "@/icons";
 import useEvent from "@/utils/use-event";
 import { useI18n } from "@/utils/use-i18n";
@@ -25,6 +26,7 @@ type PublishActionProps = {
   chartWrapperRef: RefObject<HTMLDivElement>;
   configKey: string;
   locale: string;
+  state?: ConfiguratorStatePublished;
 };
 
 export const PublishActions = (props: PublishActionProps) => {
@@ -62,7 +64,12 @@ const TriggeredPopover = (props: TriggeredPopoverProps) => {
   );
 };
 
-const Embed = ({ chartWrapperRef, configKey, locale }: PublishActionProps) => {
+const Embed = ({
+  chartWrapperRef,
+  configKey,
+  locale,
+  state,
+}: PublishActionProps) => {
   const [embedUrl, setEmbedUrl] = useState("");
   const [embedAEMUrl, setEmbedAEMUrl] = useState("");
   const [isResponsive, setIsResponsive] = useState(true);
@@ -161,20 +168,22 @@ const Embed = ({ chartWrapperRef, configKey, locale }: PublishActionProps) => {
                   "For embedding visualizations in systems without JavaScript support (e.g. WordPress).",
               })}
             />
-            <EmbedToggleSwitch
-              value="remove-border"
-              checked={isWithoutBorder}
-              onChange={handleStylingChange}
-              label={t({
-                id: "publication.embed.iframe.remove-border",
-                message: "Remove border",
-              })}
-              infoMessage={t({
-                id: "publication.embed.iframe.remove-border.warn",
-                message:
-                  "For embedding visualizations in systems without a border.",
-              })}
-            />
+            {state?.chartConfigs.length === 1 && (
+              <EmbedToggleSwitch
+                value="remove-border"
+                checked={isWithoutBorder}
+                onChange={handleStylingChange}
+                label={t({
+                  id: "publication.embed.iframe.remove-border",
+                  message: "Remove border",
+                })}
+                infoMessage={t({
+                  id: "publication.embed.iframe.remove-border.warn",
+                  message:
+                    "For embedding visualizations in systems without a border.",
+                })}
+              />
+            )}
           </Flex>
           <CopyToClipboardTextInput
             content={`<iframe src="${embedUrl}" width="100%" style="${isResponsive ? "" : `height: ${iframeHeight || 640}px; `}border: 0px #ffffff none;"  name="visualize.admin.ch"></iframe>${isResponsive ? `<script type="text/javascript">!function(){window.addEventListener("message", function (e) { if (e.data.type === "${CHART_RESIZE_EVENT_TYPE}") { document.querySelectorAll("iframe").forEach((iframe) => { if (iframe.contentWindow === e.source) { iframe.style.height = e.data.height + "px"; } }); } })}();</script>` : ""}`}

--- a/app/components/publish-actions.tsx
+++ b/app/components/publish-actions.tsx
@@ -168,22 +168,23 @@ const Embed = ({
                   "For embedding visualizations in systems without JavaScript support (e.g. WordPress).",
               })}
             />
-            {state?.chartConfigs.length === 1 && (
-              <EmbedToggleSwitch
-                value="remove-border"
-                checked={isWithoutBorder}
-                onChange={handleStylingChange}
-                label={t({
-                  id: "publication.embed.iframe.remove-border",
-                  message: "Remove border",
-                })}
-                infoMessage={t({
-                  id: "publication.embed.iframe.remove-border.warn",
-                  message:
-                    "For embedding visualizations in systems without a border.",
-                })}
-              />
-            )}
+            {state?.chartConfigs.length === 1 &&
+              state.layout.type === "tab" && (
+                <EmbedToggleSwitch
+                  value="remove-border"
+                  checked={isWithoutBorder}
+                  onChange={handleStylingChange}
+                  label={t({
+                    id: "publication.embed.iframe.remove-border",
+                    message: "Remove border",
+                  })}
+                  infoMessage={t({
+                    id: "publication.embed.iframe.remove-border.warn",
+                    message:
+                      "For embedding visualizations in systems without a border.",
+                  })}
+                />
+              )}
           </Flex>
           <CopyToClipboardTextInput
             content={`<iframe src="${embedUrl}" width="100%" style="${isResponsive ? "" : `height: ${iframeHeight || 640}px; `}border: 0px #ffffff none;"  name="visualize.admin.ch"></iframe>${isResponsive ? `<script type="text/javascript">!function(){window.addEventListener("message", function (e) { if (e.data.type === "${CHART_RESIZE_EVENT_TYPE}") { document.querySelectorAll("iframe").forEach((iframe) => { if (iframe.contentWindow === e.source) { iframe.style.height = e.data.height + "px"; } }); } })}();</script>` : ""}`}

--- a/app/pages/v/[chartId].tsx
+++ b/app/pages/v/[chartId].tsx
@@ -172,6 +172,7 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
               chartWrapperRef={chartWrapperRef}
               configKey={key}
               locale={locale}
+              state={state}
             />
           </Box>
         )}


### PR DESCRIPTION
**This PR:** 
- This PR tackles the request from @sosiology to only allow border removable for single Charts
- Resolves #1794 

### How to test
1. Go to this [Link](https://vercel.live/open-feedback/visualization-tool-git-feat-border-embed-layouts-ixt1.vercel.app?via=pr-comment-visit-preview-link&passThrough=1)
2. Create a Visualization 
3. Publish a Single Chart, See how "remove border toggle" is available ✅
4. Publish multiple Charts, See how "remove border toggle" is no available ✅

CC: @KerstinFaye 