### PR TITLE
fix: Infinite loop when resizing text blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ You can also check the
 - Fixes
   - Color picker's HEX code input now stays up-to-date with the selected color
   - Markdown links now open in a new tab
+  - Publishing of a dashboard with text blocks doesn't crash the application in
+    some rare cases anymore
 
 # [5.2.5] - 2025-02-18
 

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -1198,10 +1198,9 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
       if (draft.state === "LAYOUTING" || draft.state === "PUBLISHED") {
         if (!isEqual(draft.layout, action.value)) {
           draft.layout = action.value;
+          ensureDashboardLayoutIsCorrect(draft);
         }
       }
-
-      ensureDashboardLayoutIsCorrect(draft);
 
       return draft;
 


### PR DESCRIPTION
<!--- Describe the changes -->

This PR fixes an infinite loop that was sometimes triggered by `useSyncTextBlockHeight` due to `ensureDashboardLayoutIsCorrect` that was creating a new `layout` object when it shouldn't.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-sync-text-height-ixt1.vercel.app/en/v/BvJSoR3239IX?dataSource=Prod).
2. Copy and edit the chart.
3. Add a H1 text in the text block.
4. ✅ Publish the chart and see that it works.

<!--- Reproduction steps, in case of a bug -->

## How to reproduce

1. Go to [this link](https://int.visualize.admin.ch/v/sJNhBzYBM_za?dataSource=Prod).
3. Copy and edit the chart.
4. Add a H1 text in the text block.
5. ❌ Publish the chart and see that the application crashes.

---

- [x] Add a CHANGELOG entry
