### PR TITLE
fix: Dual axis Y label colors in PNG download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ You can also check the
     mode in Chrome
   - Tall dashboard layouts now correctly align chart elements between columns in
     published mode
+  - PNG image download now correctly retains Y axis label colors in combo charts
 
 # [5.2.1] - 2025-01-29
 

--- a/app/charts/combo/axis-height-linear-dual.tsx
+++ b/app/charts/combo/axis-height-linear-dual.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/charts/shared/axis-height-linear";
 import { useChartState } from "@/charts/shared/chart-state";
 import { useChartTheme } from "@/charts/shared/use-chart-theme";
+import { DISABLE_SCREENSHOT_COLOR_WIPE_ATTR } from "@/components/chart-shared";
 import { OpenMetadataPanelWrapper } from "@/components/metadata-panel";
 import { theme } from "@/themes/federal";
 import { getTextWidth } from "@/utils/get-text-width";
@@ -83,6 +84,7 @@ export const AxisHeightLinearDual = (props: AxisHeightLinearDualProps) => {
       >
         <OpenMetadataPanelWrapper component={y[orientation].dimension}>
           <span
+            {...DISABLE_SCREENSHOT_COLOR_WIPE_ATTR}
             style={{
               width: titleWidth,
               fontSize: axisLabelFontSize,

--- a/app/charts/shared/axis-height-band.tsx
+++ b/app/charts/shared/axis-height-band.tsx
@@ -89,6 +89,7 @@ export const AxisHeightBand = () => {
     xScale,
     yTimeUnit,
     yScale,
+    fontSize,
   ]);
 
   return (

--- a/app/components/chart-shared.tsx
+++ b/app/components/chart-shared.tsx
@@ -484,15 +484,24 @@ const useModifyNode = () => {
       // and not have underlines.
       const color = theme.palette.grey[700];
       select(clonedNode)
-        .selectAll(`p, button, a, span, div, li, h1, h2, h3, h4, h5, h6`)
+        .selectAll(
+          `:is(p, button, a, span, div, li, h1, h2, h3, h4, h5, h6):not([${DISABLE_SCREENSHOT_COLOR_WIPE_KEY}='true'])`
+        )
         .style("color", color)
         .style("text-decoration", "none");
       // SVG elements have fill instead of color. Here we only target text elements,
       // to avoid changing the color of other SVG elements (charts).
-      select(clonedNode).selectAll("text").style("fill", color);
+      select(clonedNode)
+        .selectAll(`text:not([${DISABLE_SCREENSHOT_COLOR_WIPE_KEY}='true'])`)
+        .style("fill", color);
     },
     [chartWithFiltersClasses.chartWithFilters, theme]
   );
+};
+
+const DISABLE_SCREENSHOT_COLOR_WIPE_KEY = "data-disable-screenshot-color";
+export const DISABLE_SCREENSHOT_COLOR_WIPE_ATTR = {
+  [DISABLE_SCREENSHOT_COLOR_WIPE_KEY]: true,
 };
 
 const usePNGMetadata = ({


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2045

<!--- Describe the changes -->

This PR makes sure we keep correct colors in dual-axis charts' Y axis labels.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-dual-axis-colors-png-ixt1.vercel.app/en/v/wU3yCKqXSAJs?dataSource=Prod).
2. Download PNG image.
3. ✅ See that the Y axis labels have correct colors.

<!--- Reproduction steps, in case of a bug -->

## How to reproduce
See #2045.

---

- [x] Add a CHANGELOG entry
