### PR TITLE
fix: Entering dates via text input in DatePickerField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ You can also check the
   - Sorting dataset results by score option is now correctly available to select
   - Created with visualize.admin.ch footnote is only displayed once, not twice,
     when downloading an image of a published chart
+  - Changing dates manually using keyboard works correctly now in date picker
+    inputs
 - Styles
   - Updated dataset result borders to match the design
 - Maintenance

--- a/app/configurator/components/field-date-picker.tsx
+++ b/app/configurator/components/field-date-picker.tsx
@@ -91,8 +91,11 @@ export const DatePickerField = (props: DatePickerFieldProps) => {
             views={getViews(timeUnit)}
             value={value}
             onAccept={handleChange}
-            // Need to pass onChange to avoid type error.
-            onChange={() => {}}
+            onChange={(date, keyboardInputValue) => {
+              if (keyboardInputValue) {
+                handleChange(date);
+              }
+            }}
             // We need to render the day picker ourselves to correctly highlight
             // the selected day. It's broken in the MUI date picker.
             renderDay={(day, _, dayPickerProps) => {


### PR DESCRIPTION
Fixes #1689

This PR makes entering the dates manually via text input work correctly again in date picker fields. Not sure why, but the `onChange` callback was set to an empty function, which prevented this behavior from working properly.

## How to test
1. Go to [this link](https://visualization-tool-git-fix-manual-date-entry-ixt1.vercel.app/en/create/new?cube=https://environment.ld.admin.ch/foen/ubd01041prod/4&dataSource=Prod).
2. Select `Horizontal axis`.
3. ✅ Enter 10.05.2016 in the `From` input field and see that it works.

## How to reproduce
Check https://github.com/visualize-admin/visualization-tool/issues/1689#issuecomment-2577567527.