### PR TITLE
chore: Increase the number of charts pre-loaded to Varnish cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ You can also check the
   - Improved vertical spacing between map legend items
   - Fixed the spacing between navigation and header in the /profile view
   - Regular charts now have consistent margin between the Y axis label and ticks
+- Maintenance
+  - Increased the number of charts pre-loaded to Varnish cache from 25 to 250
 
 # [5.2.1] - 2025-01-29
 

--- a/e2e/varnish-cache-preload.ts
+++ b/e2e/varnish-cache-preload.ts
@@ -102,13 +102,15 @@ const preloadChartsWithOptions = async (
   await preloadChartsPool(fetchedConfigs.data, concurrency);
 };
 
+const LIMIT = 250;
+
 const main = async () => {
   const concurrency = process.env.CI ? 2 : 4;
   // Latest charts
-  await preloadChartsWithOptions({ limit: 25 }, concurrency);
+  await preloadChartsWithOptions({ limit: LIMIT }, concurrency);
   // Most viewed charts
   await preloadChartsWithOptions(
-    { limit: 25, orderByViewCount: true },
+    { limit: LIMIT, orderByViewCount: true },
     concurrency
   );
   process.exit(0);


### PR DESCRIPTION
<!--- Describe the changes -->

This PR increases the number of charts pre-loaded to the Varnish cache from 25 to 250, as the caching capabilities improved in the meantime.

---

- [x] Add a CHANGELOG entry

cc @Rdataflow