### PR TITLE
fix: Changed map radiusScale for increased size for small values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ You can also check the
   - Fixed preview via API (iframe)
   - Fixed cut table scroll-bars and unnecessary scroll of bar charts when
     switching between chart types
+  - Fixed map dimension symbols to increase the elements size for small values, whilst preventing any 0 and undefined values from displaying
 
 # [5.0.2] - 2024-11-28
 

--- a/app/charts/map/map-state.tsx
+++ b/app/charts/map/map-state.tsx
@@ -150,6 +150,8 @@ const useMapState = (
   });
 
   const radiusScale = useMemo(() => {
+    // Measure dimension is undefined. Can be useful when the user wants to
+    // encode only the color of symbols, and the size is irrelevant.
     if (symbolLayerState.dataDomain[1] === undefined) {
       return scaleSqrt().range([0, 12]).unknown(12);
     }

--- a/app/charts/map/map-state.tsx
+++ b/app/charts/map/map-state.tsx
@@ -150,15 +150,24 @@ const useMapState = (
   });
 
   const radiusScale = useMemo(() => {
-    // Measure dimension is undefined. Can be useful when the user wants to
-    // encode only the color of symbols, and the size is irrelevant.
     if (symbolLayerState.dataDomain[1] === undefined) {
       return scaleSqrt().range([0, 12]).unknown(12);
-    } else {
-      return scaleSqrt()
-        .domain([0, symbolLayerState.dataDomain[1]])
-        .range([0, 24]);
     }
+
+    const baseScale = scaleSqrt()
+      .domain([0, symbolLayerState.dataDomain[1]])
+      .range([0, 24]);
+
+    const wrappedScale = (x: number | null) => {
+      if (x === null || x === undefined) return 0;
+      if (x === 0) return 0;
+      const scaled = baseScale(x);
+      return Math.max(2, scaled);
+    };
+
+    Object.assign(wrappedScale, baseScale);
+
+    return wrappedScale;
   }, [symbolLayerState.dataDomain]) as ScalePower<number, number>;
 
   const preparedSymbolLayerState: MapState["symbolLayer"] = useMemo(() => {


### PR DESCRIPTION
**This PR**
- fixes #480 

**Description**
Values that are null, undefined or 0 will be not displayed and values that are very small will be scaled up slightly. In the future it might make sense to display null, undefined and 0 visibly in some form.