### PR TITLE
fix: removed tooltip on toggle switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ You can also check the
   - Fixed errors regarding switching form existing categorical palette to a
     diverging color palette
   - Improved filter section styling
+  - Removed legend titles tooltip on the toggle switch
 - Maintenance
   - Added authentication method to e2e tests
   - Added authentication to Vercel previews for easier testing

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -401,24 +401,9 @@ const MultiFilterContent = ({
                   componentsProps={{ typography: { variant: "body2" } }}
                   control={<Switch {...visibleLegendProps} />}
                   label={
-                    <MaybeTooltip
-                      tooltipProps={{ enterDelay: 600 }}
-                      title={
-                        <TooltipTitle
-                          text={
-                            <Trans id="controls.filters.show-legend-toggle">
-                              Allow users to change Legend visibility
-                            </Trans>
-                          }
-                        />
-                      }
-                    >
-                      <div>
-                        <Trans id="controls.filters.show-legend.toggle">
-                          Show legend titles
-                        </Trans>
-                      </div>
-                    </MaybeTooltip>
+                    <Trans id="controls.filters.show-legend.toggle">
+                      Show legend titles
+                    </Trans>
                   }
                 />
               </Flex>


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

<!--- Describe the changes -->

**What changes?**
This PR removes the tooltip on the legend titles toggle switch, based on the request by @KerstinFaye 

<!--- Test instructions -->

## How to test

1. Go to this [link](https://visualization-tool-git-fix-remove-legend-titles-tooltip-ixt1.vercel.app/) 
2. Create Chart 
3. Add Segmenations
4. Scroll down to the Show titles toggle switch 
5. Hover over it 
6. See how there is no tooltip showing up ✅

<!--- Reproduction steps, in case of a bug -->


## How to reproduce 
1. Go to this [link](https://test.visualize.admin.ch) 
2. Create Chart 
3. Add Segmenations
4. Scroll down to the Show titles toggle switch 
5. Hover over it 
6. See how there is a tooltip showing up ❌

---

- [x] Add a CHANGELOG entry
