### PR TITLE
feat: Add limit and target values to bar charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Features
+  - Limits can now be displayed in bar charts
 
 # [5.2.6] - 2025-02-18
 

--- a/app/charts/bar/chart-bar.tsx
+++ b/app/charts/bar/chart-bar.tsx
@@ -24,8 +24,9 @@ import {
 } from "@/charts/shared/containers";
 import { Tooltip } from "@/charts/shared/interaction/tooltip";
 import { LegendColor } from "@/charts/shared/legend-color";
+import { HorizontalLimits } from "@/charts/shared/limits";
 import { BarConfig } from "@/config-types";
-import { useChartConfigFilters } from "@/config-utils";
+import { useChartConfigFilters, useLimits } from "@/config-utils";
 import { hasChartConfigs } from "@/configurator";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import { useConfiguratorState } from "@/src";
@@ -39,7 +40,7 @@ export const ChartBarsVisualization = (
 };
 
 const ChartBars = memo((props: ChartProps<BarConfig>) => {
-  const { chartConfig, dimensions, dimensionsById } = props;
+  const { chartConfig, dimensions, dimensionsById, measures } = props;
   const { fields, interactiveFiltersConfig } = chartConfig;
   const filters = useChartConfigFilters(chartConfig);
   const [{ dashboardFilters }] = useConfiguratorState(hasChartConfigs);
@@ -47,6 +48,11 @@ const ChartBars = memo((props: ChartProps<BarConfig>) => {
     interactiveFiltersConfig,
     dashboardFilters?.timeRange
   );
+  const limits = useLimits({
+    chartConfig,
+    dimensions,
+    measures,
+  });
 
   return (
     <>
@@ -119,21 +125,30 @@ const ChartBars = memo((props: ChartProps<BarConfig>) => {
               <AxisHeightBand />
               <Bars />
               <ErrorWhiskers />
+              <HorizontalLimits {...limits} />
               <AxisHeightBandDomain />
               <InteractionBars />
               {showTimeBrush && <BrushTime />}
             </ChartSvg>
             <Tooltip type="single" />
           </ChartContainer>
-          {fields.animation && (
+          {fields.animation || limits.limits.length > 0 ? (
             <ChartControlsContainer>
-              <TimeSlider
-                filters={filters}
-                dimensions={dimensions}
-                {...fields.animation}
+              <LegendColor
+                limits={limits.limits}
+                dimensionsById={dimensionsById}
+                chartConfig={chartConfig}
+                symbol="square"
               />
+              {fields.animation && (
+                <TimeSlider
+                  filters={filters}
+                  dimensions={dimensions}
+                  {...fields.animation}
+                />
+              )}
             </ChartControlsContainer>
-          )}
+          ) : null}
         </BarChart>
       )}
     </>

--- a/app/charts/shared/rendering-utils.ts
+++ b/app/charts/shared/rendering-utils.ts
@@ -6,12 +6,12 @@ import {
   AnimationField,
   Filters,
   InteractiveFiltersConfig,
-  Limit,
+  Limit
 } from "@/configurator";
 import {
   Component,
   isStandardErrorDimension,
-  Observation,
+  Observation
 } from "@/domain/data";
 import { TransitionStore } from "@/stores/transition";
 
@@ -150,6 +150,8 @@ export function maybeTransition<
 type AnySelection = Selection<any, any, any, any>;
 type AnyTransition = Transition<any, any, any, any>;
 
+const LIMIT_SIZE = 3;
+
 export type RenderVerticalLimitDatum = {
   key: string;
   x: number;
@@ -159,8 +161,6 @@ export type RenderVerticalLimitDatum = {
   fill: string;
   lineType: Limit["lineType"];
 };
-
-const LIMIT_SIZE = 3;
 
 export const renderVerticalLimits = (
   g: Selection<SVGGElement, null, SVGGElement, unknown>,
@@ -191,8 +191,8 @@ export const renderVerticalLimits = (
             g
               .append("line")
               .attr("class", "middle")
-              .attr("x1", (d) => d.x + (d.width) / 2)
-              .attr("x2", (d) => d.x + (d.width) / 2)
+              .attr("x1", (d) => d.x + d.width / 2)
+              .attr("x2", (d) => d.x + d.width / 2)
               .attr("y1", (d) => d.y1)
               .attr("y2", (d) => d.y2)
               .attr("stroke", (d) => d.fill)
@@ -234,8 +234,8 @@ export const renderVerticalLimits = (
               .call((g) =>
                 g
                   .select(".middle")
-                  .attr("x1", (d) => d.x + (d.width) / 2)
-                  .attr("x2", (d) => d.x + (d.width) / 2)
+                  .attr("x1", (d) => d.x + d.width / 2)
+                  .attr("x2", (d) => d.x + d.width / 2)
                   .attr("y1", (d) => d.y1)
                   .attr("y2", (d) => d.y2)
                   .attr("stroke", (d) => d.fill)
@@ -250,6 +250,116 @@ export const renderVerticalLimits = (
                   .attr("x", (d) => d.x)
                   .attr("y", (d) => d.y1)
                   .attr("width", (d) => d.width)
+                  .attr("fill", (d) => d.fill)
+              ),
+          transition,
+        }),
+      (exit) =>
+        maybeTransition(exit, {
+          transition,
+          s: (g) => g.attr("opacity", 0).remove(),
+        })
+    );
+};
+
+export type RenderHorizontalLimitDatum = {
+  key: string;
+  y: number;
+  x1: number;
+  x2: number;
+  height: number;
+  fill: string;
+  lineType: Limit["lineType"];
+};
+
+export const renderHorizontalLimits = (
+  g: Selection<SVGGElement, null, SVGGElement, unknown>,
+  data: RenderHorizontalLimitDatum[],
+  options: RenderOptions
+) => {
+  const { transition } = options;
+
+  g.selectAll<SVGGElement, RenderHorizontalLimitDatum>("g")
+    .data(data, (d) => d.key)
+    .join(
+      (enter) =>
+        enter
+          .append("g")
+          .attr("opacity", 0)
+          .call((g) =>
+            g
+              .append("rect")
+              .attr("class", "left")
+              .attr("x", (d) => d.x1)
+              .attr("y", (d) => d.y)
+              .attr("width", LIMIT_SIZE)
+              .attr("height", (d) => d.height)
+              .attr("fill", (d) => d.fill)
+              .attr("stroke", "none")
+          )
+          .call((g) =>
+            g
+              .append("line")
+              .attr("class", "middle")
+              .attr("x1", (d) => d.x1)
+              .attr("x2", (d) => d.x2)
+              .attr("y1", (d) => d.y + d.height / 2)
+              .attr("y2", (d) => d.y + d.height / 2)
+              .attr("stroke", (d) => d.fill)
+              .attr("stroke-width", LIMIT_SIZE)
+              .attr("stroke-dasharray", (d) =>
+                d.lineType === "dashed" ? "3 3" : "none"
+              )
+          )
+          .call((g) =>
+            g
+              .append("rect")
+              .attr("class", "right")
+              .attr("x", (d) => d.x2)
+              .attr("y", (d) => d.y)
+              .attr("width", LIMIT_SIZE)
+              .attr("height", d => d.height)
+              .attr("fill", (d) => d.fill)
+              .attr("stroke", "none")
+          )
+          .call((enter) =>
+            maybeTransition(enter, {
+              s: (g) => g.attr("opacity", 1),
+              transition,
+            })
+          ),
+      (update) =>
+        maybeTransition(update, {
+          s: (g) =>
+            g
+              .attr("opacity", 1)
+              .call((g) =>
+                g
+                  .select(".left")
+                  .attr("x", (d) => d.x1)
+                  .attr("y", (d) => d.y)
+                  .attr("height", (d) => d.height)
+                  .attr("fill", (d) => d.fill)
+              )
+              .call((g) =>
+                g
+                  .select(".middle")
+                  .attr("x1", (d) => d.x1)
+                  .attr("x2", (d) => d.x2)
+                  .attr("y1", (d) => d.y + d.height / 2)
+                  .attr("y2", (d) => d.y + d.height / 2)
+                  .attr("stroke", (d) => d.fill)
+                  .attr("stroke-width", LIMIT_SIZE)
+                  .attr("stroke-dasharray", (d) =>
+                    d.lineType === "dashed" ? "3 3" : "none"
+                  )
+              )
+              .call((g) =>
+                g
+                  .select(".right")
+                  .attr("x", (d) => d.x2)
+                  .attr("y", (d) => d.y)
+                  .attr("height", d => d.height)
                   .attr("fill", (d) => d.fill)
               ),
           transition,

--- a/app/charts/table/chart-table.tsx
+++ b/app/charts/table/chart-table.tsx
@@ -12,6 +12,7 @@ export const ChartTableVisualization = (
   props: Omit<VisualizationProps<TableConfig>, "observationQueryFilters">
 ) => {
   const { chartConfig, componentIds } = props;
+
   return (
     <ChartDataWrapper
       {...props}

--- a/app/charts/table/table-state.tsx
+++ b/app/charts/table/table-state.tsx
@@ -120,7 +120,6 @@ const useTableState = (
   );
   const rowHeight = hasBar ? 56 : 40;
 
-  // Dimensions
   const { width } = useSize();
   const margins = {
     top: 10,
@@ -128,7 +127,7 @@ const useTableState = (
     bottom: 10,
     left: 10,
   };
-  const chartWidth = width - margins.left - margins.right; // We probably don't need this
+  const chartWidth = width - margins.left - margins.right;
   const chartHeight = Math.min(
     TABLE_HEIGHT,
     // + 1 for the header row
@@ -166,23 +165,24 @@ const useTableState = (
     function replaceKeys() {
       // Only read keys once
       const keys = Object.keys(chartData[0] ?? []);
-      const lkey = keys.length;
+      const n = keys.length;
       const slugifiedKeys = keys.map(getSlugifiedId);
 
       return chartData.map((d, index) => {
         const o = { id: index } as $IntentionalAny;
-        // This is run often, so let's optimize it
-        for (let i = 0; i < lkey; i++) {
-          const ski = slugifiedKeys[i];
-          const ki = keys[i];
-          const v = d[ki];
-          o[ski] =
-            types[ski] !== "NumericalMeasure"
-              ? v
-              : v !== null && v !== undefined
-                ? +v!
+
+        for (let i = 0; i < n; i++) {
+          const slugifiedKey = slugifiedKeys[i];
+          const key = keys[i];
+          const value = d[key];
+          o[slugifiedKey] =
+            types[slugifiedKey] !== "NumericalMeasure"
+              ? value
+              : value !== null && value !== undefined
+                ? +value
                 : null;
         }
+
         return o;
       });
     },
@@ -320,17 +320,13 @@ const useTableState = (
         } else if (columnStyleType === "category") {
           const { colorMapping } = columnStyle as ColumnStyleCategory;
           const dimension = allColumnsById[id];
-
-          // Color scale (always from colorMappings)
           const colorScale = scaleOrdinal<string>();
-
-          // get label (translated) matched with color
           const labelsAndColor = Object.keys(colorMapping).map(
             (colorMappingIri) => {
               const dvLabel = (
                 dimension.values.find((s) => {
                   return s.value === colorMappingIri;
-                }) || { label: "unknown" }
+                }) ?? { label: "unknown" }
               ).label;
 
               return {


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #1894

<!--- Describe the changes -->

This PR adds support for showing target values and limits in bar charts.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-feat-bar-table-limits-ixt1.vercel.app/en/create/new?cube=https://environment.ld.admin.ch/foen/test_target/cube/target_1/1&dataSource=Test).
2. Switch to a bar chart.
3. ✅ Go to Horizontal Axis and see that you can add limits.
4. Add a few of them.
5. ✅ See that they appear on the chart.

<!--- Reproduction steps, in case of a bug -->

---

- [x] Add a CHANGELOG entry
