### PR TITLE
fix: Map legend items overlap in PNG download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ You can also check the
     mode in Chrome
   - Tall dashboard layouts now correctly align chart elements between columns in
     published mode
+- Style
+  - Improved vertical spacing between map legend items
 
 # [5.2.1] - 2025-01-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ You can also check the
     mode in Chrome
   - Tall dashboard layouts now correctly align chart elements between columns in
     published mode
+  - Map legend items do not overlap anymore in PNG image downloads
 - Style
   - Improved vertical spacing between map legend items
 

--- a/app/charts/map/map-legend.tsx
+++ b/app/charts/map/map-legend.tsx
@@ -98,7 +98,7 @@ export const MapLegend = ({
   const formatters = useDimensionFormatters(measureDimensions);
 
   return (
-    <Box>
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 3 }}>
       <Flex sx={{ flexWrap: "wrap", gap: 4 }}>
         {areaLayer && showAreaLegend && (
           <Box>

--- a/app/charts/shared/containers.tsx
+++ b/app/charts/shared/containers.tsx
@@ -52,6 +52,8 @@ export const ChartContainer = ({ children }: { children: ReactNode }) => {
   );
 };
 
+export const CHART_SVG_ID = "chart-svg";
+
 export const ChartSvg = ({ children }: { children: ReactNode }) => {
   const ref = useRef<SVGSVGElement>(null);
   const enableTransition = useTransitionStore((state) => state.enable);
@@ -88,6 +90,7 @@ export const ChartSvg = ({ children }: { children: ReactNode }) => {
   return (
     <svg
       ref={ref}
+      id={CHART_SVG_ID}
       width={width}
       style={{ position: "absolute", left: 0, top: 0 }}
     >

--- a/app/utils/use-screenshot.ts
+++ b/app/utils/use-screenshot.ts
@@ -3,6 +3,7 @@ import { toPng, toSvg } from "html-to-image";
 import { addMetadata } from "meta-png";
 import { useCallback, useState } from "react";
 
+import { CHART_SVG_ID } from "@/charts/shared/containers";
 import { TABLE_PREVIEW_WRAPPER_CLASS_NAME } from "@/components/chart-table-preview";
 import { animationFrame } from "@/utils/animation-frame";
 
@@ -127,14 +128,14 @@ const makeScreenshot = async ({
   const tableWrapper = clonedNode.querySelector(
     `.${TABLE_PREVIEW_WRAPPER_CLASS_NAME}`
   ) as HTMLElement | null;
-  const svg = tableWrapper?.querySelector("svg");
-  const svgHeight = svg?.getAttribute("height");
-  const svgParent = svg?.parentElement;
+  const chartSvg = tableWrapper?.querySelector(`#${CHART_SVG_ID}`);
+  const chartSvgHeight = chartSvg?.getAttribute("height");
+  const chartSvgParent = chartSvg?.parentElement;
 
-  if (tableWrapper && svgHeight && svgParent) {
+  if (tableWrapper && chartSvgHeight && chartSvgParent) {
     tableWrapper.style.height = "fit-content";
-    svgParent.style.height = `${svgHeight}px`;
-    svgParent.style.overflow = "visible";
+    chartSvgParent.style.height = `${chartSvgHeight}px`;
+    chartSvgParent.style.overflow = "visible";
   }
 
   await animationFrame();


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2012

<!--- Describe the changes -->

This PR:
- fixes map legend items overlap in PNG download,
- improves vertical spacing between map legend items.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-screenshot-overlaps-map-ixt1.vercel.app/en/v/B-kwpu3axtnI?dataSource=Prod).
2. Download a PNG image.
3. ✅ See that the map legend elements do not overlap.

<!--- Reproduction steps, in case of a bug -->

## How to reproduce
See #2012.

---

- [x] Add a CHANGELOG entry
