### PR TITLE
feat: Add support for showing confidence intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ You can also check the
     application will try to use dual-line chart with measures from different
     cubes)
   - Added tooltip that explains why a given chart type can't be selected
+  - Added support for confidence intervals
 - Fixes
   - Introduced a `componentId` concept which makes the dimensions and measures
     unique by adding an unversioned cube iri to the unversioned component iri on
@@ -30,6 +31,7 @@ You can also check the
   - Map legend is now correctly updated (in some cases it was rendered
     incorrectly on the initial render)
   - Vertical Axis measure names are now correctly displayed in the left panel
+  - Uncertainties are now correctly displayed in map symbol layer tooltip
 - Performance
   - We no longer load non-key dimensions when initializing a chart
 - Maintenance

--- a/app/charts/chart-config-ui-options.ts
+++ b/app/charts/chart-config-ui-options.ts
@@ -112,6 +112,9 @@ type EncodingOption<T extends ChartConfig = ChartConfig> =
       field: "showStandardError";
     }
   | {
+      field: "showConfidenceInterval";
+    }
+  | {
       field: "sorting";
     }
   | {
@@ -643,6 +646,7 @@ const chartConfigOptionsUISpec: ChartSpecs = {
         },
         options: {
           showStandardError: {},
+          showConfidenceInterval: {},
         },
       },
       {
@@ -776,6 +780,7 @@ const chartConfigOptionsUISpec: ChartSpecs = {
         filters: false,
         options: {
           showStandardError: {},
+          showConfidenceInterval: {},
         },
       },
       {

--- a/app/charts/column/columns-grouped-state-props.ts
+++ b/app/charts/column/columns-grouped-state-props.ts
@@ -62,7 +62,7 @@ export const useColumnsGroupedStateVariables = (
     measuresById,
   });
   const numericalYErrorVariables = useNumericalYErrorVariables(y, {
-    numericalYVariables,
+    getValue: numericalYVariables.getY,
     dimensions,
     measures,
   });

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -84,10 +84,8 @@ const useColumnsGroupedState = (
     yMeasure,
     getY,
     getMinY,
-    showYStandardError,
-    yErrorMeasure,
-    getYError,
     getYErrorRange,
+    getFormattedYUncertainty,
     segmentDimension,
     segmentsByAbbreviationOrLabel,
     getSegment,
@@ -398,14 +396,6 @@ const useColumnsGroupedState = (
           topAnchor: !fields.segment,
         });
 
-    const getError = (d: Observation) => {
-      if (!showYStandardError || !getYError || getYError(d) == null) {
-        return;
-      }
-
-      return `${getYError(d)}${yErrorMeasure?.unit ?? ""}`;
-    };
-
     return {
       xAnchor: xAnchorRaw + (placement.x === "right" ? 0.5 : -0.5) * bw,
       yAnchor,
@@ -414,7 +404,7 @@ const useColumnsGroupedState = (
       datum: {
         label: fields.segment && getSegmentAbbreviationOrLabel(datum),
         value: yValueFormatter(getY(datum)),
-        error: getError(datum),
+        error: getFormattedYUncertainty(datum),
         color: colors(getSegment(datum)) as string,
       },
       values: sortedTooltipValues.map((td) => ({
@@ -422,7 +412,7 @@ const useColumnsGroupedState = (
         value: yMeasure.unit
           ? `${formatNumber(getY(td))} ${yMeasure.unit}`
           : formatNumber(getY(td)),
-        error: getError(td),
+        error: getFormattedYUncertainty(td),
         color: colors(getSegment(td)) as string,
       })),
     };

--- a/app/charts/column/columns-grouped.tsx
+++ b/app/charts/column/columns-grouped.tsx
@@ -8,7 +8,6 @@ import {
 import { useChartState } from "@/charts/shared/chart-state";
 import {
   RenderWhiskerDatum,
-  filterWithoutErrors,
   renderContainer,
   renderWhiskers,
 } from "@/charts/shared/rendering-utils";
@@ -20,24 +19,24 @@ export const ErrorWhiskers = () => {
     xScale,
     xScaleIn,
     getYErrorRange,
-    getYError,
+    getYErrorPresent,
     yScale,
     getSegment,
     grouped,
-    showYStandardError,
+    showYUncertainty,
   } = useChartState() as GroupedColumnsState;
   const { margins, width, height } = bounds;
   const ref = useRef<SVGGElement>(null);
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
   const renderData: RenderWhiskerDatum[] = useMemo(() => {
-    if (!getYErrorRange || !showYStandardError) {
+    if (!getYErrorRange || !showYUncertainty) {
       return [];
     }
 
     const bandwidth = xScaleIn.bandwidth();
     return grouped
-      .filter((d) => d[1].some(filterWithoutErrors(getYError)))
+      .filter((d) => d[1].some(getYErrorPresent))
       .flatMap(([segment, observations]) =>
         observations.map((d) => {
           const x0 = xScaleIn(getSegment(d)) as number;
@@ -56,9 +55,9 @@ export const ErrorWhiskers = () => {
   }, [
     getSegment,
     getYErrorRange,
-    getYError,
+    getYErrorPresent,
     grouped,
-    showYStandardError,
+    showYUncertainty,
     xScale,
     xScaleIn,
     yScale,

--- a/app/charts/column/columns-state-props.ts
+++ b/app/charts/column/columns-state-props.ts
@@ -57,7 +57,7 @@ export const useColumnsStateVariables = (
     measuresById,
   });
   const numericalYErrorVariables = useNumericalYErrorVariables(y, {
-    numericalYVariables,
+    getValue: numericalYVariables.getY,
     dimensions,
     measures,
   });

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -75,10 +75,8 @@ const useColumnsState = (
     yMeasure,
     getY,
     getMinY,
-    showYStandardError,
-    yErrorMeasure,
-    getYError,
     getYErrorRange,
+    getFormattedYUncertainty,
   } = variables;
   const { chartData, scalesData, timeRangeData, paddingData, allData } = data;
   const { fields, interactiveFiltersConfig } = chartConfig;
@@ -245,15 +243,6 @@ const useColumnsState = (
         formatters[yMeasure.id] ?? formatNumber,
         yMeasure.unit
       );
-
-    const getError = (d: Observation) => {
-      if (!showYStandardError || !getYError || getYError(d) === null) {
-        return;
-      }
-
-      return `${getYError(d)}${yErrorMeasure?.unit ?? ""}`;
-    };
-
     const y = getY(d);
 
     return {
@@ -264,7 +253,7 @@ const useColumnsState = (
       datum: {
         label: undefined,
         value: y !== null && isNaN(y) ? "-" : `${yValueFormatter(getY(d))}`,
-        error: getError(d),
+        error: getFormattedYUncertainty(d),
         color: "",
       },
       values: undefined,

--- a/app/charts/column/columns.tsx
+++ b/app/charts/column/columns.tsx
@@ -9,7 +9,6 @@ import {
 import { useChartState } from "@/charts/shared/chart-state";
 import {
   RenderWhiskerDatum,
-  filterWithoutErrors,
   renderContainer,
   renderWhiskers,
 } from "@/charts/shared/rendering-utils";
@@ -19,12 +18,12 @@ import { useTheme } from "@/themes";
 export const ErrorWhiskers = () => {
   const {
     getX,
-    getYError,
+    getYErrorPresent,
     getYErrorRange,
     chartData,
     yScale,
     xScale,
-    showYStandardError,
+    showYUncertainty,
     bounds,
   } = useChartState() as ColumnsState;
   const { margins, width, height } = bounds;
@@ -32,12 +31,12 @@ export const ErrorWhiskers = () => {
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
   const renderData: RenderWhiskerDatum[] = useMemo(() => {
-    if (!getYErrorRange || !showYStandardError) {
+    if (!getYErrorRange || !showYUncertainty) {
       return [];
     }
 
     const bandwidth = xScale.bandwidth();
-    return chartData.filter(filterWithoutErrors(getYError)).map((d, i) => {
+    return chartData.filter(getYErrorPresent).map((d, i) => {
       const x0 = xScale(getX(d)) as number;
       const barWidth = Math.min(bandwidth, 15);
       const [y1, y2] = getYErrorRange(d);
@@ -53,9 +52,9 @@ export const ErrorWhiskers = () => {
   }, [
     chartData,
     getX,
-    getYError,
+    getYErrorPresent,
     getYErrorRange,
-    showYStandardError,
+    showYUncertainty,
     xScale,
     yScale,
     width,

--- a/app/charts/line/lines-state-props.ts
+++ b/app/charts/line/lines-state-props.ts
@@ -53,7 +53,7 @@ export const useLinesStateVariables = (
     measuresById,
   });
   const numericalYErrorVariables = useNumericalYErrorVariables(y, {
-    numericalYVariables,
+    getValue: numericalYVariables.getY,
     dimensions,
     measures,
   });

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -80,10 +80,8 @@ const useLinesState = (
     getXAsString,
     yMeasure,
     getY,
-    showYStandardError,
-    getYError,
     getYErrorRange,
-    yErrorMeasure,
+    getFormattedYUncertainty,
     getMinY,
     segmentDimension,
     segmentsByAbbreviationOrLabel,
@@ -279,14 +277,6 @@ const useLinesState = (
         yMeasure.unit
       );
 
-    const getError = (d: Observation) => {
-      if (!showYStandardError || !getYError || getYError(d) === null) {
-        return;
-      }
-
-      return `${getYError(d)}${yErrorMeasure?.unit ?? ""}`;
-    };
-
     return {
       xAnchor,
       yAnchor,
@@ -295,7 +285,7 @@ const useLinesState = (
       datum: {
         label: fields.segment && getSegmentAbbreviationOrLabel(datum),
         value: yValueFormatter(getY(datum)),
-        error: getError(datum),
+        error: getFormattedYUncertainty(datum),
         color: colors(getSegment(datum)) as string,
       },
       values: sortedTooltipValues.map((td) => ({

--- a/app/charts/line/lines.tsx
+++ b/app/charts/line/lines.tsx
@@ -5,7 +5,6 @@ import { LinesState } from "@/charts/line/lines-state";
 import { useChartState } from "@/charts/shared/chart-state";
 import {
   RenderWhiskerDatum,
-  filterWithoutErrors,
   renderContainer,
   renderWhiskers,
 } from "@/charts/shared/rendering-utils";
@@ -15,12 +14,12 @@ import { useTransitionStore } from "@/stores/transition";
 export const ErrorWhiskers = () => {
   const {
     getX,
-    getYError,
+    getYErrorPresent,
     getYErrorRange,
     chartData,
     yScale,
     xScale,
-    showYStandardError,
+    showYUncertainty,
     colors,
     getSegment,
     bounds,
@@ -30,11 +29,11 @@ export const ErrorWhiskers = () => {
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
   const renderData: RenderWhiskerDatum[] = useMemo(() => {
-    if (!getYErrorRange || !showYStandardError) {
+    if (!getYErrorRange || !showYUncertainty) {
       return [];
     }
 
-    return chartData.filter(filterWithoutErrors(getYError)).map((d, i) => {
+    return chartData.filter(getYErrorPresent).map((d, i) => {
       const x0 = xScale(getX(d)) as number;
       const segment = getSegment(d);
       const barWidth = 15;
@@ -54,9 +53,9 @@ export const ErrorWhiskers = () => {
     colors,
     getSegment,
     getX,
-    getYError,
+    getYErrorPresent,
     getYErrorRange,
-    showYStandardError,
+    showYUncertainty,
     xScale,
     yScale,
   ]);

--- a/app/charts/line/lines.tsx
+++ b/app/charts/line/lines.tsx
@@ -14,6 +14,7 @@ import { useTransitionStore } from "@/stores/transition";
 export const ErrorWhiskers = () => {
   const {
     getX,
+    getY,
     getYErrorPresent,
     getYErrorRange,
     chartData,
@@ -37,10 +38,12 @@ export const ErrorWhiskers = () => {
       const x0 = xScale(getX(d)) as number;
       const segment = getSegment(d);
       const barWidth = 15;
+      const y = getY(d) as number;
       const [y1, y2] = getYErrorRange(d);
       return {
         key: `${i}`,
         x: x0 - barWidth / 2,
+        y: yScale(y),
         y1: yScale(y1),
         y2: yScale(y2),
         width: barWidth,
@@ -53,6 +56,7 @@ export const ErrorWhiskers = () => {
     colors,
     getSegment,
     getX,
+    getY,
     getYErrorPresent,
     getYErrorRange,
     showYUncertainty,

--- a/app/charts/map/map-state.tsx
+++ b/app/charts/map/map-state.tsx
@@ -20,7 +20,7 @@ import {
 } from "geojson";
 import keyBy from "lodash/keyBy";
 import mapValues from "lodash/mapValues";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { ckmeans } from "simple-statistics";
 
 import { ChartMapProps } from "@/charts/map/chart-map";
@@ -36,35 +36,29 @@ import {
   useOptionalNumericVariable,
   useStringVariable,
 } from "@/charts/shared/chart-helpers";
-import { ChartContext, CommonChartState } from "@/charts/shared/chart-state";
+import {
+  ChartContext,
+  CommonChartState,
+  useNumericalYErrorVariables,
+} from "@/charts/shared/chart-state";
 import { colorToRgbArray } from "@/charts/shared/colors";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useSize } from "@/charts/shared/use-size";
 import {
   BBox,
-  CategoricalColorField,
   ColorScaleInterpolationType,
-  FixedColorField,
   MapSymbolLayer,
   NumericalColorField,
 } from "@/config-types";
-import {
-  getErrorMeasure,
-  useErrorMeasure,
-  useErrorVariable,
-} from "@/configurator/components/ui-helpers";
 import {
   Component,
   Dimension,
   GeoData,
   Measure,
   Observation,
-  ObservationValue,
-  findRelatedErrorDimension,
   isGeoShapesDimension,
 } from "@/domain/data";
 import { truthy } from "@/domain/types";
-import { formatNumberWithUnit, useFormatNumber } from "@/formatters";
 import { getColorInterpolator } from "@/palettes";
 
 export type MapState = CommonChartState &
@@ -92,8 +86,7 @@ export type MapState = CommonChartState &
           measureLabel: string;
           getLabel: (d: Observation) => string;
           getValue: (d: Observation) => number | null;
-          errorDimension?: Component;
-          getFormattedError: null | ((d: Observation) => string);
+          getFormattedError: null | ((d: Observation) => string | undefined);
           radiusScale: ScalePower<number, number>;
           colors: SymbolLayerColors;
         }
@@ -129,7 +122,7 @@ const useMapState = (
 
   const preparedAreaLayerState: MapState["areaLayer"] = useMemo(() => {
     if (areaLayer?.componentId === undefined) {
-      return undefined;
+      return;
     }
 
     return {
@@ -157,7 +150,7 @@ const useMapState = (
   });
 
   const radiusScale = useMemo(() => {
-    // Measure dimension is undefined. Can be useful when the user want to
+    // Measure dimension is undefined. Can be useful when the user wants to
     // encode only the color of symbols, and the size is irrelevant.
     if (symbolLayerState.dataDomain[1] === undefined) {
       return scaleSqrt().range([0, 12]).unknown(12);
@@ -170,7 +163,7 @@ const useMapState = (
 
   const preparedSymbolLayerState: MapState["symbolLayer"] = useMemo(() => {
     if (symbolLayer?.componentId === undefined) {
-      return undefined;
+      return;
     }
 
     return {
@@ -205,12 +198,12 @@ const useMapState = (
       areaLayer?.componentId !== undefined
         ? filterFeatureCollection(
             features.areaLayer?.shapes,
-            (f) => f?.properties?.observation !== undefined
+            (f) => !!f?.properties?.observation
           )
         : undefined,
       symbolLayer?.componentId !== undefined
         ? features.symbolLayer?.points.filter(
-            (p) => p?.properties?.observation !== undefined
+            (p) => !!p?.properties?.observation
           )
         : undefined
     );
@@ -317,113 +310,148 @@ const getNumericalColorScale = ({
   }
 };
 
-const getFixedColors = (color: FixedColorField) => {
-  const c = colorToRgbArray(color.value, color.opacity * 2.55);
-  return { type: "fixed" as const, getColor: (_: Observation) => c };
+const useFixedColors = (colorSpec: MapSymbolLayer["color"] | undefined) => {
+  return useMemo(() => {
+    if (colorSpec?.type !== "fixed") {
+      return;
+    }
+
+    const color = colorToRgbArray(colorSpec.value, colorSpec.opacity * 2.55);
+
+    return {
+      type: "fixed" as const,
+      getColor: () => color,
+    };
+  }, [colorSpec]);
 };
 
-const getCategoricalColors = (
-  color: CategoricalColorField,
-  dimensions: Dimension[],
-  measures: Measure[]
+const useCategoricalColors = (
+  colorSpec: MapSymbolLayer["color"] | undefined,
+  {
+    dimensions,
+    measures,
+  }: {
+    dimensions: Dimension[];
+    measures: Measure[];
+  }
 ) => {
-  const component = [...dimensions, ...measures].find(
-    (d) => d.id === color.componentId
-  ) as Component;
-  const valuesByLabel = keyBy(component.values, (d) => d.label);
-  const valuesByAbbreviationOrLabel = keyBy(
-    component.values,
-    color.useAbbreviations ? (d) => d.alternateName ?? d.label : (d) => d.label
-  );
-  const domain: string[] = component.values.map((d) => `${d.value}`) || [];
-  const rgbColorMapping = mapValues(color.colorMapping, (c) =>
-    colorToRgbArray(c, color.opacity * 2.55)
-  );
-  const getDimensionValue = (d: Observation) => {
-    const abbreviationOrLabel = d[color.componentId] as string;
+  return useMemo(() => {
+    if (colorSpec?.type !== "categorical") {
+      return;
+    }
 
-    return (
-      valuesByAbbreviationOrLabel[abbreviationOrLabel] ??
-      valuesByLabel[abbreviationOrLabel]
+    const component = [...dimensions, ...measures].find(
+      (d) => d.id === colorSpec.componentId
+    ) as Component;
+    const valuesByLabel = keyBy(component.values, (d) => d.label);
+    const valuesByAbbreviationOrLabel = keyBy(
+      component.values,
+      colorSpec.useAbbreviations
+        ? (d) => d.alternateName ?? d.label
+        : (d) => d.label
     );
-  };
+    const domain = component.values.map((d) => `${d.value}`) ?? [];
+    const rgbColorMapping = mapValues(colorSpec.colorMapping, (c) =>
+      colorToRgbArray(c, colorSpec.opacity * 2.55)
+    );
+    const getDimensionValue = (d: Observation) => {
+      const abbreviationOrLabel = d[colorSpec.componentId] as string;
 
-  return {
-    type: "categorical" as const,
-    palette: color.palette,
-    component,
-    domain,
-    getValue: color.useAbbreviations
-      ? (d: Observation) => {
-          const v = getDimensionValue(d);
+      return (
+        valuesByAbbreviationOrLabel[abbreviationOrLabel] ??
+        valuesByLabel[abbreviationOrLabel]
+      );
+    };
 
-          return v.alternateName || v.label;
-        }
-      : (d: Observation) => {
-          return getDimensionValue(d).label;
-        },
-    getColor: (d: Observation) => {
-      const value = getDimensionValue(d);
-      return rgbColorMapping[value.value];
-    },
-    useAbbreviations: color.useAbbreviations ?? false,
-  };
+    return {
+      type: "categorical" as const,
+      palette: colorSpec.palette,
+      component,
+      domain,
+      getValue: colorSpec.useAbbreviations
+        ? (d: Observation) => {
+            const v = getDimensionValue(d);
+            return v.alternateName || v.label;
+          }
+        : (d: Observation) => {
+            return getDimensionValue(d).label;
+          },
+      getColor: (d: Observation) => {
+        const value = getDimensionValue(d);
+        return rgbColorMapping[value.value];
+      },
+      useAbbreviations: colorSpec.useAbbreviations ?? false,
+    };
+  }, [colorSpec, dimensions, measures]);
 };
 
-const getNumericalColors = (
-  color: NumericalColorField,
-  data: Observation[],
-  dimensions: Dimension[],
-  measures: Measure[],
-  { formatNumber }: { formatNumber: ReturnType<typeof useFormatNumber> }
-) => {
-  const component = measures.find((d) => d.id === color.componentId) as Measure;
-  const domain = extent(
-    data.map((d) => d[color.componentId]),
-    (d) => +d!
-  ) as [number, number];
-  const getValue = (d: Observation) =>
-    d[color.componentId] !== null ? Number(d[color.componentId]) : null;
-  const colorScale = getNumericalColorScale({
-    color,
-    getValue,
+const useNumericalColors = (
+  colorSpec: MapSymbolLayer["color"] | undefined,
+  {
     data,
-    dataDomain: domain,
-  });
-  const errorDimension = findRelatedErrorDimension(
-    color.componentId,
-    dimensions
+    dimensions,
+    measures,
+  }: {
+    data: Observation[];
+    dimensions: Dimension[];
+    measures: Measure[];
+  }
+) => {
+  const componentId =
+    colorSpec?.type === "numerical" ? colorSpec.componentId : "";
+  const getValue = useCallback(
+    (d: Observation) =>
+      componentId
+        ? d[componentId] !== null
+          ? Number(d[componentId])
+          : null
+        : null,
+    [componentId]
   );
-  const errorMeasure = getErrorMeasure(
-    { dimensions, measures },
-    color.componentId
-  );
-  const getError = errorMeasure ? (d: Observation) => d[errorMeasure.id] : null;
-  const getFormattedError = makeErrorFormatter(
-    getError,
-    formatNumber,
-    errorDimension?.unit
+  const { getFormattedYUncertainty } = useNumericalYErrorVariables(
+    { componentId },
+    { getValue, dimensions, measures }
   );
 
-  return {
-    type: "continuous" as const,
-    palette: color.palette,
-    component,
-    scale: colorScale,
-    interpolationType: color.interpolationType,
-    getValue,
-    getColor: (d: Observation) => {
-      const c = colorScale(+d[color.componentId]!);
+  return useMemo(() => {
+    if (colorSpec?.type !== "numerical") {
+      return;
+    }
 
-      if (c) {
-        return colorToRgbArray(c, color.opacity * 2.55);
-      }
+    const component = measures.find(
+      (d) => d.id === colorSpec.componentId
+    ) as Measure;
+    const domain = extent(
+      data.map((d) => d[colorSpec.componentId]),
+      (d) => +d!
+    ) as [number, number];
+    const colorScale = getNumericalColorScale({
+      color: colorSpec,
+      getValue,
+      data,
+      dataDomain: domain,
+    });
 
-      return [0, 0, 0, 255 * 0.1];
-    },
-    getFormattedError,
-    domain,
-  };
+    return {
+      type: "continuous" as const,
+      palette: colorSpec.palette,
+      component,
+      scale: colorScale,
+      interpolationType: colorSpec.interpolationType,
+      getValue,
+      getColor: (d: Observation) => {
+        const c = colorScale(+d[colorSpec.componentId]!);
+
+        if (c) {
+          return colorToRgbArray(c, colorSpec.opacity * 2.55);
+        }
+
+        return [0, 0, 0, 255 * 0.1];
+      },
+      getFormattedError: getFormattedYUncertainty,
+      domain,
+    };
+  }, [colorSpec, data, getFormattedYUncertainty, getValue, measures]);
 };
 
 const useColors = ({
@@ -437,38 +465,31 @@ const useColors = ({
   dimensions: Dimension[];
   measures: Measure[];
 }) => {
-  const formatNumber = useFormatNumber();
+  const fixedColors = useFixedColors(color);
+  const categoricalColors = useCategoricalColors(color, {
+    dimensions,
+    measures,
+  });
+  const numericalColors = useNumericalColors(color, {
+    data,
+    dimensions,
+    measures,
+  });
 
-  return useMemo(() => {
-    if (!color) {
-      return undefined;
-    }
+  if (!color) {
+    return undefined;
+  }
 
-    switch (color.type) {
-      case "fixed":
-        return getFixedColors(color);
-      case "categorical":
-        return getCategoricalColors(color, dimensions, measures);
-      case "numerical":
-        return getNumericalColors(color, data, dimensions, measures, {
-          formatNumber,
-        });
-    }
-  }, [color, data, dimensions, measures, formatNumber]);
-};
-
-const makeErrorFormatter = (
-  getter: ((d: Observation) => ObservationValue) | null,
-  formatter: (n: number) => string,
-  unit?: string | null
-) => {
-  if (!getter) {
-    return null;
-  } else {
-    return (d: Observation) => {
-      const error = getter(d);
-      return formatNumberWithUnit(error as number, formatter, unit);
-    };
+  switch (color.type) {
+    case "fixed":
+      return fixedColors;
+    case "categorical":
+      return categoricalColors;
+    case "numerical":
+      return numericalColors;
+    default:
+      const _exhaustiveCheck: never = color;
+      return _exhaustiveCheck;
   }
 };
 
@@ -528,24 +549,15 @@ const useLayerState = ({
   dimensions: Dimension[];
   measures: Measure[];
 }) => {
-  const formatNumber = useFormatNumber();
-
   const getLabel = useStringVariable(componentId);
   const getValue = useOptionalNumericVariable(measureId);
-
   const measureDimension = measures.find((d) => d.id === measureId);
 
-  const errorDimension = findRelatedErrorDimension(measureId, dimensions);
-  const errorMeasure = useErrorMeasure(measureId, {
-    dimensions,
-    measures,
-  });
-  const getError = useErrorVariable(errorMeasure);
-  const getFormattedError = makeErrorFormatter(
-    getError,
-    formatNumber,
-    errorDimension?.unit
-  );
+  const { showYUncertainty, getFormattedYUncertainty } =
+    useNumericalYErrorVariables(
+      { componentId: measureId },
+      { getValue, dimensions, measures }
+    );
 
   const preparedData = usePreparedData({
     geoDimensionId: componentId,
@@ -568,8 +580,7 @@ const useLayerState = ({
     measureLabel: measureDimension?.label || "",
     getLabel,
     getValue,
-    errorDimension,
-    getFormattedError,
+    getFormattedError: showYUncertainty ? getFormattedYUncertainty : null,
   };
 };
 

--- a/app/charts/map/map-tooltip.tsx
+++ b/app/charts/map/map-tooltip.tsx
@@ -264,7 +264,7 @@ export const MapTooltip = () => {
                             color: "#000",
                           })}
                       value={symbolTooltipState.value}
-                      error={symbolTooltipState.colors.error}
+                      error={symbolTooltipState.error}
                     />
                   )}
 

--- a/app/charts/map/map-tooltip.tsx
+++ b/app/charts/map/map-tooltip.tsx
@@ -53,7 +53,7 @@ export const MapTooltip = () => {
     useChartState() as MapState;
   const formatNumber = useFormatNumber();
 
-  const { getFormattedError: formatSymbolError } = symbolLayer || {};
+  const { getFormattedError: formatSymbolError } = symbolLayer ?? {};
   const formatters = useChartFormatters({
     dimensions: [
       areaLayer?.colors.type === "continuous"
@@ -75,10 +75,8 @@ export const MapTooltip = () => {
       const { colors } = areaLayer;
       const value = colors.getValue(obs);
       if (value !== null) {
-        const error =
-          colors.type === "continuous" && colors.getFormattedError
-            ? ` ± ${colors.getFormattedError(obs)}`
-            : null;
+        const formattedError =
+          colors.type === "continuous" ? colors.getFormattedError?.(obs) : null;
         const show = identicalLayerComponentIds || hoverObjectType === "area";
         const color = rgbArrayToHex(colors.getColor(obs));
         const textColor = getTooltipTextColor(color);
@@ -94,7 +92,7 @@ export const MapTooltip = () => {
         return {
           show,
           value: formattedValue,
-          error,
+          error: formattedError,
           componentId: colors.component.id,
           label: colors.component.label,
           color,
@@ -113,11 +111,13 @@ export const MapTooltip = () => {
 
   const symbolTooltipState = useMemo(() => {
     const obs = interaction.d;
+
     if (symbolLayer && obs) {
       const { colors } = symbolLayer;
       const value = symbolLayer.getValue(obs);
+
       if (value !== null) {
-        const error = formatSymbolError ? ` ± ${formatSymbolError(obs)}` : null;
+        const formattedError = formatSymbolError?.(obs);
         const show = identicalLayerComponentIds || hoverObjectType === "symbol";
         const color = rgbArrayToHex(colors.getColor(obs));
         const textColor = getTooltipTextColor(color);
@@ -153,7 +153,7 @@ export const MapTooltip = () => {
           };
         } else {
           const rawValue = obs[colors.component.id] as number;
-          const rawError = colors.getFormattedError?.(obs);
+          const formattedError = colors.getFormattedError?.(obs);
           preparedColors = {
             type: "continuous",
             component: colors.component,
@@ -162,7 +162,7 @@ export const MapTooltip = () => {
               formatNumber,
               colors.component.unit
             ),
-            error: rawError ? ` ± ${rawError}` : null,
+            error: formattedError,
             color,
             textColor,
             sameAsValue:
@@ -172,7 +172,7 @@ export const MapTooltip = () => {
 
         return {
           value: formattedValue,
-          error,
+          error: formattedError,
           measureDimension: symbolLayer.measureDimension,
           show,
           color,
@@ -287,17 +287,21 @@ export const MapTooltip = () => {
   );
 };
 
-type TooltipRowProps = {
+const TooltipRow = ({
+  title,
+  background,
+  color,
+  value,
+  error,
+  border = "none",
+}: {
   title: string;
   background: string;
   color: string;
   value: string;
-  error: string | null;
+  error?: string | null;
   border?: string;
-};
-
-const TooltipRow = (props: TooltipRowProps) => {
-  const { title, background, color, value, error, border = "none" } = props;
+}) => {
   return (
     <>
       <Typography component="div" variant="caption">

--- a/app/charts/shared/chart-state.ts
+++ b/app/charts/shared/chart-state.ts
@@ -350,11 +350,11 @@ export type NumericalYErrorVariables = {
 export const useNumericalYErrorVariables = (
   y: GenericField,
   {
-    numericalYVariables,
+    getValue,
     dimensions,
     measures,
   }: {
-    numericalYVariables: NumericalYVariables;
+    getValue: NumericalYVariables["getY"];
     dimensions: Dimension[];
     measures: Measure[];
   }
@@ -409,7 +409,7 @@ export const useNumericalYErrorVariables = (
     showYStandardError && yStandardErrorMeasure
       ? yStandardErrorMeasure
       : yConfidenceIntervalLowerMeasure,
-    numericalYVariables.getY
+    getValue
   );
   const getFormattedYUncertainty = useCallback(
     (d: Observation) => {

--- a/app/charts/shared/chart-state.ts
+++ b/app/charts/shared/chart-state.ts
@@ -42,7 +42,6 @@ import {
   useErrorVariable,
 } from "@/configurator/components/ui-helpers";
 import {
-  Component,
   Dimension,
   DimensionValue,
   GeoCoordinatesDimension,
@@ -50,7 +49,6 @@ import {
   Measure,
   NumericalMeasure,
   Observation,
-  ObservationValue,
   TemporalDimension,
   TemporalEntityDimension,
   isNumericalMeasure,
@@ -58,6 +56,7 @@ import {
   isTemporalEntityDimension,
 } from "@/domain/data";
 import { Has } from "@/domain/types";
+import { RelatedDimensionType } from "@/graphql/query-hooks";
 import { ScaleType, TimeUnit } from "@/graphql/resolver-types";
 import {
   useChartInteractiveFilters,
@@ -342,10 +341,10 @@ export const useNumericalYVariables = (
 };
 
 export type NumericalYErrorVariables = {
-  showYStandardError: boolean;
-  yErrorMeasure: Component | undefined;
-  getYError: ((d: Observation) => ObservationValue) | null;
+  showYUncertainty: boolean;
+  getYErrorPresent: (d: Observation) => boolean;
   getYErrorRange: null | ((d: Observation) => [number, number]);
+  getFormattedYUncertainty: (d: Observation) => string | undefined;
 };
 
 export const useNumericalYErrorVariables = (
@@ -361,18 +360,102 @@ export const useNumericalYErrorVariables = (
   }
 ): NumericalYErrorVariables => {
   const showYStandardError = get(y, ["showStandardError"], true);
-  const yErrorMeasure = useErrorMeasure(y.componentId, {
+  const yStandardErrorMeasure = useErrorMeasure(y.componentId, {
     dimensions,
     measures,
+    type: RelatedDimensionType.StandardError,
   });
-  const getYErrorRange = useErrorRange(yErrorMeasure, numericalYVariables.getY);
-  const getYError = useErrorVariable(yErrorMeasure);
+  const getYStandardError = useErrorVariable(yStandardErrorMeasure);
+
+  const showYConfidenceInterval = get(y, ["showConfidenceInterval"], true);
+  const yConfidenceIntervalUpperMeasure = useErrorMeasure(y.componentId, {
+    dimensions,
+    measures,
+    type: RelatedDimensionType.ConfidenceUpperBound,
+  });
+  const getYConfidenceIntervalUpper = useErrorVariable(
+    yConfidenceIntervalUpperMeasure
+  );
+  const yConfidenceIntervalLowerMeasure = useErrorMeasure(y.componentId, {
+    dimensions,
+    measures,
+    type: RelatedDimensionType.ConfidenceLowerBound,
+  });
+  const getYConfidenceIntervalLower = useErrorVariable(
+    yConfidenceIntervalLowerMeasure
+  );
+
+  const getYErrorPresent = useCallback(
+    (d: Observation) => {
+      return (
+        (showYStandardError && getYStandardError?.(d) !== null) ||
+        (showYConfidenceInterval &&
+          getYConfidenceIntervalUpper?.(d) !== null &&
+          getYConfidenceIntervalLower?.(d) !== null)
+      );
+    },
+    [
+      showYStandardError,
+      getYStandardError,
+      showYConfidenceInterval,
+      getYConfidenceIntervalUpper,
+      getYConfidenceIntervalLower,
+    ]
+  );
+  const getYErrorRange = useErrorRange(
+    showYStandardError && yStandardErrorMeasure
+      ? yStandardErrorMeasure
+      : yConfidenceIntervalUpperMeasure,
+    showYStandardError && yStandardErrorMeasure
+      ? yStandardErrorMeasure
+      : yConfidenceIntervalLowerMeasure,
+    numericalYVariables.getY
+  );
+  const getFormattedYUncertainty = useCallback(
+    (d: Observation) => {
+      if (
+        showYStandardError &&
+        getYStandardError &&
+        getYStandardError(d) !== null
+      ) {
+        const sd = getYStandardError(d);
+        const unit = yStandardErrorMeasure?.unit ?? "";
+        return ` ± ${sd}${unit}`;
+      }
+
+      if (
+        showYConfidenceInterval &&
+        getYConfidenceIntervalUpper &&
+        getYConfidenceIntervalLower &&
+        getYConfidenceIntervalUpper(d) !== null &&
+        getYConfidenceIntervalLower(d) !== null
+      ) {
+        const cil = getYConfidenceIntervalLower(d);
+        const ciu = getYConfidenceIntervalUpper(d);
+        const unit = yConfidenceIntervalUpperMeasure?.unit ?? "";
+        return ` -${cil}${unit}, +${ciu}${unit}`;
+      }
+    },
+    [
+      showYStandardError,
+      getYStandardError,
+      showYConfidenceInterval,
+      getYConfidenceIntervalUpper,
+      getYConfidenceIntervalLower,
+      yStandardErrorMeasure?.unit,
+      yConfidenceIntervalUpperMeasure?.unit,
+    ]
+  );
 
   return {
-    showYStandardError,
-    yErrorMeasure,
-    getYError,
+    showYUncertainty:
+      (showYStandardError && !!yStandardErrorMeasure) ||
+      (showYConfidenceInterval &&
+        !!yConfidenceIntervalUpperMeasure &&
+        !!yConfidenceIntervalLowerMeasure),
+    getYErrorPresent,
     getYErrorRange,
+    getFormattedYUncertainty,
   };
 };
 

--- a/app/charts/shared/interaction/tooltip-content.tsx
+++ b/app/charts/shared/interaction/tooltip-content.tsx
@@ -34,7 +34,7 @@ export const TooltipSingle = ({
       {yValue && (
         <Typography component="div" variant="caption">
           {yValue}
-          {yError ? <> ± {yError}</> : null}
+          {yError ?? null}
         </Typography>
       )}
     </Box>
@@ -62,7 +62,7 @@ export const TooltipMultiple = ({
       {segmentValues.map((d, i) => (
         <LegendItem
           key={i}
-          item={`${d.label}: ${d.value}${d.error ? ` ± ${d.error}` : ""}`}
+          item={`${d.label}: ${d.value}${d.error ?? ""}`}
           color={d.color}
           symbol={d.symbol ?? "square"}
           usage="tooltip"

--- a/app/charts/shared/rendering-utils.ts
+++ b/app/charts/shared/rendering-utils.ts
@@ -11,7 +11,6 @@ import {
   Component,
   isStandardErrorDimension,
   Observation,
-  ObservationValue,
 } from "@/domain/data";
 import { TransitionStore } from "@/stores/transition";
 
@@ -273,10 +272,4 @@ export const renderWhiskers = (
           s: (g) => g.attr("opacity", 0).remove(),
         })
     );
-};
-
-export const filterWithoutErrors = (
-  getError: ((d: Observation) => ObservationValue) | null
-) => {
-  return (d: Observation): boolean => !!getError?.(d);
 };

--- a/app/charts/shared/rendering-utils.ts
+++ b/app/charts/shared/rendering-utils.ts
@@ -155,6 +155,7 @@ const ERROR_WHISKER_MIDDLE_CIRCLE_RADIUS = 3.5;
 export type RenderWhiskerDatum = {
   key: string;
   x: number;
+  y: number;
   y1: number;
   y2: number;
   width: number;
@@ -215,7 +216,7 @@ export const renderWhiskers = (
               .append("circle")
               .attr("class", "middle-circle")
               .attr("cx", (d) => d.x + d.width / 2)
-              .attr("cy", (d) => (d.y1 + d.y2) / 2)
+              .attr("cy", (d) => d.y)
               .attr("r", ERROR_WHISKER_MIDDLE_CIRCLE_RADIUS)
               .attr("fill", (d) => d.fill ?? "black")
               .attr("stroke", "none")
@@ -259,7 +260,7 @@ export const renderWhiskers = (
                 g
                   .select(".middle-circle")
                   .attr("cx", (d) => d.x + d.width / 2)
-                  .attr("cy", (d) => (d.y1 + d.y2) / 2)
+                  .attr("cy", (d) => d.y)
                   .attr("r", ERROR_WHISKER_MIDDLE_CIRCLE_RADIUS)
                   .attr("fill", (d) => d.fill ?? "black")
                   .attr("stroke", "none")

--- a/app/components/data-download.tsx
+++ b/app/components/data-download.tsx
@@ -461,6 +461,8 @@ const getDimensionParsers = (
           return [d.id, (d) => d];
         case "NumericalMeasure":
         case "StandardErrorDimension":
+        case "ConfidenceUpperBoundDimension":
+        case "ConfidenceLowerBoundDimension":
           return [d.id, (d) => +d];
         case "OrdinalMeasure":
           return d.isNumerical ? [d.id, (d) => +d] : [d.id, (d) => d];

--- a/app/components/metadata-panel.tsx
+++ b/app/components/metadata-panel.tsx
@@ -59,6 +59,8 @@ import {
 import {
   Component,
   DimensionValue,
+  isConfidenceLowerBoundDimension,
+  isConfidenceUpperBoundDimension,
   isJoinByComponent,
   isStandardErrorDimension,
   TemporalDimension,
@@ -862,7 +864,11 @@ const ComponentValues = ({ component }: { component: Component }) => {
     ) as DimensionValue[];
   }, [component]);
 
-  if (isStandardErrorDimension(component)) {
+  if (
+    isStandardErrorDimension(component) ||
+    isConfidenceUpperBoundDimension(component) ||
+    isConfidenceLowerBoundDimension(component)
+  ) {
     return <MeasureValuesNumeric values={sortedValues} />;
   }
 

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -287,6 +287,7 @@ export type ColumnSegmentField = t.TypeOf<typeof ColumnSegmentField>;
 
 const UncertaintyFieldExtension = t.partial({
   showStandardError: t.boolean,
+  showConfidenceInterval: t.boolean,
 });
 export type UncertaintyFieldExtension = t.TypeOf<
   typeof UncertaintyFieldExtension

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -16,6 +16,8 @@ const DimensionType = t.union([
   t.literal("GeoCoordinatesDimension"),
   t.literal("GeoShapesDimension"),
   t.literal("StandardErrorDimension"),
+  t.literal("ConfidenceUpperBoundDimension"),
+  t.literal("ConfidenceLowerBoundDimension"),
 ]);
 export type DimensionType = t.TypeOf<typeof DimensionType>;
 

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -285,10 +285,17 @@ const ColumnSegmentField = t.intersection([
 ]);
 export type ColumnSegmentField = t.TypeOf<typeof ColumnSegmentField>;
 
+const UncertaintyFieldExtension = t.partial({
+  showStandardError: t.boolean,
+});
+export type UncertaintyFieldExtension = t.TypeOf<
+  typeof UncertaintyFieldExtension
+>;
+
 const ColumnFields = t.intersection([
   t.type({
     x: t.intersection([GenericField, SortingField]),
-    y: GenericField,
+    y: t.intersection([GenericField, UncertaintyFieldExtension]),
   }),
   t.partial({
     segment: ColumnSegmentField,
@@ -315,7 +322,7 @@ export type LineSegmentField = t.TypeOf<typeof LineSegmentField>;
 const LineFields = t.intersection([
   t.type({
     x: GenericField,
-    y: GenericField,
+    y: t.intersection([GenericField, UncertaintyFieldExtension]),
   }),
   t.partial({
     segment: LineSegmentField,

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -29,6 +29,7 @@ import {
   SelectOption,
   SelectOptionGroup,
 } from "@/components/form";
+import { InfoIconTooltip } from "@/components/info-icon-tooltip";
 import { MaybeTooltip } from "@/components/maybe-tooltip";
 import { TooltipTitle } from "@/components/tooltip-utils";
 import { GenericField } from "@/config-types";
@@ -439,20 +440,20 @@ const EncodingOptionsPanel = ({
                   label={t({ id: "controls.section.show-standard-error" })}
                   sx={{ marginRight: 0 }}
                 />
-                <Tooltip
+                <InfoIconTooltip
                   enterDelay={600}
                   PopperProps={{ sx: { maxWidth: 160 } }}
                   title={
-                    <Trans id="controls.section.show-standard-error.explanation">
-                      Show uncertainties extending from data points to represent
-                      standard errors
-                    </Trans>
+                    <TooltipTitle
+                      text={
+                        <Trans id="controls.section.show-standard-error.explanation">
+                          Show uncertainties extending from data points to
+                          represent standard errors
+                        </Trans>
+                      }
+                    />
                   }
-                >
-                  <Box sx={{ color: "primary.main" }}>
-                    <SvgIcInfoOutline width={16} height={16} />
-                  </Box>
-                </Tooltip>
+                />
               </Box>
             )}
             {encoding.options?.useAbbreviations && (

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -389,11 +389,26 @@ const EncodingOptionsPanel = ({
   }, [components, fields, encoding.field]);
 
   const hasStandardError = useMemo(() => {
-    return components.find((d) =>
+    return !!components.find((d) =>
       d.related?.some(
         (r) => r.type === "StandardError" && r.id === component?.id
       )
     );
+  }, [components, component]);
+
+  const hasConfidenceInterval = useMemo(() => {
+    const upperBoundComponent = components.find((d) =>
+      d.related?.some(
+        (r) => r.type === "ConfidenceUpperBound" && r.id === component?.id
+      )
+    );
+    const lowerBoundComponent = components.find((d) =>
+      d.related?.some(
+        (r) => r.type === "ConfidenceLowerBound" && r.id === component?.id
+      )
+    );
+
+    return !!upperBoundComponent && !!lowerBoundComponent;
   }, [components, component]);
 
   const hasColorPalette = !!encoding.options?.colorPalette;
@@ -436,7 +451,7 @@ const EncodingOptionsPanel = ({
                 <ChartOptionSwitchField
                   path="showStandardError"
                   field={encoding.field}
-                  defaultValue={true}
+                  defaultValue
                   label={t({ id: "controls.section.show-standard-error" })}
                   sx={{ marginRight: 0 }}
                 />
@@ -456,6 +471,41 @@ const EncodingOptionsPanel = ({
                 />
               </Box>
             )}
+            {encoding.options?.showConfidenceInterval &&
+              hasConfidenceInterval && (
+                <Box
+                  sx={{
+                    display: "flex",
+                    gap: 1,
+                    alignItems: "center",
+                    mt: 3,
+                  }}
+                >
+                  <ChartOptionSwitchField
+                    path="showConfidenceInterval"
+                    field={encoding.field}
+                    defaultValue
+                    label={t({
+                      id: "controls.section.show-confidence-interval",
+                    })}
+                    sx={{ marginRight: 0 }}
+                  />
+                  <InfoIconTooltip
+                    enterDelay={600}
+                    PopperProps={{ sx: { maxWidth: 160 } }}
+                    title={
+                      <TooltipTitle
+                        text={
+                          <Trans id="controls.section.show-confidence-interval.explanation">
+                            Show uncertainties extending from data points to
+                            represent confidence intervals
+                          </Trans>
+                        }
+                      />
+                    }
+                  />
+                </Box>
+              )}
             {encoding.options?.useAbbreviations && (
               <ControlSectionContent
                 component="fieldset"

--- a/app/domain/data.ts
+++ b/app/domain/data.ts
@@ -661,15 +661,6 @@ export const isConfidenceLowerBoundDimension = (
   return dim.__typename === "ConfidenceLowerBoundDimension";
 };
 
-export const findRelatedErrorDimension = (
-  dimIri: string,
-  dimensions: Component[]
-) => {
-  return dimensions.find((x) =>
-    x.related?.some((r) => r.id === dimIri && r.type === "StandardError")
-  );
-};
-
 export const shouldLoadMinMaxValues = (dim: ResolvedDimension) => {
   const {
     data: { isNumerical, scaleType, dataKind },

--- a/app/domain/data.ts
+++ b/app/domain/data.ts
@@ -180,6 +180,18 @@ const ComponentsRenderingConfig: {
     enableMultiFilter: false,
     enableSegment: false,
   },
+  ConfidenceUpperBoundDimension: {
+    enableAnimation: false,
+    enableCustomSort: false,
+    enableMultiFilter: false,
+    enableSegment: false,
+  },
+  ConfidenceLowerBoundDimension: {
+    enableAnimation: false,
+    enableCustomSort: false,
+    enableMultiFilter: false,
+    enableSegment: false,
+  },
 };
 
 export const ANIMATION_ENABLED_COMPONENTS = Object.entries(
@@ -261,7 +273,9 @@ export type Dimension =
   | TemporalOrdinalDimension
   | GeoCoordinatesDimension
   | GeoShapesDimension
-  | StandardErrorDimension;
+  | StandardErrorDimension
+  | ConfidenceUpperBoundDimension
+  | ConfidenceLowerBoundDimension;
 
 export type DimensionType = Dimension["__typename"];
 
@@ -314,6 +328,14 @@ export type GeoShapesDimension = BaseDimension & {
 
 export type StandardErrorDimension = BaseDimension & {
   __typename: "StandardErrorDimension";
+};
+
+export type ConfidenceUpperBoundDimension = BaseDimension & {
+  __typename: "ConfidenceUpperBoundDimension";
+};
+
+export type ConfidenceLowerBoundDimension = BaseDimension & {
+  __typename: "ConfidenceLowerBoundDimension";
 };
 
 export type Measure = NumericalMeasure | OrdinalMeasure;
@@ -610,13 +632,33 @@ export const isTemporalDimensionWithTimeUnit = (
 };
 
 const isStandardErrorResolvedDimension = (dim: ResolvedDimension) => {
-  return dim.data?.related.some((x) => x.type === "StandardError");
+  return dim.data?.related.some((r) => r.type === "StandardError");
+};
+
+const isConfidenceLowerBoundResolvedDimension = (dim: ResolvedDimension) => {
+  return dim.data?.related.some((r) => r.type === "ConfidenceLowerBound");
+};
+
+const isConfidenceUpperBoundResolvedDimension = (dim: ResolvedDimension) => {
+  return dim.data?.related.some((r) => r.type === "ConfidenceUpperBound");
 };
 
 export const isStandardErrorDimension = (
   dim: Component
 ): dim is StandardErrorDimension => {
   return dim.__typename === "StandardErrorDimension";
+};
+
+export const isConfidenceUpperBoundDimension = (
+  dim: Component
+): dim is ConfidenceUpperBoundDimension => {
+  return dim.__typename === "ConfidenceUpperBoundDimension";
+};
+
+export const isConfidenceLowerBoundDimension = (
+  dim: Component
+): dim is ConfidenceLowerBoundDimension => {
+  return dim.__typename === "ConfidenceLowerBoundDimension";
 };
 
 export const findRelatedErrorDimension = (
@@ -632,8 +674,11 @@ export const shouldLoadMinMaxValues = (dim: ResolvedDimension) => {
   const {
     data: { isNumerical, scaleType, dataKind },
   } = dim;
+
   return (
     (isNumerical && scaleType !== "Ordinal" && dataKind !== "Time") ||
-    isStandardErrorResolvedDimension(dim)
+    isStandardErrorResolvedDimension(dim) ||
+    isConfidenceUpperBoundResolvedDimension(dim) ||
+    isConfidenceLowerBoundResolvedDimension(dim)
   );
 };

--- a/app/graphql/query-hooks.ts
+++ b/app/graphql/query-hooks.ts
@@ -229,9 +229,15 @@ export type QueryDataCubeDimensionGeoShapesArgs = {
 
 export type RelatedDimension = {
   __typename: 'RelatedDimension';
-  type: Scalars['String'];
+  type: RelatedDimensionType;
   id: Scalars['String'];
 };
+
+export enum RelatedDimensionType {
+  StandardError = 'StandardError',
+  ConfidenceUpperBound = 'ConfidenceUpperBound',
+  ConfidenceLowerBound = 'ConfidenceLowerBound'
+}
 
 export enum ScaleType {
   Ordinal = 'Ordinal',

--- a/app/graphql/resolver-types.ts
+++ b/app/graphql/resolver-types.ts
@@ -229,9 +229,15 @@ export type QueryDataCubeDimensionGeoShapesArgs = {
 
 export type RelatedDimension = {
   __typename?: 'RelatedDimension';
-  type: Scalars['String'];
+  type: RelatedDimensionType;
   id: Scalars['String'];
 };
+
+export enum RelatedDimensionType {
+  StandardError = 'StandardError',
+  ConfidenceUpperBound = 'ConfidenceUpperBound',
+  ConfidenceLowerBound = 'ConfidenceLowerBound'
+}
 
 export enum ScaleType {
   Ordinal = 'Ordinal',
@@ -379,6 +385,7 @@ export type ResolversTypes = ResolversObject<{
   Query: ResolverTypeWrapper<{}>;
   RawObservation: ResolverTypeWrapper<Scalars['RawObservation']>;
   RelatedDimension: ResolverTypeWrapper<RelatedDimension>;
+  RelatedDimensionType: RelatedDimensionType;
   ScaleType: ScaleType;
   SearchCube: ResolverTypeWrapper<Scalars['SearchCube']>;
   SearchCubeFilter: SearchCubeFilter;
@@ -521,7 +528,7 @@ export interface RawObservationScalarConfig extends GraphQLScalarTypeConfig<Reso
 }
 
 export type RelatedDimensionResolvers<ContextType = VisualizeGraphQLContext, ParentType extends ResolversParentTypes['RelatedDimension'] = ResolversParentTypes['RelatedDimension']> = ResolversObject<{
-  type?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  type?: Resolver<ResolversTypes['RelatedDimensionType'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;

--- a/app/graphql/resolvers/index.ts
+++ b/app/graphql/resolvers/index.ts
@@ -63,8 +63,21 @@ export const resolveDimensionType = (
   timeUnit: ResolvedDimension["data"]["timeUnit"] | undefined,
   related: ResolvedDimension["data"]["related"]
 ): DimensionType => {
+  const relatedTypes = Array.from(new Set(related.map((d) => d.type)));
+
+  if (relatedTypes.length > 1) {
+    console.warn(
+      `WARNING: dimension has more than 1 related type`,
+      relatedTypes
+    );
+  }
+
   if (related.some((d) => d.type === "StandardError")) {
     return "StandardErrorDimension";
+  } else if (related.some((d) => d.type === "ConfidenceUpperBound")) {
+    return "ConfidenceUpperBoundDimension";
+  } else if (related.some((d) => d.type === "ConfidenceLowerBound")) {
+    return "ConfidenceLowerBoundDimension";
   }
 
   if (dataKind === "Time") {

--- a/app/graphql/schema.graphql
+++ b/app/graphql/schema.graphql
@@ -28,8 +28,14 @@ enum ScaleType {
   Ratio
 }
 
+enum RelatedDimensionType {
+  StandardError
+  ConfidenceUpperBound
+  ConfidenceLowerBound
+}
+
 type RelatedDimension {
-  type: String!
+  type: RelatedDimensionType!
   id: String!
 }
 

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -412,6 +412,7 @@ msgid "controls.chart.disabled.same-unit"
 msgstr "Es sind mindestens zwei Zahlenwerte mit gleicher Einheit erforderlich."
 
 #: app/charts/index.ts
+#: app/charts/index.ts
 msgid "controls.chart.disabled.temporal"
 msgstr "Es ist mindestens eine zeitliche Dimension erforderlich."
 
@@ -887,6 +888,14 @@ msgstr "Geteilte Filter"
 #: app/charts/shared/use-combined-temporal-dimension.ts
 msgid "controls.section.shared-filters.date"
 msgstr "Datum"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.section.show-confidence-interval"
+msgstr "Konfidenzintervall anzeigen"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.section.show-confidence-interval.explanation"
+msgstr "Zeigen Sie Unsicherheiten an, die sich aus Datenpunkten ergeben, um Konfidenzintervalle darzustellen"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.section.show-standard-error"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -412,6 +412,7 @@ msgid "controls.chart.disabled.same-unit"
 msgstr "At least two numerical measures with the same unit are required."
 
 #: app/charts/index.ts
+#: app/charts/index.ts
 msgid "controls.chart.disabled.temporal"
 msgstr "At least one temporal dimension is required."
 
@@ -887,6 +888,14 @@ msgstr "Shared filters"
 #: app/charts/shared/use-combined-temporal-dimension.ts
 msgid "controls.section.shared-filters.date"
 msgstr "Date"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.section.show-confidence-interval"
+msgstr "Show confidence interval"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.section.show-confidence-interval.explanation"
+msgstr "Show uncertainties extending from data points to represent confidence intervals"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.section.show-standard-error"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -890,6 +890,14 @@ msgid "controls.section.shared-filters.date"
 msgstr "Date"
 
 #: app/configurator/components/chart-options-selector.tsx
+msgid "controls.section.show-confidence-interval"
+msgstr "Afficher l'intervalle de confiance"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.section.show-confidence-interval.explanation"
+msgstr "Afficher les incertitudes s'étendant des points de données pour représenter les intervalles de confiance"
+
+#: app/configurator/components/chart-options-selector.tsx
 msgid "controls.section.show-standard-error"
 msgstr "Afficher l'erreur type"
 

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -412,6 +412,7 @@ msgid "controls.chart.disabled.same-unit"
 msgstr "Sono necessarie almeno due misure numeriche con la stessa unità."
 
 #: app/charts/index.ts
+#: app/charts/index.ts
 msgid "controls.chart.disabled.temporal"
 msgstr "È richiesta almeno una dimensione temporale."
 
@@ -887,6 +888,14 @@ msgstr "Filtri condivisi"
 #: app/charts/shared/use-combined-temporal-dimension.ts
 msgid "controls.section.shared-filters.date"
 msgstr "Data"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.section.show-confidence-interval"
+msgstr "Mostra intervallo di confidenza"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.section.show-confidence-interval.explanation"
+msgstr "Mostra le incertezze che si estendono dai punti dati per rappresentare gli intervalli di confidenza"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.section.show-standard-error"

--- a/app/rdf/parse.ts
+++ b/app/rdf/parse.ts
@@ -2,7 +2,11 @@ import { CubeDimension } from "rdf-cube-view-query";
 import { Term } from "rdf-js";
 
 import { truthy } from "@/domain/types";
-import { ScaleType, TimeUnit } from "@/graphql/query-hooks";
+import {
+  RelatedDimensionType,
+  ScaleType,
+  TimeUnit,
+} from "@/graphql/query-hooks";
 import { ResolvedDimension } from "@/graphql/shared-types";
 import { ExtendedCube } from "@/rdf/extended-cube";
 import { timeFormats, timeUnitFormats, timeUnits } from "@/rdf/mappings";
@@ -74,11 +78,11 @@ export const parseDimensionDatatype = (dim: CubeDimension) => {
   return { isLiteral, dataType, hasUndefinedValues };
 };
 
-type RelationType = "StandardError";
-
 const sparqlRelationToVisualizeRelation = {
   "https://cube.link/relation/StandardError": "StandardError",
-} as Record<string, RelationType>;
+  "https://cube.link/relation/ConfidenceUpperBound": "ConfidenceUpperBound",
+  "https://cube.link/relation/ConfidenceLowerBound": "ConfidenceLowerBound",
+} as Record<string, RelatedDimensionType>;
 
 export const parseRelatedDimensions = (dim: CubeDimension) => {
   const relatedDimensionNodes = dim.out(ns.cube`meta/dimensionRelation`);


### PR DESCRIPTION
Closes #1857

This PR adds support for displaying confidence intervals in Visualize.

**Details**
- Added `ConfidenceUpperBoundDimension` and `ConfidenceLowerBoundDimension`
- Updated Y field type for columns and lines to correctly indicate that it can contain additional, uncertainty-related properties
- Standardized error formatting logic across all charts
- Added a way to display confidence intervals, which use the existing `ErrorWhiskers` components and tooltip formatting
- Fixed showing errors in symbol layer tooltip

## How to test
1. Go to [this link](https://visualization-tool-git-feat-non-symmetrical-error-bar-ixt1.vercel.app/en/create/new?cube=https://mock.ld.admin.ch/cube/mock-two-sided/1&dataSource=Test).
2. ✅ See that confidence intervals are displayed by default.
3. ✅ Open Vertical Axis field and see that there's an option to control their appearance.
4. ✅ Hover over columns and see that the tooltip displays the values in a different way than standard errors.