### PR TITLE
fix: PNG download colors and fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ You can also check the
 
 - Fixes
   - Bar chart tooltip doesn't go off the screen anymore during scroll
+  - PNG image download now correctly retains interactive legend's colors
 
 # [5.2.0] - 2025-01-22
 

--- a/app/components/chart-shared.tsx
+++ b/app/components/chart-shared.tsx
@@ -3,6 +3,7 @@ import {
   Box,
   IconButton,
   Theme,
+  ThemeProvider,
   useEventCallback,
   useTheme,
 } from "@mui/material";
@@ -459,9 +460,11 @@ const useModifyNode = () => {
         footnotes.appendChild(container);
         const root = createRoot(container);
         root.render(
-          <VisualizeLink
-            createdWith={t({ id: "metadata.link.created.with" })}
-          />
+          <ThemeProvider theme={theme}>
+            <VisualizeLink
+              createdWith={t({ id: "metadata.link.created.with" })}
+            />
+          </ThemeProvider>
         );
         await animationFrame();
       }
@@ -483,7 +486,7 @@ const useModifyNode = () => {
       // to avoid changing the color of other SVG elements (charts).
       select(clonedNode).selectAll("text").style("fill", color);
     },
-    [chartWithFiltersClasses.chartWithFilters, theme.palette.grey]
+    [chartWithFiltersClasses.chartWithFilters, theme]
   );
 };
 

--- a/app/components/chart-shared.tsx
+++ b/app/components/chart-shared.tsx
@@ -476,7 +476,7 @@ const useModifyNode = () => {
       // and not have underlines.
       const color = theme.palette.grey[700];
       select(clonedNode)
-        .selectAll("*")
+        .selectAll(`p, button, a, span, div, li, h1, h2, h3, h4, h5, h6`)
         .style("color", color)
         .style("text-decoration", "none");
       // SVG elements have fill instead of color. Here we only target text elements,


### PR DESCRIPTION
Closes #2007
Closes #2023

This PR brings back interactive legend colors and uses a correct font family styles for "Created with visualize.admin.ch" footnote in PNG image downloads.

## How to test

1. Go to [this link](https://visualization-tool-git-fix-interactive-filter-colors-png-ixt1.vercel.app/en/v/k3xovfSAmIjQ?dataSource=Prod).
2. Export a PNG image.
3. ✅ See that the interactive legend colors are persisted and the "Created with visualize.admin.ch" font style is the same as above footnotes.

## How to reproduce

1. Go to [this link](https://test.visualize.admin.ch/en/v/BNvRsJwgC70E?dataSource=Prod).
2. Export a PNG image.
3. ❌ See that the interactive legend colors are not persisted and the "Created with visualize.admin.ch" font style is not the same as above footnotes.

---

- [x] Add a CHANGELOG entry
