### PR TITLE
chore: Add new translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ You can also check the
 
 - Features
   - Added option for hiding legend titles using a toggle switch
+- Fixes
+  - Added dynamic translations for color contrast checking warnings
 - Maintenance
   - Added authentication method to e2e tests
   - Added authentication to vercel previews for easier testing

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -596,6 +596,10 @@ msgid "controls.custom-color-palettes.create-palette"
 msgstr "Farbpalette erstellen"
 
 #: app/login/components/color-palettes/color-palette-types.tsx
+msgid "controls.custom-color-palettes.diverging-contrast-warning"
+msgstr "Die gewählte Farbe hat nicht genügend Kontrast. Erwägen Sie die Verwendung einer dunkleren Farbe für eine abweichende Farbpalette."
+
+#: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.end"
 msgstr "Endfarbe"
 
@@ -608,8 +612,8 @@ msgid "controls.custom-color-palettes.mid"
 msgstr "Mittlere Farbe"
 
 #: app/login/components/color-palettes/color-palette-types.tsx
-msgid "controls.custom-color-palettes.non-categorical-contrast-warning"
-msgstr "Die gewählte Farbe hat nicht genügend Kontrast. Erwägen Sie die Verwendung einer dunkleren Farbe für eine {type} Palette."
+msgid "controls.custom-color-palettes.sequential-contrast-warning"
+msgstr "Die gewählte Farbe hat nicht genügend Kontrast. Erwägen Sie die Verwendung einer dunkleren Farbe für eine sequenzielle Palette."
 
 #: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes.set-values-apply"

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -39,6 +39,22 @@ msgstr "[ Text hinzufügen ]"
 msgid "annotation.add.title"
 msgstr "[ Ohne Titel ]"
 
+#: app/components/dashboard-shared.tsx
+msgid "block-controls.delete"
+msgstr "Löschen"
+
+#: app/components/dashboard-shared.tsx
+msgid "block-controls.delete.confirmation"
+msgstr "Sind Sie sicher, dass Sie diesen Block löschen wollen?"
+
+#: app/components/dashboard-shared.tsx
+msgid "block-controls.delete.title"
+msgstr "Block löschen?"
+
+#: app/components/dashboard-shared.tsx
+msgid "block-controls.duplicate"
+msgstr "Duplizieren"
+
 #: app/browser/dataset-browse.tsx
 msgid "browse-panel.organizations"
 msgstr "Organisationen"

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -37,7 +37,6 @@ msgstr "[ Text hinzufügen ]"
 #: app/configurator/components/annotators.tsx
 #: app/login/components/profile-tables.tsx
 msgid "annotation.add.title"
-
 msgstr "[ Ohne Titel ]"
 
 #: app/browser/dataset-browse.tsx
@@ -554,8 +553,7 @@ msgstr "Gestapelt"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
-#: app/configurator/components/chart-controls/color-ramp.tsx
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes"
 msgstr "Benutzerdefinierte Farbpaletten"
 
@@ -568,14 +566,14 @@ msgstr "Farbe hinzufügen"
 msgid "controls.custom-color-palettes.base"
 msgstr "Basis Farbe"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.caption"
 msgstr "Verwenden Sie klare, kontrastreiche Farben. Vermeiden Sie die Verwendung von zu vielen Farben, maximal 5-7. Verwenden Sie sequenzielle Paletten für geordnete Daten und divergierende Paletten für Extreme."
 
 #: app/login/components/color-palettes/color-palette-types.tsx
-msgid "controls.custom-color-palettes.contrast-warning"
-msgstr "Die gewählte Farbe hat nicht genügend Kontrast. Erwägen Sie die Verwendung einer dunkleren Farbe für eine sequenzielle Palette."
+msgid "controls.custom-color-palettes.categorical-contrast-warning"
+msgstr "Die gewählte Farbe ist vor einem weißen Hintergrund schwer zu lesen. Wählen Sie eine Farbe mit höherem Kontrast, um die Zugänglichkeit zu verbessern."
 
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.create-palette"
@@ -593,7 +591,11 @@ msgstr "Beispiel"
 msgid "controls.custom-color-palettes.mid"
 msgstr "Mittlere Farbe"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/login/components/color-palettes/color-palette-types.tsx
+msgid "controls.custom-color-palettes.non-categorical-contrast-warning"
+msgstr "Die gewählte Farbe hat nicht genügend Kontrast. Erwägen Sie die Verwendung einer dunkleren Farbe für eine {type} Palette."
+
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes.set-values-apply"
 msgstr "Farbpalette speichern"
 
