### PR TITLE
fix: Chart area overflowing when changing chart type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Fixes
+  - Chart area doesn't overflow anymore when changing chart types in editing
+    mode in Chrome
 
 # [5.2.1] - 2025-01-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ You can also check the
     filters
   - Chart area doesn't overflow anymore when changing chart types in editing
     mode in Chrome
+  - Tall dashboard layouts now correctly align chart elements between columns in
+    published mode
 
 # [5.2.1] - 2025-01-29
 

--- a/app/components/chart-panel.tsx
+++ b/app/components/chart-panel.tsx
@@ -13,10 +13,10 @@ import { ChartSelectionTabs } from "@/components/chart-selection-tabs";
 import { DashboardInteractiveFilters } from "@/components/dashboard-interactive-filters";
 import { useSyncTextBlockHeight } from "@/components/text-block";
 import { Layout, LayoutDashboard } from "@/config-types";
-import { hasChartConfigs, isLayouting, LayoutBlock } from "@/configurator";
+import { hasChartConfigs, LayoutBlock } from "@/configurator";
 import { useConfiguratorState } from "@/src";
 
-const useStyles = makeStyles<Theme, { editable?: boolean }>((theme) => ({
+const useStyles = makeStyles<Theme>((theme) => ({
   panelLayout: {
     containerType: "inline-size",
     display: "flex",
@@ -56,7 +56,7 @@ export type ChartWrapperProps = BoxProps & {
 export const ChartWrapper = forwardRef<HTMLDivElement, ChartWrapperProps>(
   (props, ref) => {
     const { children, editing, layoutType, ...rest } = props;
-    const classes = useStyles({});
+    const classes = useStyles();
 
     return (
       <Box
@@ -106,8 +106,7 @@ export const ChartPanelLayout = ({
   ...rest
 }: ChartPanelLayoutProps) => {
   const [state] = useConfiguratorState(hasChartConfigs);
-  const layouting = isLayouting(state);
-  const classes = useStyles({ editable: layouting });
+  const classes = useStyles();
   const Wrapper = Wrappers[layoutType];
   const { layout } = state;
   const { blocks } = layout;

--- a/app/components/chart-panel.tsx
+++ b/app/components/chart-panel.tsx
@@ -24,8 +24,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
     gap: theme.spacing(4),
   },
   chartWrapper: {
-    display: "flex",
-    flexDirection: "column",
+    display: "contents",
     overflow: "hidden",
     [`.${chartPanelLayoutGridClasses.root} &`]: {
       transition: theme.transitions.create(["box-shadow"], {

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -348,6 +348,7 @@ const DndChartPreview = (props: CommonChartPreviewProps) => {
         className={clsx(className, dragOverClasses.root)}
         style={{
           display: active ? "flex" : "contents",
+          flexDirection: "column",
         }}
       >
         <ChartPreviewInner

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -473,7 +473,13 @@ const ChartPreviewInner = ({
   }, [dimensions, measures]);
 
   return (
-    <Box ref={ref} className={chartClasses.root}>
+    <Box
+      ref={ref}
+      className={clsx(
+        chartClasses.root,
+        configuring ? chartClasses.editing : chartClasses.pastEditing
+      )}
+    >
       {children}
       <ChartErrorBoundary resetKeys={[state]}>
         {hasChartConfigs(state) && (

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -241,7 +241,6 @@ const usePublishedChartStyles = makeStyles<Theme, { shrink: boolean }>(
       [theme.breakpoints.up("lg")]: {
         padding: theme.spacing(6),
       },
-
       gap: 16,
       display: "flex",
       flexDirection: "column",
@@ -339,7 +338,12 @@ const ChartPublishedInnerImpl = (props: ChartPublishInnerProps) => {
   return (
     <Box
       ref={rootRef}
-      className={clsx(chartClasses.root, publishedChartClasses.root, className)}
+      className={clsx(
+        chartClasses.root,
+        chartClasses.pastEditing,
+        publishedChartClasses.root,
+        className
+      )}
     >
       {children}
       <ChartErrorBoundary resetKeys={[chartConfig]}>

--- a/app/components/chart-shared.tsx
+++ b/app/components/chart-shared.tsx
@@ -70,11 +70,6 @@ export const CHART_GRID_ROW_COUNT = 7;
 export const useChartStyles = makeStyles<Theme, { disableBorder?: boolean }>(
   (theme) => ({
     root: {
-      flexGrow: 1,
-      display: "grid",
-      gridTemplateRows: "subgrid",
-      /** Should stay in sync with the number of rows contained in a chart */
-      gridRow: `span ${CHART_GRID_ROW_COUNT}`,
       padding: theme.spacing(6),
       backgroundColor: theme.palette.background.paper,
       border: ({ disableBorder }) =>
@@ -84,6 +79,16 @@ export const useChartStyles = makeStyles<Theme, { disableBorder?: boolean }>(
         display: "flex",
         flexDirection: "column",
       },
+    },
+    editing: {
+      display: "flex",
+      flexDirection: "column",
+    },
+    pastEditing: {
+      display: "grid",
+      gridTemplateRows: "subgrid",
+      /** Should stay in sync with the number of rows contained in a chart */
+      gridRow: `span ${CHART_GRID_ROW_COUNT}`,
     },
   })
 );

--- a/app/test/__fixtures/config/prod/dashboard-tall.json
+++ b/app/test/__fixtures/config/prod/dashboard-tall.json
@@ -1,0 +1,297 @@
+{
+  "key": "JByj4f0SODiv",
+  "data": {
+    "version": "4.2.0",
+    "dataSource": {
+      "type": "sparql",
+      "url": "https://lindas-cached.cluster.ldbar.ch/query"
+    },
+    "layout": {
+      "type": "dashboard",
+      "meta": {
+        "title": {
+          "de": "",
+          "en": "",
+          "fr": "",
+          "it": ""
+        },
+        "description": {
+          "de": "",
+          "en": "",
+          "fr": "",
+          "it": ""
+        },
+        "label": {
+          "de": "",
+          "en": "",
+          "fr": "",
+          "it": ""
+        }
+      },
+      "blocks": [
+        {
+          "type": "chart",
+          "key": "JByj4f0SODiv",
+          "initialized": false
+        },
+        {
+          "key": "lIcGcN1135mp",
+          "type": "chart",
+          "initialized": false
+        },
+        {
+          "key": "iDGrJJF7knWK",
+          "type": "chart",
+          "initialized": false
+        }
+      ],
+      "layout": "tall"
+    },
+    "chartConfigs": [
+      {
+        "key": "JByj4f0SODiv",
+        "version": "4.1.0",
+        "meta": {
+          "title": {
+            "en": "",
+            "de": "",
+            "fr": "",
+            "it": ""
+          },
+          "description": {
+            "en": "",
+            "de": "",
+            "fr": "",
+            "it": ""
+          },
+          "label": {
+            "en": "",
+            "de": "",
+            "fr": "",
+            "it": ""
+          }
+        },
+        "cubes": [
+          {
+            "iri": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10",
+            "filters": {
+              "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Kanton": {
+                "type": "single",
+                "value": "https://ld.admin.ch/canton/1"
+              }
+            }
+          }
+        ],
+        "chartType": "column",
+        "interactiveFiltersConfig": {
+          "legend": {
+            "active": false,
+            "componentId": ""
+          },
+          "timeRange": {
+            "active": false,
+            "componentId": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr",
+            "presets": {
+              "type": "range",
+              "from": "",
+              "to": ""
+            }
+          },
+          "dataFilters": {
+            "active": false,
+            "componentIds": []
+          },
+          "calculation": {
+            "active": false,
+            "type": "identity"
+          }
+        },
+        "fields": {
+          "x": {
+            "componentId": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr",
+            "sorting": {
+              "sortingType": "byAuto",
+              "sortingOrder": "asc"
+            }
+          },
+          "y": {
+            "componentId": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/AnzahlAnlagen"
+          },
+          "color": {
+            "type": "single",
+            "paletteId": "category10",
+            "color": "#006699"
+          }
+        }
+      },
+      {
+        "key": "lIcGcN1135mp",
+        "version": "4.1.0",
+        "meta": {
+          "title": {
+            "en": "Einmalvergütung für Photovoltaikanlagen is the best cube ever! None ever comes close. Einmalvergütung für Photovoltaikanlagen is the best cube ever! None ever comes close.",
+            "de": "",
+            "fr": "",
+            "it": ""
+          },
+          "description": {
+            "en": "It was last updated on 29.07.2024, 09:15.",
+            "de": "",
+            "fr": "",
+            "it": ""
+          },
+          "label": {
+            "en": "",
+            "de": "",
+            "fr": "",
+            "it": ""
+          }
+        },
+        "cubes": [
+          {
+            "iri": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10",
+            "filters": {
+              "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Kanton": {
+                "type": "single",
+                "value": "https://ld.admin.ch/canton/1"
+              }
+            }
+          }
+        ],
+        "activeField": "title",
+        "chartType": "column",
+        "interactiveFiltersConfig": {
+          "legend": {
+            "active": false,
+            "componentId": ""
+          },
+          "timeRange": {
+            "active": false,
+            "componentId": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr",
+            "presets": {
+              "type": "range",
+              "from": "",
+              "to": ""
+            }
+          },
+          "dataFilters": {
+            "active": false,
+            "componentIds": []
+          },
+          "calculation": {
+            "active": false,
+            "type": "identity"
+          }
+        },
+        "fields": {
+          "x": {
+            "componentId": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr",
+            "sorting": {
+              "sortingType": "byAuto",
+              "sortingOrder": "asc"
+            }
+          },
+          "y": {
+            "componentId": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/AnzahlAnlagen"
+          },
+          "color": {
+            "type": "single",
+            "paletteId": "category10",
+            "color": "#006699"
+          }
+        }
+      },
+      {
+        "key": "iDGrJJF7knWK",
+        "version": "4.1.0",
+        "meta": {
+          "title": {
+            "en": "",
+            "de": "",
+            "fr": "",
+            "it": ""
+          },
+          "description": {
+            "en": "",
+            "de": "",
+            "fr": "",
+            "it": ""
+          },
+          "label": {
+            "en": "",
+            "de": "",
+            "fr": "",
+            "it": ""
+          }
+        },
+        "cubes": [
+          {
+            "iri": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10",
+            "filters": {
+              "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Kanton": {
+                "type": "single",
+                "value": "https://ld.admin.ch/canton/1"
+              }
+            }
+          }
+        ],
+        "chartType": "column",
+        "interactiveFiltersConfig": {
+          "legend": {
+            "active": false,
+            "componentId": ""
+          },
+          "timeRange": {
+            "active": false,
+            "componentId": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr",
+            "presets": {
+              "type": "range",
+              "from": "",
+              "to": ""
+            }
+          },
+          "dataFilters": {
+            "active": false,
+            "componentIds": []
+          },
+          "calculation": {
+            "active": false,
+            "type": "identity"
+          }
+        },
+        "fields": {
+          "x": {
+            "componentId": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr",
+            "sorting": {
+              "sortingType": "byAuto",
+              "sortingOrder": "asc"
+            }
+          },
+          "y": {
+            "componentId": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/AnzahlAnlagen"
+          },
+          "color": {
+            "type": "single",
+            "paletteId": "category10",
+            "color": "#006699"
+          }
+        }
+      }
+    ],
+    "activeChartKey": "JByj4f0SODiv",
+    "dashboardFilters": {
+      "timeRange": {
+        "active": false,
+        "timeUnit": "",
+        "presets": {
+          "from": "",
+          "to": ""
+        }
+      },
+      "dataFilters": {
+        "componentIds": [],
+        "filters": {}
+      }
+    }
+  }
+}

--- a/e2e/dashboard-date-filter.spec.ts
+++ b/e2e/dashboard-date-filter.spec.ts
@@ -5,7 +5,6 @@ const { expect, test } = setup();
 
 test("the application shouldn't crash in case of adding a global, week-based filter", async ({
   page,
-  screen,
   selectors,
 }) => {
   const key = "123";

--- a/e2e/dashboard-tall-subgrid.spec.ts
+++ b/e2e/dashboard-tall-subgrid.spec.ts
@@ -1,0 +1,23 @@
+import { setup } from "./common";
+
+const { expect, test } = setup();
+
+test("elements should be aligned with each other in tall dashboard's columns", async ({
+  page,
+  selectors,
+}) => {
+  await page.goto(`/en/__test/prod/dashboard-tall`);
+  await selectors.chart.loaded();
+
+  const chartTableWrappers = await page.locator(".table-preview-wrapper").all();
+  const [_, secondChartTableWrapper, thirdChartTableWrapper] =
+    chartTableWrappers;
+
+  const secondChart = secondChartTableWrapper.locator("svg");
+  const thirdChart = thirdChartTableWrapper.locator("svg");
+
+  const secondChartBox = await secondChart.boundingBox();
+  const thirdChartBox = await thirdChart.boundingBox();
+
+  expect(secondChartBox.y).toEqual(thirdChartBox.y);
+});

--- a/e2e/dashboard-tall-subgrid.spec.ts
+++ b/e2e/dashboard-tall-subgrid.spec.ts
@@ -1,3 +1,5 @@
+import { argosScreenshot } from "@argos-ci/playwright";
+
 import { setup } from "./common";
 
 const { expect, test } = setup();
@@ -19,5 +21,6 @@ test("elements should be aligned with each other in tall dashboard's columns", a
   const secondChartBox = await secondChart.boundingBox();
   const thirdChartBox = await thirdChart.boundingBox();
 
+  await argosScreenshot(page, "dashboard-tall-subgrid");
   expect(secondChartBox.y).toEqual(thirdChartBox.y);
 });


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2039
Closes #2042

<!--- Describe the changes -->

This PR fixes chart area overflowing the available space in Chrome. While I was not able to narrow down the exact reason for the bug, we don't need a grid layout when in editing mode, as we always only look at one chart, so that should be safe to change anyways.

It also fixes tall layout dashboard in published mode (elements are correctly aligned between columns again).

<!--- Test instructions -->

## How to test
#2039

1. Go to [this link](https://visualization-tool-git-fix-overflow-editing-mode-ixt1.vercel.app/en/create/new?cube=https://agriculture.ld.admin.ch/foag/cube/MilkDairyProducts/Consumption_Price_Month&dataSource=Prod) on Chrome.
2. Change chart type to pie, then table, and then area.
3. ✅ See that the chart area stays the same for all chart types.

#2042

1. Go to [this link](https://visualization-tool-git-fix-overflow-editing-mode-ixt1.vercel.app/en/v/UZkbe6Reb4se?dataSource=Prod).
2. ✅ See that two bottom charts are correctly aligned, in contrast to [the same chart on INT](https://int.visualize.admin.ch/en/v/710Fp25OvsZG).

---

- [x] Add a CHANGELOG entry
- [x] Add an end-to-end test
