### PR TITLE
Fix interactive filter bar chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ You can also check the
 
 - Fixes
   - Bar chart tooltip doesn't go off the screen anymore during scroll
+  - Bar chart interactive switch on y axis
 
 # [5.2.0] - 2025-01-22
 

--- a/app/charts/bar/bars-grouped-state.tsx
+++ b/app/charts/bar/bars-grouped-state.tsx
@@ -199,7 +199,7 @@ const useBarsGroupedState = (
           label: segment,
           color:
             fields.color.type === "segment"
-              ? fields.color.colorMapping![dvIri] ?? schemeCategory10[0]
+              ? (fields.color.colorMapping![dvIri] ?? schemeCategory10[0])
               : schemeCategory10[0],
         };
       });
@@ -336,6 +336,7 @@ const useBarsGroupedState = (
   }, [getSegment, getY, chartData, segmentSortingOrder, segments, yScale]);
 
   const { left, bottom } = useChartPadding({
+    xLabelPresent: !!xMeasure.label,
     yScale: paddingYScale,
     width,
     height,
@@ -351,7 +352,7 @@ const useBarsGroupedState = (
   const margins = {
     top: 55,
     right,
-    bottom: bottom + 30,
+    bottom: bottom + 10,
     left,
   };
   const bounds = useChartBounds(width, margins, height);

--- a/app/charts/bar/bars-stacked-state.tsx
+++ b/app/charts/bar/bars-stacked-state.tsx
@@ -245,7 +245,7 @@ const useBarsStackedState = (
           label: segment,
           color:
             fields.color.type === "segment"
-              ? fields.color.colorMapping![dvIri] ?? schemeCategory10[0]
+              ? (fields.color.colorMapping![dvIri] ?? schemeCategory10[0])
               : schemeCategory10[0],
         };
       });
@@ -396,6 +396,7 @@ const useBarsStackedState = (
 
   /** Chart dimensions */
   const { left, bottom } = useChartPadding({
+    xLabelPresent: !!xMeasure.label,
     yScale: paddingXScale,
     width,
     height,
@@ -412,23 +413,24 @@ const useBarsStackedState = (
   const margins = {
     top: 65,
     right,
-    bottom: bottom + 30,
+    bottom: bottom + 10,
     left,
   };
 
   const barCount = yScale.domain().length;
-  // Here we adjust the height to make sure the bars have a minimum height and are legible
-  const adjustedHeight =
-    barCount * MIN_BAR_HEIGHT > height
-      ? barCount * MIN_BAR_HEIGHT
-      : height - margins.bottom;
 
-  const bounds = useChartBounds(width, margins, adjustedHeight);
+  const bounds = useChartBounds(width, margins, height);
   const { chartWidth, chartHeight } = bounds;
 
-  yScale.range([0, adjustedHeight]);
-  yScaleInteraction.range([0, adjustedHeight]);
-  yScaleTimeRange.range([0, adjustedHeight]);
+  // Here we adjust the height to make sure the bars have a minimum height and are legible
+  const adjustedChartHeight =
+    barCount * MIN_BAR_HEIGHT > chartHeight
+      ? barCount * MIN_BAR_HEIGHT
+      : chartHeight;
+
+  yScale.range([0, adjustedChartHeight]);
+  yScaleInteraction.range([0, adjustedChartHeight]);
+  yScaleTimeRange.range([0, adjustedChartHeight]);
   xScale.range([0, chartWidth]);
 
   const isMobile = useIsMobile();
@@ -513,7 +515,7 @@ const useBarsStackedState = (
     chartType: "bar",
     bounds: {
       ...bounds,
-      chartHeight: adjustedHeight,
+      chartHeight: adjustedChartHeight,
     },
     chartData,
     allData,

--- a/app/charts/bar/bars-state.tsx
+++ b/app/charts/bar/bars-state.tsx
@@ -193,6 +193,7 @@ const useBarsState = (
   ]);
 
   const { left, bottom } = useChartPadding({
+    xLabelPresent: !!xMeasure.label,
     yScale: paddingYScale,
     width,
     height,
@@ -208,25 +209,25 @@ const useBarsState = (
   const margins = {
     top: 55,
     right,
-    bottom: bottom + 65,
+    bottom: bottom + 45,
     left,
   };
 
   const barCount = yScale.domain().length;
 
-  // Here we adjust the height to make sure the bars have a minimum height and are legible
-  const adjustedHeight =
-    barCount * MIN_BAR_HEIGHT > height
-      ? barCount * MIN_BAR_HEIGHT
-      : height - margins.bottom;
-
-  const bounds = useChartBounds(width, margins, adjustedHeight);
+  const bounds = useChartBounds(width, margins, height);
   const { chartWidth, chartHeight } = bounds;
 
+  // Here we adjust the height to make sure the bars have a minimum height and are legible
+  const adjustedChartHeight =
+    barCount * MIN_BAR_HEIGHT > chartHeight
+      ? barCount * MIN_BAR_HEIGHT
+      : chartHeight;
+
   xScale.range([0, chartWidth]);
-  yScaleInteraction.range([0, adjustedHeight]);
-  yScaleTimeRange.range([0, adjustedHeight]);
-  yScale.range([0, adjustedHeight]);
+  yScaleInteraction.range([0, adjustedChartHeight]);
+  yScaleTimeRange.range([0, adjustedChartHeight]);
+  yScale.range([0, adjustedChartHeight]);
 
   const isMobile = useIsMobile();
 
@@ -274,7 +275,7 @@ const useBarsState = (
     chartType: "bar",
     bounds: {
       ...bounds,
-      chartHeight: adjustedHeight,
+      chartHeight: adjustedChartHeight,
     },
     chartData,
     allData,

--- a/app/charts/bar/bars-state.tsx
+++ b/app/charts/bar/bars-state.tsx
@@ -208,7 +208,7 @@ const useBarsState = (
   const margins = {
     top: 55,
     right,
-    bottom: bottom + 30,
+    bottom: bottom + 65,
     left,
   };
 

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -1,5 +1,5 @@
 import { max } from "d3-array";
-import { ScaleLinear, ScaleOrdinal, scaleLinear, scaleOrdinal } from "d3-scale";
+import { ScaleLinear, scaleLinear, ScaleOrdinal, scaleOrdinal } from "d3-scale";
 import { schemeCategory10 } from "d3-scale-chromatic";
 import orderBy from "lodash/orderBy";
 import { useMemo } from "react";
@@ -138,7 +138,7 @@ const useScatterplotState = (
         label: segment,
         color:
           fields.color.type === "segment"
-            ? fields.color.colorMapping![dvIri] ?? schemeCategory10[0]
+            ? (fields.color.colorMapping![dvIri] ?? schemeCategory10[0])
             : schemeCategory10[0],
       };
     });
@@ -156,6 +156,7 @@ const useScatterplotState = (
   }
   // Dimensions
   const { left, bottom } = useChartPadding({
+    xLabelPresent: !!xAxisLabel,
     yScale: paddingYScale,
     width,
     height,

--- a/app/charts/shared/axis-width-linear.tsx
+++ b/app/charts/shared/axis-width-linear.tsx
@@ -97,7 +97,7 @@ export const AxisWidthLinear = () => {
     <>
       <foreignObject
         x={margins.left + chartWidth / 2 - labelWidth / 2}
-        y={margins.top + chartHeight + 35}
+        y={margins.top + chartHeight + 40}
         width={chartWidth}
         height={height}
         style={{ display: "flex", textAlign: "right" }}

--- a/app/charts/shared/axis-width-linear.tsx
+++ b/app/charts/shared/axis-width-linear.tsx
@@ -97,7 +97,7 @@ export const AxisWidthLinear = () => {
     <>
       <foreignObject
         x={margins.left + chartWidth / 2 - labelWidth / 2}
-        y={margins.top + chartHeight + 34}
+        y={margins.top + chartHeight + 35}
         width={chartWidth}
         height={height}
         style={{ display: "flex", textAlign: "right" }}

--- a/app/charts/shared/brush/index.tsx
+++ b/app/charts/shared/brush/index.tsx
@@ -119,27 +119,19 @@ export const BrushTime = () => {
 
   // Brush dimensions
   const { width, margins, chartHeight } = bounds;
+  const scaleTimeRange =
+    chartType === "bar" ? yScaleTimeRange : xScaleTimeRange;
   const brushLabelsWidth =
-    chartType === "bar"
-      ? getTextWidth(formatDate(yScaleTimeRange.domain()[0]), {
-          fontSize: labelFontSize,
-        }) +
-        getTextWidth(" - ", { fontSize: labelFontSize }) +
-        getTextWidth(formatDate(yScaleTimeRange.domain()[1]), {
-          fontSize: labelFontSize,
-        }) +
-        HANDLE_HEIGHT
-      : getTextWidth(formatDate(xScaleTimeRange.domain()[0]), {
-          fontSize: labelFontSize,
-        }) +
-        getTextWidth(" - ", { fontSize: labelFontSize }) +
-        getTextWidth(formatDate(xScaleTimeRange.domain()[1]), {
-          fontSize: labelFontSize,
-        }) +
-        HANDLE_HEIGHT;
+    getTextWidth(formatDate(scaleTimeRange.domain()[0]), {
+      fontSize: labelFontSize,
+    }) +
+    getTextWidth(" - ", { fontSize: labelFontSize }) +
+    getTextWidth(formatDate(scaleTimeRange.domain()[1]), {
+      fontSize: labelFontSize,
+    }) +
+    HANDLE_HEIGHT;
   const brushWidth = width - brushLabelsWidth - margins.right;
-  const brushWidthScale =
-    chartType === "bar" ? yScaleTimeRange.copy() : xScaleTimeRange.copy();
+  const brushWidthScale = scaleTimeRange.copy();
 
   brushWidthScale.range([0, brushWidth]);
 

--- a/app/charts/shared/chart-dimensions.tsx
+++ b/app/charts/shared/chart-dimensions.tsx
@@ -19,6 +19,7 @@ import {
 import { getTextWidth } from "@/utils/get-text-width";
 
 type ComputeChartPaddingProps = {
+  xLabelPresent?: boolean;
   yScale: ScaleLinear<number, number>;
   width: number;
   height: number;
@@ -37,6 +38,7 @@ const computeChartPadding = (
   }
 ) => {
   const {
+    xLabelPresent,
     yScale,
     height,
     interactiveFiltersConfig,
@@ -72,7 +74,7 @@ const computeChartPadding = (
       ? BRUSH_BOTTOM_SPACE
       : isFlipped
         ? 15 // Eyeballed value
-        : 48;
+        : 48 + (xLabelPresent ? 20 : 0);
 
   if (bandDomain?.length) {
     bottom +=
@@ -85,6 +87,7 @@ const computeChartPadding = (
 
 export const useChartPadding = (props: ComputeChartPaddingProps) => {
   const {
+    xLabelPresent,
     yScale,
     width,
     height,
@@ -98,6 +101,7 @@ export const useChartPadding = (props: ComputeChartPaddingProps) => {
   const [{ dashboardFilters }] = useConfiguratorState(hasChartConfigs);
   return useMemo(() => {
     return computeChartPadding({
+      xLabelPresent,
       yScale,
       width,
       height,
@@ -110,6 +114,7 @@ export const useChartPadding = (props: ComputeChartPaddingProps) => {
       isFlipped,
     });
   }, [
+    xLabelPresent,
     yScale,
     width,
     height,

--- a/app/charts/shared/chart-state.ts
+++ b/app/charts/shared/chart-state.ts
@@ -110,6 +110,8 @@ export type ChartWithInteractiveXTimeRangeState =
   | ColumnsState
   | LinesState;
 
+export type ChartWithInteractiveYTimeRangeState = BarsState;
+
 export type NumericalValueGetter = (d: Observation) => number | null;
 
 export type StringValueGetter = (d: Observation) => string;


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes [#2003](https://github.com/visualize-admin/visualization-tool/issues/2003)

<!--- Describe the changes -->

This PR fixes a bug where the chart would crash when the interactive filter was selected on the y axis of a bar chart. The reason was that the computations necessary to make the brushes were not expecting a bar chart that has the axis flipped (when comparing to column charts). 

<!--- Test instructions -->

## How to test

1. Go to a dataset
2. Select the Y axis
3. Toggle the interactive switch
4. Notice the chart works as intended

- [x] Add a CHANGELOG entry
