### PR TITLE
Created by visualize link points to Chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Nothing yet.
 
 # [5.2.1] - 2025-01-29
 
+- Features
+
+  - Created by visualize.admin.ch Link now navigates users to the corresponding
+    Chart
+
 - Fixes
   - Bar chart tooltip doesn't go off the screen anymore during scroll
   - Preview via API using iframe (`/preview`) now ignores invalid messages sent

--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -115,7 +115,7 @@ export const ChartFootnotes = ({
           ) : null}
         </div>
       ))}
-      {showVisualizeLink && configKey ? (
+      {showVisualizeLink ? (
         <VisualizeLink
           configKey={configKey}
           createdWith={t({ id: "metadata.link.created.with" })}
@@ -299,11 +299,11 @@ export const VisualizeLink = ({
   configKey,
 }: {
   createdWith: ReactNode;
-  configKey: string;
+  configKey?: string;
 }) => {
   const locale = useLocale();
 
-  return (
+  return configKey ? (
     <Typography variant="caption" color="grey.600" {...DISABLE_SCREENSHOT_ATTR}>
       {createdWith}
       <Link
@@ -317,5 +317,5 @@ export const VisualizeLink = ({
         visualize.admin.ch
       </Link>
     </Typography>
-  );
+  ) : null;
 };

--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -115,7 +115,7 @@ export const ChartFootnotes = ({
           ) : null}
         </div>
       ))}
-      {showVisualizeLink ? (
+      {showVisualizeLink && configKey ? (
         <VisualizeLink
           configKey={configKey}
           createdWith={t({ id: "metadata.link.created.with" })}
@@ -299,11 +299,11 @@ export const VisualizeLink = ({
   configKey,
 }: {
   createdWith: ReactNode;
-  configKey?: string;
+  configKey: string;
 }) => {
   const locale = useLocale();
 
-  return configKey ? (
+  return (
     <Typography variant="caption" color="grey.600" {...DISABLE_SCREENSHOT_ATTR}>
       {createdWith}
       <Link
@@ -317,5 +317,5 @@ export const VisualizeLink = ({
         visualize.admin.ch
       </Link>
     </Typography>
-  ) : null;
+  );
 };

--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -50,12 +50,14 @@ export const ChartFootnotes = ({
   dashboardFilters,
   components,
   showVisualizeLink = false,
+  configKey,
 }: {
   dataSource: DataSource;
   chartConfig: ChartConfig;
   dashboardFilters: DashboardFiltersConfig | undefined;
   components: Component[];
   showVisualizeLink?: boolean;
+  configKey?: string;
 }) => {
   const locale = useLocale();
   const usedComponents = useMemo(() => {
@@ -113,8 +115,11 @@ export const ChartFootnotes = ({
           ) : null}
         </div>
       ))}
-      {showVisualizeLink ? (
-        <VisualizeLink createdWith={t({ id: "metadata.link.created.with" })} />
+      {showVisualizeLink && configKey ? (
+        <VisualizeLink
+          configKey={configKey}
+          createdWith={t({ id: "metadata.link.created.with" })}
+        />
       ) : null}
     </Box>
   );

--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -289,14 +289,20 @@ const ChartFootnotesComboLineSingle = ({
   ) : null;
 };
 
-export const VisualizeLink = ({ createdWith }: { createdWith: ReactNode }) => {
+export const VisualizeLink = ({
+  createdWith,
+  configKey,
+}: {
+  createdWith: ReactNode;
+  configKey: string;
+}) => {
   const locale = useLocale();
 
   return (
     <Typography variant="caption" color="grey.600" {...DISABLE_SCREENSHOT_ATTR}>
       {createdWith}
       <Link
-        href={`https://visualize.admin.ch/${locale}/`}
+        href={`https://visualize.admin.ch/${locale}/v/${configKey}`}
         target="_blank"
         rel="noopener noreferrer"
         color="primary.main"

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -601,6 +601,7 @@ const ChartPreviewInner = ({
                   )}
                 </TablePreviewWrapper>
                 <ChartFootnotes
+                  configKey={state?.key}
                   dataSource={dataSource}
                   chartConfig={chartConfig}
                   dashboardFilters={state.dashboardFilters}

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -601,7 +601,6 @@ const ChartPreviewInner = ({
                   )}
                 </TablePreviewWrapper>
                 <ChartFootnotes
-                  configKey={state?.key}
                   dataSource={dataSource}
                   chartConfig={chartConfig}
                   dashboardFilters={state.dashboardFilters}

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -173,9 +173,9 @@ export const ChartPublished = ({
                 layoutType={state.layout.layout}
                 renderBlock={renderBlock}
               />
-              {state.chartConfigs.length !== 1 && state.key && (
+              {state.chartConfigs.length !== 1 && (
                 <VisualizeLink
-                  configKey={state.key}
+                  configKey={configKey}
                   createdWith={t({ id: "metadata.link.created.with" })}
                 />
               )}

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -173,8 +173,9 @@ export const ChartPublished = ({
                 layoutType={state.layout.layout}
                 renderBlock={renderBlock}
               />
-              {state.chartConfigs.length !== 1 && (
+              {state.chartConfigs.length !== 1 && state.key && (
                 <VisualizeLink
+                  configKey={state.key}
                   createdWith={t({ id: "metadata.link.created.with" })}
                 />
               )}
@@ -456,6 +457,7 @@ const ChartPublishedInnerImpl = (props: ChartPublishInnerProps) => {
               )}
             </TablePreviewWrapper>
             <ChartFootnotes
+              configKey={configKey}
               dataSource={dataSource}
               chartConfig={chartConfig}
               dashboardFilters={state.dashboardFilters}

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -173,7 +173,7 @@ export const ChartPublished = ({
                 layoutType={state.layout.layout}
                 renderBlock={renderBlock}
               />
-              {state.chartConfigs.length !== 1 && (
+              {state.chartConfigs.length !== 1 && configKey && (
                 <VisualizeLink
                   configKey={configKey}
                   createdWith={t({ id: "metadata.link.created.with" })}

--- a/app/components/chart-shared.tsx
+++ b/app/components/chart-shared.tsx
@@ -402,7 +402,7 @@ const DownloadPNGImageMenuActionItem = ({
   chartKey: string;
   components: Component[];
 } & Omit<UseScreenshotProps, "type" | "modifyNode" | "pngMetadata">) => {
-  const modifyNode = useModifyNode(configKey);
+  const modifyNode = useModifyNode();
   const metadata = usePNGMetadata({
     configKey,
     chartKey,
@@ -428,7 +428,7 @@ const DownloadPNGImageMenuActionItem = ({
   );
 };
 
-const useModifyNode = (configKey?: string) => {
+const useModifyNode = () => {
   const theme = useTheme();
   const chartWithFiltersClasses = useChartWithFiltersClasses();
 
@@ -455,14 +455,13 @@ const useModifyNode = (configKey?: string) => {
         `.${CHART_FOOTNOTES_CLASS_NAME}`
       );
 
-      if (footnotes && configKey) {
+      if (footnotes) {
         const container = document.createElement("div");
         footnotes.appendChild(container);
         const root = createRoot(container);
         root.render(
           <ThemeProvider theme={theme}>
             <VisualizeLink
-              configKey={configKey}
               createdWith={t({ id: "metadata.link.created.with" })}
             />
           </ThemeProvider>
@@ -487,7 +486,7 @@ const useModifyNode = (configKey?: string) => {
       // to avoid changing the color of other SVG elements (charts).
       select(clonedNode).selectAll("text").style("fill", color);
     },
-    [chartWithFiltersClasses.chartWithFilters, theme, configKey]
+    [chartWithFiltersClasses.chartWithFilters, theme]
   );
 };
 

--- a/app/components/chart-shared.tsx
+++ b/app/components/chart-shared.tsx
@@ -402,7 +402,7 @@ const DownloadPNGImageMenuActionItem = ({
   chartKey: string;
   components: Component[];
 } & Omit<UseScreenshotProps, "type" | "modifyNode" | "pngMetadata">) => {
-  const modifyNode = useModifyNode();
+  const modifyNode = useModifyNode(configKey);
   const metadata = usePNGMetadata({
     configKey,
     chartKey,
@@ -428,7 +428,7 @@ const DownloadPNGImageMenuActionItem = ({
   );
 };
 
-const useModifyNode = () => {
+const useModifyNode = (configKey?: string) => {
   const theme = useTheme();
   const chartWithFiltersClasses = useChartWithFiltersClasses();
 
@@ -455,13 +455,14 @@ const useModifyNode = () => {
         `.${CHART_FOOTNOTES_CLASS_NAME}`
       );
 
-      if (footnotes) {
+      if (footnotes && configKey) {
         const container = document.createElement("div");
         footnotes.appendChild(container);
         const root = createRoot(container);
         root.render(
           <ThemeProvider theme={theme}>
             <VisualizeLink
+              configKey={configKey}
               createdWith={t({ id: "metadata.link.created.with" })}
             />
           </ThemeProvider>
@@ -486,7 +487,7 @@ const useModifyNode = () => {
       // to avoid changing the color of other SVG elements (charts).
       select(clonedNode).selectAll("text").style("fill", color);
     },
-    [chartWithFiltersClasses.chartWithFilters, theme]
+    [chartWithFiltersClasses.chartWithFilters, theme, configKey]
   );
 };
 


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2031 

<!--- Describe the changes -->

**What's new?**
This PR Now navigates users to the corresponding Chart when clicked on the "Created by visualize.admin.ch" section in the footer, like this users can benefit from quick chart creation & potentially starting out with a more established Chart.

<!--- Test instructions -->

## How to test

1. Go to this Link
2. Create a new Visualisation 
3. Publish Visualisation 
4. Memorize last part of the URL (e.g `Xx3-xKHq9K2G`) -> this is necessary because we only support production charts
5. Click the "Created by visualize.admin.ch"
6. See how it navigates to the same Chart (See url) ✅

<!--- Reproduction steps, in case of a bug -->

---

@bprusinowski please let me know if it makes sense here to make the URL dynamic or if I should keep it only for visualize.admin.ch, Vercel also has a URL called VERCEL_URL we could be using this for cases like these. Let me know what you think. 👀
