### PR TITLE
Combo Chart Axis Title improvements

### DIFF
--- a/app/charts/combo/axis-height-linear-dual.tsx
+++ b/app/charts/combo/axis-height-linear-dual.tsx
@@ -11,6 +11,7 @@ import { useChartTheme } from "@/charts/shared/use-chart-theme";
 import { OpenMetadataPanelWrapper } from "@/components/metadata-panel";
 import { theme } from "@/themes/federal";
 import { getTextWidth } from "@/utils/get-text-width";
+import { splitTextByWidth } from "@/utils/text-adjustments";
 
 import { TITLE_VPADDING } from "./combo-line-container";
 const TITLE_HPADDING = 8;
@@ -90,7 +91,13 @@ export const AxisHeightLinearDual = (props: AxisHeightLinearDualProps) => {
               borderRadius: 4,
             }}
           >
-            {axisTitle}
+            {splitTextByWidth(
+              axisTitle,
+              axisTitleWidth / overLappingAmount - TITLE_HPADDING * 2,
+              {
+                fontSize: axisLabelFontSize,
+              }
+            )}
           </span>
         </OpenMetadataPanelWrapper>
       </foreignObject>

--- a/app/charts/combo/combo-line-column-state.tsx
+++ b/app/charts/combo/combo-line-column-state.tsx
@@ -45,6 +45,8 @@ import { useIsMobile } from "@/utils/use-is-mobile";
 
 import { ChartProps } from "../shared/ChartProps";
 
+import { TITLE_VPADDING } from "./combo-line-container";
+
 export type ComboLineColumnState = CommonChartState &
   ComboLineColumnStateVariables &
   InteractiveXTimeRangeState & {
@@ -147,8 +149,31 @@ const useComboLineColumnState = (
         TICK_PADDING
     )
   );
+
+  const axisTitleLeft = variables.y.left.label;
+  const axisTitleRight = variables.y.right.label;
+  const axisTitleWidthLeft =
+    getTextWidth(axisTitleLeft, { fontSize: TICK_FONT_SIZE }) + TICK_PADDING;
+  const axisTitleWidthRight =
+    getTextWidth(axisTitleRight, { fontSize: TICK_FONT_SIZE }) + TICK_PADDING;
+  const overLappingTitles = axisTitleWidthLeft + axisTitleWidthRight > width;
+  const overLappingAmount = (axisTitleWidthLeft + axisTitleWidthRight) / width;
+
+  const axisTitleAdjustment =
+    (overLappingTitles
+      ? TICK_FONT_SIZE * Math.ceil(overLappingAmount)
+      : TICK_FONT_SIZE + TITLE_VPADDING) *
+      2 -
+    TICK_FONT_SIZE * 2;
+
+  const topMarginAxisTitleAdjustment = 50 + axisTitleAdjustment;
   const right = Math.max(maxRightTickWidth, 40);
-  const margins = getMargins({ left, right, bottom });
+  const margins = getMargins({
+    left,
+    right,
+    bottom,
+    top: topMarginAxisTitleAdjustment,
+  });
   const bounds = useChartBounds(width, margins, height);
   const { chartWidth, chartHeight } = bounds;
   const xScales = [xScale, xScaleTime, xScaleTimeRange];

--- a/app/charts/combo/combo-line-dual-state.tsx
+++ b/app/charts/combo/combo-line-dual-state.tsx
@@ -132,8 +132,32 @@ const useComboLineDualState = (
         TICK_PADDING
     )
   );
+
+  const axisTitleLeft = variables.y.left.label;
+  const axisTitleRight = variables.y.right.label;
+  const axisTitleWidthLeft =
+    getTextWidth(axisTitleLeft, { fontSize: TICK_FONT_SIZE }) + TICK_PADDING;
+  const axisTitleWidthRight =
+    getTextWidth(axisTitleRight, { fontSize: TICK_FONT_SIZE }) + TICK_PADDING;
+  const overLappingTitles = axisTitleWidthLeft + axisTitleWidthRight > width;
+  const overLappingAmount = (axisTitleWidthLeft + axisTitleWidthRight) / width;
+
+  const axisTitleAdjustment =
+    (overLappingTitles
+      ? TICK_FONT_SIZE * Math.ceil(overLappingAmount)
+      : TICK_FONT_SIZE + TITLE_VPADDING) *
+      2 -
+    TICK_FONT_SIZE * 2;
+
+  const topMarginAxisTitleAdjustment = 50 + axisTitleAdjustment;
+
   const right = Math.max(maxRightTickWidth, 40);
-  const margins = getMargins({ left, right, bottom });
+  const margins = getMargins({
+    left,
+    right,
+    bottom,
+    top: topMarginAxisTitleAdjustment,
+  });
   const bounds = useChartBounds(width, margins, height);
   const { chartWidth, chartHeight } = bounds;
   const xScales = [xScale, xScaleTimeRange];

--- a/app/utils/text-adjustments.ts
+++ b/app/utils/text-adjustments.ts
@@ -1,0 +1,46 @@
+import { getTextWidth } from "./get-text-width";
+
+const WORD_SPLITTING_THRESHOLD = 0.75;
+
+export const splitTextByWidth = (
+  text: string,
+  width: number,
+  options: { fontSize: number }
+): string => {
+  const { fontSize } = options;
+  const words = text.split(" ");
+  let currentLine = "";
+  const lines: string[] = [];
+
+  words.forEach((word) => {
+    const wordWidth = getTextWidth(word, { fontSize });
+
+    if (wordWidth > width * WORD_SPLITTING_THRESHOLD) {
+      let partialWord = "";
+      for (const char of word) {
+        if (getTextWidth(partialWord + char, { fontSize }) > width) {
+          lines.push(partialWord + "-");
+          partialWord = char;
+        } else {
+          partialWord += char;
+        }
+      }
+      if (partialWord) {
+        lines.push(partialWord);
+      }
+    } else {
+      if (getTextWidth(currentLine + " " + word, { fontSize }) > width) {
+        lines.push(currentLine.trim());
+        currentLine = word;
+      } else {
+        currentLine += " " + word;
+      }
+    }
+  });
+
+  if (currentLine.trim()) {
+    lines.push(currentLine.trim());
+  }
+
+  return lines.join("\n");
+};


### PR DESCRIPTION
**This PR**
- This PR prevents all kind of overlapping of axis titles in combo Charts
- This includes Text overlapping and Label overlapping the chart itself
- This PR resolves #1878 

---

### How to test
1. Go to this link
2. Create a new visualization (f.e Einmalvergütung für Photovoltaikanlagen) - works better with this 
3. Select Column + Line Chart
4. Select these f.e
![image](https://github.com/user-attachments/assets/95316972-30fd-45c6-8229-b7713067c28a)
5. These are long Axis Title's allowing you to view the full potential 
6. Resize the screen to any size you'd like 
7. See how text is not overflowing the label ✅
8. See how label is not covering the chart ✅

---