### PR TITLE
fix: Layout blocks sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ You can also check the
 
 - Fixes
   - Bar chart tooltip doesn't go off the screen anymore during scroll
+  - Charts based on a new cube are not hidden anymore in the layouting step
 
 # [5.2.0] - 2025-01-22
 

--- a/app/configurator/configurator-state/reducer.spec.tsx
+++ b/app/configurator/configurator-state/reducer.spec.tsx
@@ -151,10 +151,23 @@ describe("add dataset", () => {
   });
 });
 
-describe("add chart", () => {
+describe("add chart based on the same cube", () => {
   const state = configStateMock.groupedColumnChart;
-  const action: ConfiguratorStateAction = {
+  const actionSameCube: ConfiguratorStateAction = {
     type: "CHART_CONFIG_ADD",
+    value: {
+      chartConfig: getNewChartConfig({
+        chartType: "line",
+        chartConfig: state.chartConfigs[0],
+        state,
+        dimensions: groupedColumnChartDimensions,
+        measures: groupedColumnChartMeasures,
+      }),
+      locale: "en",
+    },
+  };
+  const actionNewCube: ConfiguratorStateAction = {
+    type: "CHART_CONFIG_ADD_NEW_DATASET",
     value: {
       chartConfig: getNewChartConfig({
         chartType: "line",
@@ -179,12 +192,12 @@ describe("add chart", () => {
         measures: groupedColumnChartMeasures,
       };
     });
-    const newState = runReducer(
+    const newStateAfterSameCube = runReducer(
       state,
-      action
+      actionSameCube
     ) as ConfiguratorStateConfiguringChart;
-    const config = newState.chartConfigs[1];
-    expect(Object.keys(config.cubes[0].filters)).toEqual([
+    const newConfigSameCube = newStateAfterSameCube.chartConfigs[1];
+    expect(Object.keys(newConfigSameCube.cubes[0].filters)).toEqual([
       stringifyComponentId({
         unversionedCubeIri:
           "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen",
@@ -192,6 +205,16 @@ describe("add chart", () => {
           "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Kanton",
       }),
     ]);
+  });
+
+  it("should keep blocks in sync when adding a new chart based on new cube", () => {
+    const newStateAfterSameCube = runReducer(
+      state,
+      actionNewCube
+    ) as ConfiguratorStateConfiguringChart;
+    expect(newStateAfterSameCube.chartConfigs.map((c) => c.key)).toEqual(
+      newStateAfterSameCube.layout.blocks.map((b) => b.key)
+    );
   });
 });
 

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -981,9 +981,9 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
 
     case "CHART_CONFIG_ADD_NEW_DATASET":
       if (isConfiguring(draft)) {
-        draft.chartConfigs.push(action.value.chartConfig);
-        draft.activeChartKey = action.value.chartConfig.key;
+        handleAddNewChartConfig(draft, action.value.chartConfig);
       }
+
       return draft;
 
     case "DATASET_ADD":

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -523,6 +523,7 @@ export const updateColorMapping = (
 
   return draft;
 };
+
 const handleInteractiveFilterChanged = (
   draft: ConfiguratorState,
   action: Extract<
@@ -579,6 +580,26 @@ export const setRangeFilter = (
     };
   }
 };
+
+const handleAddNewChartConfig = (
+  draft: ConfiguratorState,
+  chartConfig: ChartConfig
+) => {
+  if (isConfiguring(draft)) {
+    draft.chartConfigs.push(chartConfig);
+    draft.activeChartKey = chartConfig.key;
+    draft.layout.blocks.push({
+      key: chartConfig.key,
+      type: "chart",
+      initialized: false,
+    });
+
+    ensureDashboardLayoutIsCorrect(draft);
+  }
+
+  return draft;
+};
+
 const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
   draft,
   action
@@ -952,16 +973,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
             },
             { dimensions: dataCubesComponents.dimensions }
           );
-          const key = action.value.chartConfig.key;
-          draft.chartConfigs.push(newConfig);
-          draft.activeChartKey = key;
-          draft.layout.blocks.push({
-            key,
-            type: "chart",
-            initialized: false,
-          });
-
-          ensureDashboardLayoutIsCorrect(draft);
+          handleAddNewChartConfig(draft, newConfig);
         }
       }
 


### PR DESCRIPTION
This PR makes sure we keep the layout blocks in sync when adding a new chart based on a new cube.

## How to test

1. Go to this link.
2. 

## How to reproduce

1. Go to this link.
2. 

---

- [ ] Add a CHANGELOG entry
