### PR TITLE
fix: Only allow title checks on add mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ You can also check the
     if the color palette title is missing
 - Fixes
   - Added error displaying for title names that already exists on the custom
-    color palette form inside the user profile
+    color palette form inside the user profile only when adding palettes
   - Fixed button translations for custom color palette update and create button.
 - Maintenance
   - Added authentication method to e2e tests

--- a/app/login/components/color-palettes/profile-color-palette-form.tsx
+++ b/app/login/components/color-palettes/profile-color-palette-form.tsx
@@ -129,7 +129,7 @@ const ProfileColorPaletteForm = ({
       (palette) => palette.name === titleInput
     );
 
-    if (titleExistsAlready) {
+    if (titleExistsAlready && formMode === "add") {
       setIsNotAvailable(true);
     } else {
       setIsNotAvailable(false);


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2109 

<!--- Describe the changes -->

**What changes?**
This PR fixes the missing makes sure duplicate title errors only arise when adding a palette not when updating.

<!--- Test instructions -->

## How to test

1. Go to this [Link](https://visualization-tool-git-feat-highlight-missing-color-805a11-ixt1.vercel.app/)
2. Click Sign in button 
3. Click on `My Color Palettes`
4. Add a new color palette
5. See how palette title has a new (required) hint ✅
6. See how `Add color palette` button is disabled when there is no title specified ✅
7. Enter a title that already exists and see how you get the same error as in the editor ✅

<!--- Reproduction steps, in case of a bug -->

## How to Reproduce

1. Go to this [Link](https://test.visualize.admin.ch/en)
2. Click Sign in button 
3. Click on `My Color Palettes`
4. Add a new color palette
5. See how palette title has no (required) hint ❌
6. See how `Add color palette` button is **not** disabled when there is no title specified ❌
7. Enter a title that already exists and see how the error is missing ❌

---

- [x] Add a CHANGELOG entry
