### PR TITLE
chore: Added translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ You can also check the
 
 - Features
   - Limits can now be displayed in bar charts
+  - Added a fallback to color selector
 
 # [5.2.6] - 2025-02-18
 

--- a/app/configurator/components/chart-controls/color-palette.tsx
+++ b/app/configurator/components/chart-controls/color-palette.tsx
@@ -216,6 +216,14 @@ export const ColorPalette = ({
     }
   );
 
+  const isValidValue = (value: string) => {
+    const isPaletteValue = palettes.some((p) => p.value === value);
+    const isCustomPaletteValue = customColorPalettes?.some(
+      (p) => p.paletteId === value
+    );
+    return isPaletteValue || isCustomPaletteValue;
+  };
+
   return (
     <Box mt={2} sx={{ pointerEvents: disabled ? "none" : "auto" }}>
       <Label smaller htmlFor="color-palette-toggle" sx={{ mb: 1 }}>
@@ -224,7 +232,16 @@ export const ColorPalette = ({
       <Select
         className={classes.root}
         classes={classes}
-        renderValue={() => {
+        renderValue={(selected) => {
+          if (!selected || !isValidValue(selected)) {
+            return (
+              <Typography color={"secondary.active"} variant="body2">
+                <Trans id="controls.color.palette.select">
+                  Select a color palette
+                </Trans>
+              </Typography>
+            );
+          }
           return (
             <Grid
               container
@@ -260,11 +277,18 @@ export const ColorPalette = ({
             </Grid>
           );
         }}
-        value={
-          currentPalette
+        value={(() => {
+          let valueToUse = currentPalette
             ? currentPalette.value
-            : withColorField && chartConfig.fields.color.paletteId
-        }
+            : (withColorField && chartConfig.fields.color.paletteId) || "";
+
+          if (!isValidValue(valueToUse)) {
+            return "";
+          }
+
+          return valueToUse;
+        })()}
+        displayEmpty
         onChange={handleChangePalette}
       >
         {user && (

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -515,6 +515,10 @@ msgstr "Divergierend"
 msgid "controls.color.palette.reset"
 msgstr "Farbpalette zurücksetzen"
 
+#: app/configurator/components/chart-controls/color-palette.tsx
+msgid "controls.color.palette.select"
+msgstr "Wähle eine Farbpalette"
+
 #: app/configurator/components/chart-controls/color-ramp.tsx
 msgid "controls.color.palette.sequential"
 msgstr "Sequentiell"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -515,6 +515,10 @@ msgstr "Diverging"
 msgid "controls.color.palette.reset"
 msgstr "Reset color palette"
 
+#: app/configurator/components/chart-controls/color-palette.tsx
+msgid "controls.color.palette.select"
+msgstr "Select a color palette"
+
 #: app/configurator/components/chart-controls/color-ramp.tsx
 msgid "controls.color.palette.sequential"
 msgstr "Sequential"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -515,6 +515,10 @@ msgstr "Divergent"
 msgid "controls.color.palette.reset"
 msgstr "Réinitialiser la palette de couleurs"
 
+#: app/configurator/components/chart-controls/color-palette.tsx
+msgid "controls.color.palette.select"
+msgstr "choisir une palette de couleurs"
+
 #: app/configurator/components/chart-controls/color-ramp.tsx
 msgid "controls.color.palette.sequential"
 msgstr "Séquentielle"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -515,6 +515,10 @@ msgstr "Divergente"
 msgid "controls.color.palette.reset"
 msgstr "Ripristina la tavolozza dei colori"
 
+#: app/configurator/components/chart-controls/color-palette.tsx
+msgid "controls.color.palette.select"
+msgstr "selezionare una tavolozza di colori"
+
 #: app/configurator/components/chart-controls/color-ramp.tsx
 msgid "controls.color.palette.sequential"
 msgstr "Sequenziale"


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2123 

<!--- Describe the changes -->

**What changes?**
This PR adds a fallback for the color selector when color palettes are not available.

<!--- Test instructions -->

## How to test

1. Go to this [link](https://visualization-tool-git-feat-color-palette-default-text-ixt1.vercel.app/) 
2. Create a visualization 
3. Use a custom color palette
4. Publish chart 
5. Log out 
6. Copy and edit chart 
7. See how where you picked a custom color palette it now says `Select a color palette` ✅

---

- [x] Add a CHANGELOG entry
