### PR TITLE
feat: Tooltip for disabled chart types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ You can also check the
   - Improved default chart selection when adding a new cube (by default the
     application will try to use dual-line chart with measures from different
     cubes)
+  - Added tooltip that explains why a given chart type can't be selected
 - Fixes
   - Introduced a `componentId` concept which makes the dimensions and measures
     unique by adding an unversioned cube iri to the unversioned component iri on

--- a/app/browse/datatable.tsx
+++ b/app/browse/datatable.tsx
@@ -8,7 +8,6 @@ import {
   TableRow,
   TableSortLabel,
   Theme,
-  Tooltip,
   TooltipProps,
 } from "@mui/material";
 import { ascending, descending } from "d3-array";
@@ -19,7 +18,9 @@ import {
   useQueryFilters,
 } from "@/charts/shared/chart-helpers";
 import { Loading } from "@/components/hint";
+import { MaybeTooltip } from "@/components/maybe-tooltip";
 import { OpenMetadataPanelWrapper } from "@/components/metadata-panel";
+import { TooltipTitle } from "@/components/tooltip-utils";
 import {
   ChartConfig,
   DashboardFiltersConfig,
@@ -59,11 +60,14 @@ const ComponentLabel = (props: ComponentLabelProps) => {
       <span style={{ fontWeight: "bold" }}>{label}</span>
     </OpenMetadataPanelWrapper>
   ) : component.description ? (
-    <Tooltip title={component.description} arrow {...tooltipProps}>
+    <MaybeTooltip
+      title={<TooltipTitle text={component.description} />}
+      tooltipProps={tooltipProps}
+    >
       <span style={{ fontWeight: "bold", textDecoration: "underline" }}>
         {label}
       </span>
-    </Tooltip>
+    </MaybeTooltip>
   ) : (
     <span style={{ fontWeight: "bold" }}>{label}</span>
   );

--- a/app/charts/index.spec.ts
+++ b/app/charts/index.spec.ts
@@ -21,6 +21,11 @@ jest.mock("../rdf/extended-cube", () => ({
   ExtendedCube: jest.fn(),
 }));
 
+jest.mock("@lingui/macro", () => ({
+  defineMessage: (str: string) => str,
+  t: (str: string) => str,
+}));
+
 const mockDimensions: Record<string, Dimension> = {
   geoCoordinates: {
     __typename: "GeoCoordinatesDimension",

--- a/app/charts/index.spec.ts
+++ b/app/charts/index.spec.ts
@@ -13,8 +13,8 @@ import forestAreaData from "../test/__fixtures/data/forest-area-by-production-re
 
 import {
   getChartConfigAdjustedToChartType,
+  getEnabledChartTypes,
   getInitialConfig,
-  getPossibleChartTypes,
 } from "./index";
 
 jest.mock("../rdf/extended-cube", () => ({
@@ -175,42 +175,42 @@ describe("initial config", () => {
   });
 });
 
-describe("possible chart types", () => {
+describe("enabled chart types", () => {
   it("should allow appropriate chart types based on available dimensions", () => {
     const expectedChartTypes = ["area", "column", "line", "pie", "table"];
-    const possibleChartTypes = getPossibleChartTypes({
+    const { enabledChartTypes } = getEnabledChartTypes({
       dimensions: bathingWaterData.data.dataCubeByIri
         .dimensions as any as Dimension[],
       measures: bathingWaterData.data.dataCubeByIri
         .measures as any as Measure[],
       cubeCount: 1,
-    }).sort();
+    });
 
-    expect(possibleChartTypes).toEqual(expectedChartTypes);
+    expect(enabledChartTypes.sort()).toEqual(expectedChartTypes);
   });
 
   it("should only allow table if there are only measures available", () => {
-    const possibleChartTypes = getPossibleChartTypes({
+    const { enabledChartTypes } = getEnabledChartTypes({
       dimensions: [],
       measures: [{ __typename: "NumericalMeasure" }] as any,
       cubeCount: 1,
     });
 
-    expect(possibleChartTypes).toEqual(["table"]);
+    expect(enabledChartTypes).toEqual(["table"]);
   });
 
   it("should only allow column, map, pie and table if only geo dimensions are available", () => {
-    const possibleChartTypes = getPossibleChartTypes({
+    const { enabledChartTypes } = getEnabledChartTypes({
       dimensions: [{ __typename: "GeoShapesDimension" }] as any,
       measures: [{ __typename: "NumericalMeasure" }] as any,
       cubeCount: 1,
-    }).sort();
+    });
 
-    expect(possibleChartTypes).toEqual(["column", "map", "pie", "table"]);
+    expect(enabledChartTypes.sort()).toEqual(["column", "map", "pie", "table"]);
   });
 
   it("should not allow multiline chart if there are no several measures of the same unit", () => {
-    const possibleChartTypes = getPossibleChartTypes({
+    const { enabledChartTypes } = getEnabledChartTypes({
       dimensions: [],
       measures: [
         { __typename: "NumericalMeasure", unit: "m" },
@@ -219,7 +219,7 @@ describe("possible chart types", () => {
       cubeCount: 1,
     });
 
-    expect(possibleChartTypes).not.toContain("comboLineSingle");
+    expect(enabledChartTypes).not.toContain("comboLineSingle");
   });
 });
 

--- a/app/charts/index.spec.ts
+++ b/app/charts/index.spec.ts
@@ -183,7 +183,7 @@ describe("initial config", () => {
 describe("enabled chart types", () => {
   it("should allow appropriate chart types based on available dimensions", () => {
     const expectedChartTypes = ["area", "column", "line", "pie", "table"];
-    const { enabledChartTypes } = getEnabledChartTypes({
+    const { enabledChartTypes, possibleChartTypesDict } = getEnabledChartTypes({
       dimensions: bathingWaterData.data.dataCubeByIri
         .dimensions as any as Dimension[],
       measures: bathingWaterData.data.dataCubeByIri
@@ -192,30 +192,39 @@ describe("enabled chart types", () => {
     });
 
     expect(enabledChartTypes.sort()).toEqual(expectedChartTypes);
+    expect(possibleChartTypesDict["comboLineSingle"].message).toBeDefined();
+    expect(possibleChartTypesDict["comboLineDual"].message).toBeDefined();
+    expect(possibleChartTypesDict["map"].message).toBeDefined();
   });
 
   it("should only allow table if there are only measures available", () => {
-    const { enabledChartTypes } = getEnabledChartTypes({
+    const { enabledChartTypes, possibleChartTypesDict } = getEnabledChartTypes({
       dimensions: [],
       measures: [{ __typename: "NumericalMeasure" }] as any,
       cubeCount: 1,
     });
 
     expect(enabledChartTypes).toEqual(["table"]);
+    expect(
+      Object.entries(possibleChartTypesDict)
+        .filter(([k]) => k !== "table")
+        .every(([, { message }]) => !!message)
+    ).toBe(true);
   });
 
   it("should only allow column, map, pie and table if only geo dimensions are available", () => {
-    const { enabledChartTypes } = getEnabledChartTypes({
+    const { enabledChartTypes, possibleChartTypesDict } = getEnabledChartTypes({
       dimensions: [{ __typename: "GeoShapesDimension" }] as any,
       measures: [{ __typename: "NumericalMeasure" }] as any,
       cubeCount: 1,
     });
 
     expect(enabledChartTypes.sort()).toEqual(["column", "map", "pie", "table"]);
+    expect(possibleChartTypesDict["line"].message).toBeDefined();
   });
 
   it("should not allow multiline chart if there are no several measures of the same unit", () => {
-    const { enabledChartTypes } = getEnabledChartTypes({
+    const { enabledChartTypes, possibleChartTypesDict } = getEnabledChartTypes({
       dimensions: [],
       measures: [
         { __typename: "NumericalMeasure", unit: "m" },
@@ -225,6 +234,7 @@ describe("enabled chart types", () => {
     });
 
     expect(enabledChartTypes).not.toContain("comboLineSingle");
+    expect(possibleChartTypesDict["comboLineSingle"].message).toBeDefined();
   });
 });
 

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -1,3 +1,4 @@
+import { t } from "@lingui/macro";
 import { ascending, descending, group, rollup, rollups } from "d3-array";
 import produce from "immer";
 import get from "lodash/get";
@@ -563,7 +564,7 @@ export const getInitialConfig = (
         ) as TableFields,
       };
     case "comboLineSingle": {
-      // It's guaranteed by getPossibleChartTypes that there are at least two units.
+      // It's guaranteed by getEnabledChartTypes that there are at least two units.
       const mostCommonUnit = rollups(
         numericalMeasures.filter((d) => d.unit),
         (v) => v.length,
@@ -597,7 +598,7 @@ export const getInitialConfig = (
       };
     }
     case "comboLineDual": {
-      // It's guaranteed by getPossibleChartTypes that there are at least two units.
+      // It's guaranteed by getEnabledChartTypes that there are at least two units.
       const [firstUnit, secondUnit] = Array.from(
         new Set(numericalMeasures.filter((d) => d.unit).map((d) => d.unit))
       );
@@ -634,7 +635,7 @@ export const getInitialConfig = (
       };
     }
     case "comboLineColumn": {
-      // It's guaranteed by getPossibleChartTypes that there are at least two units.
+      // It's guaranteed by getEnabledChartTypes that there are at least two units.
       const [firstUnit, secondUnit] = Array.from(
         new Set(numericalMeasures.filter((d) => d.unit).map((d) => d.unit))
       );
@@ -1955,7 +1956,7 @@ const multipleNumericalMeasuresEnabledChartTypes: RegularChartType[] = [
 ];
 const timeEnabledChartTypes: RegularChartType[] = ["area", "column", "line"];
 
-export const getPossibleChartTypes = ({
+export const getEnabledChartTypes = ({
   dimensions,
   measures,
   cubeCount,
@@ -1963,7 +1964,7 @@ export const getPossibleChartTypes = ({
   dimensions: Dimension[];
   measures: Measure[];
   cubeCount: number;
-}): ChartType[] => {
+}) => {
   const numericalMeasures = measures.filter(isNumericalMeasure);
   const ordinalMeasures = measures.filter(isOrdinalMeasure);
   const categoricalDimensions = getCategoricalDimensions(dimensions);
@@ -1972,19 +1973,76 @@ export const getPossibleChartTypes = ({
     (d) => isTemporalDimension(d) || isTemporalEntityDimension(d)
   );
 
-  const possibleChartTypes: ChartType[] = ["table"];
+  const possibleChartTypesDict = Object.fromEntries(
+    chartTypes.map((chartType) => [
+      chartType,
+      {
+        enabled: chartType === "table",
+        message: undefined,
+      },
+    ])
+  ) as Record<
+    ChartType,
+    {
+      enabled: boolean;
+      message: string | undefined;
+    }
+  >;
+  const enableChartType = (chartType: ChartType) => {
+    possibleChartTypesDict[chartType] = {
+      enabled: true,
+      message: undefined,
+    };
+  };
+  const enableChartTypes = (chartTypes: ChartType[]) => {
+    for (const chartType of chartTypes) {
+      enableChartType(chartType);
+    }
+  };
+  const maybeDisableChartType = (chartType: ChartType, message: string) => {
+    if (
+      !possibleChartTypesDict[chartType].enabled &&
+      !possibleChartTypesDict[chartType].message
+    ) {
+      possibleChartTypesDict[chartType] = {
+        enabled: false,
+        message,
+      };
+    }
+  };
+  const maybeDisableChartTypes = (chartTypes: ChartType[], message: string) => {
+    for (const chartType of chartTypes) {
+      maybeDisableChartType(chartType, message);
+    }
+  };
 
   if (numericalMeasures.length > 0) {
     if (categoricalDimensions.length > 0) {
-      possibleChartTypes.push(...categoricalEnabledChartTypes);
+      enableChartTypes(categoricalEnabledChartTypes);
+    } else {
+      maybeDisableChartTypes(
+        categoricalEnabledChartTypes,
+        t({
+          id: "controls.chart.disabled.categorical",
+          message: "At least one categorical dimension is required.",
+        })
+      );
     }
 
     if (geoDimensions.length > 0) {
-      possibleChartTypes.push(...geoEnabledChartTypes);
+      enableChartTypes(geoEnabledChartTypes);
+    } else {
+      maybeDisableChartTypes(
+        geoEnabledChartTypes,
+        t({
+          id: "controls.chart.disabled.geographical",
+          message: "At least one geographical dimension is required.",
+        })
+      );
     }
 
     if (numericalMeasures.length > 1) {
-      possibleChartTypes.push(...multipleNumericalMeasuresEnabledChartTypes);
+      enableChartTypes(multipleNumericalMeasuresEnabledChartTypes);
 
       if (temporalDimensions.length > 0) {
         const measuresWithUnit = numericalMeasures.filter((d) => d.unit);
@@ -1993,7 +2051,16 @@ export const getPossibleChartTypes = ({
         );
 
         if (uniqueUnits.length > 1) {
-          possibleChartTypes.push(...comboDifferentUnitChartTypes);
+          enableChartTypes(comboDifferentUnitChartTypes);
+        } else {
+          maybeDisableChartTypes(
+            comboDifferentUnitChartTypes,
+            t({
+              id: "controls.chart.disabled.different-unit",
+              message:
+                "At least two numerical measures with different units are required.",
+            })
+          );
         }
 
         const unitCounts = rollup(
@@ -2003,29 +2070,77 @@ export const getPossibleChartTypes = ({
         );
 
         if (Array.from(unitCounts.values()).some((d) => d > 1)) {
-          possibleChartTypes.push(...comboSameUnitChartTypes);
+          enableChartTypes(comboSameUnitChartTypes);
+        } else {
+          maybeDisableChartTypes(
+            comboSameUnitChartTypes,
+            t({
+              id: "controls.chart.disabled.same-unit",
+              message:
+                "At least two numerical measures with the same unit are required.",
+            })
+          );
         }
+      } else {
+        maybeDisableChartTypes(
+          comboChartTypes,
+          t({
+            id: "controls.chart.disabled.temporal",
+            message: "At least one temporal dimension is required.",
+          })
+        );
       }
+    } else {
+      maybeDisableChartTypes(
+        [...multipleNumericalMeasuresEnabledChartTypes, ...comboChartTypes],
+        t({
+          id: "controls.chart.disabled.multiple-measures",
+          message: "At least two numerical measures are required.",
+        })
+      );
     }
 
     if (temporalDimensions.length > 0) {
-      possibleChartTypes.push(...timeEnabledChartTypes);
+      enableChartTypes(timeEnabledChartTypes);
+    } else {
+      maybeDisableChartTypes(
+        timeEnabledChartTypes,
+        t({
+          id: "controls.chart.disabled.temporal",
+          message: "At least one temporal dimension is required.",
+        })
+      );
     }
+  } else {
+    maybeDisableChartTypes(
+      chartTypes.filter((d) => d !== "table"),
+      t({
+        id: "controls.chart.disabled.numerical",
+        message: "At least one numerical measure is required.",
+      })
+    );
   }
 
-  if (
-    ordinalMeasures.length > 0 &&
-    geoDimensions.length > 0 &&
-    !possibleChartTypes.includes("map")
-  ) {
-    possibleChartTypes.push("map");
+  if (ordinalMeasures.length > 0 && geoDimensions.length > 0) {
+    enableChartType("map");
+  } else {
+    maybeDisableChartType(
+      "map",
+      "At least one ordinal measure and one geographical dimension are required."
+    );
   }
+
+  console.log({ possibleChartTypesDict });
 
   const chartTypesOrder = getChartTypeOrder({ cubeCount });
-
-  return chartTypes
-    .filter((d) => possibleChartTypes.includes(d))
+  const enabledChartTypes = chartTypes
+    .filter((d) => possibleChartTypesDict[d].enabled)
     .sort((a, b) => chartTypesOrder[a] - chartTypesOrder[b]);
+
+  return {
+    enabledChartTypes,
+    possibleChartTypesDict,
+  };
 };
 
 export const getFieldComponentIds = (fields: ChartConfig["fields"]) => {

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -1948,6 +1948,13 @@ const adjustSegmentSorting = ({
   return newSorting;
 };
 
+const categoricalEnabledChartTypes: RegularChartType[] = ["column", "pie"];
+const geoEnabledChartTypes: RegularChartType[] = ["column", "map", "pie"];
+const multipleNumericalMeasuresEnabledChartTypes: RegularChartType[] = [
+  "scatterplot",
+];
+const timeEnabledChartTypes: RegularChartType[] = ["area", "column", "line"];
+
 export const getPossibleChartTypes = ({
   dimensions,
   measures,
@@ -1965,23 +1972,19 @@ export const getPossibleChartTypes = ({
     (d) => isTemporalDimension(d) || isTemporalEntityDimension(d)
   );
 
-  const categoricalEnabled: RegularChartType[] = ["column", "pie"];
-  const geoEnabled: RegularChartType[] = ["column", "map", "pie"];
-  const multipleNumericalMeasuresEnabled: RegularChartType[] = ["scatterplot"];
-  const timeEnabled: RegularChartType[] = ["area", "column", "line"];
+  const possibleChartTypes: ChartType[] = ["table"];
 
-  const possibles: ChartType[] = ["table"];
   if (numericalMeasures.length > 0) {
     if (categoricalDimensions.length > 0) {
-      possibles.push(...categoricalEnabled);
+      possibleChartTypes.push(...categoricalEnabledChartTypes);
     }
 
     if (geoDimensions.length > 0) {
-      possibles.push(...geoEnabled);
+      possibleChartTypes.push(...geoEnabledChartTypes);
     }
 
     if (numericalMeasures.length > 1) {
-      possibles.push(...multipleNumericalMeasuresEnabled);
+      possibleChartTypes.push(...multipleNumericalMeasuresEnabledChartTypes);
 
       if (temporalDimensions.length > 0) {
         const measuresWithUnit = numericalMeasures.filter((d) => d.unit);
@@ -1990,7 +1993,7 @@ export const getPossibleChartTypes = ({
         );
 
         if (uniqueUnits.length > 1) {
-          possibles.push(...comboDifferentUnitChartTypes);
+          possibleChartTypes.push(...comboDifferentUnitChartTypes);
         }
 
         const unitCounts = rollup(
@@ -2000,24 +2003,28 @@ export const getPossibleChartTypes = ({
         );
 
         if (Array.from(unitCounts.values()).some((d) => d > 1)) {
-          possibles.push(...comboSameUnitChartTypes);
+          possibleChartTypes.push(...comboSameUnitChartTypes);
         }
       }
     }
 
     if (temporalDimensions.length > 0) {
-      possibles.push(...timeEnabled);
+      possibleChartTypes.push(...timeEnabledChartTypes);
     }
   }
 
-  if (ordinalMeasures.length > 0 && geoDimensions.length > 0) {
-    possibles.push("map");
+  if (
+    ordinalMeasures.length > 0 &&
+    geoDimensions.length > 0 &&
+    !possibleChartTypes.includes("map")
+  ) {
+    possibleChartTypes.push("map");
   }
 
   const chartTypesOrder = getChartTypeOrder({ cubeCount });
 
   return chartTypes
-    .filter((d) => possibles.includes(d))
+    .filter((d) => possibleChartTypes.includes(d))
     .sort((a, b) => chartTypesOrder[a] - chartTypesOrder[b]);
 };
 

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -2130,8 +2130,6 @@ export const getEnabledChartTypes = ({
     );
   }
 
-  console.log({ possibleChartTypesDict });
-
   const chartTypesOrder = getChartTypeOrder({ cubeCount });
   const enabledChartTypes = chartTypes
     .filter((d) => possibleChartTypesDict[d].enabled)

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -1951,12 +1951,10 @@ const adjustSegmentSorting = ({
 export const getPossibleChartTypes = ({
   dimensions,
   measures,
-  allowedChartTypes,
   cubeCount,
 }: {
   dimensions: Dimension[];
   measures: Measure[];
-  allowedChartTypes?: ChartType[];
   cubeCount: number;
 }): ChartType[] => {
   const numericalMeasures = measures.filter(isNumericalMeasure);
@@ -2019,11 +2017,7 @@ export const getPossibleChartTypes = ({
   const chartTypesOrder = getChartTypeOrder({ cubeCount });
 
   return chartTypes
-    .filter(
-      (d) =>
-        possibles.includes(d) &&
-        (!allowedChartTypes || allowedChartTypes.includes(d))
-    )
+    .filter((d) => possibles.includes(d))
     .sort((a, b) => chartTypesOrder[a] - chartTypesOrder[b]);
 };
 

--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -12,6 +12,7 @@ import Flex from "@/components/flex";
 import { Checkbox, CheckboxProps } from "@/components/form";
 import { MaybeTooltip } from "@/components/maybe-tooltip";
 import { OpenMetadataPanelWrapper } from "@/components/metadata-panel";
+import { TooltipTitle } from "@/components/tooltip-utils";
 import {
   ChartConfig,
   GenericSegmentField,
@@ -396,12 +397,12 @@ export const LegendItem = (props: LegendItemProps) => {
     <MaybeTooltip
       title={
         disabled ? (
-          <Typography variant="body2">
-            {t({
+          <TooltipTitle
+            text={t({
               id: "controls.filters.interactive.color.min-1-filter",
               message: "At least one filter must be selected.",
             })}
-          </Typography>
+          />
         ) : undefined
       }
     >

--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -46,6 +46,7 @@ import React, {
 import { useBrowseContext } from "@/browser/context";
 import { MaybeTooltip } from "@/components/maybe-tooltip";
 import { BANNER_MARGIN_TOP } from "@/components/presence";
+import { TooltipTitle } from "@/components/tooltip-utils";
 import VisuallyHidden from "@/components/visually-hidden";
 import {
   FieldProps,
@@ -107,11 +108,7 @@ export const Radio = ({
 
   return (
     <MaybeTooltip
-      title={
-        warnMessage ? (
-          <Typography variant="body2">{warnMessage}</Typography>
-        ) : undefined
-      }
+      title={warnMessage ? <TooltipTitle text={warnMessage} /> : undefined}
     >
       <FormControlLabel
         label={label || "-"}

--- a/app/components/info-icon-tooltip.tsx
+++ b/app/components/info-icon-tooltip.tsx
@@ -1,15 +1,17 @@
-import { Theme, Tooltip, TooltipProps, Typography } from "@mui/material";
-import { makeStyles } from "@mui/styles";
-import React from "react";
+import { Tooltip, TooltipProps, Typography } from "@mui/material";
+import { ReactNode } from "react";
 
+import {
+  TooltipTitle,
+  TooltipVariant,
+  useTooltipStyles,
+} from "@/components/tooltip-utils";
 import { Icon } from "@/icons";
-
-type InfoIconTooltipVariant = "primary" | "secondary";
 
 export const InfoIconTooltip = (
   props: {
-    title: NonNullable<React.ReactNode>;
-    variant?: InfoIconTooltipVariant;
+    title: NonNullable<ReactNode>;
+    variant?: TooltipVariant;
   } & Omit<TooltipProps, "children" | "title">
 ) => {
   const {
@@ -19,17 +21,13 @@ export const InfoIconTooltip = (
     placement = "top",
     ...rest
   } = props;
-  const classes = useStyles({ variant });
+  const classes = useTooltipStyles({ variant });
 
   return (
     <Tooltip
       arrow
       placement={placement}
-      title={
-        <Typography variant="caption" color="secondary">
-          {title}
-        </Typography>
-      }
+      title={<TooltipTitle text={title} />}
       componentsProps={{
         ...componentsProps,
         tooltip: {
@@ -44,17 +42,3 @@ export const InfoIconTooltip = (
     </Tooltip>
   );
 };
-
-const useStyles = makeStyles<Theme, { variant: "primary" | "secondary" }>(
-  (theme) => ({
-    tooltip: {
-      width: 150,
-      padding: theme.spacing(1, 2),
-      lineHeight: "18px",
-    },
-    icon: {
-      color: ({ variant }) => theme.palette[variant].main,
-      pointerEvents: "auto",
-    },
-  })
-);

--- a/app/components/info-icon-tooltip.tsx
+++ b/app/components/info-icon-tooltip.tsx
@@ -28,6 +28,7 @@ export const InfoIconTooltip = (
       arrow
       placement={placement}
       title={<TooltipTitle text={title} />}
+      disableInteractive
       componentsProps={{
         ...componentsProps,
         tooltip: {

--- a/app/components/maybe-tooltip.tsx
+++ b/app/components/maybe-tooltip.tsx
@@ -1,5 +1,7 @@
 import { Tooltip, TooltipProps } from "@mui/material";
 
+import { useTooltipStyles } from "@/components/tooltip-utils";
+
 export const MaybeTooltip = ({
   title,
   children,
@@ -9,8 +11,19 @@ export const MaybeTooltip = ({
   children: JSX.Element;
   tooltipProps?: Omit<TooltipProps, "children" | "title">;
 }) => {
+  const classes = useTooltipStyles({ variant: "primary" });
+
   return title ? (
-    <Tooltip arrow title={title} {...tooltipProps}>
+    <Tooltip
+      arrow
+      title={title}
+      componentsProps={{
+        tooltip: {
+          className: classes.tooltip,
+        },
+      }}
+      {...tooltipProps}
+    >
       {children}
     </Tooltip>
   ) : (

--- a/app/components/maybe-tooltip.tsx
+++ b/app/components/maybe-tooltip.tsx
@@ -17,6 +17,7 @@ export const MaybeTooltip = ({
     <Tooltip
       arrow
       title={title}
+      disableInteractive
       componentsProps={{
         tooltip: {
           className: classes.tooltip,

--- a/app/components/tooltip-utils.tsx
+++ b/app/components/tooltip-utils.tsx
@@ -1,0 +1,28 @@
+import { Theme, Typography } from "@mui/material";
+import { makeStyles } from "@mui/styles";
+import { ReactNode } from "react";
+
+export type TooltipVariant = "primary" | "secondary";
+
+export const TooltipTitle = ({ text }: { text: string | ReactNode }) => {
+  return (
+    <Typography variant="caption" color="grey.700">
+      {text}
+    </Typography>
+  );
+};
+
+export const useTooltipStyles = makeStyles<Theme, { variant: TooltipVariant }>(
+  (theme) => ({
+    tooltip: {
+      width: "100%",
+      maxWidth: 240,
+      padding: theme.spacing(1, 2),
+      lineHeight: "18px",
+    },
+    icon: {
+      color: ({ variant }) => theme.palette[variant].main,
+      pointerEvents: "auto",
+    },
+  })
+);

--- a/app/configurator/components/add-dataset-dialog.tsx
+++ b/app/configurator/components/add-dataset-dialog.tsx
@@ -52,7 +52,7 @@ import { useClient } from "urql";
 
 import { DatasetResults, PartialSearchCube } from "@/browser/dataset-browse";
 import { FirstTenRowsCaption } from "@/browser/dataset-preview";
-import { getPossibleChartTypes } from "@/charts";
+import { getEnabledChartTypes } from "@/charts";
 import { Error as ErrorHint, Loading } from "@/components/hint";
 import Tag from "@/components/tag";
 import {
@@ -1105,9 +1105,9 @@ const useAddDataset = () => {
           value: addDatasetOptions,
         });
         const { dimensions, measures } = res.data.dataCubesComponents;
-        const possibleType = getPossibleChartTypes({
-          dimensions: dimensions,
-          measures: measures,
+        const { enabledChartTypes } = getEnabledChartTypes({
+          dimensions,
+          measures,
           cubeCount: chartConfig.cubes.length,
         });
         dispatch({
@@ -1115,7 +1115,7 @@ const useAddDataset = () => {
           value: {
             locale,
             chartKey: state.activeChartKey,
-            chartType: possibleType[0],
+            chartType: enabledChartTypes[0],
             isAddingNewCube: true,
           },
         });

--- a/app/configurator/components/chart-controls/control-tab.tsx
+++ b/app/configurator/components/chart-controls/control-tab.tsx
@@ -1,9 +1,11 @@
 import { Trans } from "@lingui/macro";
-import { Box, Button, Theme, Tooltip, Typography } from "@mui/material";
+import { Box, Button, Theme, Typography } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import React, { ReactNode } from "react";
 
 import Flex from "@/components/flex";
+import { MaybeTooltip } from "@/components/maybe-tooltip";
+import { TooltipTitle } from "@/components/tooltip-utils";
 import {
   ChartConfig,
   FieldProps,
@@ -136,11 +138,11 @@ const WarnIconTooltip = (props: WarnIconTooltipProps) => {
   const iconStyles = useIconStyles({ isActive: false });
 
   return (
-    <Tooltip arrow title={<Typography variant="body2">{title}</Typography>}>
+    <MaybeTooltip title={<TooltipTitle text={title} />}>
       <Typography>
         <SvgIcExclamation className={iconStyles.warn} />
       </Typography>
-    </Tooltip>
+    </MaybeTooltip>
   );
 };
 

--- a/app/configurator/components/chart-controls/section.tsx
+++ b/app/configurator/components/chart-controls/section.tsx
@@ -4,7 +4,6 @@ import {
   Collapse,
   Skeleton,
   Theme,
-  Tooltip,
   Typography,
   TypographyProps,
 } from "@mui/material";
@@ -14,13 +13,15 @@ import React, {
   ElementType,
   HTMLProps,
   ReactNode,
+  createContext,
   forwardRef,
   useContext,
   useEffect,
   useMemo,
-  createContext,
 } from "react";
 
+import { MaybeTooltip } from "@/components/maybe-tooltip";
+import { TooltipTitle } from "@/components/tooltip-utils";
 import { Icon, IconName } from "@/icons";
 import SvgIcAdd from "@/icons/components/IcAdd";
 import SvgIcExclamation from "@/icons/components/IcExclamation";
@@ -313,10 +314,10 @@ const Warning = (props: WarningProps) => {
   const { title } = props;
 
   return (
-    <Tooltip arrow title={<Typography variant="body2">{title}</Typography>}>
+    <MaybeTooltip title={<TooltipTitle text={title} />}>
       <Typography color="warning.main" sx={{ mr: 2 }}>
         <SvgIcExclamation width={18} height={18} />
       </Typography>
-    </Tooltip>
+    </MaybeTooltip>
   );
 };

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -29,6 +29,8 @@ import {
   SelectOption,
   SelectOptionGroup,
 } from "@/components/form";
+import { MaybeTooltip } from "@/components/maybe-tooltip";
+import { TooltipTitle } from "@/components/tooltip-utils";
 import { GenericField } from "@/config-types";
 import {
   AnimationField,
@@ -1395,14 +1397,16 @@ const ChartFieldCalculation = ({
         </Flex>
         <ChartOptionSwitchField
           label={
-            <Tooltip
-              enterDelay={600}
+            <MaybeTooltip
+              tooltipProps={{ enterDelay: 600 }}
               title={
-                <Typography variant="body2">
-                  <Trans id="controls.filters.interactive.calculation">
-                    Allow users to change chart mode
-                  </Trans>
-                </Typography>
+                <TooltipTitle
+                  text={
+                    <Trans id="controls.filters.interactive.calculation">
+                      Allow users to change chart mode
+                    </Trans>
+                  }
+                />
               }
             >
               <div>
@@ -1410,7 +1414,7 @@ const ChartFieldCalculation = ({
                   Interactive
                 </Trans>
               </div>
-            </Tooltip>
+            </MaybeTooltip>
           }
           field={null}
           path="interactiveFiltersConfig.calculation.active"

--- a/app/configurator/components/dataset-control-section.tsx
+++ b/app/configurator/components/dataset-control-section.tsx
@@ -17,6 +17,7 @@ import { useClient } from "urql";
 import Flex from "@/components/flex";
 import { MaybeTooltip } from "@/components/maybe-tooltip";
 import { useMetadataPanelStoreActions } from "@/components/metadata-panel-store";
+import { TooltipTitle } from "@/components/tooltip-utils";
 import useDisclosure from "@/components/use-disclosure";
 import { getChartConfig } from "@/configurator";
 import { DatasetDialog } from "@/configurator/components/add-dataset-dialog";
@@ -99,11 +100,13 @@ const DatasetRow = ({
           <Box color="success.main">
             <SvgIcChecked width={24} height={24} />
           </Box>
-          {t({
-            id: "dataset.search.preview.added-dataset",
-            message:
-              "New dataset added. You can now use its data in the chart(s).",
-          })}
+          <TooltipTitle
+            text={t({
+              id: "dataset.search.preview.added-dataset",
+              message:
+                "New dataset added. You can now use its data in the chart(s).",
+            })}
+          />
         </Box>
       }
       tooltipProps={{

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -42,6 +42,8 @@ import { useFootnotesStyles } from "@/components/chart-footnotes";
 import Flex from "@/components/flex";
 import { Select } from "@/components/form";
 import { Loading } from "@/components/hint";
+import { MaybeTooltip } from "@/components/maybe-tooltip";
+import { TooltipTitle } from "@/components/tooltip-utils";
 import {
   ChartConfig,
   getChartConfig,
@@ -342,12 +344,16 @@ const MultiFilterContent = ({
               componentsProps={{ typography: { variant: "body2" } }}
               control={<Switch {...interactiveFilterProps} />}
               label={
-                <Tooltip
-                  enterDelay={600}
+                <MaybeTooltip
+                  tooltipProps={{ enterDelay: 600 }}
                   title={
-                    <Trans id="controls.filters.interactive.tooltip">
-                      Allow users to change filters
-                    </Trans>
+                    <TooltipTitle
+                      text={
+                        <Trans id="controls.filters.interactive.tooltip">
+                          Allow users to change filters
+                        </Trans>
+                      }
+                    />
                   }
                 >
                   <div>
@@ -355,7 +361,7 @@ const MultiFilterContent = ({
                       Interactive
                     </Trans>
                   </div>
-                </Tooltip>
+                </MaybeTooltip>
               }
             />
           ) : null}

--- a/app/configurator/configurator-state/index.spec.tsx
+++ b/app/configurator/configurator-state/index.spec.tsx
@@ -40,6 +40,11 @@ jest.mock("@/utils/chart-config/api", () => ({
   fetchChartConfig: jest.fn(),
 }));
 
+jest.mock("@lingui/macro", () => ({
+  defineMessage: (str: string) => str,
+  t: (str: string) => str,
+}));
+
 const possibleFilters: PossibleFilterValue[] = [
   {
     __typename: "PossibleFilterValue",

--- a/app/configurator/configurator-state/init.tsx
+++ b/app/configurator/configurator-state/init.tsx
@@ -1,6 +1,6 @@
 import { Client } from "urql";
 
-import { getInitialConfig, getPossibleChartTypes } from "@/charts";
+import { getEnabledChartTypes, getInitialConfig } from "@/charts";
 import { getPossibleFiltersQueryVariables } from "@/charts/shared/ensure-possible-filters";
 import {
   ConfiguratorState,
@@ -88,13 +88,13 @@ export const initChartStateFromCube = async (
   }
 
   const { dimensions, measures } = components.dataCubesComponents;
-  const possibleChartTypes = getPossibleChartTypes({
+  const { enabledChartTypes } = getEnabledChartTypes({
     dimensions,
     measures,
     cubeCount: 1,
   });
   const initialChartConfig = getInitialConfig({
-    chartType: possibleChartTypes[0],
+    chartType: enabledChartTypes[0],
     iris: [{ iri: latestCubeIri }],
     dimensions,
     measures,

--- a/app/configurator/configurator-state/reducer.spec.tsx
+++ b/app/configurator/configurator-state/reducer.spec.tsx
@@ -71,6 +71,11 @@ jest.mock("@/urql-cache", () => {
   };
 });
 
+jest.mock("@lingui/macro", () => ({
+  defineMessage: (str: string) => str,
+  t: (str: string) => str,
+}));
+
 type getCachedComponents = typeof getCachedComponentsOriginal;
 const getCachedComponents = getCachedComponentsOriginal as unknown as jest.Mock<
   ReturnType<getCachedComponents>,

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -9,11 +9,11 @@ import { Reducer } from "use-immer";
 
 import {
   getChartConfigAdjustedToChartType,
+  getEnabledChartTypes,
   getFieldComponentIds,
   getGroupedFieldIds,
   getHiddenFieldIds,
   getInitialConfig,
-  getPossibleChartTypes,
 } from "@/charts";
 import {
   getChartFieldChangeSideEffect,
@@ -958,19 +958,19 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
         const iris = chartConfig.cubes
           .filter((c) => c.iri !== removedCubeIri)
           .map(({ iri }) => ({ iri }));
-        const possibleChartTypes = getPossibleChartTypes({
+        const { enabledChartTypes } = getEnabledChartTypes({
           dimensions,
           measures,
           cubeCount: iris.length,
         });
         const initialConfig = getInitialConfig({
-          chartType: possibleChartTypes.includes(chartConfig.chartType)
+          chartType: enabledChartTypes.includes(chartConfig.chartType)
             ? chartConfig.chartType
-            : possibleChartTypes[0],
+            : enabledChartTypes[0],
           iris,
           dimensions,
           measures,
-          meta: current(chartConfig.meta), // Cast proxy to object
+          meta: current(chartConfig.meta),
         });
         const newChartConfig = deriveFiltersFromFields(initialConfig, {
           dimensions,

--- a/app/configurator/interactive-filters/interactive-filters-configurator.tsx
+++ b/app/configurator/interactive-filters/interactive-filters-configurator.tsx
@@ -1,8 +1,10 @@
 import { Trans } from "@lingui/macro";
-import { FormControlLabel, Switch, Tooltip, Typography } from "@mui/material";
+import { FormControlLabel, Switch, Typography } from "@mui/material";
 
 import { getFieldComponentId } from "@/charts";
 import { ANIMATION_FIELD_SPEC } from "@/charts/chart-config-ui-options";
+import { MaybeTooltip } from "@/components/maybe-tooltip";
+import { TooltipTitle } from "@/components/tooltip-utils";
 import {
   ConfiguratorStateConfiguringChart,
   getChartConfig,
@@ -122,21 +124,22 @@ export const InteractiveFilterToggle = (
       }}
       control={<Switch checked={checked} onChange={() => toggle()} />}
       label={
-        <Tooltip
-          enterDelay={600}
-          arrow
+        <MaybeTooltip
+          tooltipProps={{ enterDelay: 600 }}
           title={
-            <span>
-              <Trans id="controls.filters.interactive.tooltip">
-                Allow users to change filters
-              </Trans>
-            </span>
+            <TooltipTitle
+              text={
+                <Trans id="controls.filters.interactive.tooltip">
+                  Allow users to change filters
+                </Trans>
+              }
+            />
           }
         >
           <Typography variant="body2">
             <Trans id="controls.filters.interactive.toggle">Interactive</Trans>
           </Typography>
-        </Tooltip>
+        </MaybeTooltip>
       }
     />
   );

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -387,6 +387,34 @@ msgstr "Keine Einheit"
 msgid "controls.chart.combo.y.right-axis-measure"
 msgstr "Messung der rechten Achse"
 
+#: app/charts/index.ts
+msgid "controls.chart.disabled.categorical"
+msgstr "Es ist mindestens eine kategorische Dimension erforderlich."
+
+#: app/charts/index.ts
+msgid "controls.chart.disabled.different-unit"
+msgstr "Es werden mindestens zwei Masszahlen mit unterschiedlichen Einheiten benötigt."
+
+#: app/charts/index.ts
+msgid "controls.chart.disabled.geographical"
+msgstr "Es ist mindestens eine geografische Dimension erforderlich."
+
+#: app/charts/index.ts
+msgid "controls.chart.disabled.multiple-measures"
+msgstr "Es sind mindestens zwei numerische Messungen erforderlich."
+
+#: app/charts/index.ts
+msgid "controls.chart.disabled.numerical"
+msgstr "Es ist mindestens eine numerische Massnahme erforderlich."
+
+#: app/charts/index.ts
+msgid "controls.chart.disabled.same-unit"
+msgstr "Es sind mindestens zwei Zahlenwerte mit gleicher Einheit erforderlich."
+
+#: app/charts/index.ts
+msgid "controls.chart.disabled.temporal"
+msgstr "Es ist mindestens eine zeitliche Dimension erforderlich."
+
 #: app/configurator/components/field-i18n.ts
 msgid "controls.chart.type.area"
 msgstr "Flächen"
@@ -1244,6 +1272,7 @@ msgstr "Die ersten 10 Zeilen werden angezeigt"
 
 #: app/components/metadata-panel.tsx
 #: app/components/metadata-panel.tsx
+#: app/configurator/components/chart-options-selector.tsx
 msgid "dimension.joined"
 msgstr "Verbunden"
 

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -307,7 +307,7 @@ msgstr "Fügen Sie eine Beschreibung hinzu"
 
 #: app/configurator/components/annotators.tsx
 msgid "controls.annotator.add-tab-label-warning"
-msgstr "Bitte fügen Sie eine Tab-Titel hinzu"
+msgstr "Bitte fügen Sie einen Tab-Titel hinzu"
 
 #: app/configurator/components/annotators.tsx
 #: app/configurator/components/annotators.tsx
@@ -669,7 +669,7 @@ msgstr "Dashboard"
 
 #: app/configurator/components/preview-breakpoint.tsx
 msgid "controls.layout.preview-lg"
-msgstr "Vorschau in grosser Breite"
+msgstr "Vorschau mit kleinem Desktop-Bildschirm"
 
 #: app/configurator/components/preview-breakpoint.tsx
 msgid "controls.layout.preview-md"
@@ -1144,7 +1144,7 @@ msgstr "Datensatz"
 
 #: app/components/chart-footnotes.tsx
 msgid "dataset.footnotes.updated"
-msgstr "Neuestes Datenupdate"
+msgstr "Neuestes Update"
 
 #: app/components/chart-published.tsx
 msgid "dataset.hasImputedValues"
@@ -1549,7 +1549,7 @@ msgstr "Benennen Sie die Visualisierung um"
 
 #: app/components/publish-actions.tsx
 msgid "publication.embed.external-application"
-msgstr "Einbett-Code für «Externe Applikation»"
+msgstr "Embed-Code für «Externe Applikation»"
 
 #: app/components/publish-actions.tsx
 msgid "publication.embed.external-application.caption"
@@ -1557,7 +1557,7 @@ msgstr "Verwenden Sie diesen Link, um das Diagramm ohne Iframe-Tags einzubetten.
 
 #: app/components/publish-actions.tsx
 msgid "publication.embed.iframe"
-msgstr "Einbett-Code"
+msgstr "Embed-Code"
 
 #: app/components/publish-actions.tsx
 msgid "publication.embed.iframe.caption"
@@ -1573,11 +1573,11 @@ msgstr "Zur Einbettung von Visualisierungen in Systeme ohne Rand."
 
 #: app/components/publish-actions.tsx
 msgid "publication.embed.iframe.responsive"
-msgstr "Anpassungsfähiges iframe"
+msgstr "Flexibles Iframe"
 
 #: app/components/publish-actions.tsx
 msgid "publication.embed.iframe.responsive.warn"
-msgstr "Zum Einbetten von Visualisierungen in Webseiten ohne CMS-Unterstützung. Der iframe wird responsiv sein. Der JavaScript-Teil des Einbettungscodes sorgt dafür, dass der iframe immer die richtige Größe beibehält."
+msgstr "Zum Einbetten von Visualisierungen in Webseiten ohne CMS-Unterstützung. Der Iframe wird sich anpassen. Der JavaScript-Teil des Einbettungscodes sorgt dafür, dass der Iframe immer die richtige Grösse beibehält."
 
 #: app/components/publish-actions.tsx
 msgid "publication.embed.iframe.static"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -387,6 +387,34 @@ msgstr "No unit"
 msgid "controls.chart.combo.y.right-axis-measure"
 msgstr "Right axis measure"
 
+#: app/charts/index.ts
+msgid "controls.chart.disabled.categorical"
+msgstr "At least one categorical dimension is required."
+
+#: app/charts/index.ts
+msgid "controls.chart.disabled.different-unit"
+msgstr "At least two numerical measures with different units are required."
+
+#: app/charts/index.ts
+msgid "controls.chart.disabled.geographical"
+msgstr "At least one geographical dimension is required."
+
+#: app/charts/index.ts
+msgid "controls.chart.disabled.multiple-measures"
+msgstr "At least two numerical measures are required."
+
+#: app/charts/index.ts
+msgid "controls.chart.disabled.numerical"
+msgstr "At least one numerical measure is required."
+
+#: app/charts/index.ts
+msgid "controls.chart.disabled.same-unit"
+msgstr "At least two numerical measures with the same unit are required."
+
+#: app/charts/index.ts
+msgid "controls.chart.disabled.temporal"
+msgstr "At least one temporal dimension is required."
+
 #: app/configurator/components/field-i18n.ts
 msgid "controls.chart.type.area"
 msgstr "Areas"
@@ -1244,6 +1272,7 @@ msgstr "Showing first 10 rows"
 
 #: app/components/metadata-panel.tsx
 #: app/components/metadata-panel.tsx
+#: app/configurator/components/chart-options-selector.tsx
 msgid "dimension.joined"
 msgstr "Joined"
 

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -387,6 +387,34 @@ msgstr "Aucune unité"
 msgid "controls.chart.combo.y.right-axis-measure"
 msgstr "Mesure de l'axe droit"
 
+#: app/charts/index.ts
+msgid "controls.chart.disabled.categorical"
+msgstr "Au moins une dimension catégorielle est requise."
+
+#: app/charts/index.ts
+msgid "controls.chart.disabled.different-unit"
+msgstr "Au moins deux mesures numériques avec des unités différentes sont requises."
+
+#: app/charts/index.ts
+msgid "controls.chart.disabled.geographical"
+msgstr "Au moins une dimension géographique est requise."
+
+#: app/charts/index.ts
+msgid "controls.chart.disabled.multiple-measures"
+msgstr "Au moins deux mesures numériques sont requises."
+
+#: app/charts/index.ts
+msgid "controls.chart.disabled.numerical"
+msgstr "Au moins une mesure numérique est requise."
+
+#: app/charts/index.ts
+msgid "controls.chart.disabled.same-unit"
+msgstr "Au moins deux mesures numériques avec la même unité sont requises."
+
+#: app/charts/index.ts
+msgid "controls.chart.disabled.temporal"
+msgstr "Au moins une dimension temporelle est requise."
+
 #: app/configurator/components/field-i18n.ts
 msgid "controls.chart.type.area"
 msgstr "Surfaces"
@@ -1244,6 +1272,7 @@ msgstr "Seules les 10 premières lignes sont affichées"
 
 #: app/components/metadata-panel.tsx
 #: app/components/metadata-panel.tsx
+#: app/configurator/components/chart-options-selector.tsx
 msgid "dimension.joined"
 msgstr "Jointe"
 

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -307,7 +307,7 @@ msgstr "Ajoutez une description au graphique"
 
 #: app/configurator/components/annotators.tsx
 msgid "controls.annotator.add-tab-label-warning"
-msgstr "Veuillez ajouter une étiquette d'onglet"
+msgstr "Veuillez ajouter un nom à l'onglet"
 
 #: app/configurator/components/annotators.tsx
 #: app/configurator/components/annotators.tsx
@@ -411,6 +411,7 @@ msgstr "Au moins une mesure numérique est requise."
 msgid "controls.chart.disabled.same-unit"
 msgstr "Au moins deux mesures numériques avec la même unité sont requises."
 
+#: app/charts/index.ts
 #: app/charts/index.ts
 msgid "controls.chart.disabled.temporal"
 msgstr "Au moins une dimension temporelle est requise."
@@ -632,7 +633,7 @@ msgstr "Zéros"
 
 #: app/configurator/components/field-i18n.ts
 msgid "controls.label"
-msgstr "Étiquette de l'onglet"
+msgstr "Nom de l'onglet"
 
 #: app/components/rename-dialog.tsx
 #: app/configurator/components/field-i18n.ts
@@ -669,15 +670,15 @@ msgstr "Dashboard"
 
 #: app/configurator/components/preview-breakpoint.tsx
 msgid "controls.layout.preview-lg"
-msgstr "Aperçu en utilisant une grande largeur"
+msgstr "Aperçu petit écran de bureau"
 
 #: app/configurator/components/preview-breakpoint.tsx
 msgid "controls.layout.preview-md"
-msgstr "Aperçu en utilisant une largeur moyenne"
+msgstr "Aperçu tablette"
 
 #: app/configurator/components/preview-breakpoint.tsx
 msgid "controls.layout.preview-sm"
-msgstr "Aperçu en utilisant une petite largeur"
+msgstr "Aperçu mobile"
 
 #: app/configurator/components/preview-breakpoint.tsx
 msgid "controls.layout.preview-xl"
@@ -1140,7 +1141,7 @@ msgstr "Dimensions partagées"
 
 #: app/components/chart-footnotes.tsx
 msgid "dataset.footnotes.dataset"
-msgstr "Ensemble de données"
+msgstr "Jeu de données"
 
 #: app/components/chart-footnotes.tsx
 msgid "dataset.footnotes.updated"
@@ -1406,7 +1407,7 @@ msgstr "Supprimer"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.chart.delete-draft.confirmation"
-msgstr "Etes-vous sûr de vouloir supprimer ce brouillon ?"
+msgstr "Voulez-vous vraiment supprimer ce brouillon ?"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.chart.delete.confirmation"
@@ -1459,7 +1460,7 @@ msgstr "Êtes-vous sûr de vouloir effectuer cette action ?"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.chart.delete-draft.warning"
-msgstr "Cette action ne peut pas être annulée."
+msgstr "Cette action ne peut être annulée."
 
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.chart.delete.warning"
@@ -1481,7 +1482,7 @@ msgstr "Accueil"
 #: app/login/components/profile-content-tabs.tsx
 #: app/login/components/profile-content-tabs.tsx
 msgid "login.profile.my-drafts"
-msgstr "Mes visualisations en brouillon"
+msgstr "Brouillons"
 
 #: app/login/components/profile-content-tabs.tsx
 #: app/login/components/profile-content-tabs.tsx
@@ -1549,11 +1550,11 @@ msgstr "Renommer la visualisation"
 
 #: app/components/publish-actions.tsx
 msgid "publication.embed.external-application"
-msgstr "Code pour intégrer sur comme \"External Application\""
+msgstr "Code pour intégration dans une \"Application Externe\""
 
 #: app/components/publish-actions.tsx
 msgid "publication.embed.external-application.caption"
-msgstr "Utilisez ce lien pour intégrer le graphique sans balises iframe."
+msgstr "Utilisez ce lien pour intégrer le graphique sans balise iframe."
 
 #: app/components/publish-actions.tsx
 msgid "publication.embed.iframe"
@@ -1573,11 +1574,11 @@ msgstr "Pour intégrer des visualisations dans des systèmes sans frontière."
 
 #: app/components/publish-actions.tsx
 msgid "publication.embed.iframe.responsive"
-msgstr "Iframe réactif"
+msgstr "Iframe réactive"
 
 #: app/components/publish-actions.tsx
 msgid "publication.embed.iframe.responsive.warn"
-msgstr "Pour intégrer des visualisations dans des pages web sans support CMS. L'iframe sera réactive. La partie JavaScript du code d'intégration garantit que l'iframe conserve toujours la taille correcte."
+msgstr "Pour intégrer des visualisations dans des pages web sans support CMS. L'iframe sera réactive: le code d'intégration garantit que l'iframe conserve toujours la taille correcte."
 
 #: app/components/publish-actions.tsx
 msgid "publication.embed.iframe.static"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -387,6 +387,34 @@ msgstr "Nessuna unità"
 msgid "controls.chart.combo.y.right-axis-measure"
 msgstr "Misura dell'asse destro"
 
+#: app/charts/index.ts
+msgid "controls.chart.disabled.categorical"
+msgstr "È richiesta almeno una dimensione categoriale."
+
+#: app/charts/index.ts
+msgid "controls.chart.disabled.different-unit"
+msgstr "Sono necessarie almeno due misure numeriche con unità diverse."
+
+#: app/charts/index.ts
+msgid "controls.chart.disabled.geographical"
+msgstr "È richiesta almeno una dimensione geografica."
+
+#: app/charts/index.ts
+msgid "controls.chart.disabled.multiple-measures"
+msgstr "Sono necessarie almeno due misure numeriche."
+
+#: app/charts/index.ts
+msgid "controls.chart.disabled.numerical"
+msgstr "È richiesta almeno una misura numerica."
+
+#: app/charts/index.ts
+msgid "controls.chart.disabled.same-unit"
+msgstr "Sono necessarie almeno due misure numeriche con la stessa unità."
+
+#: app/charts/index.ts
+msgid "controls.chart.disabled.temporal"
+msgstr "È richiesta almeno una dimensione temporale."
+
 #: app/configurator/components/field-i18n.ts
 msgid "controls.chart.type.area"
 msgstr "Aree"
@@ -1244,6 +1272,7 @@ msgstr "Sono mostrate soltanto le prime 10 righe"
 
 #: app/components/metadata-panel.tsx
 #: app/components/metadata-panel.tsx
+#: app/configurator/components/chart-options-selector.tsx
 msgid "dimension.joined"
 msgstr "Unita"
 

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -178,7 +178,7 @@ msgstr "Modifica"
 
 #: app/components/chart-selection-tabs.tsx
 msgid "chart-controls.edit-tab-label"
-msgstr "Modifica etichetta scheda"
+msgstr "Modifica l'etichetta della scheda"
 
 #: app/components/dataset-metadata.tsx
 msgid "chart-controls.sparql-query"
@@ -190,7 +190,7 @@ msgstr "Visualizzazione tabella"
 
 #: app/components/chart-selection-tabs.tsx
 msgid "chart-selection-tabs.add-chart"
-msgstr "Aggiungere grafico"
+msgstr "Aggiungi grafico"
 
 #: app/components/chart-selection-tabs.tsx
 msgid "chart-selection-tabs.add-chart-different-dataset.button"
@@ -307,7 +307,7 @@ msgstr "Aggiungi una descrizione"
 
 #: app/configurator/components/annotators.tsx
 msgid "controls.annotator.add-tab-label-warning"
-msgstr "Aggiungi un'etichetta di scheda"
+msgstr "Aggiungi un'etichetta alla scheda"
 
 #: app/configurator/components/annotators.tsx
 #: app/configurator/components/annotators.tsx
@@ -669,15 +669,15 @@ msgstr "Dashboard"
 
 #: app/configurator/components/preview-breakpoint.tsx
 msgid "controls.layout.preview-lg"
-msgstr "Anteprima con larghezza elevata"
+msgstr "Anteprima su un piccolo desktop"
 
 #: app/configurator/components/preview-breakpoint.tsx
 msgid "controls.layout.preview-md"
-msgstr "Anteprima utilizzando la larghezza media"
+msgstr "Anteprima sul tablet"
 
 #: app/configurator/components/preview-breakpoint.tsx
 msgid "controls.layout.preview-sm"
-msgstr "Anteprima utilizzando una larghezza ridotta"
+msgstr "Anteprima sul telefono"
 
 #: app/configurator/components/preview-breakpoint.tsx
 msgid "controls.layout.preview-xl"
@@ -1240,7 +1240,7 @@ msgstr "Set di dati"
 
 #: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.preview.description"
-msgstr "Esamina tutte le dimensioni disponibili prima di continuare a modificare la visualizzazione."
+msgstr "Esamina le dimensioni disponibili prima di continuare a modificare la visualizzazione."
 
 #: app/configurator/components/add-dataset-dialog.tsx
 msgid "dataset.search.preview.new-dimension"
@@ -1406,7 +1406,7 @@ msgstr "Cancellare"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.chart.delete-draft.confirmation"
-msgstr "Sei sicuro di voler eliminare questa bozza?"
+msgstr "Sei sicuro di voler cancellare questa bozza?"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.chart.delete.confirmation"
@@ -1481,7 +1481,7 @@ msgstr "Accoglienza"
 #: app/login/components/profile-content-tabs.tsx
 #: app/login/components/profile-content-tabs.tsx
 msgid "login.profile.my-drafts"
-msgstr "Le mie bozze"
+msgstr "Bozze"
 
 #: app/login/components/profile-content-tabs.tsx
 #: app/login/components/profile-content-tabs.tsx
@@ -1524,7 +1524,7 @@ msgstr "Accedi"
 #: app/login/components/login-menu.tsx
 #: app/login/components/profile-header.tsx
 msgid "login.sign-out"
-msgstr "Disconnessione"
+msgstr "Esci"
 
 #: app/components/header.tsx
 #: app/components/header.tsx
@@ -1553,7 +1553,7 @@ msgstr "Codice da incorporare su come \"External Application\""
 
 #: app/components/publish-actions.tsx
 msgid "publication.embed.external-application.caption"
-msgstr "Utilizza questo link per incorporare il grafico senza tag iframe."
+msgstr "Utilizzare questo link per incorporare il grafico senza tag iframe."
 
 #: app/components/publish-actions.tsx
 msgid "publication.embed.iframe"


### PR DESCRIPTION
Closes #1448

This PR adds tooltip that explains why a given chart type can be selected and consolidates the tooltips used across the editor mode (excluding chart tooltips).

## How to test
1. Go to [this link](https://visualization-tool-git-feat-tooltip-for-disabled-ch-9b046b-ixt1.vercel.app/en/create/new?cube=https://agriculture.ld.admin.ch/foag/cube/MilkDairyProducts/Consumption_Price_Month&dataSource=Prod).
2. ✅ Hover over disabled chart types and see that a tooltip with explanation on why it can't be selected is shown.

@KerstinFaye UI strings can be adjusted via Accent (string ids start with `controls.chart.disabled`), I used the most down-to-code explanations, but maybe they can be tweaked :)