### PR TITLE
chore: fix translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ You can also check the
 
 - Features
   - Added option for hiding legend titles using a toggle switch
+- Fixes
+  - Fixed button translations for custom color palette update and create button.
 - Maintenance
   - Added authentication method to e2e tests
   - Added authentication to vercel previews for easier testing

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -37,7 +37,6 @@ msgstr "[ Text hinzufügen ]"
 #: app/configurator/components/annotators.tsx
 #: app/login/components/profile-tables.tsx
 msgid "annotation.add.title"
-
 msgstr "[ Ohne Titel ]"
 
 #: app/browser/dataset-browse.tsx
@@ -554,8 +553,7 @@ msgstr "Gestapelt"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
-#: app/configurator/components/chart-controls/color-ramp.tsx
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes"
 msgstr "Benutzerdefinierte Farbpaletten"
 
@@ -568,7 +566,7 @@ msgstr "Farbe hinzufügen"
 msgid "controls.custom-color-palettes.base"
 msgstr "Basis Farbe"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.caption"
 msgstr "Verwenden Sie klare, kontrastreiche Farben. Vermeiden Sie die Verwendung von zu vielen Farben, maximal 5-7. Verwenden Sie sequenzielle Paletten für geordnete Daten und divergierende Paletten für Extreme."
@@ -593,7 +591,7 @@ msgstr "Beispiel"
 msgid "controls.custom-color-palettes.mid"
 msgstr "Mittlere Farbe"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes.set-values-apply"
 msgstr "Farbpalette speichern"
 
@@ -601,12 +599,12 @@ msgstr "Farbpalette speichern"
 msgid "controls.custom-color-palettes.start"
 msgstr "Anfangsfarbe"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.title"
 msgstr "Palettentitel"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes.title-unavailable"
 msgstr "Dieser Name ist bereits in Gebrauch. Bitte wählen Sie einen eindeutigen Namen für Ihre Farbpalette."
 
@@ -693,12 +691,12 @@ msgid "controls.filters.select.to"
 msgstr "Zu"
 
 #: app/configurator/components/filters.tsx
-msgid "controls.filters.show-legend.toggle"
-msgstr "Legendentitel anzeigen"
-
-#: app/configurator/components/filters.tsx
 msgid "controls.filters.show-legend-toggle"
 msgstr "Benutzer können die Sichtbarkeit der Legende ändern"
+
+#: app/configurator/components/filters.tsx
+msgid "controls.filters.show-legend.toggle"
+msgstr "Legendentitel anzeigen"
 
 #: app/configurator/table/table-chart-configurator.tsx
 msgid "controls.groups.empty-help"
@@ -1250,7 +1248,6 @@ msgstr "Auswählen"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
-#: app/configurator/components/chart-controls/color-ramp.tsx
 msgid "controls.visualize-color-palette"
 msgstr "Visualize Farbpaletten"
 
@@ -1623,7 +1620,6 @@ msgid "login.profile.my-color-palettes"
 msgstr "Meine Farbpaletten"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
-#: app/configurator/components/chart-controls/color-ramp.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
 #: app/login/components/color-palettes/profile-color-palette-content.tsx
 msgid "login.profile.my-color-palettes.add"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -39,7 +39,6 @@ msgstr "[ Add text ]"
 msgid "annotation.add.title"
 msgstr "[ No Title ]"
 
-
 #: app/components/dashboard-shared.tsx
 msgid "block-controls.delete"
 msgstr "Delete"
@@ -570,8 +569,7 @@ msgstr "Stacked"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
-#: app/configurator/components/chart-controls/color-ramp.tsx
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes"
 msgstr "Custom color palettes"
 
@@ -584,7 +582,7 @@ msgstr "Add Color"
 msgid "controls.custom-color-palettes.base"
 msgstr "Base Color"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.caption"
 msgstr "Use distinct, high-contrast colors. Avoid using too many colors, maximum 5–7. Apply sequential palettes for ordered data and diverging palettes for extremes."
