### PR TITLE
fix: Configurator state migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ You can also check the
 - Features
   - Added a new option to the vertical axis on the line chart, allowing users to
     display a dot over the line where it intercepts the x-axis ticks
+- Fixes
+  - Preview via API now works correctly for map charts
 
 # [5.1.0] - 2025-01-14
 

--- a/app/package.json
+++ b/app/package.json
@@ -23,6 +23,7 @@
     "@dnd-kit/utilities": "3.2.2",
     "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.8.1",
+    "@graphql-tools/schema": "^7.1.5",
     "@juggle/resize-observer": "^3.4.0",
     "@lingui/core": "^3.17.2",
     "@lingui/react": "^3.17.2",

--- a/app/pages/_preview.tsx
+++ b/app/pages/_preview.tsx
@@ -2,38 +2,49 @@ import { Box } from "@mui/material";
 import { useEffect } from "react";
 
 import { useLocale } from "@/locales/use-locale";
+import CONFIGURATOR_STATE_MAP from "@/test/__fixtures/config/prod/map-1.json";
+
+const loadIframe = (id: string, config: any) => {
+  const iframe = document.getElementById(id) as HTMLIFrameElement;
+  iframe.onload = async () => {
+    const iframeWindow = iframe?.contentWindow as Window | undefined;
+
+    if (iframeWindow) {
+      iframeWindow.postMessage(config, "*");
+    }
+  };
+};
 
 const Page = () => {
   const locale = useLocale();
-  useEffect(() => {
-    const iframe = document.getElementById("chart") as HTMLIFrameElement;
-    iframe.onload = async () => {
-      const iframeWindow = iframe?.contentWindow as Window | undefined;
 
-      if (iframeWindow) {
-        iframeWindow.postMessage(CONFIGURATOR_STATE, "*");
-      }
-    };
+  useEffect(() => {
+    loadIframe("chart-column", CONFIGURATOR_STATE_COLUMN);
+    loadIframe("chart-map", CONFIGURATOR_STATE_MAP);
   }, []);
 
   return (
-    <Box sx={{ display: "flex", flexDirection: "column", gap: 6, p: 6 }}>
-      <iframe
-        id="chart"
-        src={`/${locale}/preview`}
-        style={{
+    <Box
+      sx={{
+        display: "flex",
+        gap: 6,
+        p: 6,
+        "& > iframe": {
           width: 450,
           height: 750,
           border: "none",
-        }}
-      />
+        },
+      }}
+    >
+      <iframe id="chart-column" src={`/${locale}/preview`} />
+      <iframe id="chart-map" src={`/${locale}/preview`} />
     </Box>
   );
 };
 
 export default Page;
 
-const CONFIGURATOR_STATE = {
+const CONFIGURATOR_STATE_COLUMN = {
   state: "CONFIGURING_CHART",
   dataSet:
     "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/2",

--- a/app/pages/preview_post.tsx
+++ b/app/pages/preview_post.tsx
@@ -5,9 +5,9 @@ import { GetServerSideProps } from "next";
 import { useEffect, useState } from "react";
 
 import { ChartPublished } from "@/components/chart-published";
-import { ConfiguratorState } from "@/configurator";
+import { ConfiguratorState, decodeConfiguratorState } from "@/configurator";
 import { GraphqlProvider } from "@/graphql/GraphqlProvider";
-import { Locale, defaultLocale, i18n } from "@/locales/locales";
+import { defaultLocale, i18n, Locale } from "@/locales/locales";
 import { LocaleProvider } from "@/locales/use-locale";
 import { ConfiguratorStateProvider } from "@/src";
 import * as federalTheme from "@/themes/federal";
@@ -62,8 +62,12 @@ export default function Preview({ configuratorState, locale }: PageProps) {
   const [migrated, setMigrated] = useState<ConfiguratorState>();
   useEffect(() => {
     const run = async () => {
+      const migratedConfiguratorState = decodeConfiguratorState(
+        await migrateConfiguratorState(configuratorState)
+      );
       setMigrated({
-        ...(await migrateConfiguratorState(configuratorState)),
+        ...migratedConfiguratorState,
+        // Force state published for <ChartPublished /> to work correctly
         state: "PUBLISHED",
       } as ConfiguratorState);
     };

--- a/app/test/__fixtures/config/prod/map-1.json
+++ b/app/test/__fixtures/config/prod/map-1.json
@@ -1,0 +1,152 @@
+{
+  "version": "3.4.0",
+  "state": "CONFIGURING_CHART",
+  "dataSource": {
+    "type": "sparql",
+    "url": "https://lindas-cached.cluster.ldbar.ch/query"
+  },
+  "layout": {
+    "type": "tab",
+    "meta": {
+      "title": {
+        "de": "",
+        "en": "",
+        "fr": "",
+        "it": ""
+      },
+      "description": {
+        "de": "",
+        "en": "",
+        "fr": "",
+        "it": ""
+      }
+    }
+  },
+  "chartConfigs": [
+    {
+      "key": "jEASF-9qEqaC",
+      "version": "3.3.0",
+      "meta": {
+        "title": {
+          "en": "",
+          "de": "",
+          "fr": "",
+          "it": ""
+        },
+        "description": {
+          "en": "",
+          "de": "",
+          "fr": "",
+          "it": ""
+        }
+      },
+      "cubes": [
+        {
+          "iri": "https://environment.ld.admin.ch/foen/nfi/nfi_C-2637/cube/2024-1",
+          "publishIri": "https://environment.ld.admin.ch/foen/nfi/nfi_C-2637/cube/2024-1",
+          "filters": {
+            "https://environment.ld.admin.ch/foen/nfi/unitOfReference": {
+              "type": "multi",
+              "values": {
+                "https://ld.admin.ch/canton/19": true,
+                "https://ld.admin.ch/canton/15": true,
+                "https://ld.admin.ch/canton/16": true,
+                "https://ld.admin.ch/canton/2": true,
+                "https://ld.admin.ch/canton/10": true,
+                "https://ld.admin.ch/canton/25": true,
+                "https://ld.admin.ch/canton/8": true,
+                "https://ld.admin.ch/canton/18": true,
+                "https://ld.admin.ch/canton/26": true,
+                "https://ld.admin.ch/canton/3": true,
+                "https://ld.admin.ch/canton/24": true,
+                "https://ld.admin.ch/canton/7": true,
+                "https://ld.admin.ch/canton/6": true,
+                "https://ld.admin.ch/canton/14": true,
+                "https://ld.admin.ch/canton/5": true,
+                "https://ld.admin.ch/canton/11": true,
+                "https://ld.admin.ch/canton/17": true,
+                "https://ld.admin.ch/canton/21": true,
+                "https://ld.admin.ch/canton/20": true,
+                "https://ld.admin.ch/canton/4": true,
+                "https://ld.admin.ch/canton/22": true,
+                "https://ld.admin.ch/canton/23": true,
+                "https://ld.admin.ch/canton/9": true,
+                "https://ld.admin.ch/canton/1": true,
+                "https://ld.admin.ch/dimension/bgdi/biota/cantonregions/13": true
+              }
+            },
+            "https://environment.ld.admin.ch/foen/nfi/classificationUnit": {
+              "type": "single",
+              "value": "https://environment.ld.admin.ch/foen/nfi/ClassificationUnit/Total"
+            },
+            "https://environment.ld.admin.ch/foen/nfi/evaluationType": {
+              "type": "single",
+              "value": "https://environment.ld.admin.ch/foen/nfi/EvaluationType/1"
+            },
+            "https://environment.ld.admin.ch/foen/nfi/grid": {
+              "type": "single",
+              "value": "https://environment.ld.admin.ch/foen/nfi/Grid/410"
+            },
+            "https://environment.ld.admin.ch/foen/nfi/unitOfEvaluation": {
+              "type": "single",
+              "value": "https://environment.ld.admin.ch/foen/nfi/UnitOfEvaluation/434"
+            }
+          }
+        }
+      ],
+      "activeField": "animation",
+      "chartType": "map",
+      "interactiveFiltersConfig": {
+        "legend": {
+          "active": false,
+          "componentIri": ""
+        },
+        "timeRange": {
+          "active": false,
+          "componentIri": "https://environment.ld.admin.ch/foen/nfi/inventory",
+          "presets": {
+            "type": "range",
+            "from": "",
+            "to": ""
+          }
+        },
+        "dataFilters": {
+          "active": false,
+          "componentIris": []
+        },
+        "calculation": {
+          "active": false,
+          "type": "identity"
+        }
+      },
+      "baseLayer": {
+        "show": true,
+        "locked": false
+      },
+      "fields": {
+        "areaLayer": {
+          "componentIri": "https://environment.ld.admin.ch/foen/nfi/unitOfReference",
+          "color": {
+            "type": "numerical",
+            "componentIri": "https://environment.ld.admin.ch/foen/nfi/Topic/144",
+            "palette": "oranges",
+            "scaleType": "continuous",
+            "interpolationType": "linear",
+            "opacity": 100
+          }
+        },
+        "animation": {
+          "componentIri": "https://environment.ld.admin.ch/foen/nfi/inventory",
+          "showPlayButton": true,
+          "duration": 10,
+          "type": "stepped",
+          "dynamicScales": false
+        }
+      }
+    }
+  ],
+  "activeChartKey": "jEASF-9qEqaC",
+  "dashboardFilters": {
+    "filters": []
+  }
+}

--- a/app/utils/chart-config/versioning.spec.ts
+++ b/app/utils/chart-config/versioning.spec.ts
@@ -6,19 +6,19 @@ import {
 } from "@/config-types";
 import { configJoinedCubes } from "@/configurator/configurator-state/mocks";
 import { stringifyComponentId } from "@/graphql/make-component-id";
+import mapConfigV3_3_0 from "@/test/__fixtures/config/prod/map-1.json";
 import dualLine1Fixture from "@/test/__fixtures/config/test/chartConfig-photovoltaik-und-gebaudeprogramm.json";
 import tableFixture from "@/test/__fixtures/config/test/chartConfig-table-covid19.json";
 import {
   CHART_CONFIG_VERSION,
   CONFIGURATOR_STATE_VERSION,
 } from "@/utils/chart-config/constants";
-
 import {
   chartConfigMigrations,
   configuratorStateMigrations,
   migrateChartConfig,
   upOrDown,
-} from "./versioning";
+} from "@/utils/chart-config/versioning";
 
 const CONFIGURATOR_STATE = {
   dataSource: {
@@ -43,7 +43,7 @@ const CONFIGURATOR_STATE = {
 } as unknown as ConfiguratorStateConfiguringChart;
 
 describe("config migrations", () => {
-  const oldMapConfig = {
+  const mapConfigV1_0_0 = {
     version: "1.0.0",
     chartType: "map",
     interactiveFiltersConfig: {
@@ -87,7 +87,7 @@ describe("config migrations", () => {
       show: true,
     },
   };
-  const oldLineConfig = {
+  const lineConfigV1_0_0 = {
     version: "1.0.0",
     chartType: "line",
     interactiveFiltersConfig: {
@@ -120,43 +120,41 @@ describe("config migrations", () => {
     },
   };
 
-  it("should migrate to newest config and back (but might lost some info for major version changes", async () => {
-    const migratedConfig = await migrateChartConfig(oldMapConfig, {
+  it("should migrate to newest config and back (but might lost some info for major version changes)", async () => {
+    const migratedConfig = await migrateChartConfig(mapConfigV1_0_0, {
       migrationProps: CONFIGURATOR_STATE,
     });
-
     expect(migratedConfig).toBeDefined();
 
     const migratedOldConfig = (await migrateChartConfig(migratedConfig, {
       toVersion: "1.0.0",
     })) as any;
     expect(migratedOldConfig.version).toEqual("1.0.0");
-    const symbolLayer = migratedOldConfig.fields.symbolLayer!;
-    // @ts-ignore - show does not existing in the newer version of the types
+    const symbolLayer = migratedOldConfig.fields.symbolLayer;
     expect(symbolLayer.show).toEqual(false);
     // Should migrate "GeoCoordinatesDimensionIri" to iri defined in Area Layer.
     expect(symbolLayer.componentIri).toEqual(
-      oldMapConfig.fields.areaLayer.componentIri
+      mapConfigV1_0_0.fields.areaLayer.componentIri
     );
     expect(symbolLayer.measureIri).toEqual(
-      oldMapConfig.fields.areaLayer.measureIri
+      mapConfigV1_0_0.fields.areaLayer.measureIri
     );
     expect(symbolLayer.color).toEqual("#1f77b4");
   });
 
   it("should migrate to initial config from migrated config for minor version changes", async () => {
-    const migratedConfig = await migrateChartConfig(oldMapConfig, {
+    const migratedConfig = await migrateChartConfig(mapConfigV1_0_0, {
       toVersion: "1.0.2",
     });
     const migratedOldConfig = await migrateChartConfig(migratedConfig, {
       toVersion: "1.0.0",
     });
 
-    expect(migratedOldConfig).toEqual(oldMapConfig);
+    expect(migratedOldConfig).toEqual(mapConfigV1_0_0);
   });
 
   it("should correctly migrate interactiveFiltersConfig", async () => {
-    const migratedConfig = await migrateChartConfig(oldLineConfig, {
+    const migratedConfig = await migrateChartConfig(lineConfigV1_0_0, {
       migrationProps: CONFIGURATOR_STATE,
     });
     const decodedConfig = decodeChartConfig(migratedConfig);
@@ -164,7 +162,7 @@ describe("config migrations", () => {
     expect(decodedConfig).toBeDefined();
     expect(
       (decodedConfig as LineConfig).interactiveFiltersConfig?.timeRange
-        .componentId === oldLineConfig.fields.x.componentIri
+        .componentId === lineConfigV1_0_0.fields.x.componentIri
     ).toBeDefined();
 
     const migratedOldConfig = (await migrateChartConfig(decodedConfig, {
@@ -202,6 +200,18 @@ describe("config migrations", () => {
       toVersion: CHART_CONFIG_VERSION,
       migrationProps: CONFIGURATOR_STATE,
     });
+    const decodedConfig = decodeChartConfig(migratedConfig);
+    expect(decodedConfig).toBeDefined();
+  });
+
+  it("should correctly migrate map charts", async () => {
+    const migratedConfig = await migrateChartConfig(
+      mapConfigV3_3_0.chartConfigs[0],
+      {
+        toVersion: CHART_CONFIG_VERSION,
+        migrationProps: CONFIGURATOR_STATE,
+      }
+    );
     const decodedConfig = decodeChartConfig(migratedConfig);
     expect(decodedConfig).toBeDefined();
   });

--- a/app/utils/chart-config/versioning.ts
+++ b/app/utils/chart-config/versioning.ts
@@ -1317,14 +1317,13 @@ export const chartConfigMigrations: Migration[] = [
         return newConfig;
       }
 
-      // Only set default color if no existing color configurations
       if (!newConfig.fields?.color) {
-        const hasNoColorMapping = !(
+        const hasColorMapping = !!(
           newConfig.fields?.y?.colorMapping ||
           newConfig.fields?.segment?.colorMapping
         );
 
-        if (hasNoColorMapping) {
+        if (!hasColorMapping) {
           newConfig.fields = {
             ...newConfig.fields,
             color: {
@@ -1342,10 +1341,7 @@ export const chartConfigMigrations: Migration[] = [
           color: {
             type: "segment",
             paletteId: newConfig.fields.segment.palette || "category10",
-            colorMapping: { ...newConfig.fields.segment.colorMapping },
-          },
-          segment: {
-            ...newConfig.fields.segment,
+            colorMapping: newConfig.fields.segment.colorMapping,
           },
         };
         delete newConfig.fields.segment.colorMapping;
@@ -1358,10 +1354,7 @@ export const chartConfigMigrations: Migration[] = [
           color: {
             type: "measures",
             paletteId: newConfig.fields.y.palette || "category10",
-            colorMapping: { ...newConfig.fields.y.colorMapping },
-          },
-          y: {
-            ...newConfig.fields.y,
+            colorMapping: newConfig.fields.y.colorMapping,
           },
         };
         delete newConfig.fields.y.colorMapping;
@@ -1371,44 +1364,42 @@ export const chartConfigMigrations: Migration[] = [
       return newConfig;
     },
     down: (config) => {
-      const oldConfig = {
+      const newConfig = {
         ...config,
         version: "4.0.0",
       };
 
-      if (oldConfig.chartType === "table" || oldConfig.chartType === "map") {
-        return oldConfig;
+      if (newConfig.chartType === "table" || newConfig.chartType === "map") {
+        return newConfig;
       }
 
-      if (oldConfig.fields?.color) {
-        if (oldConfig.fields.color.type === "segment") {
-          oldConfig.fields = {
-            ...oldConfig.fields,
+      if (newConfig.fields?.color) {
+        if (newConfig.fields.color.type === "segment") {
+          newConfig.fields = {
+            ...newConfig.fields,
             segment: {
-              ...oldConfig.fields.segment,
-              colorMapping: { ...oldConfig.fields.color.colorMapping },
-              palette: oldConfig.fields.color.paletteId,
+              ...newConfig.fields.segment,
+              colorMapping: newConfig.fields.color.colorMapping,
+              palette: newConfig.fields.color.paletteId,
             },
           };
         }
 
-        if (oldConfig.fields.color.type === "measures") {
-          oldConfig.fields = {
-            ...oldConfig.fields,
+        if (newConfig.fields.color.type === "measures") {
+          newConfig.fields = {
+            ...newConfig.fields,
             y: {
-              ...oldConfig.fields.y,
-              colorMapping: { ...oldConfig.fields.color.colorMapping },
-              palette: oldConfig.fields.color.paletteId,
+              ...newConfig.fields.y,
+              colorMapping: newConfig.fields.color.colorMapping,
+              palette: newConfig.fields.color.paletteId,
             },
           };
         }
 
-        // Create a new fields object without the color property
-        const { color, ...fieldsWithoutColor } = oldConfig.fields;
-        oldConfig.fields = fieldsWithoutColor;
+        delete newConfig.fields.color;
       }
 
-      return oldConfig;
+      return newConfig;
     },
   },
 ];

--- a/app/utils/chart-config/versioning.ts
+++ b/app/utils/chart-config/versioning.ts
@@ -1313,7 +1313,29 @@ export const chartConfigMigrations: Migration[] = [
         version: "4.1.0",
       };
 
-      if (newConfig.chartType === "table" || newConfig.chartType === "map") {
+      if (newConfig.chartType === "table") {
+        return newConfig;
+      }
+
+      if (newConfig.chartType === "map") {
+        if (
+          newConfig.fields.areaLayer?.color &&
+          "palette" in newConfig.fields.areaLayer.color
+        ) {
+          newConfig.fields.areaLayer.color.paletteId =
+            newConfig.fields.areaLayer.color.palette;
+          delete newConfig.fields.areaLayer.color.palette;
+        }
+
+        if (
+          newConfig.fields.symbolLayer?.color &&
+          "palette" in newConfig.fields.symbolLayer.color
+        ) {
+          newConfig.fields.symbolLayer.color.paletteId =
+            newConfig.fields.symbolLayer.color.palette;
+          delete newConfig.fields.symbolLayer.color.palette;
+        }
+
         return newConfig;
       }
 
@@ -1369,7 +1391,29 @@ export const chartConfigMigrations: Migration[] = [
         version: "4.0.0",
       };
 
-      if (newConfig.chartType === "table" || newConfig.chartType === "map") {
+      if (newConfig.chartType === "table") {
+        return newConfig;
+      }
+
+      if (newConfig.chartType === "map") {
+        if (
+          newConfig.fields.areaLayer?.color &&
+          "paletteId" in newConfig.fields.areaLayer.color
+        ) {
+          newConfig.fields.areaLayer.color.palette =
+            newConfig.fields.areaLayer.color.paletteId;
+          delete newConfig.fields.areaLayer.color.paletteId;
+        }
+
+        if (
+          newConfig.fields.symbolLayer?.color &&
+          "paletteId" in newConfig.fields.symbolLayer.color
+        ) {
+          newConfig.fields.symbolLayer.color.palette =
+            newConfig.fields.symbolLayer.color.paletteId;
+          delete newConfig.fields.symbolLayer.color.paletteId;
+        }
+
         return newConfig;
       }
 

--- a/e2e/preview-via-api.spec.ts
+++ b/e2e/preview-via-api.spec.ts
@@ -1,15 +1,48 @@
+import { Page } from "@playwright/test";
+
 import { setup } from "./common";
+import { Selectors } from "./selectors";
 
 const { test } = setup();
+
+type IframeDef = {
+  elLocator: string;
+  chartLocator: string;
+};
+
+const waitForIframe = async ({
+  page,
+  selectors,
+  elLocator,
+  chartLocator,
+}: {
+  page: Page;
+  selectors: Selectors;
+} & IframeDef) => {
+  await page.waitForSelector(elLocator);
+  const iframe = page.locator(elLocator);
+  const contentFrame = iframe.contentFrame();
+  await selectors.chart.loaded();
+  await contentFrame.locator(chartLocator).first().waitFor({ timeout: 10_000 });
+};
+
+const iframeDefs: IframeDef[] = [
+  {
+    elLocator: "#chart-column",
+    chartLocator: "svg",
+  },
+  {
+    elLocator: "#chart-map",
+    chartLocator: "canvas.maplibregl-canvas",
+  },
+];
 
 test("should be possible to preview charts via API (iframe)", async ({
   page,
   selectors,
 }) => {
   await page.goto("/en/_preview");
-  await page.waitForSelector("iframe");
-  const iframe = page.locator("iframe");
-  const contentFrame = iframe.contentFrame();
-  await selectors.chart.loaded();
-  await contentFrame.locator("svg").first().waitFor({ timeout: 10_000 });
+  await Promise.all(
+    iframeDefs.map((def) => waitForIframe({ page, selectors, ...def }))
+  );
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3916,15 +3916,7 @@
     lodash "4.17.21"
     tslib "~2.2.0"
 
-"@graphql-tools/schema@^6.0.9":
-  version "6.2.4"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-6.2.4.tgz#cc4e9f5cab0f4ec48500e666719d99fc5042481d"
-  integrity sha512-rh+14lSY1q8IPbEv2J9x8UBFJ5NrDX9W5asXEUlPp+7vraLp/Tiox4GXdgyA92JhwpYco3nTf5Bo2JDMt1KnAQ==
-  dependencies:
-    "@graphql-tools/utils" "^6.2.4"
-    tslib "~2.0.1"
-
-"@graphql-tools/schema@^7.0.0", "@graphql-tools/schema@^7.1.4", "@graphql-tools/schema@^7.1.5":
+"@graphql-tools/schema@7.1.5", "@graphql-tools/schema@^7.0.0", "@graphql-tools/schema@^7.1.4", "@graphql-tools/schema@^7.1.5":
   version "7.1.5"
   resolved "https://registry.npmjs.org/@graphql-tools/schema/-/schema-7.1.5.tgz"
   integrity sha512-uyn3HSNSckf4mvQSq0Q07CPaVZMNFCYEVxroApOaw802m9DcZPgf9XVPy/gda5GWj9AhbijfRYVTZQgHnJ4CXA==
@@ -3932,6 +3924,14 @@
     "@graphql-tools/utils" "^7.1.2"
     tslib "~2.2.0"
     value-or-promise "1.0.6"
+
+"@graphql-tools/schema@^6.0.9":
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-6.2.4.tgz#cc4e9f5cab0f4ec48500e666719d99fc5042481d"
+  integrity sha512-rh+14lSY1q8IPbEv2J9x8UBFJ5NrDX9W5asXEUlPp+7vraLp/Tiox4GXdgyA92JhwpYco3nTf5Bo2JDMt1KnAQ==
+  dependencies:
+    "@graphql-tools/utils" "^6.2.4"
+    tslib "~2.0.1"
 
 "@graphql-tools/schema@^8.0.0":
   version "8.5.1"


### PR DESCRIPTION
Fixes #1941

This PR:
- fixes chart config migrations for maps (correctly migrates `palette` to `paletteId`),
- adds a map chart to `_preview` page,
- adds a `decodeConfiguratorState` call in POST preview.

## How to reproduce
See the comments from #1941.

## How to test
1. Go to [this link](https://visualization-tool-git-fix-config-migrations-ixt1.vercel.app/_preview).
2. ✅ See that two charts loaded (column and map) – map being the chart from #1941 that is currently broken on INT.