### PR TITLE
fix: increased yAdjustment for axis labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Nothing yet.
   - Changed component id separator text to be more unique, as it was causing
     issues with some cubes that had iris ending with "-"
   - Datasets section in the sidebar is now correctly shown at all times
+  - Improved Preventation of overlapping axis titles for combo charts
 
 # [5.0.1] - 2024-11-26
 

--- a/app/charts/combo/axis-height-linear-dual.tsx
+++ b/app/charts/combo/axis-height-linear-dual.tsx
@@ -16,6 +16,7 @@ import { useAxisTitleAdjustments } from "@/utils/use-axis-title-adjustments";
 import { TITLE_VPADDING } from "./combo-line-container";
 
 const TITLE_HPADDING = 8;
+const TOP_MARGIN = 4;
 
 type AxisHeightLinearDualProps = {
   orientation?: "left" | "right";
@@ -72,8 +73,10 @@ export const AxisHeightLinearDual = (props: AxisHeightLinearDualProps) => {
         width={axisTitleWidth + TITLE_HPADDING * 2}
         height={
           (isOverlapping
-            ? axisLabelFontSize * Math.ceil(overlapAmount) + TITLE_VPADDING 
-            : axisLabelFontSize + TITLE_VPADDING) * 2
+            ? axisLabelFontSize * Math.ceil(overlapAmount) + TITLE_VPADDING
+            : axisLabelFontSize + TITLE_VPADDING) *
+            2 +
+          TOP_MARGIN
         }
         color={theme.palette.getContrastText(color)}
         style={{ display: "flex" }}

--- a/app/charts/combo/combo-line-dual-state.tsx
+++ b/app/charts/combo/combo-line-dual-state.tsx
@@ -37,6 +37,7 @@ import { ComboLineDualConfig } from "@/configurator";
 import { Observation } from "@/domain/data";
 import { truthy } from "@/domain/types";
 import { getTextWidth } from "@/utils/get-text-width";
+import { useAxisTitleAdjustments } from "@/utils/use-axis-title-adjustments";
 import { useIsMobile } from "@/utils/use-is-mobile";
 
 import { ChartProps } from "../shared/ChartProps";
@@ -133,23 +134,11 @@ const useComboLineDualState = (
     )
   );
 
-  const axisTitleLeft = variables.y.left.label;
-  const axisTitleRight = variables.y.right.label;
-  const axisTitleWidthLeft =
-    getTextWidth(axisTitleLeft, { fontSize: TICK_FONT_SIZE }) + TICK_PADDING;
-  const axisTitleWidthRight =
-    getTextWidth(axisTitleRight, { fontSize: TICK_FONT_SIZE }) + TICK_PADDING;
-  const overLappingTitles = axisTitleWidthLeft + axisTitleWidthRight > width;
-  const overLappingAmount = (axisTitleWidthLeft + axisTitleWidthRight) / width;
-
-  const axisTitleAdjustment =
-    (overLappingTitles
-      ? TICK_FONT_SIZE * Math.ceil(overLappingAmount)
-      : TICK_FONT_SIZE + TITLE_VPADDING) *
-      2 -
-    TICK_FONT_SIZE * 2;
-
-  const topMarginAxisTitleAdjustment = 50 + axisTitleAdjustment;
+  const { topMarginAxisTitleAdjustment } = useAxisTitleAdjustments({
+    leftAxisTitle: variables.y.left.label,
+    rightAxisTitle: variables.y.right.label,
+    containerWidth: width,
+  });
 
   const right = Math.max(maxRightTickWidth, 40);
 
@@ -159,12 +148,12 @@ const useComboLineDualState = (
     bottom,
     top: topMarginAxisTitleAdjustment,
   });
-  
+
   const bounds = useChartBounds(width, margins, height, {
     leftLabel: variables.y.left.label,
     rightLabel: variables.y.right.label,
   });
-        
+
   const { chartWidth, chartHeight } = bounds;
   const xScales = [xScale, xScaleTimeRange];
   const yScales = [yScale, yScaleLeft, yScaleRight];

--- a/app/utils/use-axis-title-adjustments.ts
+++ b/app/utils/use-axis-title-adjustments.ts
@@ -40,7 +40,7 @@ export const useAxisTitleAdjustments = ({
       2 -
     fontSize * 2;
 
-  const topMarginAxisTitleAdjustment = 50 + axisTitleAdjustment;
+  const topMarginAxisTitleAdjustment = 60 + axisTitleAdjustment;
 
   return {
     axisTitleAdjustment,


### PR DESCRIPTION
**This PR:** 
- This PR increase yAdjustment for axis Titles, like this they stop overlapping 
- This PR resolves #1878 

### How to Test
1. Go to this [link](https://visualization-tool-git-fix-minor-bugs-ixt1.vercel.app/) 
2. Search Photo and Select (Einmalvergütung für Photovoltaikanlagen) Dataset
3. Select a Combo Chart type 
4. Select the longest titles for but indicators 
5. Publish the Chart resize your screen up to 350px
6. See how the Titles never overlap ✅

---

CC: @sosiology 