### PR TITLE
fix: Opening temporal timezone dimension table field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ You can also check the
     when downloading an image of a published chart
   - Changing dates manually using keyboard works correctly now in date picker
     inputs
+  - Opening a temporal dimension with timezone in table chart configurator
+    doesn't crash the application anymore
 - Styles
   - Updated dataset result borders to match the design
 - Maintenance

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -1181,19 +1181,23 @@ export const TimeFilter = (props: TimeFilterProps) => {
   }
 };
 
-type LeftRightFormContainerProps = {
+const LeftRightFormContainer = ({
+  left,
+  right,
+}: {
   left: ReactNode;
   right: ReactNode;
-};
+}) => {
+  const columnGap = 12;
+  const middleElementSize = 8;
+  const sideElementSize = DRAWER_WIDTH / 2 - columnGap * 2 - middleElementSize;
 
-const LeftRightFormContainer = (props: LeftRightFormContainerProps) => {
-  const { left, right } = props;
   return (
     <Box
       sx={{
         display: "grid",
-        columnGap: "0.75rem",
-        gridTemplateColumns: "1fr auto 1fr",
+        columnGap: `${columnGap}px`,
+        gridTemplateColumns: `${sideElementSize}px ${middleElementSize}px ${sideElementSize}px`,
         alignItems: "center",
       }}
     >

--- a/app/themes/federal.tsx
+++ b/app/themes/federal.tsx
@@ -208,7 +208,6 @@ theme.components = {
     styleOverrides: {
       root: {
         textAlign: "left",
-        pr: 1,
         WebkitLineClamp: 2,
         WebkitBoxOrient: "vertical",
         display: "-webkit-box",

--- a/app/utils/time-filter-options.spec.ts
+++ b/app/utils/time-filter-options.spec.ts
@@ -1,0 +1,37 @@
+import { TemporalDimension } from "@/domain/data";
+import { TimeUnit } from "@/graphql/resolver-types";
+import { getD3TimeFormatLocale } from "@/locales/locales";
+import { getTimeFilterOptions } from "@/utils/time-filter-options";
+
+describe("getTimeFilterOptions", () => {
+  const dimension = {
+    __typename: "TemporalDimension",
+    timeFormat: "%Y-%m-%dT%H:%M:%S",
+    timeUnit: TimeUnit.Second,
+    values: [
+      {
+        value: "2025-01-10T00:00:00+01:00",
+        label: "2025-01-10T00:00:00+01:00",
+      },
+      {
+        value: "2025-01-11T00:00:00+01:00",
+        label: "2025-01-11T00:00:00+01:00",
+      },
+      {
+        value: "2025-01-12T00:00:00+01:00",
+        label: "2025-01-12T00:00:00+01:00",
+      },
+    ],
+  } as TemporalDimension;
+  const formatLocale = getD3TimeFormatLocale("de");
+  const timeFormatUnit = jest.fn();
+
+  it("should correctly parse dates with timezone", () => {
+    const { sortedOptions } = getTimeFilterOptions({
+      dimension,
+      formatLocale,
+      timeFormatUnit,
+    });
+    expect(sortedOptions).toHaveLength(3);
+  });
+});

--- a/app/utils/time-filter-options.tsx
+++ b/app/utils/time-filter-options.tsx
@@ -7,16 +7,18 @@ import {
 } from "@/domain/data";
 import { useTimeFormatLocale, useTimeFormatUnit } from "@/formatters";
 
-type GetTimeFilterOptionsProps = {
+export const getTimeFilterOptions = ({
+  dimension,
+  formatLocale,
+  timeFormatUnit,
+}: {
   dimension: TemporalDimension | TemporalEntityDimension;
   formatLocale: ReturnType<typeof useTimeFormatLocale>;
   timeFormatUnit: ReturnType<typeof useTimeFormatUnit>;
-};
-
-export const getTimeFilterOptions = (props: GetTimeFilterOptionsProps) => {
-  const { dimension, formatLocale, timeFormatUnit } = props;
+}) => {
   const { timeFormat, timeUnit } = dimension;
-  const parse = formatLocale.parse(timeFormat);
+  const parseDate = getMaybeTimezoneDateParser({ formatLocale, timeFormat });
+  const formatDate = formatLocale.format(timeFormat);
   const sortedOptions: {
     value: ObservationValue;
     label: string;
@@ -39,11 +41,12 @@ export const getTimeFilterOptions = (props: GetTimeFilterOptionsProps) => {
         return _exhaustiveCheck;
     }
 
-    const date = parse(`${value}`);
+    const date = parseDate(value);
 
     if (date) {
       sortedOptions.push({
-        value,
+        // By formatting the date, we remove potential timezone.
+        value: formatDate(date),
         label: timeFormatUnit(date, timeUnit),
         date,
       });
@@ -54,5 +57,20 @@ export const getTimeFilterOptions = (props: GetTimeFilterOptionsProps) => {
   return {
     sortedOptions,
     sortedValues,
+  };
+};
+
+const getMaybeTimezoneDateParser = ({
+  formatLocale,
+  timeFormat,
+}: {
+  formatLocale: ReturnType<typeof useTimeFormatLocale>;
+  timeFormat: string;
+}) => {
+  const parse = formatLocale.parse(timeFormat);
+  const timezoneParse = formatLocale.parse(`${timeFormat}%Z`);
+
+  return (v: string | number | null) => {
+    return (parse(`${v}`) ?? timezoneParse(`${v}`)) as Date;
   };
 };

--- a/app/utils/time-filter-options.tsx
+++ b/app/utils/time-filter-options.tsx
@@ -46,6 +46,7 @@ export const getTimeFilterOptions = ({
     if (date) {
       sortedOptions.push({
         // By formatting the date, we remove potential timezone.
+        // FIXME: This might lead to issues with SPARQL filtering.
         value: formatDate(date),
         label: timeFormatUnit(date, timeUnit),
         date,


### PR DESCRIPTION
This PR fixes #1963

## How to test
1. Go to [this link](https://visualization-tool-git-fix-timezone-parsing-ixt1.vercel.app/en/create/new?cube=https://environment.ld.admin.ch/foen/gefahren-waldbrand-warnung/1&dataSource=Prod).
2. Switch to a table chart.
3. Open `Active since` field.
4. ✅ See that the application didn't crash.

## How to reproduce
Follow the steps from #1963.