### PR TITLE
feat: Resize dashboard text block also in published charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ You can also check the
 
 - Features
   - Added option for hiding legend titles using a toggle switch
+  - Dashboard text block are now automatically resized also in published charts
 - Fixes
   - Fixed button translations for custom color palette update and create button.
 - Maintenance

--- a/app/components/text-block.tsx
+++ b/app/components/text-block.tsx
@@ -5,7 +5,12 @@ import { makeStyles } from "@mui/styles";
 import clsx from "clsx";
 import { selectAll } from "d3-selection";
 import isEqual from "lodash/isEqual";
-import { ComponentProps, forwardRef, useCallback, useEffect } from "react";
+import {
+  ComponentProps,
+  forwardRef,
+  useCallback,
+  useLayoutEffect,
+} from "react";
 
 import { ActionElementsContainer } from "@/components/action-elements-container";
 import { CHART_GRID_ROW_COUNT } from "@/components/chart-shared";
@@ -173,12 +178,11 @@ const TextBlockActionElements = ({
 export const useSyncTextBlockHeight = () => {
   const [state, dispatch] = useConfiguratorState(hasChartConfigs);
   const layout = state.layout;
-  const layouting = isLayouting(state);
-  const layoutingFreeCanvas =
-    layouting && layout.type === "dashboard" && layout.layout === "canvas";
+  const isFreeCanvas =
+    layout.type === "dashboard" && layout.layout === "canvas";
 
-  useEffect(() => {
-    if (!layoutingFreeCanvas) {
+  useLayoutEffect(() => {
+    if (!isFreeCanvas) {
       return;
     }
 
@@ -216,5 +220,5 @@ export const useSyncTextBlockHeight = () => {
         }
       }
     );
-  }, [dispatch, layout, layoutingFreeCanvas]);
+  }, [dispatch, layout, isFreeCanvas]);
 };

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -1121,7 +1121,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       return draft;
 
     case "LAYOUT_CHANGED":
-      if (draft.state === "LAYOUTING") {
+      if (draft.state === "LAYOUTING" || draft.state === "PUBLISHED") {
         if (!isEqual(draft.layout, action.value)) {
           draft.layout = action.value;
         }


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2077

<!--- Describe the changes -->

This PR enables automatic dashboard text block resizing in published charts.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-feat-sync-text-block-heights-53f507-ixt1.vercel.app/en/v/CHFyazQhGXQ1?dataSource=Int-uncached) (chart state copied from #2077).
2. ✅ See that the text doesn't overlap.

<!--- Reproduction steps, in case of a bug -->

---

- [x] Add a CHANGELOG entry
