### PR TITLE
feat: Add limit values to legend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ You can also check the
 
 - Features
   - Limits can now be displayed in bar charts
+  - Exact limit values are now displayed in legend
 
 # [5.2.6] - 2025-02-18
 

--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -34,6 +34,7 @@ import {
   Measure,
   Observation,
 } from "@/domain/data";
+import { useFormatNumber } from "@/formatters";
 import SvgIcChevronRight from "@/icons/components/IcChevronRight";
 import { useChartInteractiveFilters } from "@/stores/interactive-filters";
 import { interlace } from "@/utils/interlace";
@@ -215,6 +216,10 @@ export const LegendColor = memo(function LegendColor({
         groups={groups}
         limits={limits?.map(({ configLimit, measureLimit }) => ({
           label: measureLimit.name,
+          values:
+            measureLimit.type === "single"
+              ? [measureLimit.value]
+              : [measureLimit.from, measureLimit.to],
           color: configLimit.color,
         }))}
         getColor={colors}
@@ -307,7 +312,7 @@ const LegendColorContent = ({
   numberOfOptions,
 }: {
   groups: ReturnType<typeof useLegendGroups>;
-  limits?: { label: string; color: string }[];
+  limits?: { label: string; values: number[]; color: string }[];
   getColor: (d: string) => string;
   getLabel: (d: string) => string;
   getItemDimension?: (dimensionLabel: string) => Measure | undefined;
@@ -335,6 +340,8 @@ const LegendColorContent = ({
       addCategory(item);
     }
   });
+
+  const formatNumber = useFormatNumber({ decimals: "auto" });
 
   return (
     <Flex
@@ -388,11 +395,11 @@ const LegendColorContent = ({
                   );
                 })}
                 {isLastGroup && limits
-                  ? limits.map((limit, i) => (
+                  ? limits.map(({ label, values, color }, i) => (
                       <LegendItem
                         key={i}
-                        item={limit.label}
-                        color={limit.color}
+                        item={`${label}: ${values.map(formatNumber).join("-")}`}
+                        color={color}
                         symbol="line"
                       />
                     ))


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes https://github.com/visualize-admin/visualization-tool/issues/1894#issuecomment-2668845054

<!--- Describe the changes -->

This PR adds showing of exact limit values in chart legend.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-feat-limit-values-in-legend-ixt1.vercel.app/en/v/CNbXI-xzJokt?dataSource=Test).
2. See that limit values are visible in the legend.

---

- [x] Add a CHANGELOG entry
