### PR TITLE
fix: Duplicating charts in layout mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Fixes
+  - Duplicating chart in layout mode works correctly again
 
 # [5.2.3] - 2025-02-05
 

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -585,7 +585,7 @@ const handleAddNewChartConfig = (
   draft: ConfiguratorState,
   chartConfig: ChartConfig
 ) => {
-  if (isConfiguring(draft)) {
+  if (isConfiguring(draft) || isLayouting(draft)) {
     draft.chartConfigs.push(chartConfig);
     draft.activeChartKey = chartConfig.key;
     draft.layout.blocks.push({

--- a/e2e/chart-actions.spec.ts
+++ b/e2e/chart-actions.spec.ts
@@ -7,6 +7,7 @@ import { setup } from "./common";
 const { test, expect } = setup();
 
 test("it should be possible to duplicate a chart", async ({
+  page,
   actions,
   selectors,
 }) => {
@@ -20,9 +21,19 @@ test("it should be possible to duplicate a chart", async ({
   await (await selectors.mui.popover().findByText("Duplicate")).click();
   const chartTabs = await selectors.chart.tabs();
   expect(await chartTabs.count()).toBe(2);
+  const layoutOptionsButton = page.locator(
+    "button:has-text('Proceed to layout options')"
+  );
+  await layoutOptionsButton.click();
+  await selectors.chart.loaded();
+  const chartMoreButtonLayout = await selectors.chart.moreButton();
+  await chartMoreButtonLayout.click();
+  await (await selectors.mui.popover().findByText("Duplicate")).click();
+  const chartTabsLayout = await selectors.chart.tabs();
+  expect(await chartTabsLayout.count()).toBe(3);
 });
 
-test("it should be possible to make a screenshot of a chart", async ({
+test.skip("it should be possible to make a screenshot of a chart", async ({
   page,
   actions,
   selectors,


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2087

<!--- Describe the changes -->

This PR fixes duplication of charts in layout mode.

<!--- Test instructions -->

## How to test

Try to duplicate a chart in layout mode using a link from the PR and see that it works.

<!--- Reproduction steps, in case of a bug -->

---

- [x] Add a CHANGELOG entry
- [x] Add an end-to-end test
