### PR TITLE
fix: Missing datasets section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ You can also check the
 - Fixes
   - Changed component id separator text to be more unique, as it was causing
     issues with some cubes that had iris ending with "-"
+  - Datasets section in the sidebar is now correctly shown at all times
 
 # [5.0.1] - 2024-11-26
 

--- a/app/configurator/components/dataset-control-section.tsx
+++ b/app/configurator/components/dataset-control-section.tsx
@@ -32,7 +32,6 @@ import {
   useConfiguratorState,
 } from "@/configurator/configurator-state";
 import { DataCubeMetadata } from "@/domain/data";
-import useFlag from "@/flags/useFlag";
 import {
   executeDataCubesComponentsQuery,
   useDataCubesMetadataQuery,
@@ -219,11 +218,6 @@ export const DatasetsControlSection = () => {
     setOpen(true);
     setActiveSection("general");
   };
-
-  const addDatasetFlag = useFlag("configurator.add-dataset.shared");
-  if (!addDatasetFlag) {
-    return null;
-  }
 
   return (
     <ControlSection collapse defaultExpanded={true}>

--- a/app/flags/flag.tsx
+++ b/app/flags/flag.tsx
@@ -12,7 +12,7 @@ const store = new FlagStore();
 /**
  * Public API to use flags
  */
-const flag = function flag(...args: [FlagName] | [FlagName, FlagValue]) {
+export const flag = function flag(...args: [FlagName] | [FlagName, FlagValue]) {
   if (args.length === 1) {
     return store.get(args[0]);
   } else {
@@ -80,18 +80,20 @@ const isVercelPreviewHost = (host: string) => {
 };
 
 const initFromHost = (host: string) => {
+  // @ts-ignore
   const setDefaultFlag = (name: FlagName, value: FlagValue) => {
     const flagValue = flag(name);
+
     if (flagValue === null) {
       flag(name, value);
     }
   };
-  if (
+  const shouldSetDefaultFlags =
     host.includes("localhost") ||
     host.includes("test.visualize.admin.ch") ||
-    isVercelPreviewHost(host)
-  ) {
-    setDefaultFlag("configurator.add-dataset.shared", true);
+    isVercelPreviewHost(host);
+
+  if (shouldSetDefaultFlags) {
   }
 };
 
@@ -101,5 +103,3 @@ if (isRunningInBrowser()) {
   initFromSearchParams(window.location.search);
   initFromHost(window.location.host);
 }
-
-export { flag };

--- a/app/flags/types.ts
+++ b/app/flags/types.ts
@@ -3,8 +3,6 @@ export type FlagValue = any;
 export type FlagName =
   /** Whether debug UI like the configurator debug panel is shown */
   | "debug"
-  /** Whether we can add dataset from shared dimensions */
-  | "configurator.add-dataset.shared"
   /** Whether server side cache is disabled */
   | "server-side-cache.disable"
   /** The GraphQL endpoint, is used for testing purposes */


### PR DESCRIPTION
Fixes #1924

This PR removes a flag that made the datasets section hidden in case it was not enabled.