### PR TITLE
fix: Markdown links now open in a new tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ You can also check the
     compatible chart types
 - Fixes
   - Color picker's HEX code input now stays up-to-date with the selected color
+  - Markdown links now open in a new tab
 
 # [5.2.5] - 2025-02-18
 

--- a/app/components/markdown.tsx
+++ b/app/components/markdown.tsx
@@ -41,7 +41,7 @@ const components: ComponentProps<typeof ReactMarkdown>["components"] = {
     </p>
   ),
   a: ({ children, style, ...props }) => (
-    <a style={{ ...style, marginTop: 0 }} {...props}>
+    <a target="_blank" style={{ ...style, marginTop: 0 }} {...props}>
       {children}
     </a>
   ),


### PR DESCRIPTION
<!--- Describe the changes -->

This PR makes sure links set in Markdown editor are opened in a new tab, which fixes an issue with accessing them through iframes (and prevents opening of the links in the same page).

<!--- Test instructions -->

## How to test

1. Go to this link.
2. 123

<!--- Reproduction steps, in case of a bug -->

---

- [ ] Add a CHANGELOG entry
