### PR TITLE
feat: Improve confidence intervals formatting

### DIFF
--- a/app/charts/shared/chart-state.ts
+++ b/app/charts/shared/chart-state.ts
@@ -433,7 +433,7 @@ export const useNumericalYErrorVariables = (
         const cil = getYConfidenceIntervalLower(d);
         const ciu = getYConfidenceIntervalUpper(d);
         const unit = yConfidenceIntervalUpperMeasure?.unit ?? "";
-        return ` -${cil}${unit}, +${ciu}${unit}`;
+        return `, [-${cil}${unit}, +${ciu}${unit}]`;
       }
     },
     [

--- a/app/rdf/light-cube.ts
+++ b/app/rdf/light-cube.ts
@@ -7,10 +7,7 @@ import {
 } from "@/domain/data";
 import { getCubeMetadata } from "@/rdf/query-cube-metadata";
 import { getCubePreview } from "@/rdf/query-cube-preview";
-import {
-  getCubeComponentTermsets,
-  getCubeTermsets,
-} from "@/rdf/query-termsets";
+import { getCubeComponentTermsets } from "@/rdf/query-termsets";
 
 type LightCubeOptions = {
   iri: string;
@@ -46,13 +43,6 @@ export class LightCube {
     });
 
     return this.metadata;
-  }
-
-  public async fetchTermsets() {
-    return await getCubeTermsets(this.iri, {
-      locale: this.locale,
-      sparqlClient: this.sparqlClient,
-    });
   }
 
   public async fetchComponentTermsets() {

--- a/app/rdf/query-termsets.ts
+++ b/app/rdf/query-termsets.ts
@@ -1,36 +1,10 @@
 import groupBy from "lodash/groupBy";
 import ParsingClient from "sparql-http-client/ParsingClient";
 
-import { ComponentTermsets, Termset } from "@/domain/data";
+import { ComponentTermsets } from "@/domain/data";
 import { stringifyComponentId } from "@/graphql/make-component-id";
 import { queryCubeUnversionedIri } from "@/rdf/query-cube-unversioned-iri";
 import { buildLocalizedSubQuery } from "@/rdf/query-utils";
-
-export const getCubeTermsets = async (
-  iri: string,
-  options: {
-    locale: string;
-    sparqlClient: ParsingClient;
-  }
-): Promise<Termset[]> => {
-  const { sparqlClient, locale } = options;
-  const qs = await sparqlClient.query.select(
-    `PREFIX meta: <https://cube.link/meta/>
-PREFIX schema: <http://schema.org/>
-
-SELECT DISTINCT ?termsetIri ?termsetLabel WHERE {
-  ?termsetIri meta:isUsedIn <${iri}> .
-  ${buildLocalizedSubQuery("termsetIri", "schema:name", "termsetLabel", { locale })}
-}`,
-    { operation: "postUrlencoded" }
-  );
-
-  return qs.map((result) => ({
-    iri: result.termsetIri.value,
-    label: result.termsetLabel.value,
-    __typename: "Termset",
-  }));
-};
 
 export const getCubeComponentTermsets = async (
   iri: string,


### PR DESCRIPTION
This PR:
- improves confidence intervals formatting based on @sosiology's [comment](https://github.com/visualize-admin/visualization-tool/pull/1910#issuecomment-2498778455),
- removes some unused code.

## How to test
1. Go to [this link](https://visualization-tool-git-feat-confidence-intervals-fo-e6757e-ixt1.vercel.app/en/create/new?cube=https://mock.ld.admin.ch/cube/mock-two-sided/1&dataSource=Test).
2. ✅ Hover over bars and see that errors are formatted in `, [-x, +y]` way.