### PR TITLE
Bar chart scroll issue

### DIFF
--- a/app/charts/bar/overlay-bars.tsx
+++ b/app/charts/bar/overlay-bars.tsx
@@ -13,7 +13,7 @@ export const InteractionBars = () => {
   const showTooltip = (d: Observation) => {
     dispatch({
       type: "INTERACTION_UPDATE",
-      value: { interaction: { visible: true, d } },
+      value: { interaction: { visible: true, d, isLocked: false } },
     });
   };
   const hideTooltip = () => {

--- a/app/charts/shared/containers.tsx
+++ b/app/charts/shared/containers.tsx
@@ -1,10 +1,11 @@
 import { Box, BoxProps } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import { select } from "d3-selection";
-import { ReactNode, useEffect, useRef } from "react";
+import { ReactNode, useCallback, useEffect, useRef, useState } from "react";
 
 import { useChartState } from "@/charts/shared/chart-state";
 import { CalculationToggle } from "@/charts/shared/interactive-filter-calculation-toggle";
+import { useInteraction } from "@/charts/shared/use-interaction";
 import { useObserverRef } from "@/charts/shared/use-size";
 import { getChartConfig } from "@/config-utils";
 import {
@@ -33,23 +34,62 @@ export const ChartContainer = ({ children }: { children: ReactNode }) => {
   const ref = useObserverRef();
   const { bounds } = useChartState();
   const classes = useStyles();
+  const outerRef = useScroll();
 
   return (
-    <div
-      // Re-mount to prevent issues with useSize hook when switching between
-      // chart types (that might have different sizes).
-      key={chartConfig.chartType}
-      ref={ref}
-      aria-hidden="true"
-      className={classes.chartContainer}
-      style={{
-        height: isFreeCanvas ? "initial" : bounds.height,
-        overflow: "scroll",
-      }}
-    >
-      {children}
+    <div ref={outerRef}>
+      <div
+        // Re-mount to prevent issues with useSize hook when switching between
+        // chart types (that might have different sizes).
+        key={chartConfig.chartType}
+        ref={ref}
+        aria-hidden="true"
+        className={classes.chartContainer}
+        style={{
+          height: isFreeCanvas ? "initial" : bounds.height,
+          overflow: "scroll",
+        }}
+      >
+        {children}
+      </div>
     </div>
   );
+};
+
+function usePrevious<T>(value: T): T | undefined {
+  const ref = useRef<T | undefined>(undefined);
+
+  useEffect(() => {
+    ref.current = value; // Update the ref with the current value after the render
+  }, [value]);
+
+  return ref.current; // Return the previous value
+}
+
+const useScroll = () => {
+  const [, dispatch] = useInteraction();
+  const [state, setState] = useState([0, 0]);
+  const prev = usePrevious(state);
+  const handleRef = useCallback((node: HTMLDivElement) => {
+    if (!node) {
+      return;
+    }
+    const handleScroll = (e: Event) => {
+      const target = e.target as HTMLDivElement;
+      setState([target.scrollLeft, target.scrollTop]);
+    };
+    node?.addEventListener("scroll", handleScroll, { capture: true });
+  }, []);
+  //FIXME: hack to make the state flick between locked and unlocked when scrolling which in turn
+  // makes the tooltip render where it's supposed to.
+  useEffect(() => {
+    if (prev?.[0] !== state[0] || prev?.[1] !== state[1]) {
+      dispatch({ type: "INTERACTION_LOCK" });
+    } else {
+      dispatch({ type: "INTERACTION_UNLOCK" });
+    }
+  }, [prev, state, dispatch]);
+  return handleRef;
 };
 
 export const ChartSvg = ({ children }: { children: ReactNode }) => {

--- a/app/charts/shared/interaction/tooltip.tsx
+++ b/app/charts/shared/interaction/tooltip.tsx
@@ -19,7 +19,15 @@ export const Tooltip = ({ type = "single" }: { type: TooltipType }) => {
   const [state] = useInteraction();
   const { visible, d } = state.interaction;
 
-  return <>{visible && d && <TooltipInner d={d} type={type} />}</>;
+  //FIXME: this is a hack to make the tooltip work when scrolling bar charts. Ideally we find some way of rerendering
+  // the TooltipInner on scroll.
+  return (
+    <>
+      {visible && !state.interaction.isLocked && d && (
+        <TooltipInner d={d} type={type} />
+      )}
+    </>
+  );
 };
 export type { TooltipPlacement };
 

--- a/app/charts/shared/use-interaction.tsx
+++ b/app/charts/shared/use-interaction.tsx
@@ -13,7 +13,7 @@ type InteractionElement = {
   visible: boolean;
   mouse?: { x: number; y: number } | undefined;
   d: Observation | undefined;
-  isLocked: boolean;
+  isLocked?: boolean;
 };
 
 type InteractionState = {

--- a/app/charts/shared/use-interaction.tsx
+++ b/app/charts/shared/use-interaction.tsx
@@ -13,6 +13,7 @@ type InteractionElement = {
   visible: boolean;
   mouse?: { x: number; y: number } | undefined;
   d: Observation | undefined;
+  isLocked: boolean;
 };
 
 type InteractionState = {
@@ -26,6 +27,12 @@ type InteractionStateAction =
     }
   | {
       type: "INTERACTION_HIDE";
+    }
+  | {
+      type: "INTERACTION_LOCK";
+    }
+  | {
+      type: "INTERACTION_UNLOCK";
     };
 
 const INTERACTION_INITIAL_STATE: InteractionState = {
@@ -33,6 +40,7 @@ const INTERACTION_INITIAL_STATE: InteractionState = {
     visible: false,
     mouse: undefined,
     d: undefined,
+    isLocked: false,
   },
 };
 
@@ -41,10 +49,27 @@ const InteractionStateReducer = (
   action: InteractionStateAction
 ) => {
   switch (action.type) {
+    case "INTERACTION_LOCK":
+      return {
+        ...state,
+        interaction: {
+          ...state.interaction,
+          isLocked: true,
+        },
+      };
+    case "INTERACTION_UNLOCK":
+      return {
+        ...state,
+        interaction: {
+          ...state.interaction,
+          isLocked: false,
+        },
+      };
     case "INTERACTION_UPDATE":
       return {
         ...state,
         interaction: {
+          ...state.interaction,
           visible: action.value.interaction.visible,
           mouse: action.value.interaction.mouse
             ? {


### PR DESCRIPTION
Very hacky way of solving the bar chart scrolling issue where the tooltip jumped around. Now it's always rendered in the right place. Still need to see if we can improve the current implementation to make it simpler. 