### PR TITLE
fix: Selected values display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ You can also check the
 
 - Fixes
   - Bar chart tooltip doesn't go off the screen anymore during scroll
+  - Selected values are now correctly displayed in the filter panel
 
 # [5.2.0] - 2025-01-22
 

--- a/app/configurator/components/filters.spec.ts
+++ b/app/configurator/components/filters.spec.ts
@@ -1,3 +1,4 @@
+import { getHasColorMapping } from "@/configurator/components/filters";
 import { TemporalDimension } from "@/domain/data";
 import { TimeUnit } from "@/graphql/resolver-types";
 import { getD3TimeFormatLocale } from "@/locales/locales";
@@ -30,5 +31,16 @@ describe("TimeFilter", () => {
     expect(sortedOptions).toHaveLength(1);
     expect(sortedValues).toHaveLength(1);
     expect(sortedOptions[0].value).toEqual("2020");
+  });
+});
+
+describe("colorMapping", () => {
+  it("should not detect colorMapping as present for single color fields", () => {
+    expect(
+      getHasColorMapping({
+        colorConfig: { type: "single", paletteId: "321", color: "aliceblue" },
+        filterDimensionId: "123",
+      })
+    ).toBe(false);
   });
 });

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -324,9 +324,7 @@ const MultiFilterContent = ({
 
   const hasColorMapping = useMemo(() => {
     return !!(
-      (colorConfig?.type === "single"
-        ? colorConfig.color
-        : colorConfig?.colorMapping) &&
+      (colorConfig?.type === "single" ? false : colorConfig?.colorMapping) &&
       (colorComponent !== undefined ? dimensionId === colorComponent.id : true)
     );
   }, [colorConfig, dimensionId, colorComponent]);

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -220,6 +220,23 @@ const FilterControls = ({
   );
 };
 
+export const getHasColorMapping = ({
+  colorConfig,
+  colorComponent,
+  filterDimensionId,
+}: {
+  colorConfig: ColorField | undefined;
+  colorComponent?: Component;
+  filterDimensionId: string;
+}) => {
+  return !!(
+    (colorConfig?.type === "single" ? false : colorConfig?.colorMapping) &&
+    (colorComponent !== undefined
+      ? filterDimensionId === colorComponent.id
+      : true)
+  );
+};
+
 const MultiFilterContent = ({
   field,
   colorComponent,
@@ -323,10 +340,11 @@ const MultiFilterContent = ({
   }, [chartConfig]);
 
   const hasColorMapping = useMemo(() => {
-    return !!(
-      (colorConfig?.type === "single" ? false : colorConfig?.colorMapping) &&
-      (colorComponent !== undefined ? dimensionId === colorComponent.id : true)
-    );
+    return getHasColorMapping({
+      colorConfig,
+      colorComponent,
+      filterDimensionId: dimensionId,
+    });
   }, [colorConfig, dimensionId, colorComponent]);
 
   useEnsureUpToDateColorMapping({


### PR DESCRIPTION
Closes #2000

This PR fixes the `Selected values` display by setting `hasColorMapping` to false in case of `SingleColorField`s.

## How to test

1. Go to [this link](https://visualization-tool-git-fix-color-mapping-detection-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10&dataSource=Prod).
2. Open `Horizontal Axis` field.
3. Switch the measure to `Kanton`.
4. See that Selected values are correctly displayed.

## How to reproduce
See instructions in #2000.

---

- [x] Add a CHANGELOG entry
- [x] Add a unit test