### PR TITLE
Fixed categorical palettes on symbolLayers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ You can also check the
     diverging color palette
   - Improved filter section styling
   - Removed legend titles tooltip on the toggle switch
+  - Fixed Map Symbol Layer custom color palette support for all palette types
 - Maintenance
   - Added authentication method to e2e tests
   - Added authentication to Vercel previews for easier testing

--- a/app/configurator/components/chart-controls/color-palette.tsx
+++ b/app/configurator/components/chart-controls/color-palette.tsx
@@ -260,11 +260,9 @@ export const ColorPalette = ({
                       <ColorSquare color={color} disabled={disabled} />
                     </Grid>
                   ))
-                : withColorField &&
-                  customColorPalettes
+                : customColorPalettes
                     ?.find(
-                      (palette) =>
-                        palette.paletteId === chartConfig.fields.color.paletteId
+                      (palette) => palette.paletteId === currentPaletteName
                     )
                     ?.colors.map((color, i) => (
                       <Grid item key={`color-palette-tile-${i}`}>
@@ -280,7 +278,7 @@ export const ColorPalette = ({
         value={(() => {
           const valueToUse = currentPalette
             ? currentPalette.value
-            : (withColorField && chartConfig.fields.color.paletteId) || "";
+            : currentPaletteName;
 
           if (!isValidValue(valueToUse)) {
             return "";

--- a/app/configurator/components/chart-controls/color-palette.tsx
+++ b/app/configurator/components/chart-controls/color-palette.tsx
@@ -99,7 +99,7 @@ export const ColorPalette = ({
         chartConfig,
         `fields["${chartConfig.activeField}"].${
           colorConfigPath ? `${colorConfigPath}.` : ""
-        }palette`
+        }paletteId`
       );
 
   const currentPalette = palettes.find((p) => p.value === currentPaletteName);

--- a/app/configurator/components/chart-controls/color-palette.tsx
+++ b/app/configurator/components/chart-controls/color-palette.tsx
@@ -197,8 +197,6 @@ export const ColorPalette = ({
     }
   };
 
-  const withColorField = isColorInConfig(chartConfig);
-
   const [anchorEl, setAnchorEl] = useState<HTMLElement>();
   const handleOpenCreateColorPalette: MouseEventHandler<HTMLButtonElement> =
     useEvent((ev) => {

--- a/app/configurator/components/chart-controls/color-ramp.tsx
+++ b/app/configurator/components/chart-controls/color-ramp.tsx
@@ -198,8 +198,18 @@ export const ColorRampField = (props: ColorRampFieldProps) => {
           width: "100%",
           "& .MuiSelect-select": { height: "44px", width: "100%" },
         }}
+        displayEmpty
         onChange={onSelectedItemChange}
-        renderValue={() => {
+        renderValue={(selected) => {
+          if (!selected) {
+            return (
+              <Typography color={"secondary.active"} variant="body2">
+                <Trans id="controls.color.palette.select">
+                  Select a color palette
+                </Trans>
+              </Typography>
+            );
+          }
           return (
             <ColorRamp
               colorInterpolator={selectedColorInterpolator}

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -1,8 +1,8 @@
 import { t, Trans } from "@lingui/macro";
 import {
   Box,
-  Stack,
   Switch as MUISwitch,
+  Stack,
   Tooltip,
   Typography,
 } from "@mui/material";
@@ -57,6 +57,7 @@ import {
   isAnimationInConfig,
   isColorInConfig,
   isComboChartConfig,
+  isMapConfig,
   isTableConfig,
   MapConfig,
   SortingType,
@@ -2148,6 +2149,18 @@ const ChartFieldColorComponent = ({
     | number
     | undefined;
 
+  const hasColorField = isMapConfig(chartConfig);
+  const values: { id: string; symbol: LegendSymbol }[] =
+    hasColorField &&
+    chartConfig.fields.symbolLayer?.color.type === "categorical"
+      ? Object.keys(chartConfig.fields.symbolLayer?.color.colorMapping).map(
+          (key) => ({
+            id: key,
+            symbol: "line",
+          })
+        )
+      : [];
+
   return (
     <ControlSection collapse>
       <SubsectionTitle iconName="color">
@@ -2218,7 +2231,21 @@ const ChartFieldColorComponent = ({
               colorConfigPath="color"
               colorComponent={colorComponent}
             />
-          ) : null
+          ) : (
+            <ColorPalette
+              field="symbolLayer"
+              colorConfigPath="color"
+              component={
+                {
+                  __typename: "",
+                  values: values.map(({ id }) => ({
+                    value: id,
+                    label: id,
+                  })),
+                } as any as Component
+              }
+            />
+          )
         ) : colorType === "numerical" ? (
           <div>
             <ColorRampField field={field} path="color" nSteps={nbClass} />

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -57,7 +57,6 @@ import {
   isAnimationInConfig,
   isColorInConfig,
   isComboChartConfig,
-  isMapConfig,
   isTableConfig,
   MapConfig,
   SortingType,
@@ -1554,9 +1553,6 @@ const ColorSelection = ({
       <ControlSectionContent component="fieldset" gap="none" sx={{ mt: 2 }}>
         <ColorPalette
           field="y"
-          // Faking a component here, because we don't have a real one.
-          // We use measure iris as dimension values, because that's how
-          // the color mapping is done.
           component={
             {
               __typename: "",
@@ -2149,18 +2145,6 @@ const ChartFieldColorComponent = ({
     | number
     | undefined;
 
-  const hasColorField = isMapConfig(chartConfig);
-  const values: { id: string; symbol: LegendSymbol }[] =
-    hasColorField &&
-    chartConfig.fields.symbolLayer?.color.type === "categorical"
-      ? Object.keys(chartConfig.fields.symbolLayer?.color.colorMapping).map(
-          (key) => ({
-            id: key,
-            symbol: "line",
-          })
-        )
-      : [];
-
   return (
     <ControlSection collapse>
       <SubsectionTitle iconName="color">
@@ -2235,15 +2219,7 @@ const ChartFieldColorComponent = ({
             <ColorPalette
               field="symbolLayer"
               colorConfigPath="color"
-              component={
-                {
-                  __typename: "",
-                  values: values.map(({ id }) => ({
-                    value: id,
-                    label: id,
-                  })),
-                } as any as Component
-              }
+              component={colorComponent}
             />
           )
         ) : colorType === "numerical" ? (


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2106

<!--- Describe the changes -->

**What changes?**
This PR makes sure that `symbolLayers` when using map charts support categorical color palettes aswell

<!--- Test instructions -->

## How to test

1. Go to this [link](https://visualization-tool-git-fix-arealayer-symbollayer-bug-ixt1.vercel.app/) 
2. Create a new visualization with: `Einmalvergütung für Photovoltaikanlagen`
3. Change Chart to map type 
4. Add Symbol layer (Select Kanton)
5. Under color select Kanton 
6. See how there is a categorical palettes selection possible ✅
7. See how by default it's `Select a color palette` ✅
8. See how when you change to another dimension within color it says again `Select a color palette` ✅


<!--- Reproduction steps, in case of a bug -->

1. Go to this [link](https://test.visualize.admin.ch) 
2. Create a new visualization with: `Einmalvergütung für Photovoltaikanlagen`
3. Change Chart to map type 
4. Add Symbol layer (Select Kanton)
5. Under color select Kanton 
6. See how there is no categorical palettes selection possible ❌
8. See how when you change to another dimension within color it doesn't says again `Select a color palette` ❌

---

- [x] Add a CHANGELOG entry
