### PR TITLE
Added color palettes to bar chart types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ You can also check the
   - Improved filter section styling
   - Removed legend titles tooltip on the toggle switch
   - Fixed Map Symbol Layer custom color palette support for all palette types
+  - Added color palettes for single bar chart type
 - Maintenance
   - Added authentication method to e2e tests
   - Added authentication to Vercel previews for easier testing

--- a/app/charts/bar/bars-state.tsx
+++ b/app/charts/bar/bars-state.tsx
@@ -4,6 +4,8 @@ import {
   scaleBand,
   ScaleLinear,
   scaleLinear,
+  ScaleOrdinal,
+  scaleOrdinal,
   scaleTime,
 } from "d3-scale";
 import orderBy from "lodash/orderBy";
@@ -45,6 +47,7 @@ import {
   useFormatNumber,
   useTimeFormatUnit,
 } from "@/formatters";
+import { getPalette } from "@/palettes";
 import {
   getSortingOrders,
   makeDimensionValueSorters,
@@ -62,6 +65,7 @@ export type BarsState = CommonChartState &
     yScale: ScaleBand<string>;
     minY: string;
     getAnnotationInfo: (d: Observation) => TooltipInfo;
+    colors: ScaleOrdinal<string, string>;
   };
 
 const useBarsState = (
@@ -272,6 +276,15 @@ const useBarsState = (
     };
   };
 
