### PR TITLE
fix: Free canvas layout

### DIFF
--- a/app/charts/table/table.tsx
+++ b/app/charts/table/table.tsx
@@ -292,10 +292,6 @@ export const Table = () => {
       tableColumnsMeta,
     ]
   );
-  const defaultListHeightOffset = getTableUIElementsOffset({
-    showSearch,
-    width: bounds.width,
-  });
 
   return (
     <>
@@ -345,7 +341,7 @@ export const Table = () => {
             {({ width, height }: { width: number; height: number }) => (
               <VariableSizeList
                 key={rows.length} // Reset when groups are toggled because itemSize remains cached per index
-                height={height - defaultListHeightOffset}
+                height={height}
                 itemCount={rows.length}
                 itemSize={getMobileItemSize}
                 width={width}
@@ -378,7 +374,7 @@ export const Table = () => {
                   <FixedSizeList
                     outerElementType={TableContentWrapper}
                     // row height = header row height
-                    height={height - defaultListHeightOffset - rowHeight}
+                    height={height - rowHeight}
                     itemCount={rows.length}
                     itemSize={rowHeight} // depends on whether a column has bars (40px or 56px)
                     width="100%"

--- a/app/components/add-button.tsx
+++ b/app/components/add-button.tsx
@@ -12,8 +12,10 @@ export const AddButton = (props: ButtonProps) => {
       startIcon={<Icon name="add" />}
       sx={{
         width: "fit-content",
+        minWidth: "auto",
         ml: "0.5rem",
         px: 3,
+        whiteSpace: "nowrap",
         ...sx,
       }}
       {...rest}

--- a/app/components/chart-panel.tsx
+++ b/app/components/chart-panel.tsx
@@ -16,7 +16,10 @@ import { Layout, LayoutDashboard } from "@/config-types";
 import { hasChartConfigs, LayoutBlock } from "@/configurator";
 import { useConfiguratorState } from "@/src";
 
-const useStyles = makeStyles<Theme, { freeCanvas?: boolean }>((theme) => ({
+const useStyles = makeStyles<
+  Theme,
+  { freeCanvas?: boolean; isEditing?: boolean }
+>((theme) => ({
   panelLayout: {
     containerType: "inline-size",
     display: "flex",
@@ -25,6 +28,7 @@ const useStyles = makeStyles<Theme, { freeCanvas?: boolean }>((theme) => ({
   },
   chartWrapper: {
     display: ({ freeCanvas }) => (freeCanvas ? "flex" : "contents"),
+    flexDirection: "column",
     overflow: "hidden",
     [`.${chartPanelLayoutGridClasses.root} &`]: {
       transition: theme.transitions.create(["box-shadow"], {
@@ -37,7 +41,8 @@ const useStyles = makeStyles<Theme, { freeCanvas?: boolean }>((theme) => ({
       },
   },
   chartWrapperInner: {
-    display: "contents",
+    display: ({ freeCanvas, isEditing }) =>
+      isEditing || !freeCanvas ? "contents" : "flex",
     width: "auto",
     height: "100%",
   },
@@ -57,6 +62,7 @@ export const ChartWrapper = forwardRef<HTMLDivElement, ChartWrapperProps>(
     const { children, editing, layout, ...rest } = props;
     const classes = useStyles({
       freeCanvas: layout?.type === "dashboard" && layout.layout === "canvas",
+      isEditing: editing,
     });
 
     return (

--- a/app/components/chart-panel.tsx
+++ b/app/components/chart-panel.tsx
@@ -43,6 +43,7 @@ const useStyles = makeStyles<
   chartWrapperInner: {
     display: ({ freeCanvas, isEditing }) =>
       isEditing || !freeCanvas ? "contents" : "flex",
+    flexDirection: "column",
     width: "auto",
     height: "100%",
   },

--- a/app/components/chart-shared.tsx
+++ b/app/components/chart-shared.tsx
@@ -70,6 +70,7 @@ export const CHART_GRID_ROW_COUNT = 7;
 export const useChartStyles = makeStyles<Theme, { disableBorder?: boolean }>(
   (theme) => ({
     root: {
+      flexGrow: 1,
       padding: theme.spacing(6),
       backgroundColor: theme.palette.background.paper,
       border: ({ disableBorder }) =>

--- a/e2e/dashboard-free-canvas.spec.ts
+++ b/e2e/dashboard-free-canvas.spec.ts
@@ -1,10 +1,13 @@
 import { argosScreenshot } from "@argos-ci/playwright";
 
+import CONFIGURATOR_STATE_DASHBOARD_FREE_CANVAS from "../app/test/__fixtures/config/prod/dashboard-free-canvas.json";
+
+import { loadChartInLocalStorage } from "./charts-utils";
 import { setup } from "./common";
 
 const { expect, test } = setup();
 
-test("charts should be rendered correctly in free canvas mode", async ({
+test("charts should be rendered correctly in free canvas mode when published", async ({
   page,
   selectors,
 }) => {
@@ -30,4 +33,44 @@ test("charts should be rendered correctly in free canvas mode", async ({
 
   expect(firstChartBox.y).toEqual(secondChartBox.y);
   expect(secondChartBox.y).toEqual(thirdChartBox.y);
+});
+
+test("charts should be rendered correctly in free canvas mode when editing", async ({
+  page,
+  selectors,
+}) => {
+  const key = "dashboard-free-canvas";
+  const config = {
+    ...CONFIGURATOR_STATE_DASHBOARD_FREE_CANVAS.data,
+    state: "CONFIGURING_CHART",
+  };
+  await loadChartInLocalStorage(page, key, config);
+  await page.goto(`/en/create/${key}`);
+  await selectors.chart.loaded();
+
+  const addChartButton = page.locator("button:has-text('Add chart')");
+  const addChartButtonBox = await addChartButton.boundingBox();
+
+  const chart = page.locator("#chart-svg");
+  const chartBox = await chart.boundingBox();
+
+  if (!chartBox) {
+    throw new Error("Chart box not found");
+  }
+
+  // Add chart button should be above the chart.
+  expect(addChartButtonBox.y).toBeLessThan(chartBox.y);
+
+  const middlePanel = page.locator("[data-testid=panel-body-M]");
+  const middlePanelBox = await middlePanel.boundingBox();
+
+  if (!middlePanelBox) {
+    throw new Error("Middle panel box not found");
+  }
+
+  // Chart should occupy full available space. In the past we had a bug where
+  // the chart was much smaller than the available space (middle panel width).
+  expect(chartBox.width).toBeGreaterThan(middlePanelBox.width * 0.8);
+
+  await argosScreenshot(page, "dashboard-free-canvas-editing");
 });


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2078
Closes #2079
Closes #2081 

<!--- Describe the changes -->

This PR:
- fixes editing of single chart after going back from layouting step,
- fixes wrong display that resulted in action buttons going out of the chart boundaries (missing `flex-direction: column`).

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-free-canvas-in-editor-layout-ixt1.vercel.app/en/v/wneX9wuaNcfH?dataSource=Prod).
2. Copy and edit the dashboard.
3. ✅ See that the layout is not broken.
4. Proceed to layout options.
5. ✅ See that the layout is not broken.

<!--- Reproduction steps, in case of a bug -->

---

- [x] Add an end-to-end test
