### PR TITLE
feat: Improve search options for add dataset dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Features
+  - Made it possible to sort the cube search results and filter by draft
+    datasets when looking for a cube to merge
 
 # [5.0.1] - 2024-11-26
 

--- a/app/browser/dataset-browse.tsx
+++ b/app/browser/dataset-browse.tsx
@@ -199,7 +199,7 @@ export const SearchDatasetControls = ({
     onSetOrder,
   } = browseState;
 
-  const order = stateOrder || SearchCubeResultOrder.CreatedDesc;
+  const order = stateOrder ?? SearchCubeResultOrder.CreatedDesc;
   const options = [
     {
       value: SearchCubeResultOrder.Score,

--- a/app/browser/dataset-browse.tsx
+++ b/app/browser/dataset-browse.tsx
@@ -215,13 +215,7 @@ export const SearchDatasetControls = ({
     <Flex sx={{ justifyContent: "space-between", alignItems: "center", mb: 2 }}>
       <SearchDatasetResultsCount cubes={cubes} />
       <Flex sx={{ alignItems: "center" }}>
-        <Checkbox
-          label={t({
-            id: "dataset.includeDrafts",
-            message: "Include draft datasets",
-          })}
-          name="dataset-include-drafts"
-          value="dataset-include-drafts"
+        <SearchDatasetDraftsControl
           checked={includeDrafts}
           onChange={onToggleIncludeDrafts}
         />
@@ -258,6 +252,27 @@ export const SearchDatasetResultsCount = ({
         />
       )}
     </Typography>
+  );
+};
+
+export const SearchDatasetDraftsControl = ({
+  checked,
+  onChange,
+}: {
+  checked: boolean;
+  onChange: (value: boolean) => void;
+}) => {
+  return (
+    <Checkbox
+      label={t({
+        id: "dataset.includeDrafts",
+        message: "Include draft datasets",
+      })}
+      name="dataset-include-drafts"
+      value="dataset-include-drafts"
+      checked={checked}
+      onChange={() => onChange(!checked)}
+    />
   );
 };
 

--- a/app/browser/dataset-browse.tsx
+++ b/app/browser/dataset-browse.tsx
@@ -213,23 +213,7 @@ export const SearchDatasetControls = ({
 
   return (
     <Flex sx={{ justifyContent: "space-between", alignItems: "center", mb: 2 }}>
-      <Typography
-        variant="body2"
-        fontWeight={700}
-        aria-live="polite"
-        data-testid="search-results-count"
-      >
-        {cubes.length > 0 && (
-          <Plural
-            id="dataset.results"
-            value={cubes.length}
-            zero="No datasets"
-            one="# dataset"
-            other="# datasets"
-          />
-        )}
-      </Typography>
-
+      <SearchDatasetResultsCount cubes={cubes} />
       <Flex sx={{ alignItems: "center" }}>
         <Checkbox
           label={t({
@@ -248,6 +232,32 @@ export const SearchDatasetControls = ({
         />
       </Flex>
     </Flex>
+  );
+};
+
+export const SearchDatasetResultsCount = ({
+  cubes,
+}: {
+  cubes: SearchCubeResult[];
+}) => {
+  return (
+    <Typography
+      variant="body2"
+      fontWeight={700}
+      aria-live="polite"
+      data-testid="search-results-count"
+      color="secondary.main"
+    >
+      {cubes.length > 0 && (
+        <Plural
+          id="dataset.results"
+          value={cubes.length}
+          zero="No datasets"
+          one="# dataset"
+          other="# datasets"
+        />
+      )}
+    </Typography>
   );
 };
 

--- a/app/browser/dataset-browse.tsx
+++ b/app/browser/dataset-browse.tsx
@@ -200,21 +200,6 @@ export const SearchDatasetControls = ({
   } = browseState;
 
   const order = stateOrder ?? SearchCubeResultOrder.CreatedDesc;
-  const options = [
-    {
-      value: SearchCubeResultOrder.Score,
-      label: t({ id: "dataset.order.relevance", message: `Relevance` }),
-    },
-    {
-      value: SearchCubeResultOrder.TitleAsc,
-      label: t({ id: "dataset.order.title", message: `Title` }),
-    },
-    {
-      value: SearchCubeResultOrder.CreatedDesc,
-      label: t({ id: "dataset.order.newest", message: `Newest` }),
-    },
-  ];
-
   const isSearching = search !== "" && search !== undefined;
 
   const onToggleIncludeDrafts = useEvent(async () => {
@@ -256,25 +241,65 @@ export const SearchDatasetControls = ({
           checked={includeDrafts}
           onChange={onToggleIncludeDrafts}
         />
-        <label htmlFor="datasetSort">
-          <Typography variant="body2" fontWeight={700}>
-            <Trans id="dataset.sortby">Sort by</Trans>
-          </Typography>
-        </label>
-
-        <MinimalisticSelect
-          id="datasetSort"
-          smaller
-          autoWidth
+        <SearchDatasetSortControl
           value={order}
-          data-testid="datasetSort"
-          options={isSearching ? options : options.slice(1)}
-          onChange={(e) => {
-            onSetOrder(e.target.value as SearchCubeResultOrder);
-          }}
+          onChange={onSetOrder}
+          disableScore={isSearching}
         />
       </Flex>
     </Flex>
+  );
+};
+
+export const SearchDatasetSortControl = ({
+  value,
+  onChange,
+  disableScore,
+}: {
+  value: SearchCubeResultOrder;
+  onChange: (order: SearchCubeResultOrder) => void;
+  disableScore?: boolean;
+}) => {
+  const options = useMemo(() => {
+    const options = [
+      {
+        value: SearchCubeResultOrder.Score,
+        label: t({ id: "dataset.order.relevance", message: "Relevance" }),
+      },
+      {
+        value: SearchCubeResultOrder.TitleAsc,
+        label: t({ id: "dataset.order.title", message: "Title" }),
+      },
+      {
+        value: SearchCubeResultOrder.CreatedDesc,
+        label: t({ id: "dataset.order.newest", message: "Newest" }),
+      },
+    ];
+
+    return disableScore
+      ? options.filter((o) => o.value !== SearchCubeResultOrder.Score)
+      : options;
+  }, [disableScore]);
+
+  return (
+    <Box style={{ display: "flex", alignItems: "center", gap: 1 }}>
+      <label htmlFor="datasetSort">
+        <Typography variant="body2" fontWeight={700}>
+          <Trans id="dataset.sortby">Sort by</Trans>
+        </Typography>
+      </label>
+      <MinimalisticSelect
+        id="datasetSort"
+        data-testid="datasetSort"
+        smaller
+        autoWidth
+        value={value}
+        options={options}
+        onChange={(e) => {
+          onChange(e.target.value as SearchCubeResultOrder);
+        }}
+      />
+    </Box>
   );
 };
 

--- a/app/browser/dataset-browse.tsx
+++ b/app/browser/dataset-browse.tsx
@@ -1015,7 +1015,7 @@ export const DatasetResults = ({
   }
 
   return (
-    <>
+    <div>
       {cubes.map(({ cube, highlightedTitle, highlightedDescription }) => (
         <DatasetResult
           key={cube.iri}
@@ -1025,7 +1025,7 @@ export const DatasetResults = ({
           {...datasetResultProps?.({ cube })}
         />
       ))}
-    </>
+    </div>
   );
 };
 
@@ -1037,10 +1037,11 @@ const useResultStyles = makeStyles((theme: Theme) => ({
     color: theme.palette.grey[700],
     textAlign: "left",
     padding: `${theme.spacing(4)} 0`,
-    borderTopColor: theme.palette.grey[300],
-    borderTopStyle: "solid",
-    borderTopWidth: 1,
     boxShadow: "none",
+
+    "&:not(:first-child)": {
+      borderTop: `1px solid ${theme.palette.grey[300]}`,
+    },
   },
 
   titleClickable: {

--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -548,6 +548,7 @@ export const MinimalisticSelect = (props: MinimalisticSelectProps) => {
     onChange,
     smaller = false,
     disabled,
+    sx,
     ...rest
   } = props;
 
@@ -559,21 +560,6 @@ export const MinimalisticSelect = (props: MinimalisticSelectProps) => {
         </Label>
       )}
       <MUISelect
-        sx={{
-          borderColor: "transparent",
-          fontSize: smaller ? ["0.625rem", "0.75rem", "0.75rem"] : "inherit",
-          lineHeight: "normal !important",
-
-          backgroundColor: "transparent",
-          p: 0,
-          pr: 2,
-          pl: 1,
-          mr: 1, // Fix for Chrome which cuts of the label otherwise
-          ":focus": {
-            outline: "none",
-            borderColor: "primary.main",
-          },
-        }}
         size={smaller ? "small" : "medium"}
         variant="standard"
         id={id}
@@ -586,13 +572,28 @@ export const MinimalisticSelect = (props: MinimalisticSelectProps) => {
             {...props}
             style={{
               ...props.style,
-              right: 12,
               transition: "transform 0.1s",
             }}
           >
             <Icon name="chevronDown" size={16} />
           </span>
         )}
+        sx={{
+          borderColor: "transparent",
+          fontSize: smaller ? ["0.625rem", "0.75rem", "0.75rem"] : "inherit",
+          lineHeight: "normal !important",
+          backgroundColor: "transparent",
+          p: 0,
+          pl: 1,
+          ":focus": {
+            outline: "none",
+            borderColor: "primary.main",
+          },
+          "& .MuiInput-input": {
+            paddingRight: "1.25rem !important",
+          },
+          ...sx,
+        }}
         {...rest}
       >
         {options.map((opt) => (

--- a/app/configurator/components/add-dataset-dialog.tsx
+++ b/app/configurator/components/add-dataset-dialog.tsx
@@ -901,7 +901,7 @@ export const DatasetDialog = ({
               display="flex"
               alignItems="center"
               component="form"
-              gap="0.25rem"
+              gap="0.5rem"
               mb="1rem"
               onSubmit={handleSubmit}
             >

--- a/app/configurator/components/add-dataset-dialog.tsx
+++ b/app/configurator/components/add-dataset-dialog.tsx
@@ -95,6 +95,7 @@ import SvgIcRemove from "@/icons/components/IcRemove";
 import SvgIcSearch from "@/icons/components/IcSearch";
 import { useLocale } from "@/locales/use-locale";
 import { useEventEmitter } from "@/utils/eventEmitter";
+import useEvent from "@/utils/use-event";
 import useLocalState from "@/utils/use-local-state";
 
 const DialogCloseButton = (props: IconButtonProps) => {
@@ -615,8 +616,9 @@ export const DatasetDialog = ({
   };
 
   const activeChartConfig = state.chartConfigs.find(
-    (x) => x.key === state.activeChartKey
+    (chartConfig) => chartConfig.key === state.activeChartKey
   );
+
   if (!activeChartConfig) {
     throw Error("Could not find active chart config");
   }
@@ -752,13 +754,13 @@ export const DatasetDialog = ({
 
   const currentComponents = cubesComponentQuery.data?.dataCubesComponents;
 
-  const handleSubmit = (ev: FormEvent<HTMLFormElement>) => {
-    ev.preventDefault();
+  const handleSubmit = useEvent((e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
     const formData = Object.fromEntries(
-      new FormData(ev.currentTarget).entries()
+      new FormData(e.currentTarget).entries()
     );
     setQuery(formData.search as string);
-  };
+  });
 
   const handleClose: DialogProps["onClose"] = useEventCallback((ev, reason) => {
     props.onClose?.(ev, reason);
@@ -894,7 +896,6 @@ export const DatasetDialog = ({
               <TextField
                 size="small"
                 name="search"
-                sx={{ width: 400 }}
                 InputProps={{
                   startAdornment: (
                     <InputAdornment position="start">
@@ -919,17 +920,17 @@ export const DatasetDialog = ({
                 }}
                 input={
                   <OutlinedInput
+                    id="select-multiple-chip"
+                    label="Chip"
                     notched={false}
                     startAdornment={
                       <InputAdornment position="start" sx={{ mr: 0 }}>
                         <SvgIcFilter />
                       </InputAdornment>
                     }
-                    id="select-multiple-chip"
-                    label="Chip"
+                    style={{ width: "100%" }}
                   />
                 }
-                sx={{ minWidth: 300 }}
                 renderValue={(selected) =>
                   cubeComponentTermsets.fetching ||
                   cubesComponentQuery.fetching ? (
@@ -976,7 +977,12 @@ export const DatasetDialog = ({
                   </MenuItem>
                 ))}
               </Select>
-              <Button color="primary" type="submit" variant="contained">
+              <Button
+                color="primary"
+                type="submit"
+                variant="contained"
+                style={{ minWidth: "fit-content" }}
+              >
                 {t({ id: "dataset.search.label" })}
               </Button>
             </Box>
@@ -989,7 +995,7 @@ export const DatasetDialog = ({
               </Typography>
             ) : (
               <DatasetResults
-                cubes={searchCubes ?? []}
+                cubes={searchCubes}
                 fetching={
                   searchQuery.fetching ||
                   cubeComponentTermsets.fetching ||
@@ -1000,7 +1006,6 @@ export const DatasetDialog = ({
                   disableTitleLink: true,
                   showDimensions: true,
                   showTags: true,
-
                   rowActions: () => {
                     return (
                       <Box display="flex" justifyContent="flex-end">

--- a/app/configurator/components/add-dataset-dialog.tsx
+++ b/app/configurator/components/add-dataset-dialog.tsx
@@ -53,6 +53,7 @@ import { useClient } from "urql";
 import {
   DatasetResults,
   PartialSearchCube,
+  SearchDatasetDraftsControl,
   SearchDatasetResultsCount,
   SearchDatasetSortControl,
 } from "@/browser/dataset-browse";
@@ -611,12 +612,14 @@ export const DatasetDialog = ({
   state,
   ...props
 }: { state: ConfiguratorStateConfiguringChart } & DialogProps) => {
+  const locale = useLocale();
+  const classes = useStyles();
+
   const [query, setQuery] = useState("");
   const [order, setOrder] = useState<SearchCubeResultOrder>(
     SearchCubeResultOrder.Score
   );
-  const locale = useLocale();
-  const classes = useStyles();
+  const [includeDrafts, setIncludeDrafts] = useState(false);
 
   const commonQueryVariables = {
     sourceType: state.dataSource.type,
@@ -737,7 +740,7 @@ export const DatasetDialog = ({
       locale,
       query,
       order,
-      includeDrafts: false,
+      includeDrafts,
       fetchDimensionTermsets: true,
       filters: [
         selectedTemporalDimension
@@ -1000,7 +1003,13 @@ export const DatasetDialog = ({
               style={{ alignItems: "center", justifyContent: "space-between" }}
             >
               <SearchDatasetResultsCount cubes={searchCubes} />
-              <SearchDatasetSortControl value={order} onChange={setOrder} />
+              <Flex style={{ alignItems: "center" }}>
+                <SearchDatasetDraftsControl
+                  checked={includeDrafts}
+                  onChange={setIncludeDrafts}
+                />
+                <SearchDatasetSortControl value={order} onChange={setOrder} />
+              </Flex>
             </Flex>
 
             {selectedSearchDimensions?.length === 0 ? (

--- a/app/configurator/components/add-dataset-dialog.tsx
+++ b/app/configurator/components/add-dataset-dialog.tsx
@@ -53,10 +53,12 @@ import { useClient } from "urql";
 import {
   DatasetResults,
   PartialSearchCube,
+  SearchDatasetResultsCount,
   SearchDatasetSortControl,
 } from "@/browser/dataset-browse";
 import { FirstTenRowsCaption } from "@/browser/dataset-preview";
 import { getEnabledChartTypes } from "@/charts";
+import Flex from "@/components/flex";
 import { Error as ErrorHint, Loading } from "@/components/hint";
 import Tag from "@/components/tag";
 import {
@@ -994,9 +996,12 @@ export const DatasetDialog = ({
               </Button>
             </Box>
 
-            <div style={{ display: "flex", justifyContent: "flex-end" }}>
+            <Flex
+              style={{ alignItems: "center", justifyContent: "space-between" }}
+            >
+              <SearchDatasetResultsCount cubes={searchCubes} />
               <SearchDatasetSortControl value={order} onChange={setOrder} />
-            </div>
+            </Flex>
 
             {selectedSearchDimensions?.length === 0 ? (
               <Typography variant="body1">

--- a/app/configurator/components/add-dataset-dialog.tsx
+++ b/app/configurator/components/add-dataset-dialog.tsx
@@ -50,7 +50,11 @@ import uniq from "lodash/uniq";
 import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import { useClient } from "urql";
 
-import { DatasetResults, PartialSearchCube } from "@/browser/dataset-browse";
+import {
+  DatasetResults,
+  PartialSearchCube,
+  SearchDatasetSortControl,
+} from "@/browser/dataset-browse";
 import { FirstTenRowsCaption } from "@/browser/dataset-preview";
 import { getEnabledChartTypes } from "@/charts";
 import { Error as ErrorHint, Loading } from "@/components/hint";
@@ -606,6 +610,9 @@ export const DatasetDialog = ({
   ...props
 }: { state: ConfiguratorStateConfiguringChart } & DialogProps) => {
   const [query, setQuery] = useState("");
+  const [order, setOrder] = useState<SearchCubeResultOrder>(
+    SearchCubeResultOrder.Score
+  );
   const locale = useLocale();
   const classes = useStyles();
 
@@ -726,8 +733,8 @@ export const DatasetDialog = ({
       sourceType: state.dataSource.type,
       sourceUrl: state.dataSource.url,
       locale,
-      query: query,
-      order: SearchCubeResultOrder.Score,
+      query,
+      order,
       includeDrafts: false,
       fetchDimensionTermsets: true,
       filters: [
@@ -890,7 +897,7 @@ export const DatasetDialog = ({
               alignItems="center"
               component="form"
               gap="0.25rem"
-              mb="1.5rem"
+              mb="1rem"
               onSubmit={handleSubmit}
             >
               <TextField
@@ -986,6 +993,10 @@ export const DatasetDialog = ({
                 {t({ id: "dataset.search.label" })}
               </Button>
             </Box>
+
+            <div style={{ display: "flex", justifyContent: "flex-end" }}>
+              <SearchDatasetSortControl value={order} onChange={setOrder} />
+            </div>
 
             {selectedSearchDimensions?.length === 0 ? (
               <Typography variant="body1">

--- a/app/configurator/components/layout-configurator.tsx
+++ b/app/configurator/components/layout-configurator.tsx
@@ -240,7 +240,6 @@ const LayoutSharedFiltersConfigurator = () => {
           </SubsectionTitle>
           <ControlSectionContent>
             <Stack gap="0.5rem">
-              {/* TODO: allow TemporalOrdinalDimensions to work here */}
               {timeRange && combinedTemporalDimension.values.length ? (
                 <>
                   <Box


### PR DESCRIPTION
This PR aligns the add dataset dialog search controls with the design (with one change to also include draft datasets toggle).

## How to test
1. Go to [this link](https://visualization-tool-git-feat-improve-add-dataset-dia-1fc1e3-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10&dataSource=Prod).
2. Clink on `Add dataset`.
3. ✅ See that the design of the search controls is aligned with [the Figma file](https://www.figma.com/design/Hn9wvuEYLUmdJtg4KwZYUx/visualize.admin.ch---design?node-id=4417-131083&t=rM5yJXUP5EDdPaUa-4).
4. ✅ See that it's possible to sort the results and enable draft datasets.