### PR TITLE
fix: Preview via API (iframe)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ You can also check the
 
 - Features
   - It's now possible to export charts as images
+- Fixes
+  - Fixed preview via API (iframe)
 
 # [5.0.2] - 2024-11-28
 

--- a/app/pages/_preview.tsx
+++ b/app/pages/_preview.tsx
@@ -2,7 +2,6 @@ import { Box } from "@mui/material";
 import { useEffect } from "react";
 
 import { useLocale } from "@/locales/use-locale";
-import { migrateConfiguratorState } from "@/utils/chart-config/versioning";
 
 const Page = () => {
   const locale = useLocale();
@@ -12,52 +11,7 @@ const Page = () => {
       const iframeWindow = iframe?.contentWindow as Window | undefined;
 
       if (iframeWindow) {
-        iframeWindow.postMessage(
-          await migrateConfiguratorState({
-            state: "CONFIGURING_CHART",
-            dataSet:
-              "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/2",
-            dataSource: {
-              type: "sparql",
-              url: "https://lindas.admin.ch/query",
-            },
-            meta: {
-              title: { de: "", fr: "", it: "", en: "" },
-              description: { de: "", fr: "", it: "", en: "" },
-            },
-            chartConfig: {
-              version: "1.4.2",
-              chartType: "column",
-              filters: {
-                "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Kanton":
-                  { type: "single", value: "https://ld.admin.ch/canton/1" },
-              },
-              interactiveFiltersConfig: {
-                legend: { active: false, componentIri: "" },
-                timeRange: {
-                  active: false,
-                  componentIri:
-                    "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr",
-                  presets: { type: "range", from: "", to: "" },
-                },
-                dataFilters: { active: false, componentIris: [] },
-                calculation: { active: false, type: "identity" },
-              },
-              fields: {
-                x: {
-                  componentIri:
-                    "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr",
-                  sorting: { sortingType: "byAuto", sortingOrder: "asc" },
-                },
-                y: {
-                  componentIri:
-                    "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/AnzahlAnlagen",
-                },
-              },
-            },
-          }),
-          "*"
-        );
+        iframeWindow.postMessage(CONFIGURATOR_STATE, "*");
       }
     };
   }, []);
@@ -78,3 +32,47 @@ const Page = () => {
 };
 
 export default Page;
+
+const CONFIGURATOR_STATE = {
+  state: "CONFIGURING_CHART",
+  dataSet:
+    "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/2",
+  dataSource: {
+    type: "sparql",
+    url: "https://lindas.admin.ch/query",
+  },
+  meta: {
+    title: { de: "", fr: "", it: "", en: "" },
+    description: { de: "", fr: "", it: "", en: "" },
+  },
+  chartConfig: {
+    version: "1.4.2",
+    chartType: "column",
+    filters: {
+      "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Kanton":
+        { type: "single", value: "https://ld.admin.ch/canton/1" },
+    },
+    interactiveFiltersConfig: {
+      legend: { active: false, componentIri: "" },
+      timeRange: {
+        active: false,
+        componentIri:
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr",
+        presets: { type: "range", from: "", to: "" },
+      },
+      dataFilters: { active: false, componentIris: [] },
+      calculation: { active: false, type: "identity" },
+    },
+    fields: {
+      x: {
+        componentIri:
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr",
+        sorting: { sortingType: "byAuto", sortingOrder: "asc" },
+      },
+      y: {
+        componentIri:
+          "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/AnzahlAnlagen",
+      },
+    },
+  },
+};

--- a/e2e/preview-via-api.spec.ts
+++ b/e2e/preview-via-api.spec.ts
@@ -1,0 +1,15 @@
+import { setup } from "./common";
+
+const { test } = setup();
+
+test("should be possible to preview charts via API (iframe)", async ({
+  page,
+  selectors,
+}) => {
+  await page.goto("/en/_preview");
+  await page.waitForSelector("iframe");
+  const iframe = page.locator("iframe");
+  const contentFrame = iframe.contentFrame();
+  await selectors.chart.loaded();
+  await contentFrame.locator("svg").first().waitFor({ timeout: 10_000 });
+});


### PR DESCRIPTION
Fixes #1941

This PR fixes broken chart preview via API (iframe version) and adds an E2E test so we can avoid such regression going forward.

## How to test
1. Go to [this link](https://visualization-tool-git-fix-preview-via-api-iframe-ixt1.vercel.app/_preview).
2. ✅ See that the chart loads.

## How to reproduce (INT)
1. Go to [this link](https://int.visualize.admin.ch/_preview).
2. ❌ See that the chart doesn't load.