### PR TITLE
feat: Use consistent Y axis label margins between regular charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ You can also check the
 - Style
   - Improved vertical spacing between map legend items
   - Fixed the spacing between navigation and header in the /profile view
+  - Regular charts now have consistent margin between the Y axis label and ticks
 
 # [5.2.1] - 2025-01-29
 

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -44,6 +44,7 @@ import {
   getCenteredTooltipPlacement,
   MOBILE_TOOLTIP_PLACEMENT,
 } from "@/charts/shared/interaction/tooltip-box";
+import { DEFAULT_MARGIN_TOP } from "@/charts/shared/margins";
 import {
   getStackedTooltipValueFormatter,
   getStackedYScale,
@@ -348,7 +349,7 @@ const useAreasState = (
     marginRight: right,
   });
   const margins = {
-    top: 70 + yAxisLabelMargin,
+    top: DEFAULT_MARGIN_TOP + yAxisLabelMargin,
     right,
     bottom,
     left,

--- a/app/charts/bar/bars-grouped-state.tsx
+++ b/app/charts/bar/bars-grouped-state.tsx
@@ -37,6 +37,7 @@ import {
   getCenteredTooltipPlacement,
   MOBILE_TOOLTIP_PLACEMENT,
 } from "@/charts/shared/interaction/tooltip-box";
+import { DEFAULT_MARGIN_TOP } from "@/charts/shared/margins";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useSize } from "@/charts/shared/use-size";
@@ -350,7 +351,7 @@ const useBarsGroupedState = (
   });
   const right = 40;
   const margins = {
-    top: 55,
+    top: DEFAULT_MARGIN_TOP,
     right,
     bottom: bottom + 10,
     left,

--- a/app/charts/bar/bars-stacked-state.tsx
+++ b/app/charts/bar/bars-stacked-state.tsx
@@ -49,6 +49,7 @@ import {
   getCenteredTooltipPlacement,
   MOBILE_TOOLTIP_PLACEMENT,
 } from "@/charts/shared/interaction/tooltip-box";
+import { DEFAULT_MARGIN_TOP } from "@/charts/shared/margins";
 import {
   getStackedTooltipValueFormatter,
   getStackedXScale,
@@ -411,7 +412,7 @@ const useBarsStackedState = (
   });
   const right = 40;
   const margins = {
-    top: 65,
+    top: DEFAULT_MARGIN_TOP,
     right,
     bottom: bottom + 10,
     left,

--- a/app/charts/bar/bars-state.tsx
+++ b/app/charts/bar/bars-state.tsx
@@ -34,6 +34,7 @@ import {
   getCenteredTooltipPlacement,
   MOBILE_TOOLTIP_PLACEMENT,
 } from "@/charts/shared/interaction/tooltip-box";
+import { DEFAULT_MARGIN_TOP } from "@/charts/shared/margins";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useSize } from "@/charts/shared/use-size";
@@ -207,7 +208,7 @@ const useBarsState = (
   });
   const right = 40;
   const margins = {
-    top: 55,
+    top: DEFAULT_MARGIN_TOP,
     right,
     bottom: bottom + 45,
     left,

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -38,6 +38,7 @@ import {
   getCenteredTooltipPlacement,
   MOBILE_TOOLTIP_PLACEMENT,
 } from "@/charts/shared/interaction/tooltip-box";
+import { DEFAULT_MARGIN_TOP } from "@/charts/shared/margins";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useSize } from "@/charts/shared/use-size";
@@ -357,7 +358,7 @@ const useColumnsGroupedState = (
     marginRight: right,
   });
   const margins = {
-    top: 70 + yAxisLabelMargin,
+    top: DEFAULT_MARGIN_TOP + yAxisLabelMargin,
     right,
     bottom,
     left,

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -46,6 +46,7 @@ import {
   getCenteredTooltipPlacement,
   MOBILE_TOOLTIP_PLACEMENT,
 } from "@/charts/shared/interaction/tooltip-box";
+import { DEFAULT_MARGIN_TOP } from "@/charts/shared/margins";
 import {
   getStackedTooltipValueFormatter,
   getStackedYScale,
@@ -414,7 +415,7 @@ const useColumnsStackedState = (
     marginRight: right,
   });
   const margins = {
-    top: 70 + yAxisLabelMargin,
+    top: DEFAULT_MARGIN_TOP + yAxisLabelMargin,
     right,
     bottom,
     left,

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -33,6 +33,7 @@ import {
   getCenteredTooltipPlacement,
   MOBILE_TOOLTIP_PLACEMENT,
 } from "@/charts/shared/interaction/tooltip-box";
+import { DEFAULT_MARGIN_TOP } from "@/charts/shared/margins";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useSize } from "@/charts/shared/use-size";
@@ -223,7 +224,7 @@ const useColumnsState = (
     marginRight: right,
   });
   const margins = {
-    top: 70 + yAxisLabelMargin,
+    top: DEFAULT_MARGIN_TOP + yAxisLabelMargin,
     right,
     bottom,
     left,

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -33,6 +33,7 @@ import {
   getCenteredTooltipPlacement,
   MOBILE_TOOLTIP_PLACEMENT,
 } from "@/charts/shared/interaction/tooltip-box";
+import { DEFAULT_MARGIN_TOP } from "@/charts/shared/margins";
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useSize } from "@/charts/shared/use-size";
@@ -206,7 +207,7 @@ const useLinesState = (
         label: segment,
         color:
           fields.color.type === "segment"
-            ? fields.color.colorMapping![dvIri] ?? schemeCategory10[0]
+            ? (fields.color.colorMapping![dvIri] ?? schemeCategory10[0])
             : schemeCategory10[0],
       };
     });