@@ -601,12 +603,12 @@ msgstr "Farbpalette speichern"
 msgid "controls.custom-color-palettes.start"
 msgstr "Anfangsfarbe"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.title"
 msgstr "Palettentitel"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes.title-unavailable"
 msgstr "Dieser Name ist bereits in Gebrauch. Bitte wählen Sie einen eindeutigen Namen für Ihre Farbpalette."
 
@@ -693,12 +695,12 @@ msgid "controls.filters.select.to"
 msgstr "Zu"
 
 #: app/configurator/components/filters.tsx
-msgid "controls.filters.show-legend.toggle"
-msgstr "Legendentitel anzeigen"
-
-#: app/configurator/components/filters.tsx
 msgid "controls.filters.show-legend-toggle"
 msgstr "Benutzer können die Sichtbarkeit der Legende ändern"
+
+#: app/configurator/components/filters.tsx
+msgid "controls.filters.show-legend.toggle"
+msgstr "Legendentitel anzeigen"
 
 #: app/configurator/table/table-chart-configurator.tsx
 msgid "controls.groups.empty-help"
@@ -1250,7 +1252,6 @@ msgstr "Auswählen"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
-#: app/configurator/components/chart-controls/color-ramp.tsx
 msgid "controls.visualize-color-palette"
 msgstr "Visualize Farbpaletten"
 
@@ -1623,7 +1624,6 @@ msgid "login.profile.my-color-palettes"
 msgstr "Meine Farbpaletten"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
-#: app/configurator/components/chart-controls/color-ramp.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
 #: app/login/components/color-palettes/profile-color-palette-content.tsx
 msgid "login.profile.my-color-palettes.add"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -39,7 +39,6 @@ msgstr "[ Add text ]"
 msgid "annotation.add.title"
 msgstr "[ No Title ]"
 
-
 #: app/components/dashboard-shared.tsx
 msgid "block-controls.delete"
 msgstr "Delete"
@@ -570,8 +569,7 @@ msgstr "Stacked"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
-#: app/configurator/components/chart-controls/color-ramp.tsx
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes"
 msgstr "Custom color palettes"
 
@@ -584,14 +582,14 @@ msgstr "Add Color"
 msgid "controls.custom-color-palettes.base"
 msgstr "Base Color"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.caption"
 msgstr "Use distinct, high-contrast colors. Avoid using too many colors, maximum 5–7. Apply sequential palettes for ordered data and diverging palettes for extremes."
 
 #: app/login/components/color-palettes/color-palette-types.tsx
-msgid "controls.custom-color-palettes.contrast-warning"
-msgstr "The selected color lacks sufficient contrast. Consider using a darker color for a sequential palette."
+msgid "controls.custom-color-palettes.categorical-contrast-warning"
+msgstr "The selected color is difficult to read against a white background. Choose a color with higher contrast to improve accessibility."
 
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.create-palette"
@@ -609,7 +607,11 @@ msgstr "Example"
 msgid "controls.custom-color-palettes.mid"
 msgstr "Middle Color"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/login/components/color-palettes/color-palette-types.tsx
+msgid "controls.custom-color-palettes.non-categorical-contrast-warning"
+msgstr "The selected color lacks sufficient contrast. Consider using a darker color for a {type} palette."
+
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes.set-values-apply"
 msgstr "Save color palette"
 
@@ -617,12 +619,12 @@ msgstr "Save color palette"
 msgid "controls.custom-color-palettes.start"
 msgstr "Starting Color"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.title"
 msgstr "Palette title"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes.title-unavailable"
 msgstr "This name is already in use. Please choose a unique name for your color palette."
 
@@ -709,12 +711,12 @@ msgid "controls.filters.select.to"
 msgstr "To"
 
 #: app/configurator/components/filters.tsx
-msgid "controls.filters.show-legend.toggle"
-msgstr "Show legend titles"
-
-#: app/configurator/components/filters.tsx
 msgid "controls.filters.show-legend-toggle"
 msgstr "Allow users to change legend titles visibility"
+
+#: app/configurator/components/filters.tsx
+msgid "controls.filters.show-legend.toggle"
+msgstr "Show legend titles"
 
 #: app/configurator/table/table-chart-configurator.tsx
 msgid "controls.groups.empty-help"
