### PR TITLE
fix: NaNs in map tooltip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ You can also check the
     published mode
   - Map legend items do not overlap anymore in PNG image downloads
   - PNG image download now correctly retains Y axis label colors in combo charts
+  - NaN values are not displayed in map tooltip anymore
 - Style
   - Improved vertical spacing between map legend items
 

--- a/e2e/tooltip.spec.ts
+++ b/e2e/tooltip.spec.ts
@@ -1,3 +1,4 @@
+import { loadChartInLocalStorage } from "./charts-utils";
 import { setup, sleep } from "./common";
 
 const { test, expect } = setup();
@@ -84,3 +85,155 @@ test("should keep correct position after scrolling", async ({
   expect(tooltipRect.y).toBeGreaterThanOrEqual(chartBbox.y);
   expect(tooltipRect.y).toBeLessThanOrEqual(chartBbox.y + chartBbox.height);
 });
+
+test("should not contain NaN values", async ({ page, selectors }) => {
+  const key = "map-config";
+  await loadChartInLocalStorage(page, key, MAP_CONFIG_STATE);
+  await page.goto(`/en/create/${key}`);
+  await selectors.chart.loaded();
+  const chart = page.locator(".maplibregl-canvas");
+  await chart.hover({ position: { x: 1, y: 1 } });
+  const tooltip = page.locator('[data-testid="chart-tooltip"]');
+  await tooltip.waitFor({ state: "attached", timeout: 1_000 });
+  const textContent = await tooltip.textContent();
+  expect(textContent).not.toContain("NaN");
+});
+
+// Special config that contains symbols grouped in the right top corner of the chart,
+// so that we can easily hover over them and check the tooltip content.
+const MAP_CONFIG_STATE = {
+  version: "4.2.0",
+  state: "CONFIGURING_CHART",
+  dataSource: {
+    type: "sparql",
+    url: "https://lindas-cached.cluster.ldbar.ch/query",
+  },
+  layout: {
+    type: "tab",
+    meta: {
+      title: {
+        de: "",
+        en: "",
+        fr: "",
+        it: "",
+      },
+      description: {
+        de: "",
+        en: "",
+        fr: "",
+        it: "",
+      },
+      label: {
+        de: "",
+        en: "",
+        fr: "",
+        it: "",
+      },
+    },
+    blocks: [
+      {
+        type: "chart",
+        key: "ftcfNaXEz1Dt",
+        initialized: false,
+      },
+    ],
+  },
+  chartConfigs: [
+    {
+      key: "ftcfNaXEz1Dt",
+      version: "4.1.0",
+      meta: {
+        title: {
+          en: "",
+          de: "",
+          fr: "",
+          it: "",
+        },
+        description: {
+          en: "",
+          de: "",
+          fr: "",
+          it: "",
+        },
+        label: {
+          en: "",
+          de: "",
+          fr: "",
+          it: "",
+        },
+      },
+      cubes: [
+        {
+          iri: "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10",
+          filters: {
+            "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr":
+              {
+                type: "single",
+                value: "2014",
+              },
+          },
+        },
+      ],
+      chartType: "map",
+      interactiveFiltersConfig: {
+        legend: {
+          active: false,
+          componentId: "",
+        },
+        timeRange: {
+          active: true,
+          componentId:
+            "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr",
+          presets: {
+            type: "range",
+            from: "2014",
+            to: "2023",
+          },
+        },
+        dataFilters: {
+          active: false,
+          componentIds: [],
+        },
+        calculation: {
+          active: false,
+          type: "identity",
+        },
+      },
+      baseLayer: {
+        show: true,
+        locked: true,
+        bbox: [
+          [7.037838717797797, 24.804701640425165],
+          [64.55634838244976, 47.70350279907606],
+        ],
+      },
+      fields: {
+        symbolLayer: {
+          componentId:
+            "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Kanton",
+          color: {
+            type: "fixed",
+            value: "#1f77b4",
+            opacity: 100,
+          },
+          measureId: "FIELD_VALUE_NONE",
+        },
+      },
+    },
+  ],
+  activeChartKey: "ftcfNaXEz1Dt",
+  dashboardFilters: {
+    timeRange: {
+      active: false,
+      timeUnit: "",
+      presets: {
+        from: "",
+        to: "",
+      },
+    },
+    dataFilters: {
+      componentIds: [],
+      filters: {},
+    },
+  },
+};


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2034

<!--- Describe the changes -->

This PR prevents displaying of NaN values in map tooltip.

<!--- Test instructions -->

## How to test

1. Go to this link.
2. Hover over the circles.
3. ✅ See that there are no `NaN` values in the tooltip.

<!--- Reproduction steps, in case of a bug -->

## How to reproduce
See #2034

---

- [ ] Add a CHANGELOG entry
- [ ] Add an end-to-end test