### PR TITLE
fix: GraphQL Flamegraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ You can also check the
     display a dot over the line where it intercepts the x-axis ticks
   - Downloading images of bar charts now includes the whole chart, not just the
     visible part
+- Fixes
+  - GraphQL debug panel now displays the queries again when in debug mode
 
 # [5.1.0] - 2025-01-14
 

--- a/app/gql-flamegraph/devtool.tsx
+++ b/app/gql-flamegraph/devtool.tsx
@@ -205,7 +205,7 @@ const AccordionOperation = ({
   }, [result?.extensions?.timings]);
 
   return (
-    <Accordion {...accordionProps}>
+    <Accordion {...accordionProps} data-testid="debug-panel-accordion">
       <AccordionSummary>
         <Box
           sx={{
@@ -493,7 +493,11 @@ const DebugPanel = () => {
     <>
       <Box sx={{ position: "fixed", bottom: 0, right: 0, zIndex: 10 }}>
         <Grow in>
-          <IconButton size="small" onClick={open}>
+          <IconButton
+            data-testid="debug-panel-toggle"
+            size="small"
+            onClick={open}
+          >
             🛠
           </IconButton>
         </Grow>

--- a/app/gql-flamegraph/resolvers.ts
+++ b/app/gql-flamegraph/resolvers.ts
@@ -1,7 +1,7 @@
 import { Resolver, Resolvers } from "@apollo/client/core";
 import { GraphQLResolveInfo } from "graphql";
 
-import { Timing, timed } from "@/utils/timed";
+import { timed, Timing } from "@/utils/timed";
 
 export type Timings = Record<
   string,
@@ -49,7 +49,7 @@ export const setupFlamegraph = (resolvers: Resolvers) => {
           fieldResolver.constructor.name === "AsyncFunction"
         ) {
           typeResolvers[field] = timed(
-            fieldResolver as Resolver,
+            fieldResolver,
             (timing, ...resolverArgs: Parameters<Resolver>) => {
               const [, , context, info] = resolverArgs;
               const path = info
@@ -57,7 +57,7 @@ export const setupFlamegraph = (resolvers: Resolvers) => {
                 : [];
               setTimingInContext(context, path, timing);
             }
-          ) as Resolver;
+          );
         }
       }
     }

--- a/app/graphql/resolvers/index.ts
+++ b/app/graphql/resolvers/index.ts
@@ -3,6 +3,7 @@ import { GraphQLError, GraphQLScalarType, Kind } from "graphql";
 import { MeasureType } from "@/configurator";
 import { DimensionType } from "@/domain/data";
 import { isDataSourceUrlAllowed } from "@/domain/datasource";
+import { setupFlamegraph } from "@/gql-flamegraph/resolvers";
 import {
   QueryResolvers,
   Resolvers,
@@ -149,7 +150,11 @@ const DataSourceUrlScalar = new GraphQLScalarType({
   },
 });
 
-export const resolvers: Resolvers = {
+const resolvers: Resolvers = {
   DataSourceUrl: DataSourceUrlScalar,
   Query,
 };
+
+setupFlamegraph(resolvers);
+
+export { resolvers };

--- a/app/pages/api/graphql.ts
+++ b/app/pages/api/graphql.ts
@@ -11,7 +11,6 @@ import { NextApiRequest, NextApiResponse } from "next";
 
 import { SentryPlugin } from "@/graphql/apollo-sentry-plugin";
 
-import { setupFlamegraph } from "../../gql-flamegraph/resolvers";
 import { createContext, VisualizeGraphQLContext } from "../../graphql/context";
 import { resolvers } from "../../graphql/resolvers";
 import typeDefs from "../../graphql/schema.graphql";
@@ -29,8 +28,6 @@ const schema = makeExecutableSchema({
   resolvers,
   schemaTransforms: [constraintDirective()],
 });
-
-setupFlamegraph(resolvers);
 
 const server = new ApolloServer({
   schema,

--- a/e2e/debug-panel.spec.ts
+++ b/e2e/debug-panel.spec.ts
@@ -1,0 +1,27 @@
+import { setup, sleep } from "./common";
+
+const { test, expect } = setup();
+
+test("should track GraphQL queries when in debug mode", async ({ page }) => {
+  await page.goto("/en?flag__debug=true");
+  await page.waitForLoadState("networkidle");
+
+  const debugPanelToggle = await page.waitForSelector(
+    "button[data-testid='debug-panel-toggle']"
+  );
+  await debugPanelToggle.click();
+
+  // Wait for debug panel to load.
+  await sleep(1000);
+
+  const debugPanelAccordions = await page
+    .locator("div[data-testid='debug-panel-accordion']")
+    .all();
+  expect(debugPanelAccordions.length).toBeGreaterThan(0);
+
+  // Results should contain timings.
+  for (const debugPanelAccordion of debugPanelAccordions) {
+    const text = await debugPanelAccordion.textContent();
+    expect(text).toMatch(/(\d+ms)/);
+  }
+});


### PR DESCRIPTION
Fixes #1973

This PR:
- decorates the resolvers immediately, so that the query times can be traced like when we used them directly, before switching to using [`schema`](https://github.com/visualize-admin/visualization-tool/blob/31c98836c0508471919c72d454cae51886f846ae/app/pages/api/graphql.ts#L27-L33),
- adds an end-to-end test for GQL Flamegraph.

## How to reproduce
See https://github.com/visualize-admin/visualization-tool/issues/1973.

## How to test
1. Go to [this link](https://visualization-tool-git-fix-graphql-debug-flamegraph-ixt1.vercel.app/en?flag__debug=true).
2. Click on a 🛠 emoji in the right bottom corner.
3. ✅ See that the queries are tracked.