@@ -1266,7 +1268,6 @@ msgstr "Select"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
-#: app/configurator/components/chart-controls/color-ramp.tsx
 msgid "controls.visualize-color-palette"
 msgstr "Visualize color palettes"
 
@@ -1639,7 +1640,6 @@ msgid "login.profile.my-color-palettes"
 msgstr "My Color Palettes"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
-#: app/configurator/components/chart-controls/color-ramp.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
 #: app/login/components/color-palettes/profile-color-palette-content.tsx
 msgid "login.profile.my-color-palettes.add"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -596,6 +596,10 @@ msgid "controls.custom-color-palettes.create-palette"
 msgstr "controls.custom-color-palettes.create-palette"
 
 #: app/login/components/color-palettes/color-palette-types.tsx
+msgid "controls.custom-color-palettes.diverging-contrast-warning"
+msgstr "The selected color lacks sufficient contrast. Consider using a darker color for a diverging palette."
+
+#: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.end"
 msgstr "Ending Color"
 
@@ -608,8 +612,8 @@ msgid "controls.custom-color-palettes.mid"
 msgstr "Middle Color"
 
 #: app/login/components/color-palettes/color-palette-types.tsx
-msgid "controls.custom-color-palettes.non-categorical-contrast-warning"
-msgstr "The selected color lacks sufficient contrast. Consider using a darker color for a {type} palette."
+msgid "controls.custom-color-palettes.sequential-contrast-warning"
+msgstr "The selected color lacks sufficient contrast. Consider using a darker color for a sequential palette."
 
 #: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes.set-values-apply"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -596,6 +596,10 @@ msgid "controls.custom-color-palettes.create-palette"
 msgstr "Créer une palette de couleurs"
 
 #: app/login/components/color-palettes/color-palette-types.tsx
+msgid "controls.custom-color-palettes.diverging-contrast-warning"
+msgstr "La couleur sélectionnée n'est pas suffisamment contrastée. Envisagez d'utiliser une couleur plus foncée pour obtenir une palette divergente."
+
+#: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.end"
 msgstr "Couleur finale"
 
@@ -608,8 +612,8 @@ msgid "controls.custom-color-palettes.mid"
 msgstr "Couleur moyenne"
 
 #: app/login/components/color-palettes/color-palette-types.tsx
-msgid "controls.custom-color-palettes.non-categorical-contrast-warning"
-msgstr "La couleur sélectionnée n'est pas suffisamment contrastée. Envisagez d'utiliser une couleur plus foncée pour une palette {type}."
+msgid "controls.custom-color-palettes.sequential-contrast-warning"
+msgstr "La couleur sélectionnée n'est pas suffisamment contrastée. Envisagez d'utiliser une couleur plus foncée pour une palette séquentielle."
 
 #: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes.set-values-apply"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -569,8 +569,7 @@ msgstr "empilées"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
-#: app/configurator/components/chart-controls/color-ramp.tsx
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes"
 msgstr "Palettes de couleurs personnalisées"
 
@@ -583,14 +582,14 @@ msgstr "Ajouter une couleur"
 msgid "controls.custom-color-palettes.base"
 msgstr "Couleur de base"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.caption"
 msgstr "Utilisez des couleurs distinctes et contrastées. Évitez d'utiliser trop de couleurs, au maximum 5 à 7. Appliquez des palettes séquentielles pour les données ordonnées et des palettes divergentes pour les extrêmes."
 
 #: app/login/components/color-palettes/color-palette-types.tsx
-msgid "controls.custom-color-palettes.contrast-warning"
-msgstr "La couleur sélectionnée n'est pas suffisamment contrastée. Envisagez d'utiliser une couleur plus foncée pour une palette séquentielle."
+msgid "controls.custom-color-palettes.categorical-contrast-warning"
+msgstr "La couleur sélectionnée est difficile à lire sur un fond blanc. Choisissez une couleur plus contrastée pour améliorer l'accessibilité."
 
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.create-palette"
@@ -608,7 +607,11 @@ msgstr "Exemple"
 msgid "controls.custom-color-palettes.mid"
 msgstr "Couleur moyenne"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/login/components/color-palettes/color-palette-types.tsx
+msgid "controls.custom-color-palettes.non-categorical-contrast-warning"
+msgstr "La couleur sélectionnée n'est pas suffisamment contrastée. Envisagez d'utiliser une couleur plus foncée pour une palette {type}."
+
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes.set-values-apply"
 msgstr "Enregistrer la palette de couleurs"
 
