### PR TITLE
fix: Do not show scroll bars when not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ You can also check the
     going off the screen in case of iframe embed
   - PNG image download now correctly retains interactive legend's colors
   - Charts based on a new cube are not hidden anymore in the layouting step
+  - Scroll bars are not shown in the chart area when not needed
 
 # [5.2.0] - 2025-01-22
 

--- a/app/charts/shared/containers.tsx
+++ b/app/charts/shared/containers.tsx
@@ -44,7 +44,7 @@ export const ChartContainer = ({ children }: { children: ReactNode }) => {
       className={classes.chartContainer}
       style={{
         height: isFreeCanvas ? "initial" : bounds.height,
-        overflow: "scroll",
+        overflow: "auto",
       }}
     >
       {children}


### PR DESCRIPTION
Closes #2022

This PR changes the CSS overflow property from "scroll" to "auto" to not show scroll bars when not necessary.

## How to test

1. If you are using MacOS, go to your operating system settings → `Appearance` → `Show scroll bars` → `Always`.
2. Go to [this link](https://visualization-tool-git-fix-scrollbars-ixt1.vercel.app/en/v/31mPAoyVKxB_?dataSource=Prod).
3. ✅ See that there are no scroll bars inside the chart itself.

## How to reproduce
See instructions in #2022.

---

- [x] Add a CHANGELOG entry
