### PR TITLE
Fix/fix pie chart tooltip alignment

### DIFF
--- a/app/charts/pie/pie-state.tsx
+++ b/app/charts/pie/pie-state.tsx
@@ -31,6 +31,7 @@ import {
   getSortingOrders,
   makeDimensionValueSorters,
 } from "@/utils/sorting-values";
+import { useIsMobile } from "@/utils/use-is-mobile";
 
 import { ChartProps } from "../shared/ChartProps";
 
@@ -206,6 +207,8 @@ const usePieState = (
     return `${rounded}% (${fValue})`;
   };
 
+  const isMobile = useIsMobile();
+
   // Tooltip
   const getAnnotationInfo = (
     arcDatum: PieArcDatum<Observation>
@@ -217,12 +220,17 @@ const usePieState = (
     const yTranslate = chartHeight / 2;
 
     const xAnchor = x + xTranslate;
-    const yAnchor = y + yTranslate;
+    const yAnchor = isMobile ? -chartHeight : y + yTranslate;
 
-    const xPlacement = xAnchor < chartWidth * 0.5 ? "right" : "left";
+    const xPlacement = isMobile
+      ? "center"
+      : xAnchor < chartWidth * 0.5
+        ? "right"
+        : "left";
 
-    const yPlacement =
-      yAnchor > chartHeight * 0.2
+    const yPlacement = isMobile
+      ? "top"
+      : yAnchor > chartHeight * 0.2
         ? "top"
         : yAnchor < chartHeight * 0.8
           ? "bottom"
@@ -238,6 +246,7 @@ const usePieState = (
         color: colors(getSegment(datum)) as string,
       },
       values: undefined,
+      withTriangle: !isMobile,
     };
   };
 

--- a/app/charts/pie/pie.tsx
+++ b/app/charts/pie/pie.tsx
@@ -9,6 +9,7 @@ import { useInteraction } from "@/charts/shared/use-interaction";
 import { Observation } from "@/domain/data";
 import { useTransitionStore } from "@/stores/transition";
 import useEvent from "@/utils/use-event";
+import { useIsMobile } from "@/utils/use-is-mobile";
 
 export const Pie = () => {
   const { chartData, getPieData, getSegment, colors, bounds, getRenderingKey } =
@@ -19,7 +20,11 @@ export const Pie = () => {
   const [, dispatch] = useInteraction();
   const ref = useRef<SVGGElement>(null);
 
-  const maxSide = Math.min(chartWidth, chartHeight) / 2;
+  const isMobile = useIsMobile();
+
+  const maxSide = isMobile
+    ? Math.min(chartWidth, chartHeight)
+    : Math.min(chartWidth, chartHeight) / 2;
 
   const innerRadius = 0;
   const outerRadius = maxSide;

--- a/app/charts/shared/interaction/tooltip-box.tsx
+++ b/app/charts/shared/interaction/tooltip-box.tsx
@@ -30,6 +30,7 @@ export interface TooltipBoxProps {
   x: number | undefined;
   y: number | undefined;
   placement: TooltipPlacement;
+  withTriangle?: boolean;
   margins: Margins;
   children: ReactNode;
 }
@@ -128,8 +129,9 @@ export const TooltipBox = ({
   placement,
   margins,
   children,
+  withTriangle = true,
 }: TooltipBoxProps) => {
-  const triangle = mkTriangle(placement);
+  const triangle = withTriangle ? mkTriangle(placement) : null;
   const [pos, posRef] = usePosition();
 
   const [tooltipRef, tooltipWidth] = useResizeObserver<HTMLDivElement>();
@@ -145,8 +147,8 @@ export const TooltipBox = ({
   const mobileTriangleXPosition = getTriangleXPos(x!, tooltipWidth, chartWidth);
 
   const desktopTriangleXPosition = {
-    left: triangle.left,
-    right: triangle.right,
+    left: triangle?.left,
+    right: triangle?.right,
   };
 
   const triangleXPosition = isMobile
@@ -181,21 +183,21 @@ export const TooltipBox = ({
 
               "&::before": {
                 content: "''",
-                display: "block",
+                display: withTriangle ? "block" : "none",
                 position: "absolute",
                 pointerEvents: "none",
                 zIndex: -1,
                 width: 0,
                 height: 0,
                 borderStyle: "solid",
-                top: triangle.top,
-                bottom: triangle.bottom,
+                top: triangle?.top,
+                bottom: triangle?.bottom,
                 ...triangleXPosition,
-                borderWidth: triangle.borderWidth,
-                borderTopColor: triangle.borderTopColor,
-                borderRightColor: triangle.borderRightColor,
-                borderBottomColor: triangle.borderBottomColor,
-                borderLeftColor: triangle.borderLeftColor,
+                borderWidth: triangle?.borderWidth,
+                borderTopColor: triangle?.borderTopColor,
+                borderRightColor: triangle?.borderRightColor,
+                borderBottomColor: triangle?.borderBottomColor,
+                borderLeftColor: triangle?.borderLeftColor,
               },
             }}
           >

--- a/app/charts/shared/interaction/tooltip.tsx
+++ b/app/charts/shared/interaction/tooltip.tsx
@@ -41,6 +41,7 @@ export interface TooltipInfo {
   tooltipContent?: ReactNode;
   datum: TooltipValue;
   values: TooltipValue[] | undefined;
+  withTriangle?: boolean;
 }
 
 const TooltipInner = ({ d, type }: { d: Observation; type: TooltipType }) => {
@@ -48,15 +49,29 @@ const TooltipInner = ({ d, type }: { d: Observation; type: TooltipType }) => {
     | LinesState
     | PieState;
   const { margins } = bounds;
-  const { xAnchor, yAnchor, placement, xValue, tooltipContent, datum, values } =
-    getAnnotationInfo(d as any);
+  const {
+    xAnchor,
+    yAnchor,
+    placement,
+    xValue,
+    tooltipContent,
+    datum,
+    values,
+    withTriangle,
+  } = getAnnotationInfo(d as any);
 
   if (Number.isNaN(yAnchor)) {
     return null;
   }
 
   return (
-    <TooltipBox x={xAnchor} y={yAnchor} placement={placement} margins={margins}>
+    <TooltipBox
+      x={xAnchor}
+      y={yAnchor}
+      placement={placement}
+      withTriangle={withTriangle}
+      margins={margins}
+    >
       {tooltipContent ? (
         tooltipContent
       ) : type === "multiple" && values ? (


### PR DESCRIPTION
**This PR:**
- This PR handles the Pie Chart tooltip issue for smaller screens
- It increases the Pie Chart size on Mobile Screens
- It moves the tooltip on top of the Chart
- It removes the triangle on the tooltip, therefore emphasizing the highlighting
- this PR resolves issue # 111 

### How to test
1. Go to this link 
2. Create a visualization with using a Pie Chart 
3. Publish your visualization 
4. Test the tooltip

---

CC: @KerstinFaye  