### PR TITLE
style: changed to padding for backgroundColor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ You can also check the
   - NaN values are not displayed in map tooltip anymore
 - Style
   - Improved vertical spacing between map legend items
+  - Fixed the spacing between navigation and header in the /profile view
 
 # [5.2.1] - 2025-01-29
 

--- a/app/login/components/profile-content-tabs.tsx
+++ b/app/login/components/profile-content-tabs.tsx
@@ -15,7 +15,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
   section: {
     borderBottom: 1,
     borderColor: "divider",
-    marginTop: theme.spacing(6),
+    paddingTop: theme.spacing(6),
   },
   tabList: {
     minHeight: "fit-content",


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #1985

<!--- Describe the changes -->

**What changes?**
This PR removes the white bar in between header and navigation bar of the user profile page.
<!--- Test instructions -->

## How to test

1. This feature can only be tested once merged.

<!--- Reproduction steps, in case of a bug -->
## How to reproduce bug
1. Go to this [link](https://int.visualize.admin.ch/en)
2. Login 
3. See your profile with the white bar in between ❌
---

- [x] Add a CHANGELOG entry

cc: @sosiology , @bprusinowski 
