### PR TITLE
fix: Show entire palette regardless the palette type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ You can also check the
 
 - Features
   - Added option for hiding legend titles using a toggle switch
+- Fixes
+  - Color swatches inside the color picker dynamically adjust to the colors of
+    the selected palette
+  - All colors of a selected custom color palette are displayed when selected at
+    all times regardless of the color type
 - Maintenance
   - Added authentication method to e2e tests
   - Added authentication to vercel previews for easier testing

--- a/app/configurator/components/chart-controls/color-palette.tsx
+++ b/app/configurator/components/chart-controls/color-palette.tsx
@@ -251,30 +251,19 @@ export const ColorPalette = ({
                     </Grid>
                   ))
                 : withColorField &&
-                  (chartConfig.fields.color.type === "single" ? (
-                    <Grid item>
-                      <ColorSquare
-                        key={chartConfig.fields.color.color}
-                        color={chartConfig.fields.color.color as string}
-                        disabled={disabled}
-                      />
-                    </Grid>
-                  ) : (
-                    customColorPalettes
-                      ?.find(
-                        (palette) =>
-                          palette.paletteId ===
-                          chartConfig.fields.color.paletteId
-                      )
-                      ?.colors.map((color, i) => (
-                        <Grid item key={`color-palette-tile-${i}`}>
-                          <ColorSquare
-                            color={color as string}
-                            disabled={disabled}
-                          />
-                        </Grid>
-                      ))
-                  ))}
+                  customColorPalettes
+                    ?.find(
+                      (palette) =>
+                        palette.paletteId === chartConfig.fields.color.paletteId
+                    )
+                    ?.colors.map((color, i) => (
+                      <Grid item key={`color-palette-tile-${i}`}>
+                        <ColorSquare
+                          color={color as string}
+                          disabled={disabled}
+                        />
+                      </Grid>
+                    ))}
             </Grid>
           );
         }}

