### PR TITLE
fix: aligned button left and improved spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ You can also check the
   - Added error displaying for title names that already exists on the custom
     color palette form inside the user profile
   - Fixed button translations for custom color palette update and create button.
+  - Improved filter section styling
 - Maintenance
   - Added authentication method to e2e tests
   - Added authentication to vercel previews for easier testing

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -366,7 +366,6 @@ const MultiFilterContent = ({
             justifyContent: "space-between",
             display: "flex",
             flexDirection: "column",
-            alignItems: "flex-end",
           }}
         >
           {chartConfig.activeField === "segment" ? (
@@ -430,7 +429,12 @@ const MultiFilterContent = ({
             size="small"
             color="primary"
             onClick={handleOpenAutocomplete}
-            sx={{ justifyContent: "center", mb: 2, width: "fit-content" }}
+            sx={{
+              justifyContent: "center",
+              mt: 4,
+              mb: 2,
+              width: "fit-content",
+            }}
           >
             <Trans id="controls.set-filters">Edit filters</Trans>
           </Button>


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2111 

<!--- Describe the changes -->

**What changed?**
This PR moves the `Edit filters` button from the filters section align to the left and increase spacing in that section.

<!--- Test instructions -->

## How to test

1. Go to this link
2. Create a new Visualization
3. Add Segmentation & scroll down 
4. See how the button is left aligned with more spacing ✅

<!--- Reproduction steps, in case of a bug -->
## See the previous version

1. Go to this link
2. Create a new Visualization
3. Add Segmentation & scroll down 
4. See how the button is not left aligned with only little spacing ❌
---

- [x] Add a CHANGELOG entry