@@ -616,12 +619,12 @@ msgstr "Enregistrer la palette de couleurs"
 msgid "controls.custom-color-palettes.start"
 msgstr "Couleur de départ"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.title"
-msgstr "Palette title"
+msgstr "titre de la palette (requis)"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes.title-unavailable"
 msgstr "Ce nom est déjà utilisé. Veuillez choisir un nom unique pour votre palette de couleurs."
 
@@ -708,12 +711,12 @@ msgid "controls.filters.select.to"
 msgstr "Au"
 
 #: app/configurator/components/filters.tsx
-msgid "controls.filters.show-legend.toggle"
-msgstr "Afficher les titres des légendes"
-
-#: app/configurator/components/filters.tsx
 msgid "controls.filters.show-legend-toggle"
 msgstr "Permettre aux utilisateurs de modifier la visibilité des légendes"
+
+#: app/configurator/components/filters.tsx
+msgid "controls.filters.show-legend.toggle"
+msgstr "Afficher les titres des légendes"
 
 #: app/configurator/table/table-chart-configurator.tsx
 msgid "controls.groups.empty-help"
@@ -1265,7 +1268,6 @@ msgstr "Sélectionner"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
-#: app/configurator/components/chart-controls/color-ramp.tsx
 msgid "controls.visualize-color-palette"
 msgstr "Visualize les palettes de couleurs"
 
@@ -1638,7 +1640,6 @@ msgid "login.profile.my-color-palettes"
 msgstr "Mes Palettes de Couleurs"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
-#: app/configurator/components/chart-controls/color-ramp.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
 #: app/login/components/color-palettes/profile-color-palette-content.tsx
 msgid "login.profile.my-color-palettes.add"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -569,8 +569,7 @@ msgstr "impilate"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
-#: app/configurator/components/chart-controls/color-ramp.tsx
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes"
 msgstr "Tavolozze di colori personalizzate"
 
@@ -583,14 +582,14 @@ msgstr "Aggiungi colore"
 msgid "controls.custom-color-palettes.base"
 msgstr "Colore base"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.caption"
 msgstr "Utilizzare colori distinti e ad alto contrasto. Evitare di usare troppi colori, massimo 5-7. Applicare tavolozze sequenziali per i dati ordinati e tavolozze divergenti per gli estremi."
 
 #: app/login/components/color-palettes/color-palette-types.tsx
-msgid "controls.custom-color-palettes.contrast-warning"
-msgstr "Il colore selezionato non ha un contrasto sufficiente. Considerare l'utilizzo di un colore più scuro per una tavolozza sequenziale."
+msgid "controls.custom-color-palettes.categorical-contrast-warning"
+msgstr "Il colore selezionato è difficile da leggere su uno sfondo bianco. Scegliere un colore con un contrasto maggiore per migliorare l'accessibilità."
 
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.create-palette"
@@ -608,7 +607,11 @@ msgstr "Esempio"
 msgid "controls.custom-color-palettes.mid"
 msgstr "Colore medio"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/login/components/color-palettes/color-palette-types.tsx
+msgid "controls.custom-color-palettes.non-categorical-contrast-warning"
+msgstr "Il colore selezionato non ha un contrasto sufficiente. Considerare l'utilizzo di un colore più scuro per una tavolozza {type}."
+
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes.set-values-apply"
 msgstr "Salva tavolozza colori"
 
@@ -616,12 +619,12 @@ msgstr "Salva tavolozza colori"
 msgid "controls.custom-color-palettes.start"
 msgstr "Colore iniziale"
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.title"
-msgstr "Titolo tavolozza"
+msgstr "Titolo tavolozza "
 
-#: app/configurator/components/chart-controls/create-color-palette.tsx
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes.title-unavailable"
 msgstr "Questo nome è già in uso. Scegliete un nome unico per la vostra tavolozza di colori."
 
@@ -708,12 +711,12 @@ msgid "controls.filters.select.to"
 msgstr "Alla"
 
 #: app/configurator/components/filters.tsx
-msgid "controls.filters.show-legend.toggle"
-msgstr "Mostra i titoli delle leggende"
-
-#: app/configurator/components/filters.tsx
 msgid "controls.filters.show-legend-toggle"
 msgstr "Consentire agli utenti di modificare la visibilità della legenda"