+  const colors = scaleOrdinal<string, string>();
+
+  colors.range(
+    getPalette({
+      paletteId: fields.color.paletteId,
+      colorField: fields.color,
+    })
+  );
+
   return {
     chartType: "bar",
     bounds: {
@@ -286,6 +299,7 @@ const useBarsState = (
     yScaleInteraction,
     yScale,
     getAnnotationInfo,
+    colors,
     ...variables,
   };
 };

--- a/app/charts/bar/bars.tsx
+++ b/app/charts/bar/bars.tsx
@@ -79,8 +79,16 @@ export const ErrorWhiskers = () => {
 };
 
 export const Bars = () => {
-  const { chartData, bounds, getX, xScale, getY, yScale, getRenderingKey } =
-    useChartState() as BarsState;
+  const {
+    chartData,
+    bounds,
+    getX,
+    xScale,
+    getY,
+    yScale,
+    getRenderingKey,
+    colors,
+  } = useChartState() as BarsState;
   const theme = useTheme();
   const { margins } = bounds;
   const ref = useRef<SVGGElement>(null);
@@ -89,10 +97,6 @@ export const Bars = () => {
   const bandwidth = yScale.bandwidth();
   const x0 = xScale(0);
   const renderData: RenderBarDatum[] = useMemo(() => {
-    const getColor = (d: number) => {
-      return d <= 0 ? theme.palette.secondary.main : schemeCategory10[0];
-    };
-
     return chartData.map((d) => {
       const key = getRenderingKey(d);
       const yScaled = yScale(getY(d)) as number;
@@ -101,7 +105,6 @@ export const Bars = () => {
       const xScaled = xScale(x);
       const xRender = xScale(Math.min(x, 0));
       const width = Math.max(0, Math.abs(xScaled - x0));
-      const color = getColor(x);
 
       return {
         key,
@@ -109,7 +112,7 @@ export const Bars = () => {
         y: yScaled,
         width,
         height: bandwidth,
-        color,
+        color: colors(d.key as string) ?? schemeCategory10[0],
       };
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/charts/chart-config-ui-options.ts
+++ b/app/charts/chart-config-ui-options.ts
@@ -837,6 +837,11 @@ const chartConfigOptionsUISpec: ChartSpecs = {
         options: {
           showStandardError: {},
           showConfidenceInterval: {},
+          colorPalette: {
+            type: "single",
+            paletteId: "dimension",
+            color: theme.palette.primary.main,
+          },
         },
       },
       {

--- a/app/charts/shared/chart-state.ts
+++ b/app/charts/shared/chart-state.ts
@@ -92,7 +92,7 @@ export type CommonChartState = {
   interactiveFiltersConfig: InteractiveFiltersConfig;
 };
 
-export type ColorsChartState = Has<ChartState, "colors">;
+export type ColorsChartState = Has<ChartState, "colors" | "getColorLabel">;
 export const ChartContext = createContext<ChartState>(undefined);
 
 export const useChartState = () => {

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -799,6 +799,13 @@ const BaseLayer = t.type({
   show: t.boolean,
   locked: t.boolean,
   bbox: t.union([BBox, t.undefined]),
+  customWMTSLayers: t.array(
+    t.type({
+      url: t.string,
+      isBehindAreaLayer: t.boolean,
+      syncTemporalFilters: t.boolean,
+    })
+  ),
 });
 export type BaseLayer = t.TypeOf<typeof BaseLayer>;
 

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -799,13 +799,6 @@ const BaseLayer = t.type({
   show: t.boolean,
   locked: t.boolean,
   bbox: t.union([BBox, t.undefined]),
-  customWMTSLayers: t.array(
-    t.type({
-      url: t.string,
-      isBehindAreaLayer: t.boolean,
-      syncTemporalFilters: t.boolean,
-    })
-  ),
 });
 export type BaseLayer = t.TypeOf<typeof BaseLayer>;
 
@@ -1078,8 +1071,15 @@ export const isColorInConfig = (
   | ColumnConfig
   | LineConfig
   | PieConfig
-  | ScatterPlotConfig => {
+  | ScatterPlotConfig
+  | BarConfig => {
   return !isTableConfig(chartConfig) && !isMapConfig(chartConfig);
+};
+
+export const isCustomColorPalette = (
+  palette: CustomPaletteType | string
+): palette is CustomPaletteType => {
+  return typeof palette !== "string";
 };
 
 export const isNotTableOrMap = (chartConfig: ChartConfig) => {

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -55,6 +55,7 @@ import {
   ImputationType,
   imputationTypes,
   isAnimationInConfig,
+  isBarConfig,
   isColorInConfig,
   isComboChartConfig,
   isTableConfig,
@@ -76,7 +77,6 @@ import {
   SectionTitle,
   SubsectionTitle,
 } from "@/configurator/components/chart-controls/section";
-import { CustomLayersSelector } from "@/configurator/components/custom-layers-selector";
 import {
   ChartFieldField,
   ChartOptionCheckboxField,
@@ -450,6 +450,10 @@ const EncodingOptionsPanel = (props: EncodingOptionsPanelProps) => {
 
   const hasSubOptions = encoding.options?.chartSubType ?? false;
 
+  const locale = useLocale();
+
+  const [, dispatch] = useConfiguratorState(isConfiguring);
+
   const relatedLimitDimension = getRelatedLimitDimension({
     chartConfig,
     dimensions,
@@ -562,7 +566,63 @@ const EncodingOptionsPanel = (props: EncodingOptionsPanelProps) => {
         </ControlSection>
       )}
       {encoding.options?.showDots && (
-        <ChartShowDots fields={chartConfig.fields} field={field} />
+        <ControlSection collapse>
+          <SubsectionTitle iconName="chartLine">
+            <Trans id="controls.section.data-points">Data Points</Trans>
+          </SubsectionTitle>
+          <ControlSectionContent>
+            <Stack direction="column" gap={4}>
+              <ChartOptionSwitchField
+                path="showDots"
+                field={encoding.field}
+                onChange={(e) => {
+                  const { checked } = e.target;
+                  if ("y" in fields && !("showDots" in fields.y)) {
+                    dispatch({
+                      type: "COLOR_FIELD_UPDATED",
+                      value: {
+                        locale,
+                        field: "y",
+                        path: "showDotsSize",
+                        value: "Large",
+                      },
+                    });
+                  }
+                  dispatch({
+                    type: "COLOR_FIELD_UPDATED",
+                    value: {
+                      locale,
+                      field: encoding.field,
+                      path: "showDots",
+                      value: checked,
+                    },
+                  });
+                }}
+                label={t({ id: "controls.section.show-dots" })}
+                sx={{ mt: 2 }}
+              />
+              <Typography variant="caption" sx={{ mt: 2 }}>
+                <Trans id="controls.section.dots-size">Select a Size</Trans>
+              </Typography>
+              <Flex justifyContent="flex-start">
+                {["Small", "Medium", "Large"].map((d) => (
+                  <ChartOptionRadioField
+                    key={d}
+                    label={`${d}`}
+                    field="y"
+                    path="showDotsSize"
+                    value={d}
+                    disabled={
+                      "y" in fields &&
+                      (!("showDots" in fields.y) ||
+                        ("showDots" in fields.y && !fields.y.showDots))
+                    }
+                  />
+                ))}
+              </Flex>
+            </Stack>
+          </ControlSectionContent>
+        </ControlSection>
       )}
       {isComboChartConfig(chartConfig) && encoding.field === "y" && (
         <ChartComboYField chartConfig={chartConfig} measures={measures} />
@@ -595,10 +655,7 @@ const EncodingOptionsPanel = (props: EncodingOptionsPanelProps) => {
       )}
       {/* FIXME: should be generic or shouldn't be a field at all */}
       {field === "baseLayer" && (
-        <>
-          <ChartMapBaseLayerSettings chartConfig={chartConfig as MapConfig} />
-          <CustomLayersSelector />
-        </>
+        <ChartMapBaseLayerSettings chartConfig={chartConfig as MapConfig} />
       )}
       {encoding.sorting &&
         component &&
@@ -670,10 +727,23 @@ const ChartLayoutOptions = ({
   hasSubOptions: boolean;
   measures: Measure[];
 }) => {
+  const activeField = chartConfig.activeField as EncodingFieldType | undefined;
+
+  if (!activeField) {
+    return null;
+  }
+
   const hasColorField = isColorInConfig(chartConfig);
   const values: { id: string; symbol: LegendSymbol }[] = hasColorField
     ? chartConfig.fields.color.type === "single"
-      ? [{ id: chartConfig.fields.y.componentId, symbol: "line" }]
+      ? [
+          {
+            id: isBarConfig(chartConfig)
+              ? chartConfig.fields.x.componentId
+              : chartConfig.fields.y.componentId,
+            symbol: "line",
+          },
+        ]
       : Object.keys(chartConfig.fields.color.colorMapping).map((key) => ({
           id: key,
           symbol: "line",
@@ -694,28 +764,30 @@ const ChartLayoutOptions = ({
             disabled={!component}
           />
         )}
-        <ColorPalette
-          field="y"
-          // Faking a component here, because we don't have a real one.
-          // We use measure iris as dimension values, because that's how
-          // the color mapping is done.
-          component={
-            {
-              __typename: "",
-              values: values.map(({ id }) => ({
-                value: id,
-                label: id,
-              })),
-            } as any as Component
-          }
-        />
-        {hasColorField && chartConfig.fields.color.type === "single" && (
-          <ColorPickerField
-            field="color"
-            path="color"
-            label={measures.find((d) => d.id === values[0].id)!.label}
+        <>
+          <ColorPalette
+            field={activeField}
+            // Faking a component here, because we don't have a real one.
+            // We use measure iris as dimension values, because that's how
+            // the color mapping is done.
+            component={
+              {
+                __typename: "",
+                values: values.map(({ id }) => ({
+                  value: id,
+                  label: id,
+                })),
+              } as any as Component
+            }
           />
-        )}
+          {hasColorField && chartConfig.fields.color.type === "single" && (
+            <ColorPickerField
+              field="color"
+              path="color"
+              label={measures.find((d) => d.id === values[0].id)!.label}
+            />
+          )}
+        </>
       </ControlSectionContent>
     </ControlSection>
   ) : null;
@@ -927,112 +999,6 @@ const ChartLimits = ({
       </ControlSectionContent>
     </ControlSection>
   ) : null;
-};
-
-const ChartShowDots = ({
-  fields,
-  field,
-}: {
-  fields: ChartConfig["fields"];
-  field: EncodingFieldType | null;
-}) => {
-  const locale = useLocale();
-  const [_, dispatch] = useConfiguratorState(isConfiguring);
-  const disabled =
-    "y" in fields &&
-    (!("showDots" in fields.y) ||
-      ("showDots" in fields.y && !fields.y.showDots));
-
-  return (
-    <ControlSection collapse>
-      <SubsectionTitle iconName="chartLine">
-        <Trans id="controls.section.data-points">Data Points</Trans>
-      </SubsectionTitle>
-      <ControlSectionContent>
-        <Stack direction="column" gap={4}>
-          <ChartOptionSwitchField
-            path="showDots"
-            field={field}
-            onChange={(e) => {
-              const { checked } = e.target;
-              if ("y" in fields && !("showDots" in fields.y)) {
-                dispatch({
-                  type: "COLOR_FIELD_UPDATED",
-                  value: {
-                    locale,
-                    field: "y",
-                    path: "showDotsSize",
-                    value: "Large",
-                  },
-                });
-              }
-              dispatch({
-                type: "COLOR_FIELD_UPDATED",
-                value: {
-                  locale,
-                  field,
-                  path: "showDots",
-                  value: checked,
-                },
-              });
-            }}
-            label={t({ id: "controls.section.show-dots" })}
-            sx={{ mt: 2 }}
-          />
-          <Typography variant="caption" sx={{ mt: 2 }}>
-            <Trans id="controls.section.dots-size">Select a Size</Trans>
-          </Typography>
-          <Flex justifyContent="flex-start">
-            <ChartShowDotRadio
-              size="Small"
-              label={t({
-                id: "controls.section.dots-size.small",
-                message: "Small",
-              })}
-              disabled={disabled}
-            />
-            <ChartShowDotRadio
-              size="Medium"
-              label={t({
-                id: "controls.section.dots-size.medium",
-                message: "Medium",
-              })}
-              disabled={disabled}
-            />
-            <ChartShowDotRadio
-              size="Large"
-              label={t({
-                id: "controls.section.dots-size.large",
-                message: "Large",
-              })}
-              disabled={disabled}
-            />
-          </Flex>
-        </Stack>
-      </ControlSectionContent>
-    </ControlSection>
-  );
-};
-
-const ChartShowDotRadio = ({
-  size,
-  label,
-  disabled,
-}: {
-  size: "Small" | "Medium" | "Large";
-  label: string;
-  disabled: boolean;
-}) => {
-  return (
-    <ChartOptionRadioField
-      key={size}
-      field="y"
-      path="showDotsSize"
-      value={size}
-      label={label}
-      disabled={disabled}
-    />
-  );
 };
 
 const ChartFieldAbbreviations = ({
@@ -1555,6 +1521,9 @@ const ColorSelection = ({
       <ControlSectionContent component="fieldset" gap="none" sx={{ mt: 2 }}>
         <ColorPalette
           field="y"
+          // Faking a component here, because we don't have a real one.
+          // We use measure iris as dimension values, because that's how
+          // the color mapping is done.
           component={
             {
               __typename: "",
@@ -2217,13 +2186,7 @@ const ChartFieldColorComponent = ({
               colorConfigPath="color"
               colorComponent={colorComponent}
             />
-          ) : (
-            <ColorPalette
-              field="symbolLayer"
-              colorConfigPath="color"
-              component={colorComponent}
-            />
-          )
+          ) : null
         ) : colorType === "numerical" ? (
           <div>
             <ColorRampField field={field} path="color" nSteps={nbClass} />
@@ -2425,9 +2388,9 @@ const ChartMapBaseLayerSettings = ({
   }, [chartConfig.baseLayer.locked, dispatch, locale]);
 
   return (
-    <ControlSection hideTopBorder>
+    <ControlSection>
       <SectionTitle>
-        <Trans id="chart.map.layers.base">Base Layers</Trans>
+        <Trans id="chart.map.layers.base">Map Display</Trans>
       </SectionTitle>
       <ControlSectionContent gap="large">
         <ChartOptionCheckboxField


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

**What changes?**
This PR adds custom color palettes bar chart types

<!--- Test instructions -->

## How to test

1. Go to this link
2. Create a visualization 
3. Select bars
4. Select X Axis
5. See how there is a color selector ✅

<!--- Reproduction steps, in case of a bug -->

## How to reproduce

1. Go to this [link](https://test.visualize.admin.ch)
2. Create a visualization 
3. Select bars
4. Select X Axis
5. See how there is no color selector ❌

---

- [x] Add a CHANGELOG entry
