### PR TITLE
fix: Double visualize.admin.ch footnote in published chart image downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ You can also check the
   - Fixed cut table scroll-bars and unnecessary scroll of bar charts when
     switching between chart types
   - Sorting dataset results by score option is now correctly available to select
+  - Created with visualize.admin.ch footnote is only displayed once, not twice,
+    when downloading an image of a published chart
 - Styles
   - Updated dataset result borders to match the design
 - Maintenance

--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -20,6 +20,7 @@ import { Component, Measure } from "@/domain/data";
 import { useTimeFormatLocale } from "@/formatters";
 import { useDataCubesMetadataQuery } from "@/graphql/hooks";
 import { useLocale } from "@/locales/use-locale";
+import { DISABLE_SCREENSHOT_ATTR } from "@/utils/use-screenshot";
 
 export const useFootnotesStyles = makeStyles<Theme, { useMarginTop: boolean }>(
   (theme) => ({
@@ -292,7 +293,7 @@ export const VisualizeLink = ({ createdWith }: { createdWith: ReactNode }) => {
   const locale = useLocale();
 
   return (
-    <Typography variant="caption" color="grey.600">
+    <Typography variant="caption" color="grey.600" {...DISABLE_SCREENSHOT_ATTR}>
       {createdWith}
       <Link
         href={`https://visualize.admin.ch/${locale}/`}


### PR DESCRIPTION
Closes https://github.com/visualize-admin/visualization-tool/issues/1928#issuecomment-2577355736

This PR makes sure we only have one "Created with visualize.admin.ch" footnote when making a screenshot of a published chart.

## How to test
1. Go to [this link](https://visualization-tool-git-fix-double-made-with-visuali-e7a011-ixt1.vercel.app/en/v/FwN1UJUrMywH?dataSource=Prod).
2. Download an image of the chart.
3. ✅ See that the "Created with visualize.admin.ch" footnote is only there once.

## How to reproduce
1. Go to [this link](https://test.visualize.admin.ch/en/v/Md9KZ3H4AipE?dataSource=Prod).
2. Download an image of the chart.
3. ❌ See that the "Created with visualize.admin.ch" footnote is there twice.

cc @sosiology