### PR TITLE
fix: Chart sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ You can also check the
     chart and the cube has been updated in the meantime and contains new values
     in the color dimension
   - Fixed preview via API (iframe)
+  - Fixed cut table scroll-bars and unnecessary scroll of bar charts when
+    switching between chart types
 
 # [5.0.2] - 2024-11-28
 

--- a/app/charts/shared/containers.tsx
+++ b/app/charts/shared/containers.tsx
@@ -19,6 +19,8 @@ export const useStyles = makeStyles<{}, {}, "chartContainer">(() => ({
   chartContainer: {
     overflow: "hidden",
     position: "relative",
+    display: "flex",
+    flexDirection: "column",
     width: "100%",
     flexGrow: 1,
   },

--- a/app/charts/shared/containers.tsx
+++ b/app/charts/shared/containers.tsx
@@ -7,6 +7,7 @@ import { useChartState } from "@/charts/shared/chart-state";
 import { CalculationToggle } from "@/charts/shared/interactive-filter-calculation-toggle";
 import { useObserverRef } from "@/charts/shared/use-size";
 import {
+  getChartConfig,
   hasChartConfigs,
   isLayoutingFreeCanvas,
   useConfiguratorState,
@@ -25,12 +26,15 @@ export const useStyles = makeStyles<{}, {}, "chartContainer">(() => ({
 
 export const ChartContainer = ({ children }: { children: ReactNode }) => {
   const [state] = useConfiguratorState(hasChartConfigs);
+  const chartConfig = getChartConfig(state);
   const isFreeCanvas = isLayoutingFreeCanvas(state);
   const ref = useObserverRef();
   const { bounds } = useChartState();
   const classes = useStyles();
+
   return (
     <div
+      key={chartConfig.chartType}
       ref={ref}
       aria-hidden="true"
       className={classes.chartContainer}

--- a/app/charts/shared/containers.tsx
+++ b/app/charts/shared/containers.tsx
@@ -36,6 +36,8 @@ export const ChartContainer = ({ children }: { children: ReactNode }) => {
 
   return (
     <div
+      // Re-mount to prevent issues with useSize hook when switching between
+      // chart types (that might have different sizes).
       key={chartConfig.chartType}
       ref={ref}
       aria-hidden="true"


### PR DESCRIPTION
Fixes #1939

This PR fixes some chart container sizing issues by:
- re-mounting the container when chart type changes, which fixes errors most noticeable in bar charts, which were scrollable when not needed (due to taking an old height value from the old, mounted container),
- uses flex display for chart container, which makes the table chart correctly take up 100% of the remaining parent container, not 100% of the parent container, which was resulting in cut scrollbars and double scroll.

## How to test
1. Go to [this link](https://visualization-tool-git-fix-chart-sizing-ixt1.vercel.app/en/create/new?cube=https://health.ld.admin.ch/fsvo/Lebensmittelkontrolle_Steckbriefe_Table/21&dataSource=Int).
2. Switch to a table chart.
3. ✅ See that the _Total number of lines: 389_ note is visible in the right bottom corner of the chart.
4. ✅ Scroll the table and see that you can scroll it all the way down and see the scrollbar at all times.
5. Resize the browser window so that you can scroll the table horizontally.
6. ✅ See that the horizontal scrollbar is always visible.

## How to reproduce
1. Go to [this link](https://int.visualize.admin.ch/en/create/new?cube=https://health.ld.admin.ch/fsvo/Lebensmittelkontrolle_Steckbriefe_Table/21&dataSource=Int).
2. Switch to a table chart.
3. ❌ See that the _Total number of lines: 389_ note is not visible in the right bottom corner of the chart.
4. ❌ Scroll the table and see that you can scroll it all the way down, but the scrollbar is cut near the bottom.
5. Resize the browser window so that you can scroll the table horizontally.
6. ❌ See that the horizontal scrollbar is not visible.