### PR TITLE
feat: Implement Share and Embed on Profile Page

### DIFF
--- a/app/components/publish-actions.tsx
+++ b/app/components/publish-actions.tsx
@@ -56,12 +56,13 @@ export const TriggeredPopover = (props: TriggeredPopoverProps) => {
     setAnchorEl(trigger);
   }, [trigger]);
 
-  const [ref, width, height] = useResizeObserver<HTMLElement>();
+  const [ref, width, height] = useResizeObserver<HTMLDivElement>();
 
   return (
     <>
       {renderTrigger && renderTrigger(setAnchorEl)}
       <Popover
+        ref={ref}
         open={!!anchorEl}
         anchorEl={anchorEl}
         {...popoverProps}
@@ -75,7 +76,7 @@ export const TriggeredPopover = (props: TriggeredPopoverProps) => {
         }
         onClose={() => setAnchorEl(undefined)}
       >
-        <Box ref={ref}>{children}</Box>
+        {children}
       </Popover>
     </>
   );

--- a/app/components/publish-actions.tsx
+++ b/app/components/publish-actions.tsx
@@ -56,7 +56,7 @@ export const TriggeredPopover = (props: TriggeredPopoverProps) => {
     setAnchorEl(trigger);
   }, [trigger]);
 
-  const [ref, width, height] = useResizeObserver<HTMLElement>();
+  const [ref, width, height] = useResizeObserver<HTMLDivElement>();
 
   return (
     <>

--- a/app/components/publish-actions.tsx
+++ b/app/components/publish-actions.tsx
@@ -56,13 +56,12 @@ export const TriggeredPopover = (props: TriggeredPopoverProps) => {
     setAnchorEl(trigger);
   }, [trigger]);
 
-  const [ref, width, height] = useResizeObserver<HTMLDivElement>();
+  const [ref, width, height] = useResizeObserver<HTMLElement>();
 
   return (
     <>
       {renderTrigger && renderTrigger(setAnchorEl)}
       <Popover
-        ref={ref}
         open={!!anchorEl}
         anchorEl={anchorEl}
         {...popoverProps}
@@ -76,7 +75,7 @@ export const TriggeredPopover = (props: TriggeredPopoverProps) => {
         }
         onClose={() => setAnchorEl(undefined)}
       >
-        {children}
+        <Box ref={ref}>{children}</Box>
       </Popover>
     </>
   );

--- a/app/components/publish-actions.tsx
+++ b/app/components/publish-actions.tsx
@@ -21,6 +21,7 @@ import { ConfiguratorStatePublished } from "@/configurator";
 import { Icon } from "@/icons";
 import useEvent from "@/utils/use-event";
 import { useI18n } from "@/utils/use-i18n";