@@ -595,7 +593,7 @@ msgstr "The selected color lacks sufficient contrast. Consider using a darker co
 
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.create-palette"
-msgstr "controls.custom-color-palettes.create-palette"
+msgstr "Create color palette"
 
 #: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.end"
@@ -609,7 +607,7 @@ msgstr "Example"
 msgid "controls.custom-color-palettes.mid"
 msgstr "Middle Color"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes.set-values-apply"
 msgstr "Save color palette"
 
@@ -617,12 +615,12 @@ msgstr "Save color palette"
 msgid "controls.custom-color-palettes.start"
 msgstr "Starting Color"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.title"
 msgstr "Palette title"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes.title-unavailable"
 msgstr "This name is already in use. Please choose a unique name for your color palette."
 
@@ -632,7 +630,7 @@ msgstr "Select a color palette type"
 
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.update-palette"
-msgstr "controls.custom-color-palettes.update-palette"
+msgstr "Update color palette"
 
 #: app/configurator/components/field-i18n.ts
 msgid "controls.description"
@@ -709,12 +707,12 @@ msgid "controls.filters.select.to"
 msgstr "To"
 
 #: app/configurator/components/filters.tsx
-msgid "controls.filters.show-legend.toggle"
-msgstr "Show legend titles"
-
-#: app/configurator/components/filters.tsx
 msgid "controls.filters.show-legend-toggle"
 msgstr "Allow users to change legend titles visibility"
+
+#: app/configurator/components/filters.tsx
+msgid "controls.filters.show-legend.toggle"
+msgstr "Show legend titles"
 
 #: app/configurator/table/table-chart-configurator.tsx
 msgid "controls.groups.empty-help"
@@ -1266,7 +1264,6 @@ msgstr "Select"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
-#: app/configurator/components/chart-controls/color-ramp.tsx
 msgid "controls.visualize-color-palette"
 msgstr "Visualize color palettes"
 
@@ -1639,7 +1636,6 @@ msgid "login.profile.my-color-palettes"
 msgstr "My Color Palettes"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
-#: app/configurator/components/chart-controls/color-ramp.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
 #: app/login/components/color-palettes/profile-color-palette-content.tsx
 msgid "login.profile.my-color-palettes.add"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -569,8 +569,7 @@ msgstr "empilées"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
-#: app/configurator/components/chart-controls/color-ramp.tsx
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes"
 msgstr "Palettes de couleurs personnalisées"
 
@@ -583,7 +582,7 @@ msgstr "Ajouter une couleur"
 msgid "controls.custom-color-palettes.base"
 msgstr "Couleur de base"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.caption"
 msgstr "Utilisez des couleurs distinctes et contrastées. Évitez d'utiliser trop de couleurs, au maximum 5 à 7. Appliquez des palettes séquentielles pour les données ordonnées et des palettes divergentes pour les extrêmes."
@@ -608,7 +607,7 @@ msgstr "Exemple"
 msgid "controls.custom-color-palettes.mid"
 msgstr "Couleur moyenne"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes.set-values-apply"
 msgstr "Enregistrer la palette de couleurs"
 
@@ -616,12 +615,12 @@ msgstr "Enregistrer la palette de couleurs"
 msgid "controls.custom-color-palettes.start"
 msgstr "Couleur de départ"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.title"
 msgstr "Palette title"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes.title-unavailable"
 msgstr "Ce nom est déjà utilisé. Veuillez choisir un nom unique pour votre palette de couleurs."
 
@@ -708,12 +707,12 @@ msgid "controls.filters.select.to"
 msgstr "Au"
 
 #: app/configurator/components/filters.tsx
-msgid "controls.filters.show-legend.toggle"
-msgstr "Afficher les titres des légendes"
-
-#: app/configurator/components/filters.tsx
 msgid "controls.filters.show-legend-toggle"
 msgstr "Permettre aux utilisateurs de modifier la visibilité des légendes"
+
+#: app/configurator/components/filters.tsx
+msgid "controls.filters.show-legend.toggle"
+msgstr "Afficher les titres des légendes"
 
 #: app/configurator/table/table-chart-configurator.tsx
 msgid "controls.groups.empty-help"
