### PR TITLE
fix: Base dots on data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ You can also check the
 
 - Features
   - Limits can now be displayed in bar charts
+- Fixes
+  - Line chart dots are now based on data, eliminating misaligned dots
 
 # [5.2.6] - 2025-02-18
 

--- a/app/charts/line/lines.tsx
+++ b/app/charts/line/lines.tsx
@@ -1,4 +1,3 @@
-import { bisector } from "d3-array";
 import { line } from "d3-shape";
 import { Fragment, memo, useEffect, useMemo, useRef } from "react";
 
@@ -148,25 +147,18 @@ export const Points = ({
 }) => {
   const { getX, xScale, getY, yScale, bounds, chartData, getSegment, colors } =
     useChartState() as LinesState;
-
   const { margins, chartHeight, width } = bounds;
+  const dots = useMemo(() => {
+    return chartData.map((d) => {
+      const x = xScale(getX(d));
+      const y = yScale(getY(d) as number);
+      const fill = colors(getSegment(d));
 
-  const ticksPos = useMemo(() => {
-    return xScale.ticks(bounds.chartWidth / 90).map((tick) => {
-      const x = xScale(tick);
-      const date = xScale.invert(x);
-
-      const bisectDate = bisector(
-        (d: Observation, date: Date) => getX(d).getTime() - date.getTime()
-      ).center;
-
-      const i = bisectDate(chartData, date, 0);
-      const y = yScale(getY(chartData[i]) as number);
-
-      const segment = getSegment(chartData[i]);
-      const color = colors(segment);
-
-      return { x, y, color };
+      return {
+        x,
+        y,
+        fill,
+      };
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
@@ -184,12 +176,12 @@ export const Points = ({
     return null;
   }
 
-  const radius = getPointRadius(dotSize);
+  const r = getPointRadius(dotSize);
 
   return (
     <g transform={`translate(${margins.left} ${margins.top})`}>
-      {ticksPos.map(({ x, y, color }, i) => (
-        <circle key={i} cx={x} cy={y} r={radius} fill={color} />
+      {dots.map(({ x, y, fill }, i) => (
+        <circle key={i} cx={x} cy={y} r={r} fill={fill} />
       ))}
     </g>
   );


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2129

<!--- Describe the changes -->

This PR changes the logic to not base line chart dots on X axis labels, but rather on actual data points.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-line-dots-ixt1.vercel.app/en/v/zc_75U6iS3BN?dataSource=Prod).
2. ✅ See that dots are aligned with actual data points.

<!--- Reproduction steps, in case of a bug -->

## How to reproduce

1. Go to [this link](https://int.visualize.admin.ch/en/v/THRVfaZcq4mU?dataSource=Prod).
2. ❌ See that dots are not aligned with actual data points.

---

- [x] Add a CHANGELOG entry
