### PR TITLE
fix: Keep color mapping up to date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ You can also check the
 
 - Features
   - It's now possible to export charts as images
+- Fixes
+  - Color mapping is now correctly kept up to date in case of editing an old
+    chart and the cube has been updated in the meantime and contains new values
+    in the color dimension
 
 # [5.0.2] - 2024-11-28
 
@@ -23,7 +27,7 @@ You can also check the
   - Changed component id separator text to be more unique, as it was causing
     issues with some cubes that had iris ending with "-"
   - Datasets section in the sidebar is now correctly shown at all times
-  - Improved Preventation of overlapping axis titles for combo charts
+  - Improved prevention of overlapping axis titles for combo charts
 
 # [5.0.1] - 2024-11-26
 

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -432,7 +432,7 @@ const MultiFilterContent = ({
                     />
                   ) : (
                     <>
-                      <Typography variant="body2" sx={{ flexGrow: 1 }}>
+                      <Typography variant="body2" style={{ flexGrow: 1 }}>
                         {label}
                       </Typography>
                       <SvgIcCheck />

--- a/app/configurator/components/ui-helpers.ts
+++ b/app/configurator/components/ui-helpers.ts
@@ -7,7 +7,7 @@ import { useMemo } from "react";
 import { match } from "ts-pattern";
 
 import type { BaseChartProps } from "@/charts/shared/ChartProps";
-import { TableColumn, TableFields } from "@/config-types";
+import { ColorMapping, TableColumn, TableFields } from "@/config-types";
 import { FIELD_VALUE_NONE } from "@/configurator/constants";
 import {
   Component,
@@ -270,10 +270,12 @@ const randomComparator = () => (Math.random() > 0.5 ? 1 : -1);
 export const mapValueIrisToColor = ({
   palette,
   dimensionValues,
+  colorMapping: oldColorMapping,
   random,
 }: {
   palette: string;
   dimensionValues: DimensionValue[];
+  colorMapping?: ColorMapping;
   random?: boolean;
 }) => {
   if (!dimensionValues) {
@@ -284,6 +286,7 @@ export const mapValueIrisToColor = ({
   const colors = dimensionValues.map(
     (d, i) =>
       (palette === "dimension" && d.color) ||
+      oldColorMapping?.[`${d.value}`] ||
       paletteValues[i % paletteValues.length]
   );
   const colorScale = scaleOrdinal<string, string>()

--- a/app/configurator/configurator-state/actions.tsx
+++ b/app/configurator/configurator-state/actions.tsx
@@ -2,6 +2,7 @@ import { EncodingFieldType } from "@/charts/chart-config-ui-options";
 import {
   ChartConfig,
   ChartType,
+  ColorMapping,
   ConfiguratorState,
   DashboardFiltersConfig,
   DataSource,
@@ -178,6 +179,7 @@ export type ConfiguratorStateAction =
       value: {
         field: string;
         colorConfigPath: string | undefined;
+        colorMapping?: ColorMapping;
         dimensionId: string;
         values: DimensionValue[];
         random: boolean;

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -458,8 +458,14 @@ export const updateColorMapping = (
   >
 ) => {
   if (isConfiguring(draft)) {
-    const { field, colorConfigPath, dimensionId, values, random } =
-      action.value;
+    const {
+      field,
+      colorConfigPath,
+      colorMapping: oldColorMapping,
+      dimensionId,
+      values,
+      random,
+    } = action.value;
     const chartConfig = getChartConfig(draft);
     const path = colorConfigPath
       ? ["fields", field, colorConfigPath]
@@ -476,6 +482,7 @@ export const updateColorMapping = (
         colorMapping = mapValueIrisToColor({
           palette: fieldValue.palette,
           dimensionValues: values,
+          colorMapping: oldColorMapping,
           random,
         });
       }
@@ -489,6 +496,7 @@ export const updateColorMapping = (
         colorMapping = mapValueIrisToColor({
           palette: fieldValue.palette,
           dimensionValues: values,
+          colorMapping: oldColorMapping,
           random,
         });
       }


### PR DESCRIPTION
Fixes #1513

This PR makes sure we keep the `colorMapping` up to date in case new values appear in the cube (only possible when editing a chart that's based on a cube that was updated with a new value in dimension used as a color dimension after the chart was initially made). It also makes sure we keep old colors for existing values when updating the `colorMapping`.

## How to test
1. Go to this link.
2. 123

## How to reproduce
1. Go to this link.
2. 123