### PR TITLE
refactor: Extract component out and add translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ You can also check the
   - Line chart dots are now based on data, eliminating misaligned dots
   - Added a fallback to color selector
   - Dynamic descriptions for custom color palette types
+  - Show line dot sizes are now translated
 
 # [5.2.6] - 2025-02-18
 

--- a/app/configurator/components/chart-controls/drawer-color-palette-content.tsx
+++ b/app/configurator/components/chart-controls/drawer-color-palette-content.tsx
@@ -110,6 +110,24 @@ export const ColorPaletteDrawerContent = forwardRef<
     }
   });
 
+  const captions: Record<CustomPaletteType["type"], string> = {
+    sequential: t({
+      id: "controls.custom-color-palettes.caption-sequential",
+      message:
+        "Select a dark endpoint color for a strong contrast between low and high values; the light color is calculated automatically. Sequential color palettes are suitable for ordered data such as temperatures or population densities.",
+    }),
+    diverging: t({
+      id: "controls.custom-color-palettes.caption-diverging",
+      message:
+        "Choose contrasting colors for the start and end points. These colors will help visually separate extreme values. Diverging palettes are ideal for data with a meaningful midpoint, such as zero or an average.",
+    }),
+    categorical: t({
+      id: "controls.custom-color-palettes.caption-categorical",
+      message:
+        "Use distinct, high-contrast colors. Avoid using too many colors, maximum 5–7. Apply sequential palettes for ordered data and diverging palettes for extremes.",
+    }),
+  };
+
   return (
     <div
       className={classes.autocompleteMenuContent}
@@ -137,11 +155,7 @@ export const ColorPaletteDrawerContent = forwardRef<
           </IconButton>
         </Flex>
         <Typography variant="body2" color="textSecondary">
-          <Trans id={`controls.custom-color-palettes.caption-${type}`}>
-            Use distinct, high-contrast colors. Avoid using too many colors,
-            maximum 5–7. Apply sequential palettes for ordered data and
-            diverging palettes for extremes.
-          </Trans>
+          {captions[type]}
         </Typography>
       </Box>
       <Flex

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -449,10 +449,6 @@ const EncodingOptionsPanel = (props: EncodingOptionsPanelProps) => {
 
   const hasSubOptions = encoding.options?.chartSubType ?? false;
 
-  const locale = useLocale();
-
-  const [, dispatch] = useConfiguratorState(isConfiguring);
-
   const relatedLimitDimension = getRelatedLimitDimension({
     chartConfig,
     dimensions,
@@ -565,63 +561,7 @@ const EncodingOptionsPanel = (props: EncodingOptionsPanelProps) => {
         </ControlSection>
       )}
       {encoding.options?.showDots && (
-        <ControlSection collapse>
-          <SubsectionTitle iconName="chartLine">
-            <Trans id="controls.section.data-points">Data Points</Trans>
-          </SubsectionTitle>
-          <ControlSectionContent>
-            <Stack direction="column" gap={4}>
-              <ChartOptionSwitchField
-                path="showDots"
-                field={encoding.field}
-                onChange={(e) => {
-                  const { checked } = e.target;
-                  if ("y" in fields && !("showDots" in fields.y)) {
-                    dispatch({
-                      type: "COLOR_FIELD_UPDATED",
-                      value: {
-                        locale,
-                        field: "y",
-                        path: "showDotsSize",
-                        value: "Large",
-                      },
-                    });
-                  }
-                  dispatch({
-                    type: "COLOR_FIELD_UPDATED",
-                    value: {
-                      locale,
-                      field: encoding.field,
-                      path: "showDots",
-                      value: checked,
-                    },
-                  });
-                }}
-                label={t({ id: "controls.section.show-dots" })}
-                sx={{ mt: 2 }}
-              />
-              <Typography variant="caption" sx={{ mt: 2 }}>
-                <Trans id="controls.section.dots-size">Select a Size</Trans>
-              </Typography>
-              <Flex justifyContent="flex-start">
-                {["Small", "Medium", "Large"].map((d) => (
-                  <ChartOptionRadioField
-                    key={d}
-                    label={`${d}`}
-                    field="y"
-                    path="showDotsSize"
-                    value={d}
-                    disabled={
-                      "y" in fields &&
-                      (!("showDots" in fields.y) ||
-                        ("showDots" in fields.y && !fields.y.showDots))
-                    }
-                  />
-                ))}
-              </Flex>
-            </Stack>
-          </ControlSectionContent>
-        </ControlSection>
+        <ChartShowDots fields={chartConfig.fields} field={field} />
       )}
       {isComboChartConfig(chartConfig) && encoding.field === "y" && (
         <ChartComboYField chartConfig={chartConfig} measures={measures} />
@@ -985,6 +925,112 @@ const ChartLimits = ({
       </ControlSectionContent>
     </ControlSection>
   ) : null;
+};
+
+const ChartShowDots = ({
+  fields,
+  field,
+}: {
+  fields: ChartConfig["fields"];
+  field: EncodingFieldType | null;
+}) => {
+  const locale = useLocale();
+  const [_, dispatch] = useConfiguratorState(isConfiguring);
+  const disabled =
+    "y" in fields &&
+    (!("showDots" in fields.y) ||
+      ("showDots" in fields.y && !fields.y.showDots));
+
+  return (
+    <ControlSection collapse>
+      <SubsectionTitle iconName="chartLine">
+        <Trans id="controls.section.data-points">Data Points</Trans>
+      </SubsectionTitle>
+      <ControlSectionContent>
+        <Stack direction="column" gap={4}>
+          <ChartOptionSwitchField
+            path="showDots"
+            field={field}
+            onChange={(e) => {
+              const { checked } = e.target;
+              if ("y" in fields && !("showDots" in fields.y)) {
+                dispatch({
+                  type: "COLOR_FIELD_UPDATED",
+                  value: {
+                    locale,
+                    field: "y",
+                    path: "showDotsSize",
+                    value: "Large",
+                  },
+                });
+              }
+              dispatch({
+                type: "COLOR_FIELD_UPDATED",
+                value: {
+                  locale,
+                  field,
+                  path: "showDots",
+                  value: checked,
+                },
+              });
+            }}
+            label={t({ id: "controls.section.show-dots" })}
+            sx={{ mt: 2 }}
+          />
+          <Typography variant="caption" sx={{ mt: 2 }}>
+            <Trans id="controls.section.dots-size">Select a Size</Trans>
+          </Typography>
+          <Flex justifyContent="flex-start">
+            <ChartShowDotRadio
+              size="Small"
+              label={t({
+                id: "controls.section.dots-size.small",
+                message: "Small",
+              })}
+              disabled={disabled}
+            />
+            <ChartShowDotRadio
+              size="Medium"
+              label={t({
+                id: "controls.section.dots-size.medium",
+                message: "Medium",
+              })}
+              disabled={disabled}
+            />
+            <ChartShowDotRadio
+              size="Large"
+              label={t({
+                id: "controls.section.dots-size.large",
+                message: "Large",
+              })}
+              disabled={disabled}
+            />
+          </Flex>
+        </Stack>
+      </ControlSectionContent>
+    </ControlSection>
+  );
+};
+
+const ChartShowDotRadio = ({
+  size,
+  label,
+  disabled,
+}: {
+  size: "Small" | "Medium" | "Large";
+  label: string;
+  disabled: boolean;
+}) => {
+  return (
+    <ChartOptionRadioField
+      key={size}
+      field="y"
+      path="showDotsSize"
+      value={size}
+      label={label}
+      disabled={disabled}
+    />
+  );
 };
 
 const ChartFieldAbbreviations = ({

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -593,17 +593,17 @@ msgstr "Verwenden Sie klare, kontrastreiche Farben. Vermeiden Sie die Verwendung
 
 #: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
-msgid "controls.custom-color-palettes.caption-sequential"
-msgstr "Wählen Sie eine dunkle Endpunktfarbe für einen starken Kontrast zwischen niedrigen und hohen Werten; die helle Farbe wird automatisch berechnet. Sequentielle Farbpaletten eignen sich für geordnete Daten wie Temperaturen oder Bevölkerungsdichten."
-
-#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
-#: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.caption-diverging"
 msgstr "Wählen Sie kontrastierende Farben für Start- und Endpunkt. Diese Farben unterstützen die visuelle Trennung von Extremwerten. Divergierende Paletten eignen sich besonders für Daten mit einem bedeutsamen Mittelpunkt wie Null oder einem Durchschnittswert."
 
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
+#: app/login/components/color-palettes/profile-color-palette-form.tsx
+msgid "controls.custom-color-palettes.caption-sequential"
+msgstr "Wählen Sie eine dunkle Endpunktfarbe für einen starken Kontrast zwischen niedrigen und hohen Werten; die helle Farbe wird automatisch berechnet. Sequentielle Farbpaletten eignen sich für geordnete Daten wie Temperaturen oder Bevölkerungsdichten."
+
 #: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.categorical-contrast-warning"
-msgstr "Die gewählte Farbe ist vor einem weißen Hintergrund schwer zu lesen. Wählen Sie eine Farbe mit höherem Kontrast, um die Zugänglichkeit zu verbessern."
+msgstr "Die gewählte Farbe ist auf weissem Hintergrund schwer lesbar. Wählen Sie eine Farbe mit stärkerem Kontrast, um die Barrierefreiheit zu verbessern."
 
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.create-palette"
@@ -611,7 +611,7 @@ msgstr "Farbpalette erstellen"
 
 #: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.diverging-contrast-warning"
-msgstr "Die gewählte Farbe hat nicht genügend Kontrast. Erwägen Sie die Verwendung einer dunkleren Farbe für eine abweichende Farbpalette."
+msgstr "Die gewählte Farbe weist zu wenig Kontrast auf. Verwenden Sie stattdessen eine dunklere Farbe für die divergierende Farbpalette."
 
 #: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.end"
@@ -627,7 +627,7 @@ msgstr "Mittlere Farbe"
 
 #: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.sequential-contrast-warning"
-msgstr "Die gewählte Farbe hat nicht genügend Kontrast. Erwägen Sie die Verwendung einer dunkleren Farbe für eine sequenzielle Palette."
+msgstr "Die gewählte Farbe weist zu wenig Kontrast auf. Wählen Sie eine dunklere Farbe für die sequenzielle Palette."
 
 #: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes.set-values-apply"
@@ -649,7 +649,7 @@ msgstr "Dieser Name ist bereits in Gebrauch. Bitte wählen Sie einen eindeutigen
 
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.type"
-msgstr "Wähle einen Farbpalette typ"
+msgstr "Wählen Sie einen Farbpalettentyp."
 
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.update-palette"
@@ -839,7 +839,7 @@ msgstr "Gestrichelt"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.line.solid"
-msgstr "Voll"
+msgstr "Durchgezogen"
 
 #: app/configurator/components/field-i18n.ts
 msgid "controls.measure"
@@ -1010,6 +1010,18 @@ msgid "controls.section.dots-size"
 msgstr "Wählen Sie eine Grösse"
 
 #: app/configurator/components/chart-options-selector.tsx
+msgid "controls.section.dots-size.large"
+msgstr "Gross"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.section.dots-size.medium"
+msgstr "Mittel"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.section.dots-size.small"
+msgstr "Klein"
+
+#: app/configurator/components/chart-options-selector.tsx
 #: app/configurator/components/chart-options-selector.tsx
 #: app/configurator/table/table-chart-options.tsx
 #: app/configurator/table/table-chart-options.tsx
@@ -1096,7 +1108,7 @@ msgstr "Linientyp auswählen"
 
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.section.targets-and-limit-values.show-target"
-msgstr "Ziel anzeigen"
+msgstr "Zielvorgabe anzeigen"
 
 #: app/configurator/components/annotators.tsx
 #: app/configurator/components/annotators.tsx
@@ -1694,7 +1706,7 @@ msgstr "Farbpalette löschen"
 
 #: app/login/components/color-palettes/profile-color-palette-content.tsx
 msgid "login.profile.my-color-palettes.description"
-msgstr "Speichern Sie Ihre erste benutzerdefinierte Farbpalette, um Ihre Farben bei der Erstellung einer Visualisierung einfach auszuwählen."
+msgstr "Speichern Sie eine benutzerdefinierte Farbpalette, damit Sie Farben für Ihre Visualisierungen einfach auswählen können."
 
 #: app/login/components/color-palettes/profile-color-palette-content.tsx
 msgid "login.profile.my-color-palettes.edit"
@@ -1704,13 +1716,13 @@ msgstr "Farbplatte editieren"
 #: app/login/components/profile-content-tabs.tsx
 #: app/login/components/profile-content-tabs.tsx
 msgid "login.profile.my-drafts"
-msgstr "Entwürfe"
+msgstr "Meine Entwürfe"
 
 #: app/login/components/profile-content-tabs.tsx
 #: app/login/components/profile-content-tabs.tsx
 #: app/login/components/profile-content-tabs.tsx
 msgid "login.profile.my-published-visualizations"
-msgstr "Veröffentlichte Visualisierungen"
+msgstr "Meine Visualisierungen"
 
 #: app/login/components/login-menu.tsx
 msgid "login.profile.my-visualizations"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -561,7 +561,7 @@ msgstr "Open Color Picker"
 
 #: app/configurator/components/chart-controls/color-picker.tsx
 msgid "controls.colorpicker.remove"
-msgstr "Remove Color"
+msgstr "Remove color"
 
 #: app/configurator/components/field-i18n.ts
 msgid "controls.column.grouped"
@@ -580,11 +580,11 @@ msgstr "Custom color palettes"
 #: app/login/components/color-palettes/color-palette-types.tsx
 #: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.add-color"
-msgstr "Add Color"
+msgstr "Add color"
 
 #: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.base"
-msgstr "Base Color"
+msgstr "Base color"
 
 #: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
@@ -593,14 +593,13 @@ msgstr "Use distinct, high-contrast colors. Avoid using too many colors, maximum
 
 #: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
-msgid "controls.custom-color-palettes.caption-sequential"
-msgstr "Select a dark endpoint color for a strong contrast between low and high values; the light color is calculated automatically. Sequential color palettes are suitable for ordered data such as temperatures or population densities."
-
-#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
-#: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.caption-diverging"
 msgstr "Choose contrasting colors for the start and end points. These colors will help visually separate extreme values. Diverging palettes are ideal for data with a meaningful midpoint, such as zero or an average."
 
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
+#: app/login/components/color-palettes/profile-color-palette-form.tsx
+msgid "controls.custom-color-palettes.caption-sequential"
+msgstr "Select a dark endpoint color for a strong contrast between low and high values; the light color is calculated automatically. Sequential color palettes are suitable for ordered data such as temperatures or population densities."
 
 #: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.categorical-contrast-warning"
@@ -616,7 +615,7 @@ msgstr "The selected color lacks sufficient contrast. Consider using a darker co
 
 #: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.end"
-msgstr "Ending Color"
+msgstr "Ending color"
 
 #: app/login/components/color-palettes/color-palette-examples.tsx
 msgid "controls.custom-color-palettes.example"
@@ -636,7 +635,7 @@ msgstr "Save color palette"
 
 #: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.start"
-msgstr "Starting Color"
+msgstr "Starting color"
 
 #: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
@@ -1009,6 +1008,18 @@ msgstr "Title & Description"
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.section.dots-size"
 msgstr "Select a Size"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.section.dots-size.large"
+msgstr "Large"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.section.dots-size.medium"
+msgstr "Medium"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.section.dots-size.small"
+msgstr "Small"
 
 #: app/configurator/components/chart-options-selector.tsx
 #: app/configurator/components/chart-options-selector.tsx
@@ -1677,7 +1688,7 @@ msgstr "Home"
 #: app/login/components/profile-content-tabs.tsx
 #: app/login/components/profile-content-tabs.tsx
 msgid "login.profile.my-color-palettes"
-msgstr "My Color Palettes"
+msgstr "My color palettes"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
@@ -1691,15 +1702,15 @@ msgstr "My palette"
 
 #: app/login/components/color-palettes/profile-color-palette-content.tsx
 msgid "login.profile.my-color-palettes.delete"
-msgstr "login.profile.my-color-palettes.delete"
+msgstr "Delete color palette"
 
 #: app/login/components/color-palettes/profile-color-palette-content.tsx
 msgid "login.profile.my-color-palettes.description"
-msgstr "Save your first custom color palette to easily choose your colors while creating a visualization."
+msgstr "Save a custom color palette to easily choose your colors while creating a visualization."
 
 #: app/login/components/color-palettes/profile-color-palette-content.tsx
 msgid "login.profile.my-color-palettes.edit"
-msgstr "login.profile.my-color-palettes.edit"
+msgstr "Edit color palette"
 
 #: app/login/components/profile-content-tabs.tsx
 #: app/login/components/profile-content-tabs.tsx

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -509,7 +509,7 @@ msgstr "Couleurs"
 
 #: app/configurator/components/chart-controls/color-ramp.tsx
 msgid "controls.color.palette.diverging"
-msgstr "Divergent"
+msgstr "Divergente"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 msgid "controls.color.palette.reset"
@@ -517,7 +517,7 @@ msgstr "Réinitialiser la palette de couleurs"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 msgid "controls.color.palette.select"
-msgstr "choisir une palette de couleurs"
+msgstr "Choisir une palette de couleurs"
 
 #: app/configurator/components/chart-controls/color-ramp.tsx
 msgid "controls.color.palette.sequential"
@@ -593,18 +593,17 @@ msgstr "Utilisez des couleurs distinctes et contrastées. Évitez d'utiliser tro
 
 #: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
-msgid "controls.custom-color-palettes.caption-sequential"
-msgstr "Sélectionnez une couleur d'extrémité foncée pour obtenir un fort contraste entre les valeurs faibles et élevées ; la couleur claire est calculée automatiquement. Les palettes de couleurs séquentielles conviennent aux données ordonnées telles que les températures ou les densités de population."
-
-#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
-#: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.caption-diverging"
 msgstr "Choisissez des couleurs contrastées pour les points de départ et d'arrivée. Ces couleurs permettent de distinguer visuellement les valeurs extrêmes. Les palettes divergentes sont idéales pour les données comportant un point médian significatif, tel que zéro ou une moyenne. IT Scegliere colori contrastanti per i punti iniziali e finali. Questi colori facilitano la distinzione visiva dei valori estremi. Le palette divergenti sono ideali per dati con un punto medio significativo, come zero o un valore medio."
 
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
+#: app/login/components/color-palettes/profile-color-palette-form.tsx
+msgid "controls.custom-color-palettes.caption-sequential"
+msgstr "Sélectionnez une couleur d'extrémité foncée pour obtenir un fort contraste entre les valeurs faibles et élevées ; la couleur claire est calculée automatiquement. Les palettes de couleurs séquentielles conviennent aux données ordonnées telles que les températures ou les densités de population."
 
 #: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.categorical-contrast-warning"
-msgstr "La couleur sélectionnée est difficile à lire sur un fond blanc. Choisissez une couleur plus contrastée pour améliorer l'accessibilité."
+msgstr "La couleur choisie est difficile à lire sur fond blanc. Choisissez une couleur avec plus de contraste pour améliorer l'accessibilité."
 
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.create-palette"
@@ -612,7 +611,7 @@ msgstr "Créer une palette de couleurs"
 
 #: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.diverging-contrast-warning"
-msgstr "La couleur sélectionnée n'est pas suffisamment contrastée. Envisagez d'utiliser une couleur plus foncée pour obtenir une palette divergente."
+msgstr "La couleur choisie n'a pas un contraste suffisant. Utilisez une couleur plus foncée pour créer une palette divergente."
 
 #: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.end"
@@ -628,7 +627,7 @@ msgstr "Couleur moyenne"
 
 #: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.sequential-contrast-warning"
-msgstr "La couleur sélectionnée n'est pas suffisamment contrastée. Envisagez d'utiliser une couleur plus foncée pour une palette séquentielle."
+msgstr "La couleur sélectionnée n'offre pas assez de contraste. Veuillez choisir une couleur plus sombre pour la palette séquentielle."
 
 #: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes.set-values-apply"
@@ -1009,6 +1008,18 @@ msgstr "Titre & description"
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.section.dots-size"
 msgstr "Sélectionner une taille"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.section.dots-size.large"
+msgstr "Grand"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.section.dots-size.medium"
+msgstr "Moyen"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.section.dots-size.small"
+msgstr "Petit"
 
 #: app/configurator/components/chart-options-selector.tsx
 #: app/configurator/components/chart-options-selector.tsx
@@ -1695,7 +1706,7 @@ msgstr "Supprimer la palette de couleurs"
 
 #: app/login/components/color-palettes/profile-color-palette-content.tsx
 msgid "login.profile.my-color-palettes.description"
-msgstr "Enregistrez votre première palette de couleurs personnalisée pour choisir facilement vos couleurs lors de la création d'une visualisation."
+msgstr "Enregistrez une palette de couleurs personnalisée pour sélectionner facilement les couleurs de vos visualisations."
 
 #: app/login/components/color-palettes/profile-color-palette-content.tsx
 msgid "login.profile.my-color-palettes.edit"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -517,7 +517,7 @@ msgstr "Ripristina la tavolozza dei colori"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 msgid "controls.color.palette.select"
-msgstr "selezionare una tavolozza di colori"
+msgstr "Selezionare una tavolozza di colori"
 
 #: app/configurator/components/chart-controls/color-ramp.tsx
 msgid "controls.color.palette.sequential"
@@ -593,14 +593,13 @@ msgstr "Utilizzare colori distinti e ad alto contrasto. Evitare di usare troppi 
 
 #: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
-msgid "controls.custom-color-palettes.caption-sequential"
-msgstr "Per ottenere un forte contrasto tra valori bassi e alti, è possibile selezionare un colore scuro per l'endpoint; il colore chiaro viene calcolato automaticamente. Le tavolozze di colori sequenziali sono adatte per dati ordinati come le temperature o le densità di popolazione."
-
-#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
-#: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.caption-diverging"
 msgstr "Scegliere colori contrastanti per i punti iniziali e finali. Questi colori facilitano la distinzione visiva dei valori estremi. Le palette divergenti sono ideali per dati con un punto medio significativo, come zero o un valore medio."
 
+#: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
+#: app/login/components/color-palettes/profile-color-palette-form.tsx
+msgid "controls.custom-color-palettes.caption-sequential"
+msgstr "Per ottenere un forte contrasto tra valori bassi e alti, è possibile selezionare un colore scuro per l'endpoint; il colore chiaro viene calcolato automaticamente. Le tavolozze di colori sequenziali sono adatte per dati ordinati come le temperature o le densità di popolazione."
 
 #: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.categorical-contrast-warning"
@@ -612,7 +611,7 @@ msgstr "Creare una tavolozza di colori"
 
 #: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.diverging-contrast-warning"
-msgstr "Il colore selezionato non ha un contrasto sufficiente. Considerare l'uso di un colore più scuro per una tavolozza divergente."
+msgstr "Il colore selezionato ha un contrasto insufficiente. Utilizzare un colore più scuro per creare una tavolozza divergente."
 
 #: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.end"
@@ -628,7 +627,7 @@ msgstr "Colore medio"
 
 #: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.sequential-contrast-warning"
-msgstr "Il colore selezionato non ha un contrasto sufficiente. Considerare l'utilizzo di un colore più scuro per una tavolozza sequenziale."
+msgstr "Il colore selezionato non ha un contrasto sufficiente. Si consiglia di scegliere un colore più scuro per la tavolozza sequenziale."
 
 #: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 msgid "controls.custom-color-palettes.set-values-apply"
@@ -1009,6 +1008,18 @@ msgstr "Titolo e descrizione"
 #: app/configurator/components/chart-options-selector.tsx
 msgid "controls.section.dots-size"
 msgstr "Selezionare una taglia"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.section.dots-size.large"
+msgstr "Grande"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.section.dots-size.medium"
+msgstr "Medio"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.section.dots-size.small"
+msgstr "Piccolo"
 
 #: app/configurator/components/chart-options-selector.tsx
 #: app/configurator/components/chart-options-selector.tsx
@@ -1695,7 +1706,7 @@ msgstr "Cancellare il colore Paleete"
 
 #: app/login/components/color-palettes/profile-color-palette-content.tsx
 msgid "login.profile.my-color-palettes.description"
-msgstr "Salvare la prima tavolozza di colori personalizzata per scegliere facilmente i colori durante la creazione di una visualizzazione."
+msgstr "Salvate una tavolozza di colori personalizzata per selezionare facilmente i colori delle vostre visualizzazioni."
 
 #: app/login/components/color-palettes/profile-color-palette-content.tsx
 msgid "login.profile.my-color-palettes.edit"

--- a/app/login/components/color-palettes/profile-color-palette-form.tsx
+++ b/app/login/components/color-palettes/profile-color-palette-form.tsx
@@ -167,6 +167,24 @@ const ProfileColorPaletteForm = ({
       (color, index) => color === colorValues[index].color
     );
 
+  const captions: Record<CustomPaletteType["type"], string> = {
+    sequential: t({
+      id: "controls.custom-color-palettes.caption-sequential",
+      message:
+        "Select a dark endpoint color for a strong contrast between low and high values; the light color is calculated automatically. Sequential color palettes are suitable for ordered data such as temperatures or population densities.",
+    }),
+    diverging: t({
+      id: "controls.custom-color-palettes.caption-diverging",
+      message:
+        "Choose contrasting colors for the start and end points. These colors will help visually separate extreme values. Diverging palettes are ideal for data with a meaningful midpoint, such as zero or an average.",
+    }),
+    categorical: t({
+      id: "controls.custom-color-palettes.caption-categorical",
+      message:
+        "Use distinct, high-contrast colors. Avoid using too many colors, maximum 5–7. Apply sequential palettes for ordered data and diverging palettes for extremes.",
+    }),
+  };
+
   return (
     <Flex flexDirection="column" gap="30px">
       <BackButton className={classes.backButton} onClick={onBack}>
@@ -185,11 +203,7 @@ const ProfileColorPaletteForm = ({
           selectedType={type}
         />
         <Typography variant="body2" color="textSecondary">
-          <Trans id={`controls.custom-color-palettes.caption-${type}`}>
-            Use distinct, high-contrast colors. Avoid using too many colors,
-            maximum 5–7. Apply sequential palettes for ordered data and
-            diverging palettes for extremes.
-          </Trans>
+          {captions[type]}
         </Typography>
 
         <Box className={classes.inputContainer}>


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2070

<!--- Describe the changes -->

This PR refactors show line dots component out of main encodings panel and adds translations for circle sizes.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-add-size-translations-ixt1.vercel.app/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10&dataSource=Prod).
2. Switch to a line chart.
3. Open Vertical Axis panel.
4. ✅ See that dot sizes are translated.

<!--- Reproduction steps, in case of a bug -->

---

- [x] Add a CHANGELOG entry