+import { useResizeObserver } from "@/utils/use-resize-observer";
 
 type PublishActionProps = {
   chartWrapperRef: RefObject<HTMLDivElement>;
@@ -44,11 +45,19 @@ type TriggeredPopoverProps = {
     setAnchorEl: (el: HTMLElement | undefined) => void
   ) => React.ReactNode;
   popoverProps: Omit<PopoverProps, "open" | "anchorEl" | "onClose">;
+  trigger?: HTMLElement;
 };
 
 export const TriggeredPopover = (props: TriggeredPopoverProps) => {
-  const { children, renderTrigger, popoverProps } = props;
+  const { children, renderTrigger, popoverProps, trigger } = props;
   const [anchorEl, setAnchorEl] = useState<Element | undefined>();
+
+  useEffect(() => {
+    setAnchorEl(trigger);
+  }, [trigger]);
+
+  const [ref, width, height] = useResizeObserver<HTMLElement>();
+
   return (
     <>
       {renderTrigger && renderTrigger(setAnchorEl)}
@@ -56,9 +65,17 @@ export const TriggeredPopover = (props: TriggeredPopoverProps) => {
         open={!!anchorEl}
         anchorEl={anchorEl}
         {...popoverProps}
+        anchorPosition={
+          popoverProps.anchorPosition
+            ? {
+                top: popoverProps.anchorPosition?.top - height / 2,
+                left: popoverProps.anchorPosition?.left - width,
+              }
+            : undefined
+        }
         onClose={() => setAnchorEl(undefined)}
       >
-        {children}
+        <Box ref={ref}>{children}</Box>
       </Popover>
     </>
   );
@@ -208,7 +225,7 @@ const Share = ({ configKey, locale }: PublishActionProps) => {
 };
 
 type EmbedContentProps = {
-  iframeHeight: number;
+  iframeHeight?: number;
 } & Omit<PublishActionProps, "chartWrapperRef">;
 
 export const EmbedContent = ({

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -197,8 +197,8 @@ const ProfileVisualizationsRow = (props: {
   const removeConfigMut = useMutate(removeConfig);
   const updateConfigMut = useMutate(updateConfig);
 
-  const [openShare, setOpenShare] = useState<HTMLElement | undefined>();
-  const [openEmbed, setOpenEmbed] = useState<HTMLElement | undefined>();
+  const [shareEl, setShareEl] = useState<HTMLElement | undefined>();
+  const [embedEl, setEmbedEl] = useState<HTMLElement | undefined>();
 
   const {
     isOpen: isRenameOpen,
@@ -263,14 +263,14 @@ const ProfileVisualizationsRow = (props: {
         : null,
       {
         type: "button",
-        onClick: (e) => setOpenShare(e?.currentTarget),
+        onClick: (e) => setShareEl(e?.currentTarget),
         label: t({ id: "login.chart.share", message: "Share" }),
         leadingIconName: "linkExternal",
         stayOpen: true,
       },
       {
         type: "button",
-        onClick: (e) => setOpenEmbed(e?.currentTarget),
+        onClick: (e) => setEmbedEl(e?.currentTarget),
         label: t({ id: "login.chart.embed", message: "Embed" }),
         leadingIconName: "embed",
         stayOpen: true,
@@ -423,21 +423,21 @@ const ProfileVisualizationsRow = (props: {
         <RowActions actions={actions} />
         <TriggeredPopover
           popoverProps={{
-            anchorPosition: { ...adjustPopoverPosition(openEmbed) },
+            anchorPosition: { ...getAdjustedPopoverPosition(embedEl) },
             anchorReference: "anchorPosition",
           }}
-          trigger={openEmbed}
+          trigger={embedEl}
         >
           <EmbedContent locale={locale} configKey={config.key} />
         </TriggeredPopover>
         <TriggeredPopover
           popoverProps={{
             anchorPosition: {
-              ...adjustPopoverPosition(openShare),
+              ...getAdjustedPopoverPosition(shareEl),
             },
             anchorReference: "anchorPosition",
           }}
-          trigger={openShare}
+          trigger={shareEl}
         >
           <ShareContent locale={locale} configKey={config.key} />
         </TriggeredPopover>
@@ -453,7 +453,7 @@ const ProfileVisualizationsRow = (props: {
   );
 };
 
-const adjustPopoverPosition = (
+const getAdjustedPopoverPosition = (
   element: HTMLElement | undefined
 ): PopoverPosition => {
   if (element) {

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   Button,
   Link,
+  PopoverPosition,
   Skeleton,
   styled,
   Table,
@@ -18,10 +19,15 @@ import {
 import { PUBLISHED_STATE } from "@prisma/client";
 import sortBy from "lodash/sortBy";
 import NextLink from "next/link";
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 
 import { MenuActionProps } from "@/components/menu-action-item";
 import { OverflowTooltip } from "@/components/overflow-tooltip";
+import {
+  EmbedContent,
+  ShareContent,
+  TriggeredPopover,
+} from "@/components/publish-actions";
 import { RenameDialog } from "@/components/rename-dialog";
 import { RowActions } from "@/components/row-actions";
 import useDisclosure from "@/components/use-disclosure";
@@ -37,6 +43,7 @@ import { removeConfig, updateConfig } from "@/utils/chart-config/api";
 import { useMutate } from "@/utils/use-fetch-data";
 
 const PREVIEW_LIMIT = 3;
+const POPOVER_PADDING = 8;
 
 const SectionContent = ({
   children,
@@ -190,6 +197,9 @@ const ProfileVisualizationsRow = (props: {
   const removeConfigMut = useMutate(removeConfig);
   const updateConfigMut = useMutate(updateConfig);
 
+  const [openShare, setOpenShare] = useState<HTMLElement | undefined>();
+  const [openEmbed, setOpenEmbed] = useState<HTMLElement | undefined>();
+
   const {
     isOpen: isRenameOpen,
     open: openRename,
@@ -251,6 +261,20 @@ const ProfileVisualizationsRow = (props: {
             },
           }
         : null,
+      {
+        type: "button",
+        onClick: (e) => setOpenShare(e?.currentTarget),
+        label: t({ id: "login.chart.share", message: "Share" }),
+        leadingIconName: "linkExternal",
+        stayOpen: true,
+      },
+      {
+        type: "button",
+        onClick: (e) => setOpenEmbed(e?.currentTarget),
+        label: t({ id: "login.chart.embed", message: "Embed" }),
+        leadingIconName: "embed",
+        stayOpen: true,
+      },
       {
         type: "button",
         label: t({ id: "login.chart.rename", message: "Rename" }),
@@ -397,6 +421,26 @@ const ProfileVisualizationsRow = (props: {
       </TableCell>
       <TableCell width="20%" align="right">
         <RowActions actions={actions} />
+        <TriggeredPopover
+          popoverProps={{
+            anchorPosition: { ...adjustPopoverPosition(openEmbed) },
+            anchorReference: "anchorPosition",
+          }}
+          trigger={openEmbed}
+        >
+          <EmbedContent locale={locale} configKey={config.key} />
+        </TriggeredPopover>
+        <TriggeredPopover
+          popoverProps={{
+            anchorPosition: {
+              ...adjustPopoverPosition(openShare),
+            },
+            anchorReference: "anchorPosition",
+          }}
+          trigger={openShare}
+        >
+          <ShareContent locale={locale} configKey={config.key} />
+        </TriggeredPopover>
         <RenameDialog
           config={config}
           open={isRenameOpen}
@@ -407,4 +451,19 @@ const ProfileVisualizationsRow = (props: {
       </TableCell>
     </TableRow>
   );
+};
+
+const adjustPopoverPosition = (
+  element: HTMLElement | undefined
+): PopoverPosition => {
+  if (element) {
+    const { x, y } = element.getBoundingClientRect();
+
+    return {
+      top: y,
+      left: x - POPOVER_PADDING,
+    };
+  } else {
+    return { top: 0, left: 0 };
+  }
 };


### PR DESCRIPTION
**This PR:** 
- This PR adds the possibility for embedding and sharing on the user profile page e
- This PR resolves #1758 

**Review Hints**
@bprusinowski I am not 100% certain if this is the best way of implementing it. It heavily depends on custom positioning, because the anchor element by itself would not detect the position correctly and place it at the top left of the screen.

- Perhaps there is a better place also to put the `adjustPopoverPosition`.

---

### How to test 
1. This feature can only be tested on Prod
2. Go to User Profile
3. Click the 3 dots for more on a Published Chart 
4. See that there is a Share button✅ 
5. See that there is a Embed button ✅ 
6. On click of either of those buttons, see how the same popup from the "Published Page" popup ✅ 

---
<details>
  <summary><strong>Images from my Local Machine</strong></summary>

![image](https://github.com/user-attachments/assets/e7e5adc9-919f-4e85-8e48-a1a38eb053cb)
![image](https://github.com/user-attachments/assets/ef98b4f0-287f-4341-93eb-a8160144958b)
![image](https://github.com/user-attachments/assets/7f7285d4-701b-4fed-8492-ddf3716a622b)

</details>

