### PR TITLE
Create optimal Iframe view for ODS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ You can also check the
   - Added option for hiding legend titles using a toggle switch
   - Bar charts, dashboard text blocks and Markdown inputs are not hidden behind
     flags anymore
+  - Added improved Iframe view for the use of ODS
 - Fixes
   - Added button translations for custom color palette update and create button
   - Color swatches inside the color picker dynamically adjust to the colors of

--- a/app/browser/dataset-preview.tsx
+++ b/app/browser/dataset-preview.tsx
@@ -1,3 +1,5 @@
+import { ParsedUrlQuery } from "querystring";
+
 import { Trans } from "@lingui/macro";
 import { Box, Button, Paper, Theme, Typography } from "@mui/material";
 import { makeStyles } from "@mui/styles";
@@ -7,6 +9,7 @@ import { useRouter } from "next/router";
 import React, { useCallback, useEffect } from "react";
 
 import { DataSetPreviewTable } from "@/browse/datatable";
+import { CHART_RESIZE_EVENT_TYPE } from "@/charts/shared/use-size";
 import { useFootnotesStyles } from "@/components/chart-footnotes";
 import { DataDownloadMenu } from "@/components/data-download";
 import Flex from "@/components/flex";
@@ -19,8 +22,11 @@ import {
 } from "@/graphql/query-hooks";
 import { DataCubePublicationStatus } from "@/graphql/resolver-types";
 import { useLocale } from "@/locales/use-locale";
-import { CHART_RESIZE_EVENT_TYPE } from "@/charts/shared/use-size";
 import { useResizeObserver } from "@/utils/use-resize-observer";
