### PR TITLE
feat: Added error handling to profile for color palettes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ You can also check the
 
 - Features
   - Added option for hiding legend titles using a toggle switch
+  - Added (required) hint for palette titles and disabled the "add color button"
+    if the color palette title is missing
 - Fixes
   - Added error displaying for title names that already exists on the custom
     color palette form inside the user profile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ You can also check the
 
 - Features
   - Added option for hiding legend titles using a toggle switch
+- Fixes
+  - Added error displaying for title names that already exists on the custom
+    color palette form inside the user profile
 - Maintenance
   - Added authentication method to e2e tests
   - Added authentication to vercel previews for easier testing

--- a/app/configurator/components/chart-controls/drawer-color-palette-content.tsx
+++ b/app/configurator/components/chart-controls/drawer-color-palette-content.tsx
@@ -170,6 +170,7 @@ export const ColorPaletteDrawerContent = forwardRef<
           )}
         </Flex>
         <ColorPaletteCreator
+          title={titleInput}
           type={type}
           colorValues={colorValues}
           onRemove={removeColor}

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -604,7 +604,7 @@ msgstr "Anfangsfarbe"
 #: app/configurator/components/chart-controls/create-color-palette.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.title"
-msgstr "Palettentitel"
+msgstr "Palettentitel (erforderlich)"
 
 #: app/configurator/components/chart-controls/create-color-palette.tsx
 msgid "controls.custom-color-palettes.title-unavailable"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -620,7 +620,7 @@ msgstr "Starting Color"
 #: app/configurator/components/chart-controls/create-color-palette.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.title"
-msgstr "Palette title"
+msgstr "Palette title (required)"
 
 #: app/configurator/components/chart-controls/create-color-palette.tsx
 msgid "controls.custom-color-palettes.title-unavailable"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -619,7 +619,7 @@ msgstr "Couleur de départ"
 #: app/configurator/components/chart-controls/create-color-palette.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.title"
-msgstr "Palette title"
+msgstr "titre de la palette (requis)"
 
 #: app/configurator/components/chart-controls/create-color-palette.tsx
 msgid "controls.custom-color-palettes.title-unavailable"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -619,7 +619,7 @@ msgstr "Colore iniziale"
 #: app/configurator/components/chart-controls/create-color-palette.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.title"
-msgstr "Titolo tavolozza"
+msgstr "Titolo tavolozza (obbligatorio)"
 
 #: app/configurator/components/chart-controls/create-color-palette.tsx
 msgid "controls.custom-color-palettes.title-unavailable"

--- a/app/login/components/color-palettes/color-palette-types.tsx
+++ b/app/login/components/color-palettes/color-palette-types.tsx
@@ -58,6 +58,7 @@ type ColorPaletteCreatorProps = {
   onRemove: (id: string) => void;
   onUpdate: (color: string, id: string) => void;
   colorValues: ColorItem[];
+  title: string;
   type: CustomPaletteType["type"];
 };
 
