### PR TITLE
fix: Application crash when using shared weekly date filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Fixes
+  - Weekly-based temporal dimensions now work correctly when used in dashboard
+    filters
 
 # [5.2.1] - 2025-01-29
 

--- a/app/configurator/components/layout-configurator.tsx
+++ b/app/configurator/components/layout-configurator.tsx
@@ -51,10 +51,7 @@ import {
   DatePickerFieldProps,
 } from "@/configurator/components/field-date-picker";
 import { IconButton } from "@/configurator/components/icon-button";
-import {
-  extractDataPickerOptionsFromDimension,
-  timeUnitToFormatter,
-} from "@/configurator/components/ui-helpers";
+import { timeUnitToFormatter } from "@/configurator/components/ui-helpers";
 import {
   isLayouting,
   useConfiguratorState,
@@ -373,18 +370,27 @@ const DashboardTimeRangeFilterOptions = ({
   dimension: TemporalDimension | TemporalEntityDimension;
 }) => {
   const { timeUnit, timeFormat } = dimension;
+  const timeFormatUnit = useTimeFormatUnit();
   const formatLocale = useTimeFormatLocale();
   const formatDate = formatLocale.format(timeFormat);
   const parseDate = formatLocale.parse(timeFormat);
   const [state, dispatch] = useConfiguratorState();
   const dashboardInteractiveFilters = useDashboardInteractiveFilters();
 
-  const { minDate, maxDate, optionValues, options } = useMemo(() => {
-    return extractDataPickerOptionsFromDimension({
+  const { sortedOptions, sortedValues } = useMemo(() => {
+    return getTimeFilterOptions({
       dimension,
-      parseDate,
+      formatLocale,
+      timeFormatUnit,
     });
-  }, [dimension, parseDate]);
+  }, [dimension, formatLocale, timeFormatUnit]);
+
+  const minDate = sortedOptions[0].date;
+  const maxDate = sortedOptions[sortedOptions.length - 1].date;
+  const timeRange = [
+    parseDate(filter.presets.from) as Date,
+    parseDate(filter.presets.to) as Date,
+  ];
 
   const updateChartStoresFrom = useCallback(
     (newDate: Date) => {
@@ -509,9 +515,13 @@ const DashboardTimeRangeFilterOptions = ({
         {canRenderDatePickerField(timeUnit) ? (
           <DatePickerField
             name="dashboard-time-range-filter-from"
-            value={parseDate(filter.presets.from) as Date}
+            value={timeRange[0]}
             onChange={handleChangeFromDate}
-            isDateDisabled={(date) => !optionValues.includes(formatDate(date))}
+            isDateDisabled={(date) => {
+              return (
+                date > timeRange[1] || !sortedValues.includes(formatDate(date))
+              );
+            }}
             timeUnit={timeUnit}
             dateFormat={formatDate}
             minDate={minDate}
@@ -523,7 +533,7 @@ const DashboardTimeRangeFilterOptions = ({
           <Select
             id="dashboard-time-range-filter-from"
             label={t({ id: "controls.filters.select.from", message: "From" })}
-            options={options}
+            options={sortedOptions}
             value={filter.presets.from}
             onChange={handleChangeFromGeneric}
           />
@@ -531,9 +541,13 @@ const DashboardTimeRangeFilterOptions = ({
         {canRenderDatePickerField(timeUnit) ? (
           <DatePickerField
             name="dashboard-time-range-filter-to"
-            value={parseDate(filter.presets.to) as Date}
+            value={timeRange[1]}
             onChange={handleChangeToDate}
-            isDateDisabled={(date) => !optionValues.includes(formatDate(date))}
+            isDateDisabled={(date) => {
+              return (
+                date < timeRange[0] || !sortedValues.includes(formatDate(date))
+              );
+            }}
             timeUnit={timeUnit}
             dateFormat={formatDate}
             minDate={minDate}
@@ -545,7 +559,7 @@ const DashboardTimeRangeFilterOptions = ({
           <Select
             id="dashboard-time-range-filter-to"
             label={t({ id: "controls.filters.select.to", message: "To" })}
-            options={options}
+            options={sortedOptions}
             value={filter.presets.to}
             onChange={handleChangeToGeneric}
           />

--- a/app/configurator/components/layout-configurator.tsx
+++ b/app/configurator/components/layout-configurator.tsx
@@ -268,6 +268,7 @@ const LayoutSharedFiltersConfigurator = () => {
                       {combinedTemporalDimension.label}
                     </Typography>
                     <Switch
+                      data-testid="dashboard-time-range-filter-toggle"
                       checked={timeRange.active}
                       onChange={handleTimeRangeFilterToggle}
                     />
@@ -503,6 +504,7 @@ const DashboardTimeRangeFilterOptions = ({
   return (
     <div>
       <Stack
+        data-testid="dashboard-time-range-filters"
         direction="row"
         gap="0.5rem"
         alignItems="center"

--- a/app/rdf/mappings.ts
+++ b/app/rdf/mappings.ts
@@ -26,7 +26,7 @@ export const timeFormats = new Map<string, string>([
 export const timeUnitFormats = new Map<TimeUnit, string>([
   [TimeUnit.Year, "%Y"],
   [TimeUnit.Month, "%Y-%m"],
-  [TimeUnit.Week, "%Y-%W"],
+  [TimeUnit.Week, "%Y-%m-%d"],
   [TimeUnit.Day, "%Y-%m-%d"],
   [TimeUnit.Hour, "%Y-%m-%dT%H"],
   [TimeUnit.Minute, "%Y-%m-%dT%H:%M"],

--- a/e2e/dashboards.spec.ts
+++ b/e2e/dashboards.spec.ts
@@ -1,0 +1,151 @@
+import { loadChartInLocalStorage } from "./charts-utils";
+import { setup, sleep } from "./common";
+
+const { expect, test } = setup();
+
+test("the application shouldn't crash in case of adding a global, week-based filter", async ({
+  page,
+  screen,
+  selectors,
+}) => {
+  const key = "123";
+  await loadChartInLocalStorage(page, key, CONFIGURATOR_STATE);
+  await page.goto(`/en/create/${key}`);
+  await selectors.chart.loaded();
+
+  const dateFilterToggle = page.locator(
+    "[data-testid='dashboard-time-range-filter-toggle']"
+  );
+  await dateFilterToggle.click();
+
+  await sleep(2_000);
+
+  const dateFilters = page
+    .locator("[data-testid='dashboard-time-range-filters'] input")
+    .first();
+  const dateFiltersText = await dateFilters.inputValue();
+
+  // Make sure the content is not empty and the date is formatted correctly.
+  expect(dateFiltersText).toContain(".");
+});
+
+const CONFIGURATOR_STATE = {
+  version: "4.2.0",
+  state: "LAYOUTING",
+  dataSource: {
+    type: "sparql",
+    url: "https://lindas-cached.cluster.ldbar.ch/query",
+  },
+  layout: {
+    type: "tab",
+    meta: {
+      title: { de: "", en: "", fr: "", it: "" },
+      description: { de: "", en: "", fr: "", it: "" },
+      label: { de: "", en: "", fr: "", it: "" },
+    },
+    blocks: [
+      { type: "chart", key: "P2aXwlds74qI", initialized: false },
+      { key: "SnhL6_5cK1Az", type: "chart", initialized: false },
+    ],
+  },
+  chartConfigs: [
+    {
+      key: "P2aXwlds74qI",
+      version: "4.1.0",
+      meta: {
+        title: { en: "", de: "", fr: "", it: "" },
+        description: { en: "", de: "", fr: "", it: "" },
+        label: { en: "", de: "", fr: "", it: "" },
+      },
+      cubes: [
+        {
+          iri: "https://health.ld.admin.ch/fsvo/Moderhinke_Untersuchungsperiode_2024_2025/10",
+          filters: {
+            "https://health.ld.admin.ch/fsvo/Moderhinke_Untersuchungsperiode_2024_2025(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://health.ld.admin.ch/fsvo/Moderhinke_Untersuchungsperiode_2024_2025/Variable":
+              {
+                type: "single",
+                value:
+                  "https://health.ld.admin.ch/fsvo/Moderhinke_Untersuchungsperiode_2024_2025/farms_examined_count",
+              },
+            "https://health.ld.admin.ch/fsvo/Moderhinke_Untersuchungsperiode_2024_2025(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://health.ld.admin.ch/fsvo/Moderhinke_Untersuchungsperiode_2024_2025/lastdayofweek":
+              { type: "range", from: "2024-10-06", to: "2025-01-26" },
+          },
+        },
+      ],
+      chartType: "column",
+      interactiveFiltersConfig: {
+        legend: { active: false, componentId: "" },
+        timeRange: {
+          componentId:
+            "https://health.ld.admin.ch/fsvo/Moderhinke_Untersuchungsperiode_2024_2025(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://health.ld.admin.ch/fsvo/Moderhinke_Untersuchungsperiode_2024_2025/lastdayofweek",
+          active: false,
+          presets: { type: "range", from: "2024-10-06", to: "2025-01-26" },
+        },
+        dataFilters: { active: false, componentIds: [] },
+        calculation: { active: false, type: "identity" },
+      },
+      fields: {
+        x: {
+          componentId:
+            "https://health.ld.admin.ch/fsvo/Moderhinke_Untersuchungsperiode_2024_2025(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://health.ld.admin.ch/fsvo/Moderhinke_Untersuchungsperiode_2024_2025/lastdayofweek",
+          sorting: { sortingType: "byAuto", sortingOrder: "asc" },
+        },
+        y: {
+          componentId:
+            "https://health.ld.admin.ch/fsvo/Moderhinke_Untersuchungsperiode_2024_2025(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://health.ld.admin.ch/fsvo/Moderhinke_Untersuchungsperiode_2024_2025/number",
+        },
+        color: { type: "single", paletteId: "category10", color: "#006699" },
+      },
+    },
+    {
+      key: "SnhL6_5cK1Az",
+      version: "4.1.0",
+      meta: {
+        title: { en: "", de: "", fr: "", it: "" },
+        description: { en: "", de: "", fr: "", it: "" },
+        label: { en: "", de: "", fr: "", it: "" },
+      },
+      cubes: [
+        {
+          iri: "https://health.ld.admin.ch/fsvo/Moderhinke_Untersuchungsperiode_2024_2025/10",
+          filters: {
+            "https://health.ld.admin.ch/fsvo/Moderhinke_Untersuchungsperiode_2024_2025(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://health.ld.admin.ch/fsvo/Moderhinke_Untersuchungsperiode_2024_2025/Variable":
+              {
+                type: "single",
+                value:
+                  "https://health.ld.admin.ch/fsvo/Moderhinke_Untersuchungsperiode_2024_2025/farms_examined_count",
+              },
+          },
+        },
+      ],
+      chartType: "line",
+      interactiveFiltersConfig: {
+        legend: { active: false, componentId: "" },
+        timeRange: {
+          active: false,
+          componentId:
+            "https://health.ld.admin.ch/fsvo/Moderhinke_Untersuchungsperiode_2024_2025(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://health.ld.admin.ch/fsvo/Moderhinke_Untersuchungsperiode_2024_2025/lastdayofweek",
+          presets: { type: "range", from: "", to: "" },
+        },
+        dataFilters: { active: false, componentIds: [] },
+        calculation: { active: false, type: "identity" },
+      },
+      fields: {
+        x: {
+          componentId:
+            "https://health.ld.admin.ch/fsvo/Moderhinke_Untersuchungsperiode_2024_2025(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://health.ld.admin.ch/fsvo/Moderhinke_Untersuchungsperiode_2024_2025/lastdayofweek",
+        },
+        y: {
+          componentId:
+            "https://health.ld.admin.ch/fsvo/Moderhinke_Untersuchungsperiode_2024_2025(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://health.ld.admin.ch/fsvo/Moderhinke_Untersuchungsperiode_2024_2025/number",
+        },
+        color: { type: "single", paletteId: "category10", color: "#006699" },
+      },
+    },
+  ],
+  activeChartKey: "P2aXwlds74qI",
+  dashboardFilters: {
+    timeRange: { active: false, timeUnit: "", presets: { from: "", to: "" } },
+    dataFilters: { componentIds: [], filters: {} },
+  },
+};

--- a/e2e/filter-position.spec.ts
+++ b/e2e/filter-position.spec.ts
@@ -20,12 +20,12 @@ test("Filters should be sorted by position", async ({ selectors, actions }) => {
 
   await actions.mui.selectOption("Status");
 
-  const panelRight = await selectors.panels.drawer().within();
-  await panelRight.findByText("Selected filters", undefined, {
+  const panelLeft = await selectors.panels.drawer().within();
+  await panelLeft.findByText("Selected filters", undefined, {
     timeout: 10_000,
   });
 
-  const filtersValueLocator = await panelRight.findAllByTestId(
+  const filtersValueLocator = await panelLeft.findAllByTestId(
     "chart-filters-value",
     undefined,
     {


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2013

<!--- Describe the changes -->

This PR fixes a week-based temporal dimensions parsing in dashboard shared filters.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-week-dates-global-filter-ixt1.vercel.app/en/create/new?cube=https://health.ld.admin.ch/fsvo/Moderhinke_Untersuchungsperiode_2024_2025/10&dataSource=Prod).
2. Add a second chart.
3. Proceed to layout options.
4. Enable `Date` shared filter.
5. ✅ See that the fields are filled in correctly.
6. ✅ See that you can interact with the date picker and the application doesn't break.

<!--- Reproduction steps, in case of a bug -->

## How to reproduce
See instructions in #2013.

---

- [x] Add a CHANGELOG entry
- [x] Add an end-to-end test