+
+#: app/configurator/components/filters.tsx
+msgid "controls.filters.show-legend.toggle"
+msgstr "Mostra i titoli delle leggende"
 
 #: app/configurator/table/table-chart-configurator.tsx
 msgid "controls.groups.empty-help"
@@ -1265,7 +1268,6 @@ msgstr "Selezionare"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
-#: app/configurator/components/chart-controls/color-ramp.tsx
 msgid "controls.visualize-color-palette"
 msgstr "Visualize le tavolozze dei colori"
 
@@ -1638,7 +1640,6 @@ msgid "login.profile.my-color-palettes"
 msgstr "Le Mie Tavolozze di Colori"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
-#: app/configurator/components/chart-controls/color-ramp.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
 #: app/login/components/color-palettes/profile-color-palette-content.tsx
 msgid "login.profile.my-color-palettes.add"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -596,6 +596,10 @@ msgid "controls.custom-color-palettes.create-palette"
 msgstr "Creare una tavolozza di colori"
 
 #: app/login/components/color-palettes/color-palette-types.tsx
+msgid "controls.custom-color-palettes.diverging-contrast-warning"
+msgstr "Il colore selezionato non ha un contrasto sufficiente. Considerare l'uso di un colore più scuro per una tavolozza divergente."
+
+#: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.end"
 msgstr "Colore finale"
 
@@ -608,8 +612,8 @@ msgid "controls.custom-color-palettes.mid"
 msgstr "Colore medio"
 
 #: app/login/components/color-palettes/color-palette-types.tsx
-msgid "controls.custom-color-palettes.non-categorical-contrast-warning"
-msgstr "Il colore selezionato non ha un contrasto sufficiente. Considerare l'utilizzo di un colore più scuro per una tavolozza {type}."
+msgid "controls.custom-color-palettes.sequential-contrast-warning"
+msgstr "Il colore selezionato non ha un contrasto sufficiente. Considerare l'utilizzo di un colore più scuro per una tavolozza sequenziale."
 
 #: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes.set-values-apply"