@@ -138,10 +139,11 @@ const SequentialColorPaletteCreator = (props: ColorPaletteCreatorProps) => {
 };
 
 const DivergentColorPaletteCreator = (props: ColorPaletteCreatorProps) => {
-  const { onAdd, onRemove, onUpdate, colorValues } = props;
+  const { onAdd, onRemove, onUpdate, colorValues, title } = props;
   const classes = useStyles();
 
-  const addColorCondition = DIVERGING_MAX_ALLOWED_COLORS <= colorValues.length;
+  const addColorCondition =
+    DIVERGING_MAX_ALLOWED_COLORS <= colorValues.length || title.length === 0;
 
   const [startColorHex, endColorHex, midColorHex] = colorValues;
 
@@ -219,8 +221,11 @@ const DivergentColorPaletteCreator = (props: ColorPaletteCreatorProps) => {
 };
 
 const CategoricalColorPaletteCreator = (props: ColorPaletteCreatorProps) => {
-  const { onAdd, onRemove, onUpdate, colorValues } = props;
+  const { onAdd, onRemove, onUpdate, colorValues, title } = props;
   const classes = useStyles();
+
+  const addColorCondition =
+    CATEGORICAL_MAX_ALLOWED_COLORS <= colorValues.length || title.length === 0;
 
   return (
     <>
@@ -242,7 +247,7 @@ const CategoricalColorPaletteCreator = (props: ColorPaletteCreatorProps) => {
         variant="text"
         fullWidth
         className={classes.addColorButton}
-        disabled={CATEGORICAL_MAX_ALLOWED_COLORS <= colorValues.length}
+        disabled={addColorCondition}
         startIcon={<Icon name="add" />}
         onClick={() => onAdd()}
       >

--- a/app/login/components/color-palettes/color-palette-types.tsx
+++ b/app/login/components/color-palettes/color-palette-types.tsx
@@ -142,7 +142,7 @@ const DivergentColorPaletteCreator = (props: ColorPaletteCreatorProps) => {
   const { onAdd, onRemove, onUpdate, colorValues, title } = props;
   const classes = useStyles();
 
-  const addColorCondition =
+  const disabled =
     DIVERGING_MAX_ALLOWED_COLORS <= colorValues.length || title.length === 0;
 
   const [startColorHex, endColorHex, midColorHex] = colorValues;
@@ -210,7 +210,7 @@ const DivergentColorPaletteCreator = (props: ColorPaletteCreatorProps) => {
         variant="text"
         fullWidth
         className={classes.addColorButton}
-        disabled={addColorCondition}
+        disabled={disabled}
         startIcon={<Icon name="add" />}
         onClick={() => onAdd()}
       >
@@ -224,7 +224,7 @@ const CategoricalColorPaletteCreator = (props: ColorPaletteCreatorProps) => {
   const { onAdd, onRemove, onUpdate, colorValues, title } = props;
   const classes = useStyles();
 
-  const addColorCondition =
+  const disabled =
     CATEGORICAL_MAX_ALLOWED_COLORS <= colorValues.length || title.length === 0;
 
   return (
@@ -247,7 +247,7 @@ const CategoricalColorPaletteCreator = (props: ColorPaletteCreatorProps) => {
         variant="text"
         fullWidth
         className={classes.addColorButton}
-        disabled={addColorCondition}
+        disabled={disabled}
         startIcon={<Icon name="add" />}
         onClick={() => onAdd()}
       >

--- a/app/login/components/color-palettes/profile-color-palette-content.tsx
+++ b/app/login/components/color-palettes/profile-color-palette-content.tsx
@@ -103,6 +103,7 @@ export const ProfileColorPaletteContent = ({
           formMode={formMode}
           palette={formMode === "edit" ? selectedPalette : undefined}
           onBack={returnToView}
+          customColorPalettes={customColorPalettes}
         />
       )}
     </SectionContent>

--- a/app/login/components/color-palettes/profile-color-palette-form.tsx
+++ b/app/login/components/color-palettes/profile-color-palette-form.tsx
@@ -204,6 +204,7 @@ const ProfileColorPaletteForm = ({
         </Box>
         <ColorPaletteCreator
           type={type}
+          title={titleInput}
           colorValues={colorValues}
           onRemove={removeColor}
           onUpdate={updateColor}

--- a/app/login/components/color-palettes/profile-color-palette-form.tsx
+++ b/app/login/components/color-palettes/profile-color-palette-form.tsx
@@ -128,6 +128,7 @@ const ProfileColorPaletteForm = ({
     const titleExistsAlready = customColorPalettes?.find(
       (palette) => palette.name === titleInput
     );
+    console.log(titleExistsAlready);
     if (titleExistsAlready) {
       setIsNotAvailable(true);
     } else {
@@ -146,9 +147,8 @@ const ProfileColorPaletteForm = ({
           type,
         });
       }
+      onBack();
     }
-
-    onBack();
   });
 
   const noChanges =

--- a/app/login/components/color-palettes/profile-color-palette-form.tsx
+++ b/app/login/components/color-palettes/profile-color-palette-form.tsx
@@ -128,7 +128,7 @@ const ProfileColorPaletteForm = ({
     const titleExistsAlready = customColorPalettes?.find(
       (palette) => palette.name === titleInput
     );
-    console.log(titleExistsAlready);
+
     if (titleExistsAlready) {
       setIsNotAvailable(true);
     } else {


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2095 

<!--- Describe the changes -->

**What changes?**
This PR fixes the missing error message on color palette title input when a title already exists and also adds a (required) hint + automatically disabling the `Add color button` when title is empty.

<!--- Test instructions -->

## How to test

1. Go to this [link](https://visualization-tool-git-feat-highlight-missing-color-805a11-ixt1.vercel.app/)
2. Click Sign in button 
3. Click on `My Color Palettes`
4. Add a new color palette
5. See how palette title has a new (required) hint ✅
6. See how `Add color palette` button is disabled when there is no title specified ✅
7. Enter a title that already exists and see how you get the same error as in the editor ✅

<!--- Reproduction steps, in case of a bug -->

## How to Reproduce

1. Go to this [Link](https://test.visualize.admin.ch/en)
2. Click Sign in button 
3. Click on `My Color Palettes`
4. Add a new color palette
5. See how palette title has no (required) hint ❌
6. See how `Add color palette` button is **not** disabled when there is no title specified ❌
7. Enter a title that already exists and see how the error is missing ❌

---

- [x] Add a CHANGELOG entry