@@ -1265,7 +1264,6 @@ msgstr "Sélectionner"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
-#: app/configurator/components/chart-controls/color-ramp.tsx
 msgid "controls.visualize-color-palette"
 msgstr "Visualize les palettes de couleurs"
 
@@ -1638,7 +1636,6 @@ msgid "login.profile.my-color-palettes"
 msgstr "Mes Palettes de Couleurs"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
-#: app/configurator/components/chart-controls/color-ramp.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
 #: app/login/components/color-palettes/profile-color-palette-content.tsx
 msgid "login.profile.my-color-palettes.add"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -569,8 +569,7 @@ msgstr "impilate"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
-#: app/configurator/components/chart-controls/color-ramp.tsx
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes"
 msgstr "Tavolozze di colori personalizzate"
 
@@ -583,7 +582,7 @@ msgstr "Aggiungi colore"
 msgid "controls.custom-color-palettes.base"
 msgstr "Colore base"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.caption"
 msgstr "Utilizzare colori distinti e ad alto contrasto. Evitare di usare troppi colori, massimo 5-7. Applicare tavolozze sequenziali per i dati ordinati e tavolozze divergenti per gli estremi."
@@ -608,7 +607,7 @@ msgstr "Esempio"
 msgid "controls.custom-color-palettes.mid"
 msgstr "Colore medio"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes.set-values-apply"
 msgstr "Salva tavolozza colori"
 
@@ -616,12 +615,12 @@ msgstr "Salva tavolozza colori"
 msgid "controls.custom-color-palettes.start"
 msgstr "Colore iniziale"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.title"
 msgstr "Titolo tavolozza"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes.title-unavailable"
 msgstr "Questo nome è già in uso. Scegliete un nome unico per la vostra tavolozza di colori."
 
@@ -708,12 +707,12 @@ msgid "controls.filters.select.to"
 msgstr "Alla"
 
 #: app/configurator/components/filters.tsx
-msgid "controls.filters.show-legend.toggle"
-msgstr "Mostra i titoli delle leggende"
-
-#: app/configurator/components/filters.tsx
 msgid "controls.filters.show-legend-toggle"
 msgstr "Consentire agli utenti di modificare la visibilità della legenda"
+
+#: app/configurator/components/filters.tsx
+msgid "controls.filters.show-legend.toggle"
+msgstr "Mostra i titoli delle leggende"
 
 #: app/configurator/table/table-chart-configurator.tsx
 msgid "controls.groups.empty-help"
@@ -1265,7 +1264,6 @@ msgstr "Selezionare"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
-#: app/configurator/components/chart-controls/color-ramp.tsx
 msgid "controls.visualize-color-palette"
 msgstr "Visualize le tavolozze dei colori"
 
@@ -1638,7 +1636,6 @@ msgid "login.profile.my-color-palettes"
 msgstr "Le Mie Tavolozze di Colori"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
-#: app/configurator/components/chart-controls/color-ramp.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
 #: app/login/components/color-palettes/profile-color-palette-content.tsx
 msgid "login.profile.my-color-palettes.add"


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2094 

<!--- Describe the changes -->

**What changes?**
This PR fixes the missing button translations for `updating` and `creating` a custom color palette on the user profile in English.

<!--- Test instructions -->

## How to test

1. Go to this [link](https://visualization-tool-git-fix-missing-button-label-ixt1.vercel.app/)
2. Click Sign in button 
3. Click on `My Color Palettes`
4. Add a new color palette
5. See how the button is now correctly translated in English _(make sure you are using EN translation)_ ✅
6. Save the color palette
7. Update the color palette, see how the button is now correctly translated in English ✅

<!--- Reproduction steps, in case of a bug -->

## How to Reproduce

1. Go to this [Link](https://test.visualize.admin.ch/en)
2. Click the Sign in button and sign in 
3. Click on `My Color Palettes`
4. Add a new color palette
5. See how the button is not translated in English _(make sure you are using EN translation)_ ❌
6. Save the color palette
7. Update the color palette, see how the button is not translated in English ❌

---

- [x] Add a CHANGELOG entry
