### PR TITLE
fix: Most recent filter + interactive time range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Fixes
+  - Charts that use most recent date filter and interactive time range filter
+    are initialized correctly now
 
 # [5.2.2] - 2025-02-05
 

--- a/app/charts/shared/brush/index.tsx
+++ b/app/charts/shared/brush/index.tsx
@@ -74,8 +74,6 @@ export const BrushTime = () => {
       setSelectionExtent(0);
     }
   };
-
-  const { from, to } = timeRange;
   const {
     brushOverlayColor,
     brushSelectionColor,
@@ -121,6 +119,15 @@ export const BrushTime = () => {
   const { width, margins, chartHeight } = bounds;
   const scaleTimeRange =
     chartType === "bar" ? yScaleTimeRange : xScaleTimeRange;
+
+  let { from, to } = timeRange;
+
+  // FIXME: Should be fixed in useSyncInteractiveFilters where we try to parse
+  // the date that can be a string (VISUALIZE_MOST_RECENT_VALUE).
+  if (isNaN(to?.getTime() ?? 0)) {
+    to = scaleTimeRange.domain()[1];
+  }
+
   const brushLabelsWidth =
     getTextWidth(formatDate(scaleTimeRange.domain()[0]), {
       fontSize: labelFontSize,

--- a/app/test/__fixtures/config/prod/most-recent-time-range-interactive-filter.json
+++ b/app/test/__fixtures/config/prod/most-recent-time-range-interactive-filter.json
@@ -1,0 +1,141 @@
+{
+  "key": "pnV1OjlbiPU4",
+  "data": {
+    "state": "PUBLISHED",
+    "key": "pnV1OjlbiPU4",
+    "layout": {
+      "meta": {
+        "label": {
+          "de": "",
+          "en": "",
+          "fr": "",
+          "it": ""
+        },
+        "title": {
+          "de": "",
+          "en": "",
+          "fr": "",
+          "it": ""
+        },
+        "description": {
+          "de": "",
+          "en": "",
+          "fr": "",
+          "it": ""
+        }
+      },
+      "type": "tab",
+      "blocks": [
+        {
+          "key": "wtCcf965i01W",
+          "type": "chart",
+          "initialized": false
+        }
+      ]
+    },
+    "version": "4.2.0",
+    "dataSource": {
+      "url": "https://lindas-cached.cluster.ldbar.ch/query",
+      "type": "sparql"
+    },
+    "chartConfigs": [
+      {
+        "key": "wtCcf965i01W",
+        "meta": {
+          "label": {
+            "de": "",
+            "en": "",
+            "fr": "",
+            "it": ""
+          },
+          "title": {
+            "de": "",
+            "en": "",
+            "fr": "",
+            "it": ""
+          },
+          "description": {
+            "de": "",
+            "en": "",
+            "fr": "",
+            "it": ""
+          }
+        },
+        "cubes": [
+          {
+            "iri": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10",
+            "filters": {
+              "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Kanton": {
+                "type": "single",
+                "value": "https://ld.admin.ch/canton/1"
+              },
+              "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr": {
+                "to": "VISUALIZE_MOST_RECENT_VALUE",
+                "from": "2015",
+                "type": "range"
+              }
+            }
+          }
+        ],
+        "fields": {
+          "x": {
+            "sorting": {
+              "sortingType": "byAuto",
+              "sortingOrder": "asc"
+            },
+            "componentId": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr"
+          },
+          "y": {
+            "componentId": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/AnzahlAnlagen"
+          },
+          "color": {
+            "type": "single",
+            "color": "#006699",
+            "paletteId": "category10"
+          }
+        },
+        "version": "4.1.0",
+        "chartType": "column",
+        "activeField": "x",
+        "interactiveFiltersConfig": {
+          "legend": {
+            "active": false,
+            "componentId": ""
+          },
+          "timeRange": {
+            "active": true,
+            "presets": {
+              "to": "VISUALIZE_MOST_RECENT_VALUE",
+              "from": "2015",
+              "type": "range"
+            },
+            "componentId": "https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr"
+          },
+          "calculation": {
+            "type": "identity",
+            "active": false
+          },
+          "dataFilters": {
+            "active": false,
+            "componentIds": []
+          }
+        }
+      }
+    ],
+    "activeChartKey": "wtCcf965i01W",
+    "dashboardFilters": {
+      "timeRange": {
+        "active": false,
+        "presets": {
+          "to": "",
+          "from": ""
+        },
+        "timeUnit": ""
+      },
+      "dataFilters": {
+        "filters": {},
+        "componentIds": []
+      }
+    }
+  }
+}

--- a/e2e/interactive-filters.spec.ts
+++ b/e2e/interactive-filters.spec.ts
@@ -1,8 +1,8 @@
 import { setup } from "./common";
 
-const { test } = setup();
+const { expect, test } = setup();
 
-test("it should display values in interactive filters as hierarchie", async ({
+test.skip("it should display values in interactive filters as hierarchie", async ({
   page,
   selectors,
   within,
@@ -17,4 +17,18 @@ test("it should display values in interactive filters as hierarchie", async ({
   await selectors.mui.popover().getByText("BAQUA_FR").click();
   await selectors.mui.popover().getByText("Nouvelle plage").click();
   await selectors.chart.loaded();
+});
+
+test("it should not initialize interactive time range filter in a broken state", async ({
+  page,
+  selectors,
+}) => {
+  await page.goto("/en/__test/prod/most-recent-time-range-interactive-filter");
+  await selectors.chart.loaded();
+  const chart = page.locator("#chart-svg");
+  const [startHandle, endHandle] = await chart.locator(".handle").all();
+  const startHandleBox = await startHandle.boundingBox();
+  const endHandleBox = await endHandle.boundingBox();
+
+  expect(endHandleBox.x).toBeGreaterThan(startHandleBox.x);
 });


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

<!--- Describe the changes -->

This PR fixes initialization of published charts that use most recent date filter together with interactive filter, so that the full range is displayed, instead of being "stuck" in the start date.

<!--- Test instructions -->

## How to test

1. Go to this link.
2. Open X axis field.
3. Enable most recent date filter.
4. Make the filter interactive.
5. Publish the chart.
6. ✅ See that's initialized correctly.

<!--- Reproduction steps, in case of a bug -->

## How to reproduce
Follow the above steps on TEST and see that chart is broken in published mode (only a single year is selected in interactive filter).

---

- [x] Add a CHANGELOG entry
- [x] Add an end-to-end test

cc @sosiology
