### PR TITLE
Additional CSP policies

### DIFF
--- a/app/next.config.js
+++ b/app/next.config.js
@@ -60,7 +60,7 @@ module.exports = withPreconstruct(
               } https://*.sentry.io https://vercel.live/ https://vercel.com https://*.googletagmanager.com`,
               `script-src 'self' 'unsafe-inline'${
                 process.env.NODE_ENV === "development" ? " 'unsafe-eval'" : ""
-              } https://*.sentry.io https://vercel.live/ https://vercel.com https://*.googletagmanager.com`,
+              } https://*.sentry.io https://vercel.live/ https://vercel.com https://*.googletagmanager.com https://api.mapbox.com`,
               `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net`,
               `font-src 'self'`,
               `form-action 'self'`,

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -66,7 +66,7 @@ module.exports = withPreconstruct(
               `form-action 'self'`,
               `connect-src 'self' https://*.admin.ch https://*.sentry.io https://*.vercel.app https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com wss://*.pusher.com https://*.ldbar.ch https://api.mapbox.com https://api.maptiler.com`,
               `img-src 'self' https://vercel.live https://vercel.com *.pusher.com *.pusherapp.com https://*.admin.ch https://*.opendataswiss.org https://*.google-analytics.com https://*.googletagmanager.com https://cdn.jsdelivr.net data: blob:`,
-              `script-src-elem 'self' 'unsafe-inline' https://*.admin.ch https://vercel.live https://vercel.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://cdn.jsdelivr.net`,
+              `script-src-elem 'self' 'unsafe-inline' https://*.admin.ch https://vercel.live https://vercel.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://api.mapbox.com https://cdn.jsdelivr.net`,
               `worker-src 'self' blob: https://*.admin.ch`,
             ].join("; "),
           });

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -61,12 +61,12 @@ module.exports = withPreconstruct(
               `script-src 'self' 'unsafe-inline'${
                 process.env.NODE_ENV === "development" ? " 'unsafe-eval'" : ""
               } https://*.sentry.io https://vercel.live/ https://vercel.com https://*.googletagmanager.com`,
-              `style-src 'self' 'unsafe-inline'`,
+              `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdn.jsdelivr.net`,
               `font-src 'self'`,
               `form-action 'self'`,
-              `connect-src 'self' https://*.admin.ch https://*.sentry.io https://*.vercel.app https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com wss://*.pusher.com https://*.ldbar.ch`,
-              `img-src 'self' https://vercel.live https://vercel.com *.pusher.com *.pusherapp.com https://*.admin.ch https://*.opendataswiss.org https://*.google-analytics.com https://*.googletagmanager.com data: blob:`,
-              `script-src-elem 'self' 'unsafe-inline' https://*.admin.ch https://vercel.live https://vercel.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com`,
+              `connect-src 'self' https://*.admin.ch https://*.sentry.io https://*.vercel.app https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com wss://*.pusher.com https://*.ldbar.ch https://api.mapbox.com https://api.maptiler.com`,
+              `img-src 'self' https://vercel.live https://vercel.com *.pusher.com *.pusherapp.com https://*.admin.ch https://*.opendataswiss.org https://*.google-analytics.com https://*.googletagmanager.com https://cdn.jsdelivr.net data: blob:`,
+              `script-src-elem 'self' 'unsafe-inline' https://*.admin.ch https://vercel.live https://vercel.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://cdn.jsdelivr.net`,
               `worker-src 'self' blob: https://*.admin.ch`,
             ].join("; "),
           });


### PR DESCRIPTION
This pull request includes updates to the Content Security Policy (CSP) in the `app/next.config.js` file to enhance security and functionality. The most important changes involve adding new sources for styles, images, scripts, and connections.

Updates to Content Security Policy:

* Added `https://fonts.googleapis.com` and `https://cdn.jsdelivr.net` to the `style-src` directive to allow loading styles from these sources.
* Added `https://api.mapbox.com` and `https://api.maptiler.com` to the `connect-src` directive to allow connections to these APIs.
* Added `https://cdn.jsdelivr.net` to the `img-src` directive to allow loading images from this source.
* Added `https://cdn.jsdelivr.net` to the `script-src-elem` directive to allow loading scripts from this source.

## How to reproduce
See #1988.

## How to test
**Note**: dependent on https://github.com/visualize-admin/visualization-tool/pull/1987

Go to [this link](https://visualization-tool-7me31paaw-ixt1.vercel.app/en?flag__debug=true).
Click on a 🛠 emoji in the right bottom corner.
✅ Open the GraphQL Editor and ensure it loads successfully and no CSP errors are shown in the `console`.
✅ Open a map visualization and ensure tiles load successfully and no CSP errors are shown in the `console`.