--- a/app/login/components/color-palettes/color-palette-types.tsx
+++ b/app/login/components/color-palettes/color-palette-types.tsx
@@ -270,6 +270,26 @@ const ColorSelectionRow = (props: ColorSelectionRowProps) => {
 
   const warningContrast = hasEnoughContrast(color);
 
+  const getContrastWarning = () => {
+    switch (type) {
+      case "categorical":
+        return t({
+          id: "controls.custom-color-palettes.categorical-contrast-warning",
+        });
+      case "sequential":
+        return t({
+          id: "controls.custom-color-palettes.sequential-contrast-warning",
+        });
+      case "diverging":
+        return t({
+          id: "controls.custom-color-palettes.diverging-contrast-warning",
+        });
+      default:
+        const _exhaustiveCheck: never = type;
+        return _exhaustiveCheck;
+    }
+  };
+
   return (
     <Box className={classes.colorItem}>
       <Flex className={classes.colorItemContent}>
@@ -281,30 +301,7 @@ const ColorSelectionRow = (props: ColorSelectionRowProps) => {
         />
         <Flex gap={2} alignItems={"center"}>
           {warningContrast && (
-            <DisabledMessageIcon
-              message={
-                type === "categorical"
-                  ? t({
-                      id: "controls.custom-color-palettes.categorical-contrast-warning",
-                      message:
-                        "The selected color is difficult to read against a white background. Choose a color with higher contrast to improve accessibility.",
-                    })
-                  : t({
-                      id: "controls.custom-color-palettes.non-categorical-contrast-warning",
-                      values: {
-                        type: (
-                          <span
-                            style={{
-                              textTransform: "lowercase",
-                            }}
-                          >
-                            <Trans id={`controls.color.palette.${type}`} />
-                          </span>
-                        ),
-                      },
-                    })
-              }
-            />
+            <DisabledMessageIcon message={getContrastWarning()} />
           )}
           <ColorPickerMenu
             colorId={id}

--- a/app/login/components/color-palettes/color-palette-types.tsx
+++ b/app/login/components/color-palettes/color-palette-types.tsx
@@ -126,6 +126,7 @@ const SequentialColorPaletteCreator = (props: ColorPaletteCreatorProps) => {
         </Label>
         {baseColor && (
           <ColorSelectionRow
+            type={"sequential"}
             key={baseColor.id}
             colorValues={[baseColor]}
             {...baseColor}
@@ -169,6 +170,7 @@ const DivergentColorPaletteCreator = (props: ColorPaletteCreatorProps) => {
           </Label>
           {startColorHex && (
             <ColorSelectionRow
+              type={"diverging"}
               key={startColorHex.id}
               colorValues={[startColorHex]}
               {...startColorHex}
@@ -182,6 +184,7 @@ const DivergentColorPaletteCreator = (props: ColorPaletteCreatorProps) => {
               <Trans id="controls.custom-color-palettes.mid" />
             </Label>
             <ColorSelectionRow
+              type={"diverging"}
               key={midColorHex.id}
               colorValues={[midColorHex]}
               {...midColorHex}
@@ -196,6 +199,7 @@ const DivergentColorPaletteCreator = (props: ColorPaletteCreatorProps) => {
           </Label>
           {endColorHex && (
             <ColorSelectionRow
+              type={"diverging"}
               key={endColorHex.id}
               colorValues={[endColorHex]}
               {...endColorHex}
@@ -228,6 +232,7 @@ const CategoricalColorPaletteCreator = (props: ColorPaletteCreatorProps) => {
         <Box className={classes.categoricalColorListContainer}>
           {colorValues.map((item) => (
             <ColorSelectionRow
+              type={"categorical"}
               colorValues={colorValues}
               key={item.id}
               {...item}
@@ -254,12 +259,13 @@ const CategoricalColorPaletteCreator = (props: ColorPaletteCreatorProps) => {
 
 type ColorSelectionRowProps = {
   colorValues: ColorItem[];
+  type: CustomPaletteType["type"];
   onUpdate: (color: string, id: string) => void;
   onRemove?: (id: string) => void;
 } & ColorItem;
 
 const ColorSelectionRow = (props: ColorSelectionRowProps) => {
-  const { id, color, colorValues, onRemove, onUpdate } = props;
+  const { id, color, colorValues, onRemove, onUpdate, type } = props;
   const classes = useStyles();
 
   const warningContrast = hasEnoughContrast(color);
@@ -276,11 +282,28 @@ const ColorSelectionRow = (props: ColorSelectionRowProps) => {
         <Flex gap={2} alignItems={"center"}>
           {warningContrast && (
             <DisabledMessageIcon
-              message={t({
-                id: "controls.custom-color-palettes.contrast-warning",
-                message:
-                  "The selected color lacks sufficient contrast. Consider using a darker color for a sequential palette.",
-              })}
+              message={
+                type === "categorical"
+                  ? t({
+                      id: "controls.custom-color-palettes.categorical-contrast-warning",
+                      message:
+                        "The selected color is difficult to read against a white background. Choose a color with higher contrast to improve accessibility.",
+                    })
+                  : t({
+                      id: "controls.custom-color-palettes.non-categorical-contrast-warning",
+                      values: {
+                        type: (
+                          <span
+                            style={{
+                              textTransform: "lowercase",
+                            }}
+                          >
+                            <Trans id={`controls.color.palette.${type}`} />
+                          </span>
+                        ),
+                      },
+                    })
+              }
             />
           )}
           <ColorPickerMenu


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2101  

<!--- Describe the changes -->

**What changes?**
This PR fixes makes contrast warning messages dynamic, in order to make more sense.

<!--- Test instructions -->

## How to test

1. Go to this [link](https://visualization-tool-git-fix-dynamic-contrast-warnings-ixt1.vercel.app/)
2. Click Sign in button 
3. Click on `My Color Palettes`
4. Add a new color palette
5. Select Categorical color palette
6. Add Colors that are light
7. See how the warning hint appears, hover it and see how the text changed ✅
8. Select Diverging color palette
9. Add Colors that are light
10. See how the warning hint appears, hover it and see how the text changed ✅

<!--- Reproduction steps, in case of a bug -->

## How to Reproduce

1. Go to this [Link](https://test.visualize.admin.ch/en)
2. Click Sign in button 
3. Click on `My Color Palettes`
4. Add a new color palette
5. Select Categorical color palette
6. Add Colors that are light
7. See how the warning hint appears, hover it and see how the text is same as sequential types ❌
8. Select Diverging color palette
9. Add Colors that are light
10. See how the warning hint appears, hover it and see how the text is same as sequential types ❌

---

_ps: @bprusinowski I also added missing translations from some other features ([8c5cc38](https://github.com/visualize-admin/visualization-tool/commit/8c5cc38a4d0eb7705ce717535425c6c4fb0d5a37))_

---

- [x] Add a CHANGELOG entry