@@ -239,7 +240,7 @@ const useLinesState = (
     marginRight: right,
   });
   const margins = {
-    top: 50 + yAxisLabelMargin,
+    top: DEFAULT_MARGIN_TOP + yAxisLabelMargin,
     right,
     bottom,
     left,

--- a/app/charts/scatterplot/scatterplot-state.tsx
+++ b/app/charts/scatterplot/scatterplot-state.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/charts/shared/chart-state";
 import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
 import { TooltipScatterplot } from "@/charts/shared/interaction/tooltip-content";
+import { DEFAULT_MARGIN_TOP } from "@/charts/shared/margins";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useSize } from "@/charts/shared/use-size";
 import { ScatterPlotConfig, SortingField } from "@/configurator";
@@ -178,7 +179,7 @@ const useScatterplotState = (
     marginRight: right,
   });
   const margins = {
-    top: 75 + yAxisLabelMargin,
+    top: DEFAULT_MARGIN_TOP + yAxisLabelMargin,
     right,
     bottom: bottom + xAxisLabelMargin,
     left,

--- a/app/charts/shared/chart-dimensions.tsx
+++ b/app/charts/shared/chart-dimensions.tsx
@@ -200,6 +200,7 @@ export const useAxisLabelHeightOffset = ({
   const { axisLabelFontSize: fontSize } = useChartTheme();
   const labelWidth = getTextWidth(label, { fontSize });
   const lines = Math.ceil(labelWidth / (width - marginLeft - marginRight));
+
   return {
     height: fontSize * LINE_HEIGHT * lines,
     offset: fontSize * LINE_HEIGHT * (lines - 1),

--- a/app/charts/shared/margins.ts
+++ b/app/charts/shared/margins.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_MARGIN_TOP = 70;


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2040

<!--- Describe the changes -->

This PR increases the margin between Y axis label and ticks for some charts and uses consistent margin for all of them.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-feat-improve-y-axis-label-spacing-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10&dataSource=Prod).
2. Switch between line, area, column and bar charts.
3. ✅ See that the spacing between Y axis label and ticks is consistent and not so close as before in case of some chart types.

<!--- Reproduction steps, in case of a bug -->

---

- [x] Add a CHANGELOG entry
