### PR TITLE
feat: Hide new features behind flags + remove depreciated flags automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,17 @@ You can also check the
 # Unreleased
 
 - Features
-  - Added a way to add text objects to dashboard layouts
-  - Added Markdown support in chart titles and descriptions
+  - Added a way to add text objects to dashboard layouts (hidden behind an
+    enable-experimental-features flag)
+  - Added Markdown support in chart titles and descriptions (hidden behind an
+    enable-experimental-features flag)
   - Centered x-axis labels
   - Added y-axis labels
   - Added a new option to the vertical axis on the line chart, allowing users to
     display a dot over the line where it intercepts the x-axis ticks
   - Downloading images of bar charts now includes the whole chart, not just the
     visible part
+  - Bar charts are now hidden behind a an enable-experimental-features flag
 - Fixes
   - Preview via API now works correctly for map charts
   - GraphQL debug panel now displays the queries correctly when in debug mode

--- a/app/components/markdown.tsx
+++ b/app/components/markdown.tsx
@@ -4,6 +4,8 @@ import rehypeRaw from "rehype-raw";
 import rehypeSanitize from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
 
+import { useFlag } from "@/flags";
+
 const components: ComponentProps<typeof ReactMarkdown>["components"] = {
   h1: ({ children, style, ...props }) => (
     <h1 style={{ ...style, marginTop: 0 }} {...props}>
@@ -50,12 +52,16 @@ const components: ComponentProps<typeof ReactMarkdown>["components"] = {
 export const Markdown = (
   props: Omit<ComponentProps<typeof ReactMarkdown>, "components">
 ) => {
-  return (
+  const enable = useFlag("enable-experimental-features");
+
+  return enable ? (
     <ReactMarkdown
       components={components}
       remarkPlugins={[remarkGfm]}
       rehypePlugins={[rehypeRaw, rehypeSanitize]}
       {...props}
     />
+  ) : (
+    <>{props.children}</>
   );
 };

--- a/app/configurator/components/chart-type-selector.tsx
+++ b/app/configurator/components/chart-type-selector.tsx
@@ -17,6 +17,7 @@ import { ControlSectionSkeleton } from "@/configurator/components/chart-controls
 import { IconButton } from "@/configurator/components/icon-button";
 import { useAddOrEditChartType } from "@/configurator/config-form";
 import { ConfiguratorStateWithChartConfigs } from "@/configurator/configurator-state";
+import { useFlag } from "@/flags";
 import { useDataCubesComponentsQuery } from "@/graphql/hooks";
 import { useLocale } from "@/locales/use-locale";
 
@@ -39,6 +40,7 @@ export const ChartTypeSelector = (props: ChartTypeSelectorProps) => {
     chartKey,
     ...rest
   } = props;
+  const enableBarChart = useFlag("enable-experimental-features");
   const locale = useLocale();
   const chartConfig = getChartConfig(state);
   const [{ data }] = useDataCubesComponentsQuery({
@@ -121,7 +123,11 @@ export const ChartTypeSelector = (props: ChartTypeSelectorProps) => {
                 message: "Regular",
               })}
               currentChartType={chartType}
-              chartTypes={regularChartTypes}
+              chartTypes={
+                enableBarChart
+                  ? regularChartTypes
+                  : regularChartTypes.filter((chartType) => chartType !== "bar")
+              }
               possibleChartTypesDict={possibleChartTypesDict}
               onClick={handleClick}
               testId="chart-type-selector-regular"

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -90,6 +90,7 @@ import {
   isMostRecentValue,
   VISUALIZE_MOST_RECENT_VALUE,
 } from "@/domain/most-recent-value";
+import { useFlag } from "@/flags";
 import { useTimeFormatLocale } from "@/formatters";
 import { TimeUnit } from "@/graphql/query-hooks";
 import { Locale } from "@/locales/locales";
@@ -680,12 +681,17 @@ export const MetaInputField = ({
   value?: string;
 }) => {
   const field = useMetaField({ type, metaKey, locale, value });
+  const enableMarkdown = useFlag("enable-experimental-features");
 
   switch (inputType) {
     case "text":
       return <Input label={label} {...field} />;
     case "markdown":
-      return <MarkdownInput label={label} {...field} />;
+      if (enableMarkdown) {
+        return <MarkdownInput label={label} {...field} />;
+      } else {
+        return <Input label={label} {...field} />;
+      }
   }
 };
 

--- a/app/configurator/components/layout-configurator.tsx
+++ b/app/configurator/components/layout-configurator.tsx
@@ -65,6 +65,7 @@ import {
   TemporalDimension,
   TemporalEntityDimension,
 } from "@/domain/data";
+import { useFlag } from "@/flags";
 import { useTimeFormatLocale, useTimeFormatUnit } from "@/formatters";
 import { useConfigsCubeComponents } from "@/graphql/hooks";
 import { Icon } from "@/icons";
@@ -564,6 +565,12 @@ const LayoutBlocksConfigurator = () => {
   const onClick = useEvent((blockKey: string) => {
     dispatch({ type: "LAYOUT_ACTIVE_FIELD_CHANGED", value: blockKey });
   });
+
+  const enabled = useFlag("enable-experimental-features");
+
+  if (!enabled) {
+    return null;
+  }
 
   return layout.type === "dashboard" ? (
     <ControlSection role="tablist" aria-labelledby="controls-blocks" collapse>

--- a/app/flags/flag.tsx
+++ b/app/flags/flag.tsx
@@ -61,10 +61,6 @@ const enable = (flagsToEnable: FlagName[]) => {
   });
 };
 
-export const remove = (name: FlagName) => {
-  store.remove(name);
-};
-
 flag.store = store;
 flag.listNames = listFlagNames;
 flag.list = listFlags;

--- a/app/flags/local-storage-adapter.ts
+++ b/app/flags/local-storage-adapter.ts
@@ -1,15 +1,15 @@
-import { FlagName, FlagValue } from "./types";
+import { FLAG_PREFIX } from "@/flags/flag";
 
-const prefix = "flag__";
+import { FlagName, FlagValue } from "./types";
 
 type FlagNameOrString = FlagName | (string & {});
 
-const getKey = (name: FlagNameOrString) => prefix + name;
+const getKey = (name: FlagNameOrString) => `${FLAG_PREFIX}${name}`;
 
 const listFlagLocalStorage = () => {
   return Object.keys(localStorage)
-    .filter((x) => x.indexOf(prefix) === 0)
-    .map((x) => x.replace(prefix, ""));
+    .filter((x) => x.indexOf(FLAG_PREFIX) === 0)
+    .map((x) => x.replace(FLAG_PREFIX, ""));
 };
 
 /**

--- a/app/flags/types.ts
+++ b/app/flags/types.ts
@@ -17,6 +17,11 @@ export const FLAGS = [
     name: "easter-eggs" as const,
     description: "Enables easter eggs",
   },
+  {
+    name: "enable-experimental-features" as const,
+    description:
+      "Enables experimental features, including dashboard text blocks, Markdown editor and bar charts.",
+  },
 ];
 export const FLAG_NAMES = FLAGS.map((flag) => flag.name);
 export type Flag = (typeof FLAGS)[number];

--- a/app/flags/types.ts
+++ b/app/flags/types.ts
@@ -1,11 +1,23 @@
 export type FlagValue = any;
-
-export type FlagName =
-  /** Whether debug UI like the configurator debug panel is shown */
-  | "debug"
-  /** Whether server side cache is disabled */
-  | "server-side-cache.disable"
-  /** The GraphQL endpoint, is used for testing purposes */
-  | "graphql.endpoint"
-  /** Use at your own risk */
-  | "easter-eggs";
+export const FLAGS = [
+  {
+    name: "debug" as const,
+    description:
+      "Controls whether debug elements are shown, e.g. ConfiguratorState viewer or GraphQL debug panel.",
+  },
+  {
+    name: "server-side-cache.disable" as const,
+    description: "Disables server side cache.",
+  },
+  {
+    name: "graphql.endpoint" as const,
+    description: "The GraphQL endpoint, can be used for testing purposes.",
+  },
+  {
+    name: "easter-eggs" as const,
+    description: "Enables easter eggs",
+  },
+];
+export const FLAG_NAMES = FLAGS.map((flag) => flag.name);
+export type Flag = (typeof FLAGS)[number];
+export type FlagName = Flag["name"];

--- a/app/flags/types.ts
+++ b/app/flags/types.ts
@@ -24,5 +24,5 @@ export const FLAGS = [
   },
 ];
 export const FLAG_NAMES = FLAGS.map((flag) => flag.name);
-export type Flag = (typeof FLAGS)[number];
+type Flag = (typeof FLAGS)[number];
 export type FlagName = Flag["name"];

--- a/app/flags/useFlag.ts
+++ b/app/flags/useFlag.ts
@@ -3,32 +3,40 @@ import { useEffect, useState } from "react";
 import { flag } from "./flag";
 import { FlagName } from "./types";
 
-export default function useFlag(name: FlagName) {
+export default function useFlagValue(name: FlagName) {
   const [flagValue, setFlag] = useState(() => flag(name));
+
   useEffect(() => {
     const handleChange = (changed: string) => {
       if (changed === name) {
         setFlag(flag(name));
       }
     };
+
     flag.store.ee.on("change", handleChange);
+
     return () => {
       flag.store.removeListener("change", handleChange);
     };
   }, [setFlag, name]);
+
   return flagValue;
 }
 
 export function useFlags() {
   const [flags, setFlags] = useState(flag.list());
+
   useEffect(() => {
     const handleChange = () => {
       setFlags(flag.list());
     };
+
     flag.store.ee.on("change", handleChange);
+
     return () => {
       flag.store.removeListener("change", handleChange);
     };
   }, [setFlags]);
-  return flags as FlagName[];
+
+  return flags;
 }

--- a/app/gql-flamegraph/devtool.tsx
+++ b/app/gql-flamegraph/devtool.tsx
@@ -27,7 +27,13 @@ import minBy from "lodash/minBy";
 import sortBy from "lodash/sortBy";
 import uniqBy from "lodash/uniqBy";
 import mitt from "mitt";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  ChangeEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { Exchange, Operation, OperationResult } from "urql";
 import { pipe, tap } from "wonka";
 
@@ -526,13 +532,18 @@ const DebugPanel = () => {
 
 const FlagList = () => {
   const flags = useFlags();
+
   return (
     <>
-      {flags.map((f) => {
+      {flags.map((flag) => {
         return (
-          <Box key={f} sx={{ display: "flex", gap: "1rem" }}>
-            <Typography variant="body2">{f}</Typography>
-            <FlagSwitch flagName={f} />
+          <Box
+            key={flag.name}
+            sx={{ display: "flex", alignItems: "center", gap: "0.5rem" }}
+          >
+            <FlagSwitch flagName={flag.name as FlagName} />
+            <Typography variant="body2">{flag.name}</Typography>
+            <Typography variant="caption">{flag.description}</Typography>
           </Box>
         );
       })}
@@ -544,14 +555,14 @@ const FlagSwitch = ({
   flagName,
   onChange,
   ...props
-}: { flagName: FlagName; onChange?: (value: Boolean) => void } & Omit<
-  SwitchProps,
-  "onChange"
->) => {
+}: {
+  flagName: FlagName;
+  onChange?: (value: boolean) => void;
+} & Omit<SwitchProps, "onChange">) => {
   const flagValue = useFlag(flagName);
-  const handleChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
-    flag(flagName, ev.target.checked);
-    onChange?.(ev.target.checked);
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    flag(flagName, e.target.checked);
+    onChange?.(e.target.checked);
   };
 
   return <Switch checked={!!flagValue} onChange={handleChange} {...props} />;

--- a/e2e/chart-actions.spec.ts
+++ b/e2e/chart-actions.spec.ts
@@ -30,6 +30,7 @@ test("it should be possible to make a screenshot of a chart", async ({
   await actions.chart.createFrom({
     iri: "https://agriculture.ld.admin.ch/foag/cube/MilkDairyProducts/Consumption_Price_Month",
     dataSource: "Prod",
+    createURLParams: "flag__enable-experimental-features=true",
   });
   await selectors.chart.loaded();
   await actions.editor.changeRegularChartType("Bars");


### PR DESCRIPTION
This PR:
- automatically removes depreciated flags from user's local storage,
- hides dashboard text blocks, Markdown editor and bar charts behind an `enable-experimental-features` flag.

## How to test

1. Go to [this link](https://visualization-tool-git-feat-flags-ixt1.vercel.app/en).
2. ✅ See that no bar chart is available to be selected in the left panel.
3. ✅ See that no bar chart is available to be selected in the add new chart button.
4. ✅ Check chart's title and description and see the old input field (without Markdown UI buttons).
5. Add a new chart and proceed to layout options.
6. Switch to a dashboard layout.
7. ✅ See that `Objects` are not available to be added.
8. Add `&flag__enable-experimental-features=true` to the end of the URL and hit Enter.
9. ✅ Re-do the above steps and see that previously hidden elements are now visible and functional.

cc @noahonyejese