### PR TITLE
Fix scatterplot overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ You can also check the
 
 - Fixes
   - Bar chart tooltip doesn't go off the screen anymore during scroll
+  - Scatterplot overlap with the y axis label
 
 # [5.2.0] - 2025-01-22
 

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -177,7 +177,7 @@ const useScatterplotState = (
     marginRight: right,
   });
   const margins = {
-    top: 50 + yAxisLabelMargin,
+    top: 75 + yAxisLabelMargin,
     right,
     bottom: bottom + xAxisLabelMargin,
     left,


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes [#2002](https://github.com/visualize-admin/visualization-tool/issues/2002)

<!--- Describe the changes -->

Adjusts the margin so that the chart no longer overlaps the label

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-scaterplot-overlap-ixt1.vercel.app/en/create/yT1_R3J0aGr2?dataSource=Prod)
2. switch to scatterplot chart
3. notice the label no longer overlaps

---

- [x] Add a CHANGELOG entry