--- a/app/configurator/components/chart-controls/color-palette.tsx
+++ b/app/configurator/components/chart-controls/color-palette.tsx
@@ -417,6 +417,7 @@ export const ColorSquare = ({
   return (
     <Box
       className={classes.root}
+      data-testId="select-color-square"
       sx={{
         backgroundColor: disabled ? "grey.300" : color,
       }}

--- a/app/configurator/components/chart-controls/color-palette.tsx
+++ b/app/configurator/components/chart-controls/color-palette.tsx
@@ -36,9 +36,8 @@ import {
   getDefaultCategoricalPalette,
   getPalette,
 } from "@/palettes";
-import { getCustomColorPalettes } from "@/utils/chart-config/api";
 import useEvent from "@/utils/use-event";
-import { useFetchData } from "@/utils/use-fetch-data";
+import { useUserPalettes } from "@/utils/use-user-palettes";
 
 import { ConfiguratorDrawer } from "../drawer";
 
@@ -78,13 +77,7 @@ export const ColorPalette = ({
   const classes = useStyles();
   const user = useUser();
 
-  const { data: customColorPalettes, invalidate } = useFetchData({
-    queryKey: ["colorPalettes", user?.id],
-    queryFn: getCustomColorPalettes,
-    options: {
-      enable: !!user?.id,
-    },
-  });
+  const { data: customColorPalettes, invalidate } = useUserPalettes();
 
   const hasColors = hasDimensionColors(component);
   const defaultPalette =

--- a/app/configurator/components/chart-controls/color-picker.tsx
+++ b/app/configurator/components/chart-controls/color-picker.tsx
@@ -46,6 +46,7 @@ export const Swatch = ({
   return (
     <Box
       className={classes.swatch}
+      data-testId="color-picker-swatch"
       sx={{
         borderColor: selected ? borderColor : undefined,
         boxShadow: selected ? `0 0 0.5rem 0 ${color}` : undefined,

--- a/app/configurator/components/chart-controls/color-ramp.tsx
+++ b/app/configurator/components/chart-controls/color-ramp.tsx
@@ -37,10 +37,9 @@ import {
   getColorInterpolator,
   sequentialPalettes,
 } from "@/palettes";
-import { getCustomColorPalettes } from "@/utils/chart-config/api";
 import { getFittingColorInterpolator } from "@/utils/color-palette-utils";
 import useEvent from "@/utils/use-event";
-import { useFetchData } from "@/utils/use-fetch-data";
+import { useUserPalettes } from "@/utils/use-user-palettes";
 
 import { ConfiguratorDrawer } from "../drawer";
 
@@ -109,15 +108,7 @@ export const ColorRampField = (props: ColorRampFieldProps) => {
   const [state, dispatch] = useConfiguratorState(isConfiguring);
   const chartConfig = getChartConfig(state);
 
-  const user = useUser();
-
-  const { data: customColorPalettes, invalidate } = useFetchData({
-    queryKey: ["colorPalettes", user?.id],
-    queryFn: getCustomColorPalettes,
-    options: {
-      enable: !!user?.id,
-    },
-  });
+  const { data: customColorPalettes, invalidate } = useUserPalettes();
 
   const palettes = useMemo(() => {
     const palettes = [...sequentialPalettes, ...divergingPalettes];

--- a/app/configurator/components/color-picker.tsx
+++ b/app/configurator/components/color-picker.tsx
@@ -118,6 +118,7 @@ const CustomColorPicker = ({
             <Swatch
               key={`color-picker-swatch-${item.color}-${i}`}
               color={item.color}
+             
               selected={hsvaToHex(hsva) === item.color && item.id === hsva.id}
               onClick={() => setHsva({ ...hexToHsva(item.color), id: item.id })}
             />

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -99,14 +99,12 @@ import { useTimeFormatLocale } from "@/formatters";
 import { TimeUnit } from "@/graphql/query-hooks";
 import { Locale } from "@/locales/locales";
 import { useLocale } from "@/locales/use-locale";
-import { useUser } from "@/login/utils";
 import { getPalette } from "@/palettes";
 import { assert } from "@/utils/assert";
-import { getCustomColorPalettes } from "@/utils/chart-config/api";
 import { hierarchyToOptions } from "@/utils/hierarchy";
 import { makeDimensionValueSorters } from "@/utils/sorting-values";
 import useEvent from "@/utils/use-event";
-import { useFetchData } from "@/utils/use-fetch-data";
+import { useUserPalettes } from "@/utils/use-user-palettes";
 
 const ColorPickerMenu = dynamic(
   () =>
@@ -793,6 +791,7 @@ const useMultiFilterColorPicker = (
 
   const palette = useMemo(() => {
     const paletteId = get(chartConfig, `fields["${colorField}"].paletteId`);
+
     return getPalette({
       paletteId,
       fallbackPalette: customColorPalettes?.find(
@@ -825,15 +824,7 @@ export const MultiFilterFieldColorPicker = ({
   label: string;
   symbol: LegendSymbol;
 }) => {
-  const user = useUser();
-
-  const { data: customColorPalettes } = useFetchData({
-    queryKey: ["colorPalettes", user?.id],
-    queryFn: getCustomColorPalettes,
-    options: {
-      enable: !!user?.id,
-    },
-  });
+  const { data: customColorPalettes } = useUserPalettes();
 
   const { color, checked, palette, onChange } = useMultiFilterColorPicker(
     value,
@@ -909,9 +900,15 @@ export const ColorPickerField = ({
     [locale, dispatch, field, path]
   );
 
+  const { data: customColorPalettes } = useUserPalettes();
+  const paletteId = get(chartConfig, `fields["${field}"].paletteId`);
+
   const color = get(chartConfig, `fields["${field}"].${path}`);
   const palette = getPalette({
-    paletteId: get(chartConfig, `fields["${field}"].paletteId`),
+    paletteId,
+    fallbackPalette: customColorPalettes?.find(
+      (palette) => palette.paletteId === paletteId
+    )?.colors,
   });
 
   return (

--- a/app/login/components/color-palettes/profile-color-palette-content.tsx
+++ b/app/login/components/color-palettes/profile-color-palette-content.tsx
@@ -13,11 +13,9 @@ import {
   createDivergingInterpolator,
   createSequentialInterpolator,
 } from "@/palettes";
-import {
-  deleteCustomColorPalette,
-  getCustomColorPalettes,
-} from "@/utils/chart-config/api";
-import { useFetchData, useMutate } from "@/utils/use-fetch-data";
+import { deleteCustomColorPalette } from "@/utils/chart-config/api";
+import { useMutate } from "@/utils/use-fetch-data";
+import { useUserPalettes } from "@/utils/use-user-palettes";
 
 import { SectionContent } from "../profile-tables";
 
@@ -25,20 +23,10 @@ import { default as ProfileColorPaletteForm } from "./profile-color-palette-form
 
 type ProfileContentProps = {
   title: string;
-  userId: number;
 };
 
-export const ProfileColorPaletteContent = ({
-  title,
-  userId,
-}: ProfileContentProps) => {
-  const { data: customColorPalettes, invalidate } = useFetchData({
-    queryKey: ["colorPalettes", userId],
-    queryFn: getCustomColorPalettes,
-    options: {
-      enable: !!userId,
-    },
-  });
+export const ProfileColorPaletteContent = ({ title }: ProfileContentProps) => {
+  const { data: customColorPalettes, invalidate } = useUserPalettes();
 
   type FormMode = "add" | "edit" | "view";
   const [formMode, setFormMode] = useState<FormMode>("view");

--- a/app/login/components/profile-content-tabs.tsx
+++ b/app/login/components/profile-content-tabs.tsx
@@ -169,7 +169,6 @@ export const ProfileContentTabs = (props: ProfileContentTabsProps) => {
               id: "login.profile.my-color-palettes",
               message: "My Color Palettes",
             })}
-            userId={userId}
           />
         </Box>
       </TabPanel>

--- a/app/palettes.ts
+++ b/app/palettes.ts
@@ -67,10 +67,12 @@ export const getPalette = ({
   paletteId,
   colorField,
   colors,
+  fallbackPalette,
 }: {
   paletteId?: string;
   colorField?: ColorField;
   colors?: string[];
+  fallbackPalette?: string[];
 }): ReadonlyArray<string> => {
   if (colorField?.type === "single") {
     return [colorField.color];
@@ -100,7 +102,7 @@ export const getPalette = ({
         return schemeTableau10;
 
       default:
-        return schemeCategory10;
+        return fallbackPalette ?? schemeCategory10;
     }
   }
 };

--- a/app/utils/use-user-palettes.ts
+++ b/app/utils/use-user-palettes.ts
@@ -1,0 +1,16 @@
+import { useUser } from "@/login/utils";
+
+import { getCustomColorPalettes } from "./chart-config/api";
+import { useFetchData } from "./use-fetch-data";
+
+export const useUserPalettes = () => {
+  const user = useUser();
+
+  return useFetchData({
+    queryKey: ["colorPalettes", user?.id],
+    queryFn: getCustomColorPalettes,
+    options: {
+      enable: !!user?.id,
+    },
+  });
+};

--- a/e2e/color-palettes.spec.ts
+++ b/e2e/color-palettes.spec.ts
@@ -1,0 +1,75 @@
+import { setup, sleep } from "./common";
+
+const { test, expect, describe } = setup();
+
+describe("Color Picker Swatches", () => {
+  test("Color Picker Swatches for Segmentations", async ({
+    page,
+    selectors,
+    actions,
+  }) => {
+    await page.goto(
+      "/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10&dataSource=Prod"
+    );
+    await selectors.chart.loaded();
+    await actions.editor.selectActiveField("Segmentation");
+    await selectors.edition.drawerLoaded();
+    await (await selectors.panels.drawer().within().findByText("None")).click();
+    await actions.mui.selectOption("Kanton");
+
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await sleep(1_000);
+
+    await page
+      .getByRole("button", { name: "Open Color Picker" })
+      .first()
+      .click();
+    await sleep(1_000);
+
+    const colorSquare = page.getByTestId("select-color-square").first();
+    await colorSquare.waitFor({ state: "visible", timeout: 5000 });
+    const colorSquareBgColor = await colorSquare.evaluate((el) => {
+      return window.getComputedStyle(el).backgroundColor;
+    });
+
+    const colorPickerSwatch = page.getByTestId("color-picker-swatch").first();
+    await colorPickerSwatch.waitFor({ state: "visible", timeout: 5000 });
+    const colorPickerSwatchBgColor = await colorPickerSwatch.evaluate((el) => {
+      return window.getComputedStyle(el).backgroundColor;
+    });
+
+    expect(colorSquareBgColor).toEqual(colorPickerSwatchBgColor);
+  });
+
+  test("Color Picker Swatches for Vertical Axis", async ({
+    page,
+    selectors,
+    actions,
+  }) => {
+    await page.goto(
+      "/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10&dataSource=Prod"
+    );
+    await selectors.chart.loaded();
+    await actions.editor.selectActiveField("Vertical Axis");
+
+    await page
+      .getByRole("button", { name: "Open Color Picker" })
+      .first()
+      .click();
+    await sleep(1_000);
+
+    const colorSquare = page.getByTestId("select-color-square").first();
+    await colorSquare.waitFor({ state: "visible", timeout: 5000 });
+    const colorSquareBgColor = await colorSquare.evaluate((el) => {
+      return window.getComputedStyle(el).backgroundColor;
+    });
+
+    const colorPickerSwatch = page.getByTestId("color-picker-swatch").first();
+    await colorPickerSwatch.waitFor({ state: "visible", timeout: 5000 });
+    const colorPickerSwatchBgColor = await colorPickerSwatch.evaluate((el) => {
+      return window.getComputedStyle(el).backgroundColor;
+    });
+
+    expect(colorSquareBgColor).toEqual(colorPickerSwatchBgColor);
+  });
+});


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2100   

<!--- Describe the changes -->

**What changes?**
This PR changes selected custom color palettes to always display all colors even if type is `single` and inside the custom color picker the swatches should always dynamically set palette colors.

<!--- Test instructions -->

## How to test

1. Go to this [link](https://visualization-tool-git-fix-y-axis-color-palette-ixt1.vercel.app/)
2. Create a Chart f.e (Einmalvergütung für Photovoltaikanlagen)
3. Click on `Y axis` 
4. Select a custom color palette, see how it displays all colors not just the used one ✅
5. Go back, and Select `Segmentations` (select `Kanton`, from the dropdown)
6. Select any color palette
7. Try to change a color with the custom color picker, See how the palettes colors are used for the swatches ✅

<!--- Reproduction steps, in case of a bug -->

## How to Reproduce

1. Go to this [Link](https://test.visualize.admin.ch/en)
2. Create a Chart f.e (Einmalvergütung für Photovoltaikanlagen)
3. Click on `Y axis` 
4. Select a custom color palette, see how it displays only one color from the palette ❌
5. Go back, and Select `Segmentations` (select `Kanton`, from the dropdown)
6. Select any color palette
7. Try to change a color with the custom color picker, See how the it's always the default color palette for the swatches ❌

---

- [x] Add a CHANGELOG entry
- [x] Add e2e tests
