### PR TITLE
fix: Disable multiline Input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ You can also check the
   - PNG image download now correctly retains interactive legend's colors
   - Charts based on a new cube are not hidden anymore in the layouting step
   - Scroll bars are not shown in the chart area when not needed
+  - Input fields do not extend anymore when hitting Enter
 
 # [5.2.0] - 2025-01-22
 

--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -642,7 +642,6 @@ export const Input = ({
         id={name}
         size="small"
         color="secondary"
-        multiline
         name={name}
         value={value}
         disabled={disabled}


### PR DESCRIPTION
Closes #2010

This PR removes the `multiline` property from Input so that it does not extend when hitting Enter. This change was introduced while working on the dashboard text blocks, but as we switched to using a third-party library for Markdown inputs, this should have been removed.

## How to test

1. Go to [this link](https://visualization-tool-git-fix-multiline-input-ixt1.vercel.app/en/v/Oa9u2jQOjAtr?dataSource=Prod).
2. Enter some text in the search bar above the table and hit Enter.
3. ✅ See that the input field doesn't extend.

## How to reproduce
See the instructions in #2010.

---

- [x] Add a CHANGELOG entry
