### PR TITLE
fix: API preview and configurator state migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Fixes
+  - Preview via API using iframe (`/preview`) now ignores invalid messages sent
+    from the parent window
 
 # [5.2.0] - 2025-01-22
 

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -373,20 +373,34 @@ export const getInitialConfig = (
     cubes: Cube[];
     activeField: string | undefined;
   } => {
-    return {
+    const newConfig = {
       key: key ?? createId(),
       version: CHART_CONFIG_VERSION,
       meta: meta ?? META,
       // Technically, we should scope filters per cube; but as we only set initial
       // filters for area charts, and we can only have multi-cubes for combo charts,
       // we can ignore the filters scoping for now.
-      cubes: iris.map(({ iri, joinBy }) => ({
-        iri,
-        filters: filters ?? {},
-        joinBy,
-      })),
+      cubes: iris.map(({ iri, joinBy }) => {
+        if (joinBy) {
+          return {
+            iri,
+            filters: filters ?? {},
+            joinBy,
+          };
+        } else {
+          // We need to completely remove the joinBy if not needed to prevent
+          // implicit conversion to null when saving / retrieving the config
+          // from the backend.
+          return {
+            iri,
+            filters: filters ?? {},
+          };
+        }
+      }),
       activeField: undefined,
     };
+
+    return newConfig;
   };
   const numericalMeasures = measures.filter(isNumericalMeasure);
   const temporalDimensions = dimensions.filter(
@@ -1561,6 +1575,7 @@ const chartConfigsAdjusters: ChartConfigsAdjusters = {
               cube.filters[id] = value;
             }
           }
+
           if (oldCube.joinBy !== undefined) {
             cube.joinBy = oldCube.joinBy;
           }
@@ -1645,8 +1660,8 @@ const chartConfigsAdjusters: ChartConfigsAdjusters = {
             .filter((d) => d.unit === unit)
             .map((d) => d.id);
           const paletteId = isColorInConfig(oldChartConfig)
-            ? oldChartConfig.fields.color.paletteId ??
-              DEFAULT_CATEGORICAL_PALETTE_ID
+            ? (oldChartConfig.fields.color.paletteId ??
+              DEFAULT_CATEGORICAL_PALETTE_ID)
             : isComboChartConfig(oldChartConfig)
               ? oldChartConfig.fields.color.paletteId
               : DEFAULT_CATEGORICAL_PALETTE_ID;
@@ -1761,8 +1776,8 @@ const chartConfigsAdjusters: ChartConfigsAdjusters = {
         leftMeasure = getLeftMeasure(leftMeasure.id);
 
         const paletteId = isColorInConfig(oldChartConfig)
-          ? oldChartConfig.fields.color.paletteId ??
-            DEFAULT_CATEGORICAL_PALETTE_ID
+          ? (oldChartConfig.fields.color.paletteId ??
+            DEFAULT_CATEGORICAL_PALETTE_ID)
           : isComboChartConfig(oldChartConfig)
             ? oldChartConfig.fields.color.paletteId
             : DEFAULT_CATEGORICAL_PALETTE_ID;
@@ -1854,8 +1869,8 @@ const chartConfigsAdjusters: ChartConfigsAdjusters = {
         ).id;
 
         const paletteId = isColorInConfig(oldChartConfig)
-          ? oldChartConfig.fields.color.paletteId ??
-            DEFAULT_CATEGORICAL_PALETTE_ID
+          ? (oldChartConfig.fields.color.paletteId ??
+            DEFAULT_CATEGORICAL_PALETTE_ID)
           : isComboChartConfig(oldChartConfig)
             ? oldChartConfig.fields.color.paletteId
             : DEFAULT_CATEGORICAL_PALETTE_ID;

--- a/app/pages/preview.tsx
+++ b/app/pages/preview.tsx
@@ -14,6 +14,12 @@ import { ConfiguratorStateProvider } from "@/src";
 import * as federalTheme from "@/themes/federal";
 import { migrateConfiguratorState } from "@/utils/chart-config/versioning";
 
+const isValidMessage = (e: MessageEvent) => {
+  return (
+    e.data && e.data.type !== "connection-init" && e.data.type !== "debug-event"
+  );
+};
+
 const chartStateStore = create<{
   state: ConfiguratorStatePublished | null;
   setState: (state: ConfiguratorStatePublished) => void;
@@ -24,6 +30,10 @@ const chartStateStore = create<{
 
 if (typeof window !== "undefined") {
   window.addEventListener("message", async (e) => {
+    if (!isValidMessage(e)) {
+      return;
+    }
+
     try {
       const state = decodeConfiguratorState(
         await migrateConfiguratorState(e.data)

--- a/app/pages/preview.tsx
+++ b/app/pages/preview.tsx
@@ -35,18 +35,14 @@ if (typeof window !== "undefined") {
     }
 
     try {
-      const state = decodeConfiguratorState(
-        await migrateConfiguratorState(e.data)
-      );
+      const state = decodeConfiguratorState({
+        ...(await migrateConfiguratorState(e.data)),
+        // Force state published for <ChartPublished /> to work correctly
+        state: "PUBLISHED",
+      }) as ConfiguratorStatePublished;
 
       if (state) {
-        chartStateStore.setState({
-          state: {
-            ...state,
-            // Force state published for <ChartPublished /> to work correctly
-            state: "PUBLISHED",
-          } as ConfiguratorStatePublished,
-        });
+        chartStateStore.setState({ state });
       }
     } catch (e) {
       console.error(e);

--- a/app/pages/preview_post.tsx
+++ b/app/pages/preview_post.tsx
@@ -5,7 +5,11 @@ import { GetServerSideProps } from "next";
 import { useEffect, useState } from "react";
 
 import { ChartPublished } from "@/components/chart-published";
-import { ConfiguratorState, decodeConfiguratorState } from "@/configurator";
+import {
+  ConfiguratorState,
+  ConfiguratorStatePublished,
+  decodeConfiguratorState,
+} from "@/configurator";
 import { GraphqlProvider } from "@/graphql/GraphqlProvider";
 import { defaultLocale, i18n, Locale } from "@/locales/locales";
 import { LocaleProvider } from "@/locales/use-locale";
@@ -62,14 +66,12 @@ export default function Preview({ configuratorState, locale }: PageProps) {
   const [migrated, setMigrated] = useState<ConfiguratorState>();
   useEffect(() => {
     const run = async () => {
-      const migratedConfiguratorState = decodeConfiguratorState(
-        await migrateConfiguratorState(configuratorState)
-      );
-      setMigrated({
-        ...migratedConfiguratorState,
+      const migratedConfiguratorState = decodeConfiguratorState({
+        ...(await migrateConfiguratorState(configuratorState)),
         // Force state published for <ChartPublished /> to work correctly
         state: "PUBLISHED",
-      } as ConfiguratorState);
+      }) as ConfiguratorStatePublished;
+      setMigrated(migratedConfiguratorState);
     };
 
     run();

--- a/app/utils/chart-config/versioning.spec.ts
+++ b/app/utils/chart-config/versioning.spec.ts
@@ -220,6 +220,7 @@ describe("config migrations", () => {
                   value: "E.coli",
                 },
             },
+            joinBy: null,
           },
         ],
         fields: {

--- a/app/utils/chart-config/versioning.spec.ts
+++ b/app/utils/chart-config/versioning.spec.ts
@@ -1,6 +1,7 @@
 import {
   ConfiguratorStateConfiguringChart,
   decodeChartConfig,
+  decodeConfiguratorState,
   LineConfig,
   TableConfig,
 } from "@/config-types";
@@ -17,6 +18,7 @@ import {
   chartConfigMigrations,
   configuratorStateMigrations,
   migrateChartConfig,
+  migrateConfiguratorState,
   upOrDown,
 } from "@/utils/chart-config/versioning";
 
@@ -119,6 +121,143 @@ describe("config migrations", () => {
       },
     },
   };
+  const dashboardConfigV4_0_0 = {
+    key: "ZeKjPw1_9Dqt",
+    state: "PUBLISHED",
+    layout: {
+      meta: {
+        label: { de: "", en: "", fr: "", it: "" },
+        title: { de: "", en: "", fr: "", it: "" },
+        description: { de: "", en: "", fr: "", it: "" },
+      },
+      type: "dashboard",
+      layout: "canvas",
+      layouts: {
+        lg: [
+          {
+            h: 5,
+            i: "tupdJZmSpduE",
+            w: 1,
+            x: 2,
+            y: 7,
+            maxW: 4,
+            minH: 5,
+            resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+          },
+        ],
+        md: [
+          {
+            h: 5,
+            i: "tupdJZmSpduE",
+            w: 1,
+            x: 2,
+            y: 7,
+            maxW: 4,
+            minH: 5,
+            resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+          },
+        ],
+        sm: [
+          {
+            h: 5,
+            i: "tupdJZmSpduE",
+            w: 1,
+            x: 2,
+            y: 7,
+            maxW: 4,
+            minH: 5,
+            resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+          },
+        ],
+        xl: [
+          {
+            h: 5,
+            i: "tupdJZmSpduE",
+            w: 1,
+            x: 2,
+            y: 0,
+            maxW: 4,
+            minH: 5,
+            moved: false,
+            static: false,
+            resizeHandles: ["s", "w", "e", "n", "sw", "nw", "se", "ne"],
+          },
+        ],
+      },
+      layoutsMetadata: {
+        A7_orWKNE1Bl: { initialized: true },
+        dPe76IX5KnFZ: { initialized: true },
+        eA7R4wz7Kvq3: { initialized: true },
+        tupdJZmSpduE: { initialized: true },
+      },
+    },
+    version: "4.0.0",
+    dataSource: {
+      url: "https://lindas-cached.cluster.ldbar.ch/query",
+      type: "sparql",
+    },
+    chartConfigs: [
+      {
+        key: "tupdJZmSpduE",
+        meta: {
+          label: { de: "", en: "", fr: "", it: "" },
+          title: { de: "", en: "", fr: "", it: "" },
+          description: { de: "", en: "", fr: "", it: "" },
+        },
+        cubes: [
+          {
+            iri: "https://environment.ld.admin.ch/foen/ubd01041prod/4",
+            filters: {
+              "https://environment.ld.admin.ch/foen/ubd01041prod(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://environment.ld.admin.ch/foen/ubd01041prod/location":
+                {
+                  type: "single",
+                  value:
+                    "https://ld.admin.ch/dimension/bgdi/inlandwaters/bathingwater/CH22051",
+                },
+              "https://environment.ld.admin.ch/foen/ubd01041prod(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://environment.ld.admin.ch/foen/ubd01041prod/parametertype":
+                {
+                  type: "single",
+                  value: "E.coli",
+                },
+            },
+          },
+        ],
+        fields: {
+          x: {
+            sorting: { sortingType: "byAuto", sortingOrder: "asc" },
+            componentId:
+              "https://environment.ld.admin.ch/foen/ubd01041prod(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://environment.ld.admin.ch/foen/ubd01041prod/dateofprobing",
+          },
+          y: {
+            componentId:
+              "https://environment.ld.admin.ch/foen/ubd01041prod(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://environment.ld.admin.ch/foen/ubd01041prod/value",
+          },
+        },
+        version: "4.0.0",
+        chartType: "column",
+        interactiveFiltersConfig: {
+          legend: { active: false, componentId: "" },
+          timeRange: {
+            active: false,
+            presets: { to: "", from: "", type: "range" },
+            componentId:
+              "https://environment.ld.admin.ch/foen/ubd01041prod(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://environment.ld.admin.ch/foen/ubd01041prod/dateofprobing",
+          },
+          calculation: { type: "identity", active: false },
+          dataFilters: { active: false, componentIds: [] },
+        },
+      },
+    ],
+    activeChartKey: "tupdJZmSpduE",
+    dashboardFilters: {
+      timeRange: {
+        active: false,
+        presets: { to: "", from: "" },
+        timeUnit: "",
+      },
+      dataFilters: { filters: {}, componentIds: [] },
+    },
+  };
 
   it("should migrate to newest config and back (but might lost some info for major version changes)", async () => {
     const migratedConfig = await migrateChartConfig(mapConfigV1_0_0, {
@@ -204,16 +343,26 @@ describe("config migrations", () => {
     expect(decodedConfig).toBeDefined();
   });
 
-  it("should correctly migrate map charts", async () => {
-    const migratedConfig = await migrateChartConfig(
+  it("should correctly migrate configs to newest versions", async () => {
+    const migratedDashboardConfig = await migrateConfiguratorState(
+      dashboardConfigV4_0_0,
+      {
+        toVersion: CONFIGURATOR_STATE_VERSION,
+      }
+    );
+    const decodedDashboardConfig = decodeConfiguratorState(
+      migratedDashboardConfig
+    );
+    expect(decodedDashboardConfig).toBeDefined();
+    const migratedMapConfig = await migrateChartConfig(
       mapConfigV3_3_0.chartConfigs[0],
       {
         toVersion: CHART_CONFIG_VERSION,
         migrationProps: CONFIGURATOR_STATE,
       }
     );
-    const decodedConfig = decodeChartConfig(migratedConfig);
-    expect(decodedConfig).toBeDefined();
+    const decodedMapConfig = decodeChartConfig(migratedMapConfig);
+    expect(decodedMapConfig).toBeDefined();
   });
 
   it("should not migrate joinBy iris", async () => {

--- a/app/utils/chart-config/versioning.ts
+++ b/app/utils/chart-config/versioning.ts
@@ -2082,17 +2082,9 @@ export const configuratorStateMigrations: Migration[] = [
       const newConfig = { ...config, version: "4.2.0" };
 
       if (newConfig.layout.layoutsMetadata) {
-        newConfig.layout.blocks = Object.entries(
-          newConfig.layout.layoutsMetadata
-        ).map(([k, v]) => {
-          return {
-            type: "chart",
-            key: k,
-            ...(v as object),
-          };
-        });
         delete newConfig.layout.layoutsMetadata;
-      } else {
+      }
+
         newConfig.layout.blocks = newConfig.chartConfigs.map(
           (chartConfig: any) => {
             return {
@@ -2102,7 +2094,6 @@ export const configuratorStateMigrations: Migration[] = [
             };
           }
         );
-      }
 
       return newConfig;
     },

--- a/app/utils/chart-config/versioning.ts
+++ b/app/utils/chart-config/versioning.ts
@@ -830,7 +830,6 @@ export const chartConfigMigrations: Migration[] = [
     description: `ALL {
       + cubes {
         + publishIri
-        +- joinBy (string) -> joinBy (string[])
       }
     }`,
     from: "3.1.0",
@@ -1290,28 +1289,40 @@ export const chartConfigMigrations: Migration[] = [
   },
   {
     description: `ALL {
-        fields {
-            segment {
-              - colorMapping
-            },
-            y {
-              - colorMapping
-            }
-            + color {
-                + type
-                + paletteId
-                + colorMapping / color
-            }
+      cubes {
+        - joinBy: null
+      }
+      fields {
+        segment {
+          - colorMapping
         }
+        y {
+          - colorMapping
+        }
+        + color {
+          + type
+          + paletteId
+          + colorMapping / color
+        }
+      }
     }`,
     from: "4.0.0",
     to: "4.1.0",
-
     up: (config) => {
       const newConfig = {
         ...config,
         version: "4.1.0",
       };
+
+      // Fixes some rare cases of joinBy being null, when a cube was joined and
+      // un-joined. Previously we kept the undefined field there, which was
+      // converted to null via the database saving / fetching process, now we
+      // remove the property entirely when removing a dataset.
+      newConfig.cubes.forEach((cube: any) => {
+        if (cube.joinBy === null) {
+          delete cube.joinBy;
+        }
+      });
 
       if (newConfig.chartType === "table") {
         return newConfig;
@@ -2085,15 +2096,15 @@ export const configuratorStateMigrations: Migration[] = [
         delete newConfig.layout.layoutsMetadata;
       }
 
-        newConfig.layout.blocks = newConfig.chartConfigs.map(
-          (chartConfig: any) => {
-            return {
-              type: "chart",
-              key: chartConfig.key,
-              initialized: false,
-            };
-          }
-        );
+      newConfig.layout.blocks = newConfig.chartConfigs.map(
+        (chartConfig: any) => {
+          return {
+            type: "chart",
+            key: chartConfig.key,
+            initialized: false,
+          };
+        }
+      );
 
       return newConfig;
     },


### PR DESCRIPTION
This PR:
- fixes `/preview` page to not try to load invalid data to the iframe,
- correctly adds PUBLISHED state before trying to decode configurator state in `/preview` and `/preview_post` pages,
- fixes two edge cases in configurator state migrations.

## How to test

1. Go to [this link](https://visualization-tool-git-fix-invalid-states-api-preview-ixt1.vercel.app/_preview).
2. Open debug console.
3. ✅ See that the errors about "data.version" are not there.

## How to reproduce
1. Go to [this link](https://test.visualize.admin.ch/_preview).
2. Open debug console.
3. ❌ See that the errors about "data.version" are there.

---

- [x] Add a CHANGELOG entry