+
+export const isOdsIframe = (query: ParsedUrlQuery) => {
+  return query["odsiframe"] === "true";
+};
 
 const useStyles = makeStyles<Theme, { descriptionPresent: boolean }>(
   (theme) => ({
@@ -149,8 +155,6 @@ export const DataSetPreview = ({
     const { dataCubeMetadata } = metadata;
     const { dataCubePreview } = previewData;
 
-    const isOdsIframe = router.query["odsiframe"] === "true";
-
     return (
       <Flex ref={ref} className={classes.root}>
         {dataCubeMetadata.publicationStatus ===
@@ -179,8 +183,9 @@ export const DataSetPreview = ({
               onClick={(ev) => onCreateChartFromDataset?.(ev, dataSetIri)}
               className={classes.createChartButton}
               component="a"
+              target={isOdsIframe(router.query) ? "_top" : undefined}
             >
-              {!isOdsIframe ? (
+              {!isOdsIframe(router.query) ? (
                 <Trans id="browse.dataset.create-visualization">
                   Create visualization from dataset
                 </Trans>
@@ -197,9 +202,10 @@ export const DataSetPreview = ({
               }&dataSource=${sourceToLabel(dataSource)}`}
               passHref
               legacyBehavior
+              target={isOdsIframe(router.query) ? "_top" : undefined}
             >
               <Button className={classes.createChartButton} component="a">
-                {!isOdsIframe ? (
+                {!isOdsIframe(router.query) ? (
                   <Trans id="browse.dataset.create-visualization">
                     Create visualization from dataset
                   </Trans>
@@ -232,7 +238,7 @@ export const DataSetPreview = ({
           </Flex>
           <Flex className={classes.footnotesWrapper}>
             <Flex className={footnotesClasses.actions}>
-              {!isOdsIframe && (
+              {!isOdsIframe(router.query) && (
                 <DataDownloadMenu
                   dataSource={dataSource}
                   title={dataCubeMetadata.title}

--- a/app/browser/dataset-preview.tsx
+++ b/app/browser/dataset-preview.tsx
@@ -6,10 +6,9 @@ import { makeStyles } from "@mui/styles";
 import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import React, { useCallback, useEffect } from "react";
+import React, { useEffect } from "react";
 
 import { DataSetPreviewTable } from "@/browse/datatable";
-import { CHART_RESIZE_EVENT_TYPE } from "@/charts/shared/use-size";
 import { useFootnotesStyles } from "@/components/chart-footnotes";
 import { DataDownloadMenu } from "@/components/data-download";
 import Flex from "@/components/flex";
@@ -22,7 +21,6 @@ import {
 } from "@/graphql/query-hooks";
 import { DataCubePublicationStatus } from "@/graphql/resolver-types";
 import { useLocale } from "@/locales/use-locale";
-import { useResizeObserver } from "@/utils/use-resize-observer";
 
 export const isOdsIframe = (query: ParsedUrlQuery) => {
   return query["odsiframe"] === "true";
@@ -137,14 +135,6 @@ export const DataSetPreview = ({
     window.scrollTo({ top: 0 });
   }, []);
 
-  const handleHeightChange = useCallback(
-    ({ height }: { width: number; height: number }) => {
-      window.parent.postMessage({ type: CHART_RESIZE_EVENT_TYPE, height }, "*");
-    },
-    []
-  );
-  const [ref] = useResizeObserver(handleHeightChange);
-
   if (fetchingMetadata || fetchingPreview) {
     return (
       <Flex className={classes.loadingWrapper}>
@@ -156,7 +146,7 @@ export const DataSetPreview = ({
     const { dataCubePreview } = previewData;
 
     return (
-      <Flex ref={ref} className={classes.root}>
+      <Flex className={classes.root}>
         {dataCubeMetadata.publicationStatus ===
           DataCubePublicationStatus.Draft && (
           <Box sx={{ mb: 4 }}>

--- a/app/browser/dataset-preview.tsx
+++ b/app/browser/dataset-preview.tsx
@@ -173,7 +173,7 @@ export const DataSetPreview = ({
               onClick={(ev) => onCreateChartFromDataset?.(ev, dataSetIri)}
               className={classes.createChartButton}
               component="a"
-              target={isOdsIframe(router.query) ? "_top" : undefined}
+              target={isOdsIframe(router.query) ? "_blank" : undefined}
             >
               {!isOdsIframe(router.query) ? (
                 <Trans id="browse.dataset.create-visualization">
@@ -191,8 +191,8 @@ export const DataSetPreview = ({
                 dataCubeMetadata.iri
               }&dataSource=${sourceToLabel(dataSource)}`}
               passHref
-              legacyBehavior
-              target={isOdsIframe(router.query) ? "_top" : undefined}
+              legacyBehavior={!isOdsIframe(router.query)}
+              target={isOdsIframe(router.query) ? "_blank" : undefined}
             >
               <Button className={classes.createChartButton} component="a">
                 {!isOdsIframe(router.query) ? (

--- a/app/browser/select-dataset-step.tsx
+++ b/app/browser/select-dataset-step.tsx
@@ -71,7 +71,7 @@ const useStyles = makeStyles<
   }
 >((theme) => ({
   panelLayout: {
-    maxWidth: 1400,
+    maxWidth: ({ isOdsIframe }) => (isOdsIframe ? "auto" : 1400),
     margin: "auto",
     position: "static",
     marginTop: ({ datasetPresent, variant, isOdsIframe }) =>
@@ -509,7 +509,7 @@ const SelectDatasetStepContent = ({
           </AnimatePresence>
         </PanelBodyWrapper>
       </PanelLayout>
-      {variant == "page" ? (
+      {variant == "page" && !isOdsIframe ? (
         <Box
           sx={{
             borderTop: "2px solid rgba(0,0,0,0.05)",

--- a/app/browser/select-dataset-step.tsx
+++ b/app/browser/select-dataset-step.tsx
@@ -7,7 +7,7 @@ import uniqBy from "lodash/uniqBy";
 import Head from "next/head";
 import NextLink from "next/link";
 import { Router, useRouter } from "next/router";
-import React, { useMemo } from "react";
+import React, { useCallback, useMemo } from "react";
 import { useDebounce } from "use-debounce";
 
 import {
@@ -28,6 +28,7 @@ import {
   isOdsIframe,
 } from "@/browser/dataset-preview";
 import { BrowseFilter, DataCubeAbout } from "@/browser/filters";
+import { CHART_RESIZE_EVENT_TYPE } from "@/charts/shared/use-size";
 import { DatasetMetadata } from "@/components/dataset-metadata";
 import Flex from "@/components/flex";
 import { Footer } from "@/components/footer";
@@ -57,6 +58,7 @@ import {
 } from "@/graphql/query-hooks";
 import { Icon } from "@/icons";
 import { useConfiguratorState, useLocale } from "@/src";
+import { useResizeObserver } from "@/utils/use-resize-observer";
 
 const softJSONParse = (v: string) => {
   try {
@@ -202,6 +204,13 @@ const SelectDatasetStepContent = ({
     leading: true,
   });
   const router = useRouter();
+  const handleHeightChange = useCallback(
+    ({ height }: { width: number; height: number }) => {
+      window.parent.postMessage({ type: CHART_RESIZE_EVENT_TYPE, height }, "*");
+    },
+    []
+  );
+  const [ref] = useResizeObserver(handleHeightChange);
 
   const classes = useStyles({
     datasetPresent: !!dataset,
@@ -336,7 +345,7 @@ const SelectDatasetStepContent = ({
   }
 
   return (
-    <Box>
+    <Box ref={ref}>
       <AnimatePresence>
         {!dataset && variant === "page" && (
           <MotionBox key="banner" {...bannerPresenceProps}>

--- a/app/browser/select-dataset-step.tsx
+++ b/app/browser/select-dataset-step.tsx
@@ -22,7 +22,11 @@ import {
   SearchDatasetInput,
   SearchFilters,
 } from "@/browser/dataset-browse";
-import { DataSetPreview, DataSetPreviewProps } from "@/browser/dataset-preview";
+import {
+  DataSetPreview,
+  DataSetPreviewProps,
+  isOdsIframe,
+} from "@/browser/dataset-preview";
 import { BrowseFilter, DataCubeAbout } from "@/browser/filters";
 import { DatasetMetadata } from "@/components/dataset-metadata";
 import Flex from "@/components/flex";
@@ -198,12 +202,11 @@ const SelectDatasetStepContent = ({
     leading: true,
   });
   const router = useRouter();
-  const isOdsIframe = router.query["odsiframe"] === "true";
 
   const classes = useStyles({
     datasetPresent: !!dataset,
     variant,
-    isOdsIframe,
+    isOdsIframe: isOdsIframe(router.query),
   });
   const backLink = useMemo(() => {
     return formatBackLink(router.query);
@@ -367,11 +370,11 @@ const SelectDatasetStepContent = ({
         )}
       </AnimatePresence>
       <PanelLayout
-        type={isOdsIframe ? "M" : "LM"}
+        type={isOdsIframe(router.query) ? "M" : "LM"}
         className={classes.panelLayout}
         key="panel"
       >
-        {!isOdsIframe && (
+        {!isOdsIframe(router.query) && (
           <PanelBodyWrapper type="L" className={classes.panelLeft}>
             <AnimatePresence mode="wait">
               {dataset ? (
@@ -416,7 +419,7 @@ const SelectDatasetStepContent = ({
         <PanelBodyWrapper
           type={"M"}
           className={classes.panelMiddle}
-          sx={isOdsIframe ? { p: 6 } : { maxWidth: 1040, p: 6 }}
+          sx={isOdsIframe(router.query) ? { p: 6 } : { maxWidth: 1040, p: 6 }}
         >
           <AnimatePresence mode="wait">
             {dataset ? (
@@ -509,7 +512,7 @@ const SelectDatasetStepContent = ({
           </AnimatePresence>
         </PanelBodyWrapper>
       </PanelLayout>
-      {variant == "page" && !isOdsIframe ? (
+      {variant == "page" && !isOdsIframe(router.query) ? (
         <Box
           sx={{
             borderTop: "2px solid rgba(0,0,0,0.05)",

--- a/app/browser/select-dataset-step.tsx
+++ b/app/browser/select-dataset-step.tsx
@@ -67,14 +67,17 @@ const useStyles = makeStyles<
   {
     datasetPresent: boolean;
     variant: NonNullable<SelectDatasetStepContentProps["variant"]>;
+    isOdsIframe: boolean;
   }
 >((theme) => ({
   panelLayout: {
     maxWidth: 1400,
     margin: "auto",
     position: "static",
-    marginTop: ({ datasetPresent, variant }) =>
-      datasetPresent && variant !== "drawer" ? BANNER_MARGIN_TOP : 0,
+    marginTop: ({ datasetPresent, variant, isOdsIframe }) =>
+      datasetPresent && variant !== "drawer" && !isOdsIframe
+        ? BANNER_MARGIN_TOP
+        : 0,
     height: "auto",
     transition: "margin-top 0.5s ease",
   },
@@ -195,7 +198,13 @@ const SelectDatasetStepContent = ({
     leading: true,
   });
   const router = useRouter();
-  const classes = useStyles({ datasetPresent: !!dataset, variant });
+  const isOdsIframe = router.query["odsiframe"] === "true";
+
+  const classes = useStyles({
+    datasetPresent: !!dataset,
+    variant,
+    isOdsIframe,
+  });
   const backLink = useMemo(() => {
     return formatBackLink(router.query);
   }, [router.query]);
@@ -357,51 +366,57 @@ const SelectDatasetStepContent = ({
           </MotionBox>
         )}
       </AnimatePresence>
-      <PanelLayout type="LM" className={classes.panelLayout} key="panel">
-        <PanelBodyWrapper type="L" className={classes.panelLeft}>
-          <AnimatePresence mode="wait">
-            {dataset ? (
-              <MotionBox
-                key="metadata"
-                sx={{ mx: 4, px: 4 }}
-                {...navPresenceProps}
-              >
-                <NextLink href={backLink} passHref legacyBehavior>
-                  <Button
-                    variant="contained"
-                    color="secondary"
-                    startIcon={<Icon name="chevronLeft" size={12} />}
-                    onClick={onClickBackLink}
-                  >
-                    <Trans id="dataset-preview.back-to-results">
-                      Back to the list
-                    </Trans>
-                  </Button>
-                </NextLink>
-                <MotionBox sx={{ mt: 6 }} {...smoothPresenceProps}>
-                  <DatasetMetadataSingleCubeAdapter
-                    datasetIri={dataset}
-                    dataSource={configState.dataSource}
+      <PanelLayout
+        type={isOdsIframe ? "M" : "LM"}
+        className={classes.panelLayout}
+        key="panel"
+      >
+        {!isOdsIframe && (
+          <PanelBodyWrapper type="L" className={classes.panelLeft}>
+            <AnimatePresence mode="wait">
+              {dataset ? (
+                <MotionBox
+                  key="metadata"
+                  sx={{ mx: 4, px: 4 }}
+                  {...navPresenceProps}
+                >
+                  <NextLink href={backLink} passHref legacyBehavior>
+                    <Button
+                      variant="contained"
+                      color="secondary"
+                      startIcon={<Icon name="chevronLeft" size={12} />}
+                      onClick={onClickBackLink}
+                    >
+                      <Trans id="dataset-preview.back-to-results">
+                        Back to the list
+                      </Trans>
+                    </Button>
+                  </NextLink>
+                  <MotionBox sx={{ mt: 6 }} {...smoothPresenceProps}>
+                    <DatasetMetadataSingleCubeAdapter
+                      datasetIri={dataset}
+                      dataSource={configState.dataSource}
+                    />
+                  </MotionBox>
+                </MotionBox>
+              ) : (
+                <MotionBox key="search-filters" {...navPresenceProps}>
+                  <SearchFilters
+                    cubes={allCubes}
+                    themes={themes}
+                    orgs={orgs}
+                    termsets={termsets}
+                    disableNavLinks
                   />
                 </MotionBox>
-              </MotionBox>
-            ) : (
-              <MotionBox key="search-filters" {...navPresenceProps}>
-                <SearchFilters
-                  cubes={allCubes}
-                  themes={themes}
-                  orgs={orgs}
-                  termsets={termsets}
-                  disableNavLinks
-                />
-              </MotionBox>
-            )}
-          </AnimatePresence>
-        </PanelBodyWrapper>
+              )}
+            </AnimatePresence>
+          </PanelBodyWrapper>
+        )}
         <PanelBodyWrapper
-          type="M"
+          type={"M"}
           className={classes.panelMiddle}
-          sx={{ maxWidth: 1040, p: 6 }}
+          sx={isOdsIframe ? { p: 6 } : { maxWidth: 1040, p: 6 }}
         >
           <AnimatePresence mode="wait">
             {dataset ? (

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -55,9 +55,10 @@ export const Header = ({
 }) => {
   const router = useRouter();
   const isConfiguring = router.pathname === "/create/[chartId]";
+  const isOdsIframe = router.query["odsiframe"] === "true";
   const classes = useHeaderStyles({ isConfiguring });
 
-  return (
+  return !isOdsIframe ? (
     <Box
       className={pageType === "app" ? classes.wrapper : undefined}
       sx={{ backgroundColor: "background.paper" }}
@@ -76,7 +77,7 @@ export const Header = ({
       </Flex>
       <HeaderBorder />
     </Box>
-  );
+  ) : null;
 };
 
 const MetadataMenu = ({ contentId }: { contentId?: string }) => {

--- a/app/components/layout.tsx
+++ b/app/components/layout.tsx
@@ -4,9 +4,15 @@ import Flex from "@/components/flex";
 import { Footer } from "@/components/footer";
 import { Header } from "@/components/header";
 
-export const AppLayout = ({ children }: { children?: ReactNode }) => (
+export const AppLayout = ({
+  children,
+  isOdsIframe,
+}: {
+  children?: ReactNode;
+  isOdsIframe?: boolean;
+}) => (
   <Flex sx={{ minHeight: "100vh", flexDirection: "column" }}>
-    <Header pageType="app" contentId={undefined} />
+    {!isOdsIframe && <Header pageType="app" contentId={undefined} />}
     <Flex
       component="main"
       role="main"

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -80,6 +80,11 @@ msgstr "Datensatz suchen"
 msgid "browse.dataset.create-visualization"
 msgstr "Visualisierung von diesem Datensatz erstellen"
 
+#: app/browser/dataset-preview.tsx
+#: app/browser/dataset-preview.tsx
+msgid "browse.dataset.create-visualization-visualize"
+msgstr "Visualierung auf Visualize mit diesen Datensatz erstellen"
+
 #: app/browser/select-dataset-step.tsx
 msgid "browse.datasets.description"
 msgstr "Erkunden Sie die vom LINDAS Linked Data Service bereitgestellten Datensätze, indem Sie entweder nach Kategorien oder Organisationen filtern oder direkt nach bestimmten Stichworten suchen. Klicken Sie auf einen Datensatz, um detailliertere Informationen zu erhalten und Ihre eigenen Visualisierungen zu erstellen."

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -83,7 +83,7 @@ msgstr "Visualisierung von diesem Datensatz erstellen"
 #: app/browser/dataset-preview.tsx
 #: app/browser/dataset-preview.tsx
 msgid "browse.dataset.create-visualization-visualize"
-msgstr "Visualierung auf Visualize mit diesen Datensatz erstellen"
+msgstr "Visualierung erstellen"
 
 #: app/browser/select-dataset-step.tsx
 msgid "browse.datasets.description"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -80,6 +80,11 @@ msgstr "Browse all datasets"
 msgid "browse.dataset.create-visualization"
 msgstr "Start a visualization"
 
+#: app/browser/dataset-preview.tsx
+#: app/browser/dataset-preview.tsx
+msgid "browse.dataset.create-visualization-visualize"
+msgstr "Create visualization on visualize from this dataset"
+
 #: app/browser/select-dataset-step.tsx
 msgid "browse.datasets.description"
 msgstr "Explore datasets provided by the LINDAS Linked Data Service by either filtering by categories or organizations or search directly for specific keywords. Click on a dataset to see more detailed information and start creating your own visualizations."

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -83,7 +83,7 @@ msgstr "Start a visualization"
 #: app/browser/dataset-preview.tsx
 #: app/browser/dataset-preview.tsx
 msgid "browse.dataset.create-visualization-visualize"
-msgstr "Create visualization on visualize from this dataset"
+msgstr "Create a visualization"
 
 #: app/browser/select-dataset-step.tsx
 msgid "browse.datasets.description"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -80,6 +80,11 @@ msgstr "Parcourir tous les ensembles de données"
 msgid "browse.dataset.create-visualization"
 msgstr "Démarrer une visualisation"
 
+#: app/browser/dataset-preview.tsx
+#: app/browser/dataset-preview.tsx
+msgid "browse.dataset.create-visualization-visualize"
+msgstr "Créer une visualisation sur Visualize avec cet ensemble de données"
+
 #: app/browser/select-dataset-step.tsx
 msgid "browse.datasets.description"
 msgstr "Explorez les jeux de données liés fournis par LINDAS, en filtrant par catégories ou organisations, ou en recherchant par mots-clés. Cliquez sur un ensemble de données pour afficher des informations plus détaillées et commencer à créer vos propres visualisations. "

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -83,7 +83,7 @@ msgstr "Démarrer une visualisation"
 #: app/browser/dataset-preview.tsx
 #: app/browser/dataset-preview.tsx
 msgid "browse.dataset.create-visualization-visualize"
-msgstr "Créer une visualisation sur Visualize avec cet ensemble de données"
+msgstr "Créer une visualisation"
 
 #: app/browser/select-dataset-step.tsx
 msgid "browse.datasets.description"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -80,6 +80,11 @@ msgstr "Sfoglia tutti i set di dati"
 msgid "browse.dataset.create-visualization"
 msgstr "Iniziare una visualizzazione"
 
+#: app/browser/dataset-preview.tsx
+#: app/browser/dataset-preview.tsx
+msgid "browse.dataset.create-visualization-visualize"
+msgstr "Creare una visualizzazione su Visualize con questo set di dati"
+
 #: app/browser/select-dataset-step.tsx
 msgid "browse.datasets.description"
 msgstr "Esplora i set di dati forniti dal LINDAS Linked Data Service filtrando per categorie o organizzazioni oppure cercando direttamente per parole chiave specifiche. Clicca su un set di dati per vedere informazioni più dettagliate e iniziare a creare le tue visualizzazioni."

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -83,7 +83,7 @@ msgstr "Iniziare una visualizzazione"
 #: app/browser/dataset-preview.tsx
 #: app/browser/dataset-preview.tsx
 msgid "browse.dataset.create-visualization-visualize"
-msgstr "Creare una visualizzazione su Visualize con questo set di dati"
+msgstr "Creare una visualizzazione"
 
 #: app/browser/select-dataset-step.tsx
 msgid "browse.datasets.description"

--- a/app/pages/browse/index.tsx
+++ b/app/pages/browse/index.tsx
@@ -1,3 +1,5 @@
+import { GetServerSideProps } from "next";
+
 import { SelectDatasetStep } from "@/browser/select-dataset-step";
 import { AppLayout } from "@/components/layout";
 import { ConfiguratorStateProvider } from "@/configurator/configurator-state";
@@ -15,11 +17,20 @@ export type BrowseParams = {
   order?: SearchCubeResultOrder;
   includeDrafts?: boolean;
   dataset?: string;
+  odsiframe?: string;
 };
 
-export function DatasetBrowser() {
+export const getServerSideProps: GetServerSideProps = async ({ query }) => {
+  return {
+    props: {
+      odsiframe: query.odsiframe === "true" ? true : false,
+    },
+  };
+};
+
+export function DatasetBrowser({ odsiframe }: { odsiframe: boolean }) {
   return (
-    <AppLayout>
+    <AppLayout isOdsIframe={odsiframe}>
       <ConfiguratorStateProvider chartId="new" allowDefaultRedirect={false}>
         <SelectDatasetStep variant="page" />
       </ConfiguratorStateProvider>


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2059

<!--- Describe the changes -->

**What changes?**
This PR adds an improved view of Dataset Preview for the use of ODS.

<!--- Test instructions -->

## How to test

1. Go to this [link](https://visualization-tool-git-feat-opendata-swiss-iframe-ixt1.vercel.app/) 
2. Create a Visualization w/ a Dataset
3. Go until the preview page 
4. add `&odsiframe=true` to the end of the `url` 
5. See how view is stripped of all mentioned elements under #1810

<!--- Reproduction steps, in case of a bug -->


## How it was before

1. Go to this [link](https://test.visualize.admin.ch)
2. 2. Create a Visualization w/ a Dataset
3. Go until the preview page 
4. add `&odsiframe=true` to the end of the `url` 
5. See how view has all mentioned elements under #1810

---

- [x] Add a CHANGELOG entry

---

_ps: @bprusinowski just tried to implement it the best of my understanding, so there might be a couple comments here_ 

---

cc: @KerstinFaye let me know about the translations and the button in general