### PR TITLE
fix: Changed EmbedContent to detect chart layout type changes

### DIFF
--- a/app/components/publish-actions.tsx
+++ b/app/components/publish-actions.tsx
@@ -81,7 +81,12 @@ export const TriggeredPopover = (props: TriggeredPopoverProps) => {
   );
 };
 
-const Embed = ({ chartWrapperRef, configKey, locale }: PublishActionProps) => {
+const Embed = ({
+  chartWrapperRef,
+  configKey,
+  locale,
+  state,
+}: PublishActionProps) => {
   const [iframeHeight, setIframeHeight] = useState(0);
 
   const handlePopoverOpen = useEvent(() => {
@@ -121,6 +126,7 @@ const Embed = ({ chartWrapperRef, configKey, locale }: PublishActionProps) => {
         iframeHeight={iframeHeight}
         configKey={configKey}
         locale={locale}
+        state={state}
       />
     </TriggeredPopover>
   );
@@ -232,6 +238,7 @@ export const EmbedContent = ({
   locale,
   configKey,
   iframeHeight,
+  state,
 }: EmbedContentProps) => {
   const [embedUrl, setEmbedUrl] = useState("");
   const [embedAEMUrl, setEmbedAEMUrl] = useState("");
@@ -297,20 +304,22 @@ export const EmbedContent = ({
                 "For embedding visualizations in systems without JavaScript support (e.g. WordPress).",
             })}
           />
-          <EmbedToggleSwitch
-            value="remove-border"
-            checked={isWithoutBorder}
-            onChange={handleStylingChange}
-            label={t({
-              id: "publication.embed.iframe.remove-border",
-              message: "Remove border",
-            })}
-            infoMessage={t({
-              id: "publication.embed.iframe.remove-border.warn",
-              message:
-                "For embedding visualizations in systems without a border.",
-            })}
-          />
+          {state?.layout.type !== "tab" && (
+            <EmbedToggleSwitch
+              value="remove-border"
+              checked={isWithoutBorder}
+              onChange={handleStylingChange}
+              label={t({
+                id: "publication.embed.iframe.remove-border",
+                message: "Remove border",
+              })}
+              infoMessage={t({
+                id: "publication.embed.iframe.remove-border.warn",
+                message:
+                  "For embedding visualizations in systems without a border.",
+              })}
+            />
+          )}
         </Flex>
         <CopyToClipboardTextInput
           content={`<iframe src="${embedUrl}" width="100%" style="${isResponsive ? "" : `height: ${iframeHeight || 640}px; `}border: 0px #ffffff none;"  name="visualize.admin.ch"></iframe>${isResponsive ? `<script type="text/javascript">!function(){window.addEventListener("message", function (e) { if (e.data.type === "${CHART_RESIZE_EVENT_TYPE}") { document.querySelectorAll("iframe").forEach((iframe) => { if (iframe.contentWindow === e.source) { iframe.style.height = e.data.height + "px"; } }); } })}();</script>` : ""}`}

--- a/app/components/publish-actions.tsx
+++ b/app/components/publish-actions.tsx
@@ -127,6 +127,7 @@ const Embed = ({
         configKey={configKey}
         locale={locale}
         state={state}
+        isSingleChart={state?.chartConfigs?.length === 1}
       />
     </TriggeredPopover>
   );
@@ -232,13 +233,14 @@ const Share = ({ configKey, locale }: PublishActionProps) => {
 
 type EmbedContentProps = {
   iframeHeight?: number;
+  isSingleChart?: boolean;
 } & Omit<PublishActionProps, "chartWrapperRef">;
 
 export const EmbedContent = ({
   locale,
   configKey,
   iframeHeight,
-  state,
+  isSingleChart,
 }: EmbedContentProps) => {
   const [embedUrl, setEmbedUrl] = useState("");
   const [embedAEMUrl, setEmbedAEMUrl] = useState("");
@@ -304,7 +306,7 @@ export const EmbedContent = ({
                 "For embedding visualizations in systems without JavaScript support (e.g. WordPress).",
             })}
           />
-          {state?.layout.type !== "tab" && (
+          {isSingleChart && (
             <EmbedToggleSwitch
               value="remove-border"
               checked={isWithoutBorder}

--- a/app/components/publish-actions.tsx
+++ b/app/components/publish-actions.tsx
@@ -126,8 +126,7 @@ const Embed = ({
         iframeHeight={iframeHeight}
         configKey={configKey}
         locale={locale}
-        state={state}
-        isSingleChart={state?.chartConfigs?.length === 1}
+        shouldAllowDisablingBorder={state?.chartConfigs?.length === 1}
       />
     </TriggeredPopover>
   );
@@ -233,14 +232,14 @@ const Share = ({ configKey, locale }: PublishActionProps) => {
 
 type EmbedContentProps = {
   iframeHeight?: number;
-  isSingleChart?: boolean;
-} & Omit<PublishActionProps, "chartWrapperRef">;
+  shouldAllowDisablingBorder?: boolean;
+} & Omit<PublishActionProps, "chartWrapperRef" | "state">;
 
 export const EmbedContent = ({
   locale,
   configKey,
   iframeHeight,
-  isSingleChart,
+  shouldAllowDisablingBorder,
 }: EmbedContentProps) => {
   const [embedUrl, setEmbedUrl] = useState("");
   const [embedAEMUrl, setEmbedAEMUrl] = useState("");
@@ -306,7 +305,7 @@ export const EmbedContent = ({
                 "For embedding visualizations in systems without JavaScript support (e.g. WordPress).",
             })}
           />
-          {isSingleChart && (
+          {shouldAllowDisablingBorder && (
             <EmbedToggleSwitch
               value="remove-border"
               checked={isWithoutBorder}

--- a/app/components/publish-actions.tsx
+++ b/app/components/publish-actions.tsx
@@ -126,7 +126,7 @@ const Embed = ({
         iframeHeight={iframeHeight}
         configKey={configKey}
         locale={locale}
-        shouldAllowDisablingBorder={state?.chartConfigs?.length === 1}
+        shouldAllowDisablingBorder={shouldAllowDisablingBorder(state)}
       />
     </TriggeredPopover>
   );
@@ -418,4 +418,10 @@ export const ShareContent = ({
       </Box>
     </Box>
   );
+};
+
+export const shouldAllowDisablingBorder = (
+  state?: ConfiguratorStatePublished
+) => {
+  return state?.chartConfigs?.length === 1 && state?.layout.type === "tab";
 };

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -428,7 +428,11 @@ const ProfileVisualizationsRow = (props: {
           }}
           trigger={embedEl}
         >
-          <EmbedContent locale={locale} configKey={config.key} />
+          <EmbedContent
+            isSingleChart={isSingleChart}
+            locale={locale}
+            configKey={config.key}
+          />
         </TriggeredPopover>
         <TriggeredPopover
           popoverProps={{

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -429,7 +429,7 @@ const ProfileVisualizationsRow = (props: {
           trigger={embedEl}
         >
           <EmbedContent
-            isSingleChart={isSingleChart}
+            shouldAllowDisablingBorder={isSingleChart}
             locale={locale}
             configKey={config.key}
           />

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -26,6 +26,7 @@ import { OverflowTooltip } from "@/components/overflow-tooltip";
 import {
   EmbedContent,
   ShareContent,
+  shouldAllowDisablingBorder,
   TriggeredPopover,
 } from "@/components/publish-actions";
 import { RenameDialog } from "@/components/rename-dialog";
@@ -429,7 +430,7 @@ const ProfileVisualizationsRow = (props: {
           trigger={embedEl}
         >
           <EmbedContent
-            shouldAllowDisablingBorder={isSingleChart}
+            shouldAllowDisablingBorder={shouldAllowDisablingBorder(config.data)}
             locale={locale}
             configKey={config.key}
           />


### PR DESCRIPTION
**This PR:**
- This PR prevents users from making removed border charts for tab layout. 
- This PR does not yet allow removed border charts on the user profile 
- This PR resolves #1892 

### How to test
1. Go to this [link](https://vercel.live/open-feedback/visualization-tool-git-fix-embed-remove-border-ixt1.vercel.app?via=pr-comment-visit-preview-link&passThrough=1) 
2. Create a new Chart 
3. Add a second Chart and proceed to layout selection 
4. Select Tab layout and publish the Charts
5. Try to Embed the chart and see how the "Remove Border" option is gone ✅
6. Once deployed you can also test this on the user "Visualizations" page ✅

---

CC: @sosiology , @KerstinFaye 