### PR TITLE
fix: Fixed color shuffling by fixing field selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ You can also check the
   - Map legend items do not overlap anymore in PNG image downloads
   - PNG image download now correctly retains Y axis label colors in combo charts
   - NaN values are not displayed in map tooltip anymore
-  - Fixed color shuffling to work again with custom color palettes
+  - Fixed color shuffling & resetting to work again with custom color palettes
 - Style
   - Improved vertical spacing between map legend items
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ You can also check the
   - Map legend items do not overlap anymore in PNG image downloads
   - PNG image download now correctly retains Y axis label colors in combo charts
   - NaN values are not displayed in map tooltip anymore
+  - Fixed color shuffling to work again with custom color palettes
 - Style
   - Improved vertical spacing between map legend items
 

--- a/app/configurator/components/chart-controls/color-palette.tsx
+++ b/app/configurator/components/chart-controls/color-palette.tsx
@@ -296,7 +296,7 @@ const ColorPaletteControls = ({
             return dispatch({
               type: "CHART_CONFIG_UPDATE_COLOR_MAPPING",
               value: {
-                field,
+                field: isColorInConfig(chartConfig) ? "color" : field,
                 colorConfigPath,
                 dimensionId: component.id,
                 values: component.values,

--- a/app/configurator/components/chart-controls/color-palette.tsx
+++ b/app/configurator/components/chart-controls/color-palette.tsx
@@ -259,7 +259,7 @@ const ColorPaletteControls = ({
       dispatch({
         type: "CHART_PALETTE_RESET",
         value: {
-          field,
+          field: isColorInConfig(chartConfig) ? "color" : field,
           colorConfigPath,
           colorMapping: mapValueIrisToColor({
             paletteId,
@@ -267,7 +267,7 @@ const ColorPaletteControls = ({
           }),
         },
       }),
-    [colorConfigPath, component, dispatch, field, paletteId]
+    [colorConfigPath, component, dispatch, field, paletteId, chartConfig]
   );
 
   if (colorMapping) {


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2033

<!--- Describe the changes -->

**What changes?**
This PR ensures that color shuffle and reset buttons work again and can shuffle colors with the custom color palette adaptation.

<!--- Test instructions -->

## How to test
1. Go to this [Link](https://visualization-tool-git-fix-color-shuffling-ixt1.vercel.app/)
2. Select a dataset (e.g : Einmalvergütung für Photovoltaikanlagen)
3. Select `Segmentation`
4. Select Cantons as `dimension`
5. Click `Shuffle colors` , see how colors are shuffling ✅
6. Click `Reset color palette` , see how colors are being reseted ✅

<!--- Reproduction steps, in case of a bug -->
## How to reproduce bug
1. Go to this [Link](https://test.visualize.admin.ch/en)
2. Select a dataset (e.g : Einmalvergütung für Photovoltaikanlagen)
3. Select `Segmentation`
4. Select Cantons as `dimension`
5. Click `Shuffle colors` , see how colors aren't shuffling ❌
6. Click `Reset color palette` , see how colors aren't being reseted❌
---

- [x] Add a CHANGELOG entry

cc: @sosiology , @bprusinowski 
