### PR TITLE
feat: Added color change when selecting filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ You can also check the
   - Scroll bars are not shown in the chart area when not needed
   - Scatterplot overlap with the y axis label
   - Input fields do not extend anymore when hitting Enter
+  - Fixed color changes when changing segment dimension
 
 # [5.2.0] - 2025-01-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ You can also check the
 - Fixes
   - Weekly-based temporal dimensions now work correctly when used in dashboard
     filters
+  - Fixed color changes when changing segment dimension
 
 # [5.2.1] - 2025-01-29
 
@@ -31,7 +32,6 @@ You can also check the
   - Scroll bars are not shown in the chart area when not needed
   - Scatterplot overlap with the y axis label
   - Input fields do not extend anymore when hitting Enter
-  - Fixed color changes when changing segment dimension
 
 # [5.2.0] - 2025-01-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ You can also check the
   - Weekly-based temporal dimensions now work correctly when used in dashboard
     filters
   - Fixed color changes when changing segment dimension
+  - Fixed Filter selection made it so that color are showing again correctly for
+    selected filters
 
 # [5.2.1] - 2025-01-29
 

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -940,9 +940,9 @@ export const DimensionValuesMultiFilter = ({
   const chartConfig = getChartConfig(state);
   const getValueColor = useEvent((value: string) => {
     const colorPath = getPathToColorConfigProperty({
-      field,
+      field: isColorInConfig(chartConfig) ? "color" : field,
       colorConfigPath,
-      propertyPath: `colorMapping["${value}"]`,
+      propertyPath: `["${value}"]`,
     });
     return get(chartConfig, colorPath);
   });


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #1996 

<!--- Describe the changes -->

**What changed?**
This PR ensures that selected filters have a color indication by correcting the color path that has changed during the implementation of custom color palettes. 

<!--- Test instructions -->

## How to test

1. Go to this [link](https://visualization-tool-git-fix-boxes-without-color-ixt1.vercel.app/)
2. Select the following dataset `Market figures milk and dairy products - Monthly consumer prices`
3. Select `Segmentation` 
4. Select segmentation dimension `Product`
5. Click `Edit filters`
6. See how when selecting a value the box on the left changes color (Select all for easier confirmation) ✅

<!--- Reproduction steps, in case of a bug -->
## How to Reproduce Bug
1. Go to this [link](https://int.visualize.admin.ch/en) 
2. Select the following dataset `Market figures milk and dairy products - Monthly consumer prices`
3. Select `Segmentation` 
4. Select segmentation dimension `Product`
5. Click `Edit filters`
6. See how when selecting a value the box on the left doesn't changes color (Select all for easier confirmation) ❌

---

_ps: @bprusinowski & @sosiology , this PR kind of depends on PR #2051 , so maybe it makes sense to review that one first._

---

- [x] Add a CHANGELOG entry
