### PR TITLE
feat: Make sure we screenshot the whole chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ You can also check the
   - Implemented Content Security Policy (CSP)
   - Added a new option to the vertical axis on the line chart, allowing users to
     display a dot over the line where it intercepts the x-axis ticks
+  - Downloading images of bar charts now includes the whole chart, not just the
+    visible part
 
 # [5.1.0] - 2025-01-14
 

--- a/app/utils/use-screenshot.ts
+++ b/app/utils/use-screenshot.ts
@@ -3,6 +3,7 @@ import { toPng, toSvg } from "html-to-image";
 import { addMetadata } from "meta-png";
 import { useCallback, useState } from "react";
 
+import { TABLE_PREVIEW_WRAPPER_CLASS_NAME } from "@/components/chart-table-preview";
 import { animationFrame } from "@/utils/animation-frame";
 
 type ScreenshotFileFormat = "png" | "svg";
@@ -120,6 +121,22 @@ const makeScreenshot = async ({
 
   await modifyNode?.(clonedNode, node);
   wrapperNode.appendChild(clonedNode);
+
+  // Make sure the whole chart is visible in the screenshot (currently only an
+  // issue with SVG-based, long bar charts).
+  const tableWrapper = clonedNode.querySelector(
+    `.${TABLE_PREVIEW_WRAPPER_CLASS_NAME}`
+  ) as HTMLElement | null;
+  const svg = tableWrapper?.querySelector("svg");
+  const svgHeight = svg?.getAttribute("height");
+  const svgParent = svg?.parentElement;
+
+  if (tableWrapper && svgHeight && svgParent) {
+    tableWrapper.style.height = "fit-content";
+    svgParent.style.height = `${svgHeight}px`;
+    svgParent.style.overflow = "visible";
+  }
+
   await animationFrame();
 
   // There's a bug with embedding the fonts in Safari, which appears only when


### PR DESCRIPTION
Closes #1969

This PR makes sure we screenshot whole charts, not only visible parts (currently applicable to scrollable bar charts).

## How to test
1. Go to [this link](https://visualization-tool-git-feat-screenshot-whole-svgs-ixt1.vercel.app/en/v/6_FlCR1TC3ve?dataSource=Prod).
2. Export PNG image of the chart.
3. ✅ See that the whole chart was included in the screenshot.

## How to reproduce
1. Go to [this link](https://test.visualize.admin.ch/en/v/nuUuhNIiBjeq?dataSource=Prod).
4. Export PNG image of the chart.
5. ❌ See that only the visible was included in the screenshot.