### PR TITLE
fix: Dashboard free canvas layout

### DIFF
--- a/app/components/chart-panel.tsx
+++ b/app/components/chart-panel.tsx
@@ -16,7 +16,7 @@ import { Layout, LayoutDashboard } from "@/config-types";
 import { hasChartConfigs, LayoutBlock } from "@/configurator";
 import { useConfiguratorState } from "@/src";
 
-const useStyles = makeStyles<Theme>((theme) => ({
+const useStyles = makeStyles<Theme, { freeCanvas?: boolean }>((theme) => ({
   panelLayout: {
     containerType: "inline-size",
     display: "flex",
@@ -24,7 +24,7 @@ const useStyles = makeStyles<Theme>((theme) => ({
     gap: theme.spacing(4),
   },
   chartWrapper: {
-    display: "contents",
+    display: ({ freeCanvas }) => (freeCanvas ? "flex" : "contents"),
     overflow: "hidden",
     [`.${chartPanelLayoutGridClasses.root} &`]: {
       transition: theme.transitions.create(["box-shadow"], {
@@ -48,14 +48,16 @@ export const getChartWrapperId = (chartKey: string) =>
 
 export type ChartWrapperProps = BoxProps & {
   editing?: boolean;
-  layoutType?: Layout["type"];
+  layout?: Layout;
   chartKey: string;
 };
 
 export const ChartWrapper = forwardRef<HTMLDivElement, ChartWrapperProps>(
   (props, ref) => {
-    const { children, editing, layoutType, ...rest } = props;
-    const classes = useStyles();
+    const { children, editing, layout, ...rest } = props;
+    const classes = useStyles({
+      freeCanvas: layout?.type === "dashboard" && layout.layout === "canvas",
+    });
 
     return (
       <Box
@@ -64,7 +66,7 @@ export const ChartWrapper = forwardRef<HTMLDivElement, ChartWrapperProps>(
         id={getChartWrapperId(props.chartKey)}
         className={clsx(classes.chartWrapper, props.className)}
       >
-        {(editing || layoutType === "tab") && <ChartSelectionTabs />}
+        {(editing || layout?.type === "tab") && <ChartSelectionTabs />}
         <Box
           className={classes.chartWrapperInner}
           sx={{ minHeight: [150, 300, 500] }}
@@ -105,7 +107,7 @@ export const ChartPanelLayout = ({
   ...rest
 }: ChartPanelLayoutProps) => {
   const [state] = useConfiguratorState(hasChartConfigs);
-  const classes = useStyles();
+  const classes = useStyles({});
   const Wrapper = Wrappers[layoutType];
   const { layout } = state;
   const { blocks } = layout;

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -109,7 +109,7 @@ export const ChartPreview = ({ dataSource }: { dataSource: DataSource }) => {
           <ChartTablePreviewProvider key={state.activeChartKey}>
             <ChartWrapper
               editing={editing}
-              layoutType={layout.type}
+              layout={layout}
               chartKey={state.activeChartKey}
             >
               <ChartPreviewInner dataSource={dataSource} />
@@ -157,7 +157,7 @@ const DashboardPreview = ({
           key={chartConfig.key}
           chartKey={chartConfig.key}
           dataSource={dataSource}
-          layoutType={state.layout.type}
+          layout={state.layout}
           editing={editing}
         />
       ) : (
@@ -165,12 +165,12 @@ const DashboardPreview = ({
           key={chartConfig.key}
           chartKey={chartConfig.key}
           dataSource={dataSource}
-          layoutType={state.layout.type}
+          layout={state.layout}
           editing={editing}
         />
       );
     },
-    [dataSource, editing, layoutType, state.layout.type]
+    [dataSource, editing, layoutType, state.layout]
   );
   const renderTextBlock = useCallback(
     (block: LayoutTextBlock) => {

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -75,7 +75,7 @@ const ChartPublishedIndividualChart = forwardRef<
       <ChartTablePreviewProvider key={chartConfig.key}>
         <ChartWrapper
           key={chartConfig.key}
-          layoutType={state.layout.type}
+          layout={state.layout}
           ref={ref}
           chartKey={chartConfig.key}
           {...rest}
@@ -202,7 +202,7 @@ export const ChartPublished = ({
               <ChartTablePreviewProvider>
                 <DashboardInteractiveFilters />
                 <ChartWrapper
-                  layoutType={state.layout.type}
+                  layout={state.layout}
                   chartKey={state.activeChartKey}
                 >
                   <ChartPublishedInner

--- a/app/test/__fixtures/config/prod/dashboard-free-canvas.json
+++ b/app/test/__fixtures/config/prod/dashboard-free-canvas.json
@@ -1,0 +1,433 @@
+{
+  "key": "iZHrxhq2Op8Y",
+  "data": {
+    "state": "PUBLISHED",
+    "key": "RFaQiBA4ht7o",
+    "layout": {
+      "meta": {
+        "label": {
+          "de": "",
+          "en": "",
+          "fr": "",
+          "it": ""
+        },
+        "title": {
+          "de": "",
+          "en": "",
+          "fr": "",
+          "it": ""
+        },
+        "description": {
+          "de": "",
+          "en": "",
+          "fr": "",
+          "it": ""
+        }
+      },
+      "type": "dashboard",
+      "blocks": [
+        {
+          "key": "iZHrxhq2Op8Y",
+          "type": "chart",
+          "initialized": true
+        },
+        {
+          "key": "6S1WeaCa8imo",
+          "type": "chart",
+          "initialized": true
+        },
+        {
+          "key": "JmJGEAtbDgUw",
+          "type": "chart",
+          "initialized": true
+        }
+      ],
+      "layout": "canvas",
+      "layouts": {
+        "lg": [
+          {
+            "h": 5,
+            "i": "iZHrxhq2Op8Y",
+            "w": 1,
+            "x": 0,
+            "y": 0,
+            "maxW": 4,
+            "minH": 5,
+            "moved": false,
+            "static": false,
+            "resizeHandles": ["s", "w", "e", "n", "sw", "nw", "se", "ne"]
+          },
+          {
+            "h": 5,
+            "i": "6S1WeaCa8imo",
+            "w": 1,
+            "x": 1,
+            "y": 0,
+            "maxW": 4,
+            "minH": 5,
+            "moved": false,
+            "static": false,
+            "resizeHandles": ["s", "w", "e", "n", "sw", "nw", "se", "ne"]
+          },
+          {
+            "h": 5,
+            "i": "JmJGEAtbDgUw",
+            "w": 1,
+            "x": 2,
+            "y": 0,
+            "maxW": 4,
+            "minH": 5,
+            "moved": false,
+            "static": false,
+            "resizeHandles": ["s", "w", "e", "n", "sw", "nw", "se", "ne"]
+          }
+        ],
+        "md": [
+          {
+            "h": 5,
+            "i": "iZHrxhq2Op8Y",
+            "w": 1,
+            "x": 0,
+            "y": 0,
+            "maxW": 4,
+            "minH": 5,
+            "resizeHandles": ["s", "w", "e", "n", "sw", "nw", "se", "ne"]
+          },
+          {
+            "h": 5,
+            "i": "6S1WeaCa8imo",
+            "w": 1,
+            "x": 1,
+            "y": 0,
+            "maxW": 4,
+            "minH": 5,
+            "resizeHandles": ["s", "w", "e", "n", "sw", "nw", "se", "ne"]
+          },
+          {
+            "h": 5,
+            "i": "JmJGEAtbDgUw",
+            "w": 1,
+            "x": 2,
+            "y": 7,
+            "maxW": 4,
+            "minH": 5,
+            "resizeHandles": ["s", "w", "e", "n", "sw", "nw", "se", "ne"]
+          }
+        ],
+        "sm": [
+          {
+            "h": 5,
+            "i": "iZHrxhq2Op8Y",
+            "w": 1,
+            "x": 0,
+            "y": 0,
+            "maxW": 4,
+            "minH": 5,
+            "resizeHandles": ["s", "w", "e", "n", "sw", "nw", "se", "ne"]
+          },
+          {
+            "h": 5,
+            "i": "6S1WeaCa8imo",
+            "w": 1,
+            "x": 1,
+            "y": 0,
+            "maxW": 4,
+            "minH": 5,
+            "resizeHandles": ["s", "w", "e", "n", "sw", "nw", "se", "ne"]
+          },
+          {
+            "h": 5,
+            "i": "JmJGEAtbDgUw",
+            "w": 1,
+            "x": 2,
+            "y": 7,
+            "maxW": 4,
+            "minH": 5,
+            "resizeHandles": ["s", "w", "e", "n", "sw", "nw", "se", "ne"]
+          }
+        ],
+        "xl": [
+          {
+            "h": 5,
+            "i": "iZHrxhq2Op8Y",
+            "w": 1,
+            "x": 0,
+            "y": 0,
+            "maxW": 4,
+            "minH": 5,
+            "moved": false,
+            "static": false,
+            "resizeHandles": ["s", "w", "e", "n", "sw", "nw", "se", "ne"]
+          },
+          {
+            "h": 5,
+            "i": "6S1WeaCa8imo",
+            "w": 1,
+            "x": 1,
+            "y": 0,
+            "maxW": 4,
+            "minH": 5,
+            "moved": false,
+            "static": false,
+            "resizeHandles": ["s", "w", "e", "n", "sw", "nw", "se", "ne"]
+          },
+          {
+            "h": 5,
+            "i": "JmJGEAtbDgUw",
+            "w": 1,
+            "x": 2,
+            "y": 0,
+            "maxW": 4,
+            "minH": 5,
+            "moved": false,
+            "static": false,
+            "resizeHandles": ["s", "w", "e", "n", "sw", "nw", "se", "ne"]
+          }
+        ]
+      }
+    },
+    "version": "4.2.0",
+    "dataSource": {
+      "url": "https://lindas-cached.cluster.ldbar.ch/query",
+      "type": "sparql"
+    },
+    "chartConfigs": [
+      {
+        "key": "iZHrxhq2Op8Y",
+        "meta": {
+          "label": {
+            "de": "",
+            "en": "",
+            "fr": "",
+            "it": ""
+          },
+          "title": {
+            "de": "",
+            "en": "",
+            "fr": "",
+            "it": ""
+          },
+          "description": {
+            "de": "",
+            "en": "",
+            "fr": "",
+            "it": ""
+          }
+        },
+        "cubes": [
+          {
+            "iri": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10",
+            "filters": {
+              "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Kanton": {
+                "type": "single",
+                "value": "https://ld.admin.ch/canton/1"
+              }
+            }
+          }
+        ],
+        "fields": {
+          "x": {
+            "sorting": {
+              "sortingType": "byAuto",
+              "sortingOrder": "asc"
+            },
+            "componentId": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr"
+          },
+          "y": {
+            "componentId": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/AnzahlAnlagen"
+          },
+          "color": {
+            "type": "single",
+            "color": "#006699",
+            "paletteId": "category10"
+          }
+        },
+        "version": "4.1.0",
+        "chartType": "column",
+        "interactiveFiltersConfig": {
+          "legend": {
+            "active": false,
+            "componentId": ""
+          },
+          "timeRange": {
+            "active": false,
+            "presets": {
+              "to": "",
+              "from": "",
+              "type": "range"
+            },
+            "componentId": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr"
+          },
+          "calculation": {
+            "type": "identity",
+            "active": false
+          },
+          "dataFilters": {
+            "active": false,
+            "componentIds": []
+          }
+        }
+      },
+      {
+        "key": "6S1WeaCa8imo",
+        "meta": {
+          "label": {
+            "de": "",
+            "en": "",
+            "fr": "",
+            "it": ""
+          },
+          "title": {
+            "de": "",
+            "en": "",
+            "fr": "",
+            "it": ""
+          },
+          "description": {
+            "de": "",
+            "en": "",
+            "fr": "",
+            "it": ""
+          }
+        },
+        "cubes": [
+          {
+            "iri": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10",
+            "filters": {
+              "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Kanton": {
+                "type": "single",
+                "value": "https://ld.admin.ch/canton/1"
+              }
+            }
+          }
+        ],
+        "fields": {
+          "x": {
+            "componentId": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr"
+          },
+          "y": {
+            "componentId": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/AnzahlAnlagen"
+          },
+          "color": {
+            "type": "single",
+            "color": "#006699",
+            "paletteId": "category10"
+          }
+        },
+        "version": "4.1.0",
+        "chartType": "line",
+        "interactiveFiltersConfig": {
+          "legend": {
+            "active": false,
+            "componentId": ""
+          },
+          "timeRange": {
+            "active": false,
+            "presets": {
+              "to": "",
+              "from": "",
+              "type": "range"
+            },
+            "componentId": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr"
+          },
+          "calculation": {
+            "type": "identity",
+            "active": false
+          },
+          "dataFilters": {
+            "active": false,
+            "componentIds": []
+          }
+        }
+      },
+      {
+        "key": "JmJGEAtbDgUw",
+        "meta": {
+          "label": {
+            "de": "",
+            "en": "",
+            "fr": "",
+            "it": ""
+          },
+          "title": {
+            "de": "",
+            "en": "",
+            "fr": "",
+            "it": ""
+          },
+          "description": {
+            "de": "",
+            "en": "",
+            "fr": "",
+            "it": ""
+          }
+        },
+        "cubes": [
+          {
+            "iri": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10",
+            "filters": {
+              "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Kanton": {
+                "type": "single",
+                "value": "https://ld.admin.ch/canton/1"
+              }
+            }
+          }
+        ],
+        "fields": {
+          "x": {
+            "componentId": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr"
+          },
+          "y": {
+            "componentId": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/AnzahlAnlagen",
+            "imputationType": "none"
+          },
+          "color": {
+            "type": "single",
+            "color": "#006699",
+            "paletteId": "category10"
+          }
+        },
+        "version": "4.1.0",
+        "chartType": "area",
+        "interactiveFiltersConfig": {
+          "legend": {
+            "active": false,
+            "componentId": ""
+          },
+          "timeRange": {
+            "active": false,
+            "presets": {
+              "to": "",
+              "from": "",
+              "type": "range"
+            },
+            "componentId": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr"
+          },
+          "calculation": {
+            "type": "identity",
+            "active": false
+          },
+          "dataFilters": {
+            "active": false,
+            "componentIds": []
+          }
+        }
+      }
+    ],
+    "activeChartKey": "iZHrxhq2Op8Y",
+    "dashboardFilters": {
+      "timeRange": {
+        "active": false,
+        "presets": {
+          "to": "",
+          "from": ""
+        },
+        "timeUnit": ""
+      },
+      "dataFilters": {
+        "filters": {},
+        "componentIds": []
+      }
+    }
+  }
+}

--- a/e2e/dashboard-free-canvas.spec.ts
+++ b/e2e/dashboard-free-canvas.spec.ts
@@ -4,24 +4,30 @@ import { setup } from "./common";
 
 const { expect, test } = setup();
 
-test("elements should be aligned with each other in tall dashboard's columns", async ({
+test("charts should be rendered correctly in free canvas mode", async ({
   page,
   selectors,
 }) => {
-  await page.goto(`/en/__test/prod/dashboard-tall`);
+  await page.goto(`/en/__test/prod/dashboard-free-canvas`);
   await selectors.chart.loaded();
 
   const chartTableWrappers = await page.locator(".table-preview-wrapper").all();
-  const [_, secondChartTableWrapper, thirdChartTableWrapper] =
-    chartTableWrappers;
+  const [
+    firstChartTableWrapper,
+    secondChartTableWrapper,
+    thirdChartTableWrapper,
+  ] = chartTableWrappers;
 
+  const firstChart = firstChartTableWrapper.locator("svg");
   const secondChart = secondChartTableWrapper.locator("svg");
   const thirdChart = thirdChartTableWrapper.locator("svg");
 
+  const firstChartBox = await firstChart.boundingBox();
   const secondChartBox = await secondChart.boundingBox();
   const thirdChartBox = await thirdChart.boundingBox();
 
-  await argosScreenshot(page, "dashboard-tall-subgrid");
+  await argosScreenshot(page, "dashboard-free-canvas");
 
+  expect(firstChartBox.y).toEqual(secondChartBox.y);
   expect(secondChartBox.y).toEqual(thirdChartBox.y);
 });


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2072

<!--- Describe the changes -->

This PR makes sure we don't use `display: "contains"` for free canvas layout, so that the charts are not broken when in this mode.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-free-canvas-layout-ixt1.vercel.app/en/v/2SLRKv1zbrq3?dataSource=Prod).
2. ✅ See that the dashboard displays correctly.

---

- [x] Add an end-to-end test
