### PR TITLE
feat: Merging of cubes UI improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ You can also check the
 - Features
   - Allowed previewing of charts in states different than CONFIGURING_CHART
     (iframe `/preview` page)
+  - Improved some wording and added an explanation to the `Concepts` navigation
+    menu
+  - Filters and components are now grouped in the left panel and dropdowns in
+    case of working with merged cubes
+  - Improved default chart selection when adding a new cube (by default the
+    application will try to use dual-line chart with measures from different
+    cubes)
 - Fixes
   - Introduced a `componentId` concept which makes the dimensions and measures
     unique by adding an unversioned cube iri to the unversioned component iri on
@@ -21,6 +28,7 @@ You can also check the
     same iri that come from different cubes (when merging cubes)
   - Map legend is now correctly updated (in some cases it was rendered
     incorrectly on the initial render)
+  - Vertical Axis measure names are now correctly displayed in the left panel
 - Performance
   - We no longer load non-key dimensions when initializing a chart
 - Maintenance

--- a/app/browser/dataset-browse.tsx
+++ b/app/browser/dataset-browse.tsx
@@ -1206,8 +1206,8 @@ export const DatasetResult = ({
                         dimension.termsets.length > 0 ? (
                           <>
                             <Typography variant="body2">
-                              <Trans id="dataset-result.dimension-termset-contains">
-                                Contains values from
+                              <Trans id="dataset-result.dimension-joined-by">
+                                Joined by
                               </Trans>
                               <Stack gap={1} flexDirection="row" mt={1}>
                                 {dimension.termsets.map((termset) => {

--- a/app/browser/dataset-browse.tsx
+++ b/app/browser/dataset-browse.tsx
@@ -31,6 +31,7 @@ import {
   SearchFieldProps,
 } from "@/components/form";
 import { Loading, LoadingDataError } from "@/components/hint";
+import { InfoIconTooltip } from "@/components/info-icon-tooltip";
 import MaybeLink from "@/components/maybe-link";
 import { MaybeTooltip } from "@/components/maybe-tooltip";
 import {
@@ -625,6 +626,7 @@ const NavSection = ({
     );
   }, [counts, items]);
   const { isOpen, open, close } = useDisclosure(!!currentFilter);
+
   return (
     <div>
       <NavSectionTitle theme={theme} sx={{ mb: "block" }}>
@@ -881,7 +883,21 @@ export const SearchFilters = ({
         counts={counts}
         filters={filters}
         icon={<SvgIcOrganisations width={20} height={20} />}
-        label={<Trans id="browse-panel.termsets">Concepts</Trans>}
+        label={
+          <Stack direction="row" gap={2} alignItems="center">
+            <Trans id="browse-panel.termsets">Concepts</Trans>
+            <InfoIconTooltip
+              variant="secondary"
+              placement="right"
+              title={
+                <Trans id="browse-panel.termsets.explanation">
+                  Concepts represent values that can be shared across different
+                  dimensions and datasets.
+                </Trans>
+              }
+            />
+          </Stack>
+        }
         extra={null}
         disableLinks={disableNavLinks}
       />

--- a/app/browser/dataset-browse.tsx
+++ b/app/browser/dataset-browse.tsx
@@ -584,7 +584,6 @@ const NavSectionTitle = ({
       sx={{
         alignItems: "center",
         p: 3,
-        cursor: "pointer",
         backgroundColor: theme.backgroundColor,
         borderRadius: 2,
         height: "2.5rem",

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -136,9 +136,9 @@ function getChartTypeOrder({ cubeCount }: { cubeCount: number }): ChartOrder {
     pie: 4,
     map: 5,
     table: 6,
-    comboLineSingle: 7 + multiCubeBoost,
-    comboLineDual: 8 + multiCubeBoost,
-    comboLineColumn: 9 + multiCubeBoost,
+    comboLineDual: 7 + multiCubeBoost,
+    comboLineColumn: 8 + multiCubeBoost,
+    comboLineSingle: 9 + multiCubeBoost,
   };
 }
 
@@ -1924,7 +1924,6 @@ const adjustSegmentSorting = ({
   return newSorting;
 };
 
-// Helpers
 export const getPossibleChartTypes = ({
   dimensions,
   measures,
@@ -1994,6 +1993,7 @@ export const getPossibleChartTypes = ({
   }
 
   const chartTypesOrder = getChartTypeOrder({ cubeCount });
+
   return chartTypes
     .filter(
       (d) =>

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -1457,24 +1457,24 @@ const chartConfigsAdjusters: ChartConfigsAdjusters = {
           (d) => d.id === numericalMeasureIds[0]
         ) as NumericalMeasure;
         let rightMeasureId: string | undefined;
-        const getLeftMeasure = (id: string) => {
+        const getLeftMeasure = (preferredId: string) => {
+          const preferredLeftMeasure = numericalMeasures.find(
+            (d) => d.id === preferredId
+          ) as NumericalMeasure;
+
           if (isAddingNewCube) {
             const rightMeasure = numericalMeasures.find(
               (d) => d.id === rightMeasureId
             );
-
-            // We're trying to find a measure that comes from a different cube,
-            // to better showcase the fact that we have two cubes now.
-            return (numericalMeasures.find(
+            const overrideLeftMeasure = numericalMeasures.find(
               (d) =>
                 d.cubeIri !== rightMeasure?.cubeIri &&
                 d.unit !== rightMeasure?.unit
-            ) ??
-              numericalMeasures.find((d) => d.id === id)) as NumericalMeasure;
+            );
+
+            return overrideLeftMeasure ?? preferredLeftMeasure;
           } else {
-            return numericalMeasures.find(
-              (d) => d.id === id
-            ) as NumericalMeasure;
+            return preferredLeftMeasure;
           }
         };
 

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -1526,14 +1526,16 @@ const chartConfigsAdjusters: ChartConfigsAdjusters = {
         return produce(newChartConfig, (draft) => {
           draft.fields.y = {
             leftAxisComponentId: leftMeasure.id,
-            rightAxisComponentId: rightMeasureId,
+            rightAxisComponentId: rightMeasureId as string,
             palette,
             colorMapping: mapValueIrisToColor({
               palette,
-              dimensionValues: [leftMeasure.id, rightMeasureId].map((id) => ({
-                value: id,
-                label: id,
-              })),
+              dimensionValues: [leftMeasure.id, rightMeasureId as string].map(
+                (id) => ({
+                  value: id,
+                  label: id,
+                })
+              ),
             }),
           };
         });

--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -50,7 +50,7 @@ import VisuallyHidden from "@/components/visually-hidden";
 import {
   FieldProps,
   Option,
-  OptionGroup,
+  OptionGroupKey,
   useChartOptionSliderField,
 } from "@/configurator";
 import { Icon } from "@/icons";
@@ -320,17 +320,19 @@ export type SelectOption = Option & {
   disabledMessage?: string;
 };
 
+export type SelectOptionGroup = [OptionGroupKey, SelectOption[]];
+
 export const Select = ({
   label,
   id,
   value,
   disabled,
   options,
+  optionGroups,
   onChange,
   sortOptions = true,
   topControls,
   sideControls,
-  optionGroups,
   open,
   onClose,
   onOpen,
@@ -340,12 +342,12 @@ export const Select = ({
 }: {
   id: string;
   options: SelectOption[];
+  optionGroups?: SelectOptionGroup[];
   label?: ReactNode;
   disabled?: boolean;
   sortOptions?: boolean;
-  topControls?: React.ReactNode;
-  sideControls?: React.ReactNode;
-  optionGroups?: [OptionGroup, SelectOption[]][];
+  topControls?: ReactNode;
+  sideControls?: ReactNode;
   loading?: boolean;
   hint?: string;
 } & SelectProps) => {

--- a/app/components/graphql-search.stories.tsx
+++ b/app/components/graphql-search.stories.tsx
@@ -248,7 +248,7 @@ export const Search = () => {
                                 component="div"
                                 mb={1}
                               >
-                                Contains values from{" "}
+                                Joined by{" "}
                               </Typography>
                               {sd.termsets.map((t) => (
                                 <Tag

--- a/app/components/info-icon-tooltip.tsx
+++ b/app/components/info-icon-tooltip.tsx
@@ -4,28 +4,27 @@ import React from "react";
 
 import { Icon } from "@/icons";
 
-type InfoIconTooltipProps = {
-  title: NonNullable<React.ReactNode>;
-};
-
-const useStyles = makeStyles((theme: Theme) => ({
-  tooltip: { width: 180, padding: theme.spacing(1, 2), lineHeight: "18px" },
-  icon: {
-    color: theme.palette.primary.main,
-    pointerEvents: "auto",
-  },
-}));
+type InfoIconTooltipVariant = "primary" | "secondary";
 
 export const InfoIconTooltip = (
-  props: InfoIconTooltipProps & Omit<TooltipProps, "children">
+  props: {
+    title: NonNullable<React.ReactNode>;
+    variant?: InfoIconTooltipVariant;
+  } & Omit<TooltipProps, "children" | "title">
 ) => {
-  const classes = useStyles();
-  const { title, componentsProps, ...rest } = props;
+  const {
+    title,
+    componentsProps,
+    variant = "primary",
+    placement = "top",
+    ...rest
+  } = props;
+  const classes = useStyles({ variant });
 
   return (
     <Tooltip
       arrow
-      placement="top"
+      placement={placement}
       title={
         <Typography variant="caption" color="secondary">
           {title}
@@ -33,7 +32,9 @@ export const InfoIconTooltip = (
       }
       componentsProps={{
         ...componentsProps,
-        tooltip: { className: classes.tooltip },
+        tooltip: {
+          className: classes.tooltip,
+        },
       }}
       {...rest}
     >
@@ -43,3 +44,17 @@ export const InfoIconTooltip = (
     </Tooltip>
   );
 };
+
+const useStyles = makeStyles<Theme, { variant: "primary" | "secondary" }>(
+  (theme) => ({
+    tooltip: {
+      width: 150,
+      padding: theme.spacing(1, 2),
+      lineHeight: "18px",
+    },
+    icon: {
+      color: ({ variant }) => theme.palette[variant].main,
+      pointerEvents: "auto",
+    },
+  })
+);

--- a/app/components/metadata-panel.tsx
+++ b/app/components/metadata-panel.tsx
@@ -405,7 +405,7 @@ const CubesPanel = ({
 }) => {
   const classes = useOtherStyles();
   const locale = useLocale();
-  const cubes = chartConfig.cubes.map((x) => ({ iri: x.iri }));
+  const cubes = chartConfig.cubes.map((cube) => ({ iri: cube.iri }));
   const [
     {
       data: dataCubesMetadataData,

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -905,6 +905,7 @@ export type FieldAdjuster<
   newChartConfig: NewChartConfigType;
   dimensions: Dimension[];
   measures: Measure[];
+  isAddingNewCube?: boolean;
 }) => NewChartConfigType;
 
 type AssureKeys<T, U extends { [K in keyof T]: unknown }> = {

--- a/app/configurator/components/add-dataset-dialog.tsx
+++ b/app/configurator/components/add-dataset-dialog.tsx
@@ -692,8 +692,6 @@ export const DatasetDialog = ({
     typeof searchDimensionOptions | undefined
   >(undefined);
 
-  console.log("selectedSearchDimensions", selectedSearchDimensions);
-
   const handleChangeSearchDimensions = (ev: SelectChangeEvent<string[]>) => {
     const {
       target: { value },
@@ -1118,6 +1116,7 @@ const useAddDataset = () => {
             locale,
             chartKey: state.activeChartKey,
             chartType: possibleType[0],
+            isAddingNewCube: true,
           },
         });
       } finally {

--- a/app/configurator/components/add-dataset-dialog.tsx
+++ b/app/configurator/components/add-dataset-dialog.tsx
@@ -972,33 +972,6 @@ export const DatasetDialog = ({
                     />
                     <ListItemText
                       primary={<Tag type="dimension">{sd.label}</Tag>}
-                      classes={{ secondary: classes.listItemSecondary }}
-                      secondary={
-                        sd.type === "temporal" ? (
-                          <Tag type="termset">{sd.timeUnit}</Tag>
-                        ) : (
-                          <>
-                            <Typography
-                              variant="caption"
-                              color="grey.600"
-                              mr={2}
-                              gutterBottom
-                              component="div"
-                            >
-                              <Trans id="dataset-result.dimension-termset-contains" />
-                            </Typography>
-                            {sd.termsets.map((t) => (
-                              <Tag
-                                key={t.iri}
-                                type="termset"
-                                className={classes.listTag}
-                              >
-                                {t.label}
-                              </Tag>
-                            ))}
-                          </>
-                        )
-                      }
                     />
                   </MenuItem>
                 ))}

--- a/app/configurator/components/add-dataset-dialog.tsx
+++ b/app/configurator/components/add-dataset-dialog.tsx
@@ -656,16 +656,22 @@ export const DatasetDialog = ({
       ) ?? [];
     const sharedDimensions =
       cubeComponentTermsets.data?.dataCubeComponentTermsets ?? [];
+    const sharedDimensionIds = sharedDimensions.map((dim) => dim.iri);
 
     return [
-      ...temporalDimensions.map((x) => {
-        return {
-          type: "temporal" as const,
-          id: x.id as ComponentId,
-          label: x.label,
-          timeUnit: x.timeUnit,
-        };
-      }),
+      ...temporalDimensions
+        // There are cases, e.g. for AMDP cubes, that a temporal dimension contains
+        // termsets (TemporalEntityDimension). When this happens, we prefer to show
+        // the dimension as a shared dimension.
+        .filter((dim) => !sharedDimensionIds.includes(dim.id))
+        .map((x) => {
+          return {
+            type: "temporal" as const,
+            id: x.id as ComponentId,
+            label: x.label,
+            timeUnit: x.timeUnit,
+          };
+        }),
       ...sharedDimensions.map((x) => {
         return {
           type: "shared" as const,
@@ -685,6 +691,8 @@ export const DatasetDialog = ({
   const [selectedSearchDimensions, setSelectedSearchDimensions] = useState<
     typeof searchDimensionOptions | undefined
   >(undefined);
+
+  console.log("selectedSearchDimensions", selectedSearchDimensions);
 
   const handleChangeSearchDimensions = (ev: SelectChangeEvent<string[]>) => {
     const {

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -169,7 +169,7 @@ export const DataFilterSelectGeneric = ({
     sideControls,
     id: `select-single-filter-${index}`,
     disabled: fetching || disabled,
-    isOptional: !dimension.isKeyDimension,
+    optional: !dimension.isKeyDimension,
     loading: fetching,
   };
 

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   Button,
   CircularProgress,
+  Divider,
   IconButton,
   Menu,
   MenuItem,
@@ -10,6 +11,7 @@ import {
   Typography,
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
+import groupBy from "lodash/groupBy";
 import isEmpty from "lodash/isEmpty";
 import isEqual from "lodash/isEqual";
 import pickBy from "lodash/pickBy";
@@ -84,6 +86,7 @@ import { isMostRecentValue } from "@/domain/most-recent-value";
 import { truthy } from "@/domain/types";
 import {
   useDataCubesComponentsQuery,
+  useDataCubesMetadataQuery,
   useDataCubesObservationsQuery,
 } from "@/graphql/hooks";
 import {
@@ -327,7 +330,7 @@ const useFilterReorder = ({
   onAddDimensionFilter,
 }: {
   onAddDimensionFilter?: () => void;
-}) => {
+} = {}) => {
   const [state, dispatch] = useConfiguratorState(isConfiguring);
   const chartConfig = getChartConfig(state);
   const locale = useLocale();
@@ -348,13 +351,13 @@ const useFilterReorder = ({
     // are the same  while the order of the keys has changed.
     // If this is not present, we'll have outdated dimension
     // values after we change the filter order
-    const requeryKey = cubeFilters.reduce((acc, d) => {
+    const reQueryKey = cubeFilters.reduce((acc, d) => {
       return `${acc}${d.iri}${JSON.stringify(d.filters)}`;
     }, "");
 
     return {
       cubeFilters,
-      requeryKey: requeryKey ? requeryKey : undefined,
+      reQueryKey: reQueryKey ? reQueryKey : undefined,
     };
   }, [chartConfig, joinByIds]);
 
@@ -458,34 +461,50 @@ const useFilterReorder = ({
     state,
   });
   const fetching = possibleFiltersFetching || componentsFetching;
-  const { filterDimensions, addableDimensions, missingDimensions } =
-    useMemo(() => {
-      const keysOrder = Object.fromEntries(
-        Object.keys(filters).map((k, i) => [k, i])
-      );
-      const filterDimensions = sortBy(
-        dimensions?.filter(
-          (dim) =>
-            !mappedFiltersIds.has(dim.id) && keysOrder[dim.id] !== undefined
-        ) ?? [],
-        [(x) => keysOrder[x.id] ?? Infinity]
-      );
-      const addableDimensions = dimensions?.filter(
+  const {
+    filterDimensions,
+    filterDimensionsByCubeIri,
+    addableDimensions,
+    addableDimensionsByCubeIri,
+    missingDimensions,
+  } = useMemo(() => {
+    const keysOrder = Object.fromEntries(
+      Object.keys(filters).map((k, i) => [k, i])
+    );
+    const filterDimensions = sortBy(
+      dimensions?.filter(
+        (dim) =>
+          !mappedFiltersIds.has(dim.id) && keysOrder[dim.id] !== undefined
+      ) ?? [],
+      [(x) => keysOrder[x.id] ?? Infinity]
+    );
+    const filterDimensionsByCubeIri = groupBy(
+      filterDimensions,
+      (d) => d.cubeIri
+    );
+    const addableDimensions =
+      dimensions?.filter(
         (dim) =>
           !mappedFiltersIds.has(dim.id) &&
           keysOrder[dim.id] === undefined &&
           !isStandardErrorDimension(dim)
-      );
-      const missingDimensions = dimensions?.filter(
-        (d) => d.isKeyDimension && addableDimensions?.includes(d)
-      );
+      ) ?? [];
+    const addableDimensionsByCubeIri = groupBy(
+      addableDimensions,
+      (d) => d.cubeIri
+    );
+    const missingDimensions = dimensions?.filter(
+      (d) => d.isKeyDimension && addableDimensions?.includes(d)
+    );
 
-      return {
-        filterDimensions,
-        addableDimensions,
-        missingDimensions,
-      };
-    }, [dimensions, filters, mappedFiltersIds]);
+    return {
+      filterDimensions,
+      filterDimensionsByCubeIri,
+      addableDimensions,
+      addableDimensionsByCubeIri,
+      missingDimensions,
+    };
+  }, [dimensions, filters, mappedFiltersIds]);
 
   // Technically it's possible to have a key dimension that is not in the filters
   // and not mapped. This could be achieved for example by manually modifying the
@@ -505,7 +524,9 @@ const useFilterReorder = ({
     dimensions,
     measures,
     filterDimensions,
+    filterDimensionsByCubeIri,
     addableDimensions,
+    addableDimensionsByCubeIri,
   };
 };
 
@@ -564,30 +585,42 @@ export const ChartConfigurator = ({
 }: {
   state: ConfiguratorStateConfiguringChart;
 }) => {
+  const locale = useLocale();
   const chartConfig = getChartConfig(state);
+  const [
+    {
+      data: dataCubesMetadataData,
+      fetching: fetchingDataCubesMetadata,
+      error: dataCubesMetadataError,
+    },
+  ] = useDataCubesMetadataQuery({
+    variables: {
+      sourceType: state.dataSource.type,
+      sourceUrl: state.dataSource.url,
+      locale,
+      cubeFilters: chartConfig.cubes.map((cube) => ({ iri: cube.iri })),
+    },
+    pause: chartConfig.cubes.length === 1,
+  });
+  const cubes = dataCubesMetadataData?.dataCubesMetadata;
   const {
-    isOpen: isFilterMenuOpen,
-    open: openFilterMenu,
-    close: closeFilterMenu,
-  } = useDisclosure();
-  const {
-    fetching: dataFetching,
-    handleAddDimensionFilter,
+    fetching: fetchingData,
     handleRemoveDimensionFilter,
     handleDragEnd,
     dimensions,
     measures,
     filterDimensions,
+    filterDimensionsByCubeIri,
     addableDimensions,
-  } = useFilterReorder({
-    onAddDimensionFilter: () => closeFilterMenu(),
-  });
-  const { fetching: possibleFiltersFetching, error: possibleFiltersError } =
+    addableDimensionsByCubeIri,
+  } = useFilterReorder();
+  const { fetching: fetchingPossibleFilters, error: possibleFiltersError } =
     useEnsurePossibleFilters({
       state,
     });
-  const fetching = possibleFiltersFetching || dataFetching;
-  const filterMenuButtonRef = useRef(null);
+  const error = dataCubesMetadataError || possibleFiltersError;
+  const fetching =
+    fetchingPossibleFilters || fetchingData || fetchingDataCubesMetadata;
   const classes = useStyles({ fetching });
   const components = useMemo(() => {
     return [...(dimensions ?? []), ...(measures ?? [])];
@@ -655,7 +688,7 @@ export const ChartConfigurator = ({
             aria-labelledby="controls-data"
             data-testid="configurator-filters"
           >
-            {possibleFiltersError ? (
+            {error ? (
               <Typography variant="body2" color="error">
                 <Trans id="controls.section.data.filters.possible-filters-error">
                   An error happened while fetching possible filters, please
@@ -674,77 +707,80 @@ export const ChartConfigurator = ({
                 </Trans>
               </Typography>
             ) : null}
-            <DragDropContext onDragEnd={handleDragEnd}>
-              <Droppable droppableId="filters">
-                {(provided) => (
-                  <Box {...provided.droppableProps} ref={provided.innerRef}>
-                    {filterDimensions.map((dimension, i) => (
-                      <Draggable
-                        key={dimension.id}
-                        isDragDisabled={fetching}
-                        draggableId={dimension.id}
-                        index={i}
-                      >
-                        {(provided) => (
-                          <div
-                            ref={provided.innerRef}
-                            className={classes.filterRow}
-                            {...provided.dragHandleProps}
-                            {...provided.draggableProps}
-                          >
-                            <div>
-                              <InteractiveDataFilterToggle id={dimension.id} />
-                            </div>
-                            <DataFilterSelectGeneric
-                              key={dimension.id}
-                              rawDimension={dimension}
-                              filterDimensionIds={filterDimensions
-                                .slice(0, i)
-                                .map((d) => d.id)}
-                              index={i}
-                              disabled={fetching}
-                              onRemove={() =>
-                                handleRemoveDimensionFilter(dimension)
-                              }
-                              sideControls={<MoveDragButton />}
-                            />
-                          </div>
-                        )}
-                      </Draggable>
-                    ))}
-                    {provided.placeholder}
-                  </Box>
-                )}
-              </Droppable>
-            </DragDropContext>
-            {addableDimensions && addableDimensions.length > 0 ? (
-              <Box className={classes.addDimensionContainer}>
-                <Button
-                  ref={filterMenuButtonRef}
-                  onClick={openFilterMenu}
-                  variant="contained"
-                  className={classes.addDimensionButton}
-                  color="primary"
-                >
-                  <Icon name="add" size={24} />
-                  <Trans>Add filter</Trans>
-                </Button>
-                <Menu
-                  anchorEl={filterMenuButtonRef.current}
-                  open={isFilterMenuOpen}
-                  onClose={closeFilterMenu}
-                >
-                  {addableDimensions.map((dim) => (
-                    <MenuItem
-                      key={dim.id}
-                      onClick={() => handleAddDimensionFilter(dim)}
-                    >
-                      {dim.label}
-                    </MenuItem>
-                  ))}
-                </Menu>
-              </Box>
-            ) : null}
+            {Object.entries(filterDimensionsByCubeIri).map(
+              ([cubeIri, dims], i) => {
+                const cubeTitle = cubes?.find(
+                  (cube) => cube.iri === cubeIri
+                )?.title;
+                const cubeAddableDims = addableDimensionsByCubeIri[cubeIri];
+
+                return (
+                  <React.Fragment key={cubeIri}>
+                    <div>
+                      {cubeTitle ? (
+                        <Typography variant="caption" component="p" mb={3}>
+                          {cubeTitle}
+                        </Typography>
+                      ) : null}
+                      <DragDropContext onDragEnd={handleDragEnd}>
+                        <Droppable droppableId="filters">
+                          {(provided) => (
+                            <Box
+                              {...provided.droppableProps}
+                              ref={provided.innerRef}
+                            >
+                              {dims.map((dim, i) => (
+                                <Draggable
+                                  key={dim.id}
+                                  isDragDisabled={fetching}
+                                  draggableId={dim.id}
+                                  index={i}
+                                >
+                                  {(provided) => (
+                                    <div
+                                      ref={provided.innerRef}
+                                      className={classes.filterRow}
+                                      {...provided.dragHandleProps}
+                                      {...provided.draggableProps}
+                                    >
+                                      <div>
+                                        <InteractiveDataFilterToggle
+                                          id={dim.id}
+                                        />
+                                      </div>
+                                      <DataFilterSelectGeneric
+                                        key={dim.id}
+                                        rawDimension={dim}
+                                        filterDimensionIds={filterDimensions
+                                          .slice(0, i)
+                                          .map((d) => d.id)}
+                                        index={i}
+                                        disabled={fetching}
+                                        onRemove={() =>
+                                          handleRemoveDimensionFilter(dim)
+                                        }
+                                        sideControls={<MoveDragButton />}
+                                      />
+                                    </div>
+                                  )}
+                                </Draggable>
+                              ))}
+                              {provided.placeholder}
+                            </Box>
+                          )}
+                        </Droppable>
+                      </DragDropContext>
+                    </div>
+                    {cubeAddableDims && cubeAddableDims.length > 0 ? (
+                      <AddFilterButton dims={cubeAddableDims} />
+                    ) : null}
+                    {cubes && i < cubes.length - 1 ? (
+                      <Divider sx={{ my: 4, mr: 6 }} />
+                    ) : null}
+                  </React.Fragment>
+                );
+              }
+            )}
           </ControlSectionContent>
         </ControlSection>
       )}
@@ -761,6 +797,41 @@ export const ChartConfigurator = ({
         renderToggle={false}
       />
     </InteractiveFiltersChartProvider>
+  );
+};
+
+const AddFilterButton = ({ dims }: { dims: Dimension[] }) => {
+  const ref = useRef<HTMLButtonElement>(null);
+  const {
+    isOpen: isMenuOpen,
+    open: openMenu,
+    close: closeMenu,
+  } = useDisclosure();
+  const { handleAddDimensionFilter } = useFilterReorder({
+    onAddDimensionFilter: () => closeMenu(),
+  });
+  const classes = useStyles({ fetching: false });
+
+  return (
+    <Box className={classes.addDimensionContainer}>
+      <Button
+        ref={ref}
+        onClick={openMenu}
+        variant="contained"
+        className={classes.addDimensionButton}
+        color="primary"
+      >
+        <Icon name="add" size={24} />
+        <Trans>Add filter</Trans>
+      </Button>
+      <Menu anchorEl={ref.current} open={isMenuOpen} onClose={closeMenu}>
+        {dims.map((dim) => (
+          <MenuItem key={dim.id} onClick={() => handleAddDimensionFilter(dim)}>
+            {dim.label}
+          </MenuItem>
+        ))}
+      </Menu>
+    </Box>
   );
 };
 

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -866,7 +866,11 @@ const ChartFields = (props: ChartFieldsProps) => {
         .map((encoding) => {
           const { field, getDisabledState, idAttributes } = encoding;
           const componentIds = idAttributes
-            .map((x) => (chartConfig.fields as any)[field]?.[x])
+            .flatMap(
+              (x) =>
+                // componentId or componentIds
+                (chartConfig.fields as any)[field]?.[x] as string | string[]
+            )
             .filter(truthy) as string[];
           const fieldComponents = componentIds
             .map((cId) => components.find((d) => cId === d.id))

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -954,14 +954,14 @@ const ChartComboLineColumnYField = (
             })}
             value={y.columnComponentId}
             onChange={(e) => {
-              const newIri = e.target.value as string;
+              const newId = e.target.value as string;
               dispatch({
                 type: "CHART_OPTION_CHANGED",
                 value: {
                   locale,
                   field: "y",
                   path: "columnComponentId",
-                  value: newIri,
+                  value: newId,
                 },
               });
             }}
@@ -979,14 +979,14 @@ const ChartComboLineColumnYField = (
             })}
             value={y.lineComponentId}
             onChange={(e) => {
-              const newIri = e.target.value as string;
+              const newId = e.target.value as string;
               dispatch({
                 type: "CHART_OPTION_CHANGED",
                 value: {
                   locale,
                   field: "y",
                   path: "lineComponentId",
-                  value: newIri,
+                  value: newId,
                 },
               });
             }}

--- a/app/configurator/components/configurator.tsx
+++ b/app/configurator/components/configurator.tsx
@@ -780,8 +780,6 @@ const PublishStep = () => {
 
 export const Configurator = () => {
   const { pathname } = useRouter();
-  // Local state, the dataset preview doesn't need to be persistent.
-  // FIXME: for a11y, "updateDataSetPreviewIri" should also move focus to "Weiter" button (?)
   const [configuratorState] = useConfiguratorState();
   const isLoadingConfigureChartStep =
     configuratorState.state === "INITIAL" && pathname === "/create/[chartId]";

--- a/app/configurator/components/dataset-control-section.tsx
+++ b/app/configurator/components/dataset-control-section.tsx
@@ -11,7 +11,7 @@ import { Theme } from "@mui/material/styles";
 import { makeStyles } from "@mui/styles";
 import clsx from "clsx";
 import uniqBy from "lodash/uniqBy";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import { useClient } from "urql";
 
 import Flex from "@/components/flex";
@@ -86,18 +86,11 @@ const DatasetRow = ({
   added?: boolean;
   onRemoveAdded?: () => void;
 }) => {
-  const ref = useRef<HTMLDivElement>(null);
   const locale = useLocale();
   const client = useClient();
   const classes = useStyles();
   const [state, dispatch] = useConfiguratorState(isConfiguring);
   const [loading, setLoading] = useState(false);
-
-  useEffect(() => {
-    if (added && ref.current) {
-      ref.current?.scrollIntoView({ behavior: "smooth" });
-    }
-  });
 
   return (
     <MaybeTooltip
@@ -123,9 +116,8 @@ const DatasetRow = ({
       }}
     >
       <div
-        ref={ref}
-        className={clsx(classes.row, { [classes.added]: added })}
         key={cube.iri}
+        className={clsx(classes.row, { [classes.added]: added })}
       >
         <div>
           <MuiLink

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -95,6 +95,7 @@ import { useLocale } from "@/locales/use-locale";
 import { getPalette } from "@/palettes";
 import { hierarchyToOptions } from "@/utils/hierarchy";
 import { makeDimensionValueSorters } from "@/utils/sorting-values";
+import useEvent from "@/utils/use-event";
 
 const useStyles = makeStyles<Theme>((theme) => ({
   root: {
@@ -189,12 +190,12 @@ export const DataFilterSelect = ({
   loading,
 }: {
   dimension: Dimension;
-  label: React.ReactNode;
+  label: ReactNode;
   id: string;
   disabled?: boolean;
   isOptional?: boolean;
-  topControls?: React.ReactNode;
-  sideControls?: React.ReactNode;
+  topControls?: ReactNode;
+  sideControls?: ReactNode;
   hierarchy?: HierarchyValue[] | null;
   onOpen?: () => void;
   loading?: boolean;
@@ -202,7 +203,7 @@ export const DataFilterSelect = ({
   const fieldProps = useSingleFilterSelect(dimensionToFieldProps(dimension));
   const noneLabel = t({
     id: "controls.dimensionvalue.none",
-    message: `No Filter`,
+    message: "No Filter",
   });
   const sortedValues = useMemo(() => {
     const sorters = makeDimensionValueSorters(dimension);
@@ -230,6 +231,7 @@ export const DataFilterSelect = ({
     if (!hierarchy) {
       return;
     }
+
     return hierarchyToOptions(
       hierarchy,
       dimension.values.map((v) => v.value)
@@ -237,14 +239,13 @@ export const DataFilterSelect = ({
   }, [hierarchy, dimension.values]);
 
   const { open, close, isOpen } = useDisclosure();
-  const handleOpen = () => {
+  const handleOpen = useEvent(() => {
     open();
     onOpen?.();
-  };
-
-  const handleClose = () => {
+  });
+  const handleClose = useEvent(() => {
     close();
-  };
+  });
 
   if (hierarchy && hierarchyOptions) {
     return (

--- a/app/configurator/config-form.tsx
+++ b/app/configurator/config-form.tsx
@@ -49,7 +49,7 @@ export type Option = {
   disabled?: boolean;
 };
 
-export type OptionGroup = $FixMe;
+export type OptionGroupKey = $FixMe;
 
 export type FieldProps = Pick<
   InputHTMLAttributes<HTMLInputElement>,

--- a/app/configurator/configurator-state/actions.tsx
+++ b/app/configurator/configurator-state/actions.tsx
@@ -56,6 +56,7 @@ export type ConfiguratorStateAction =
         locale: Locale;
         chartKey: string;
         chartType: ChartType;
+        isAddingNewCube?: boolean;
       };
     }
   | {

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -574,7 +574,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
 
     case "CHART_TYPE_CHANGED":
       if (isConfiguring(draft)) {
-        const { locale, chartKey, chartType } = action.value;
+        const { locale, chartKey, chartType, isAddingNewCube } = action.value;
         const chartConfig = getChartConfig(draft, chartKey);
         const dataCubesComponents = getCachedComponents({
           locale,
@@ -594,6 +594,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
               newChartType: chartType,
               dimensions,
               measures,
+              isAddingNewCube,
             }),
             { dimensions }
           );

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -45,7 +45,7 @@ import { mapValueIrisToColor } from "@/configurator/components/ui-helpers";
 import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import { toggleInteractiveFilterDataDimension } from "@/configurator/interactive-filters/interactive-filters-config-state";
 import { Dimension, isGeoDimension, isJoinByComponent } from "@/domain/data";
-import { getOriginalDimension, JOIN_BY_CUBE_IRI } from "@/graphql/join";
+import { getOriginalDimension, isJoinByCube } from "@/graphql/join";
 import { PossibleFilterValue } from "@/graphql/query-hooks";
 import { findInHierarchy } from "@/rdf/tree-utils";
 import { getCachedComponents } from "@/urql-cache";
@@ -86,7 +86,7 @@ export const deriveFiltersFromFields = produce(
 
     const getCubeDimensions = (dimensions: Dimension[], cubeIri: string) => {
       return dimensions.filter(
-        (d) => d.cubeIri === cubeIri || d.cubeIri === JOIN_BY_CUBE_IRI
+        (d) => d.cubeIri === cubeIri || isJoinByCube(d.cubeIri)
       );
     };
 

--- a/app/configurator/interactive-filters/time-slider.tsx
+++ b/app/configurator/interactive-filters/time-slider.tsx
@@ -211,7 +211,7 @@ const PlayButton = () => {
   );
 };
 
-const useStyles = makeStyles<{ playing: boolean }>(() => ({
+const useStyles = makeStyles(() => ({
   root: {
     width: "100%",
 

--- a/app/domain/data.ts
+++ b/app/domain/data.ts
@@ -533,7 +533,7 @@ export const getCategoricalDimensions = (dimensions: Component[]) =>
 export const getGeoDimensions = (dimensions: Component[]) =>
   dimensions.filter(isGeoDimension);
 
-export const getDimensionsByDimensionType = ({
+export const getComponentsFilteredByType = ({
   dimensionTypes,
   dimensions,
   measures,
@@ -541,10 +541,11 @@ export const getDimensionsByDimensionType = ({
   dimensionTypes: ComponentType[];
   dimensions: Component[];
   measures: Component[];
-}) =>
-  [...measures, ...dimensions].filter((component) =>
-    dimensionTypes.includes(component.__typename)
+}) => {
+  return [...measures, ...dimensions].filter((c) =>
+    dimensionTypes.includes(c.__typename)
   );
+};
 
 const isNominalDimension = (
   dimension?: Component | null

--- a/app/graphql/join.ts
+++ b/app/graphql/join.ts
@@ -22,13 +22,14 @@ import {
 } from "@/graphql/query-hooks";
 import { assert } from "@/utils/assert";
 
-export const JOIN_BY_CUBE_IRI = "joinBy";
+const JOIN_BY_CUBE_IRI = "joinBy";
 
 const keyJoiner = "$/$/$/";
 const joinByPrefix = `joinBy__`;
 
 export const mkJoinById = (index: number) => `${joinByPrefix}${index}`;
-export const isJoinById = (iri: string) => iri.startsWith(joinByPrefix);
+export const isJoinById = (id: string) => id.startsWith(joinByPrefix);
+export const isJoinByCube = (cubeIri: string) => cubeIri === JOIN_BY_CUBE_IRI;
 
 const getJoinByIdIndex = (joinById: string) => {
   return Number(joinById.slice(joinByPrefix.length));

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -1100,7 +1100,7 @@ msgstr "Schlüsselwörter"
 
 #: app/browser/dataset-browse.tsx
 #: app/configurator/components/add-dataset-dialog.tsx
-msgid "dataset-result.dimension-termset-contains"
+msgid "dataset-result.dimension-joined-by"
 msgstr "Enthält Wert von"
 
 #: app/browser/dataset-browse.tsx

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -48,6 +48,10 @@ msgid "browse-panel.termsets"
 msgstr "Konzepte"
 
 #: app/browser/dataset-browse.tsx
+msgid "browse-panel.termsets.explanation"
+msgstr "Konzepte stellen Werte dar, die über verschiedene Dimensionen und Datensätze hinweg geteilt werden können."
+
+#: app/browser/dataset-browse.tsx
 msgid "browse-panel.themes"
 msgstr "Kategorien"
 
@@ -1099,7 +1103,6 @@ msgid "dataset-preview.keywords"
 msgstr "Schlüsselwörter"
 
 #: app/browser/dataset-browse.tsx
-#: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset-result.dimension-joined-by"
 msgstr "Enthält Wert von"
 

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -48,6 +48,10 @@ msgid "browse-panel.termsets"
 msgstr "Concepts"
 
 #: app/browser/dataset-browse.tsx
+msgid "browse-panel.termsets.explanation"
+msgstr "Concepts represent values that can be shared across different dimensions and datasets."
+
+#: app/browser/dataset-browse.tsx
 msgid "browse-panel.themes"
 msgstr "Categories"
 
@@ -1099,7 +1103,6 @@ msgid "dataset-preview.keywords"
 msgstr "Keywords"
 
 #: app/browser/dataset-browse.tsx
-#: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset-result.dimension-joined-by"
 msgstr "Joined by"
 

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -1100,8 +1100,8 @@ msgstr "Keywords"
 
 #: app/browser/dataset-browse.tsx
 #: app/configurator/components/add-dataset-dialog.tsx
-msgid "dataset-result.dimension-termset-contains"
-msgstr "Contains values from"
+msgid "dataset-result.dimension-joined-by"
+msgstr "Joined by"
 
 #: app/browser/dataset-browse.tsx
 msgid "dataset-result.shared-dimensions"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -48,6 +48,10 @@ msgid "browse-panel.termsets"
 msgstr "Concepts"
 
 #: app/browser/dataset-browse.tsx
+msgid "browse-panel.termsets.explanation"
+msgstr "Les concepts représentent des valeurs qui peuvent être partagées entre différentes dimensions et ensembles de données."
+
+#: app/browser/dataset-browse.tsx
 msgid "browse-panel.themes"
 msgstr "Catégories"
 
@@ -1099,7 +1103,6 @@ msgid "dataset-preview.keywords"
 msgstr "Mots clés"
 
 #: app/browser/dataset-browse.tsx
-#: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset-result.dimension-joined-by"
 msgstr "Contient des valeurs de"
 

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -1100,7 +1100,7 @@ msgstr "Mots clés"
 
 #: app/browser/dataset-browse.tsx
 #: app/configurator/components/add-dataset-dialog.tsx
-msgid "dataset-result.dimension-termset-contains"
+msgid "dataset-result.dimension-joined-by"
 msgstr "Contient des valeurs de"
 
 #: app/browser/dataset-browse.tsx

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -1100,7 +1100,7 @@ msgstr "Parole chiave"
 
 #: app/browser/dataset-browse.tsx
 #: app/configurator/components/add-dataset-dialog.tsx
-msgid "dataset-result.dimension-termset-contains"
+msgid "dataset-result.dimension-joined-by"
 msgstr "Contiene valore da"
 
 #: app/browser/dataset-browse.tsx

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -48,6 +48,10 @@ msgid "browse-panel.termsets"
 msgstr "Concetti"
 
 #: app/browser/dataset-browse.tsx
+msgid "browse-panel.termsets.explanation"
+msgstr "I concetti rappresentano valori che possono essere condivisi tra diverse dimensioni e set di dati."
+
+#: app/browser/dataset-browse.tsx
 msgid "browse-panel.themes"
 msgstr "Categorie"
 
@@ -1099,7 +1103,6 @@ msgid "dataset-preview.keywords"
 msgstr "Parole chiave"
 
 #: app/browser/dataset-browse.tsx
-#: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset-result.dimension-joined-by"
 msgstr "Contiene valore da"
 

--- a/e2e/actions.ts
+++ b/e2e/actions.ts
@@ -58,12 +58,10 @@ export const createActions = ({
     createFrom: async ({
       iri,
       dataSource,
-      chartLoadedOptions,
       createURLParams,
     }: {
       iri: string;
       dataSource: "Int" | "Prod";
-      chartLoadedOptions?: Parameters<typeof selectors.chart.loaded>[0];
       createURLParams?: string;
     }) => {
       await page.goto(
@@ -72,7 +70,7 @@ export const createActions = ({
         )}&dataSource=${dataSource}&${createURLParams ?? ""}`
       );
 
-      await selectors.chart.loaded(chartLoadedOptions);
+      await selectors.chart.loaded();
     },
     switchToTableView: async () => {
       await (await selectors.chart.tablePreviewSwitch()).click();

--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -111,15 +111,9 @@ export const createSelectors = ({ screen, page, within }: Ctx) => {
       colorLegendItems: async () =>
         (await selectors.chart.colorLegend()).locator("div"),
       legendTicks: async () => {},
-      loaded: async (options: { timeout?: number } = {}) => {
-        await page
-          .locator(`[data-chart-loaded="true"]`)
-          .waitFor({ timeout: 40 * 1000, ...options });
-        const hasMap = (await page.locator("[data-map-loaded]").count()) > 0;
-        if (hasMap) {
-          await page.locator('[data-map-loaded="true"]');
-          await sleep(500); // Waits for tile to fade in
-        }
+      loaded: async () => {
+        await page.waitForLoadState("networkidle");
+        await sleep(1000);
       },
       tablePreviewSwitch: async () => {
         return await screen.findByText("Table view");

--- a/e2e/selectors.ts
+++ b/e2e/selectors.ts
@@ -113,7 +113,8 @@ export const createSelectors = ({ screen, page, within }: Ctx) => {
       legendTicks: async () => {},
       loaded: async () => {
         await page.waitForLoadState("networkidle");
-        await sleep(1000);
+        // Let the map tiles fade in and enter animations finish
+        await sleep(1_000);
       },
       tablePreviewSwitch: async () => {
         return await screen.findByText("Table view");


### PR DESCRIPTION
Closes #1830

This PR:
- removes termsets from merging of cubes modal dropdown,
- renames "Contains values from" to "Join by" when hovering over a shared dimension tag in merging of cubes modal,
- prefers dual-line and column-line chart before multi-line chart and tries to initialize the dual-line chart with measures from different charts, if other conditions are met (e.g. that dimensions have different units),
- adds an info tooltip to explain what `Concepts` are on the browse page,
- groups filters and dropdown options by cube, in case we have more than one.

## How to test
1. Go to [this link](https://visualization-tool-git-feat-merging-of-cubes-ui-imp-b426b5-ixt1.vercel.app/en/browse?dataSource=Prod).
2. ✅ Scroll a bit down to see that there's an icon tooltip next to `Concepts` navigation menu.
3. Search for "photo" and select `Einmalvergütung für Photovoltaikanlagen` dataset.
4. Start a visualization.
5. ✅ Go to Vertical Axis menu and open a dropdown. See that the popup menu looks the same as before.
6. Go back to previous view (`Back to main`).
7. Click on `Add dataset`.
8. ✅ Open dimensions dropdown and see that termsets are not longer visible in the popup menu.
9. See a second row (`Median electricity tariff per canton` dataset) and hover over "Canton" chip.
10. ✅ See that the text says "Joined by" Cantons instead of "Contains values from" Cantons.
11. Scroll down a bit and proceed with merging the `International comparison: Expenditure of general government by function (COFOG)` dataset.
12. ✅ See that after merging, chart type changed to dual-axis line chart and that selected dimensions come from different cubes.
13. ✅ Scroll down the left panel and see that the filters are grouped by cubes.
14. Switch chart type to column chart.
15. Open Horizontal Axis field.
16. ✅ Open dropdown and see that dimensions are grouped by cube (including indication of `joinBy` dimensions).