### PR TITLE
fix: Parsing temporal entities when changing locales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ You can also check the
   - Fixed color shuffling & resetting to work again with custom color palettes
   - Dual-axis chart y axis titles do not overlap with other chart elements in
     specific cases anymore
+  - Changing locale when editing a chart with temporal entity-based X axis now
+    correctly updates the chart
 - Style
   - Improved vertical spacing between map legend items
   - Fixed the spacing between navigation and header in the /profile view

--- a/app/charts/line/lines.tsx
+++ b/app/charts/line/lines.tsx
@@ -5,8 +5,8 @@ import { Fragment, memo, useEffect, useMemo, useRef } from "react";
 import { LinesState } from "@/charts/line/lines-state";
 import { useChartState } from "@/charts/shared/chart-state";
 import {
-  RenderVerticalWhiskerDatum,
   renderContainer,
+  RenderVerticalWhiskerDatum,
   renderVerticalWhiskers,
 } from "@/charts/shared/rendering-utils";
 import { LineConfig } from "@/config-types";
@@ -122,7 +122,7 @@ const Line = memo(function Line({
   path: string;
   color: string;
 }) {
-  return <path d={path} stroke={color} fill="none" />;
+  return <path data-testid="chart-line" d={path} stroke={color} fill="none" />;
 });
 
 const getPointRadius = (dotSize: LineConfig["fields"]["y"]["showDotsSize"]) => {

--- a/e2e/edition.spec.ts
+++ b/e2e/edition.spec.ts
@@ -4,7 +4,7 @@ import { loadChartInLocalStorage } from "./charts-utils";
 import { setup, sleep } from "./common";
 import offentlicheAusgabenChartConfigFixture from "./fixtures/offentliche-ausgaben-chart-config.json";
 
-const { test } = setup();
+const { expect, test } = setup();
 
 test("should be possible to edit filters of a hierarchy", async ({
   page,
@@ -40,4 +40,26 @@ test("should be possible to edit filters of a hierarchy", async ({
 
   await sleep(2_000);
   await argosScreenshot(page, `chart-edition-${key}`);
+});
+
+test("changing of locale shouldn't make the chart disappear", async ({
+  page,
+  actions,
+  selectors,
+}) => {
+  await actions.chart.createFrom({
+    iri: "https://agriculture.ld.admin.ch/foag/cube/MilkDairyProducts/Consumption_Price_Month",
+    dataSource: "Prod",
+  });
+  await selectors.chart.loaded();
+  await actions.editor.changeRegularChartType("Lines");
+  const deLocaleButton = page.locator('a[rel="alternate"][hreflang="de"]');
+  await deLocaleButton.click();
+  await selectors.chart.loaded();
+  // Make sure the chart had a chance to re-load.
+  await sleep(6_000);
+  const chart = page.locator("#chart-svg");
+  const chartPath = chart.locator("path[data-testid='chart-line']").first();
+  const d = await chartPath.getAttribute("d");
+  expect(d).not.toContain("NaN");
 });


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2082

<!--- Describe the changes -->

This PR makes sure we correctly re-calculate `getX` when dimensions change, which fixes a problem with disappearing line chart in BLW cubes (or any cube with temporal entity-based X dimension).

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-line-chart-locale-bug-ixt1.vercel.app/en/create/new?cube=https://agriculture.ld.admin.ch/foag/cube/MilkDairyProducts/Consumption_Price_Month&dataSource=Prod).
2. Change chart type to line.
3. Change the locale to DE.
4. ✅ See that the chart didn't disappear.

<!--- Reproduction steps, in case of a bug -->

---

- [x] Add a CHANGELOG entry
- [x] Add an end-to-end test
