### PR TITLE
fix: fixed translations

### DIFF
--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -600,13 +600,15 @@ msgstr "Verwenden Sie klare, kontrastreiche Farben. Vermeiden Sie die Verwendung
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.caption-diverging"
 msgstr "Wählen Sie kontrastierende Farben für Start- und Endpunkt. Diese Farben unterstützen die visuelle Trennung von Extremwerten. Divergierende Paletten eignen sich besonders für Daten mit einem bedeutsamen Mittelpunkt wie Null oder einem Durchschnittswert."
-msgid "controls.custom-color-palettes.categorical"
-msgstr "Kategorisch"
 
 #: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.caption-sequential"
 msgstr "Wählen Sie eine dunkle Endpunktfarbe für einen starken Kontrast zwischen niedrigen und hohen Werten; die helle Farbe wird automatisch berechnet. Sequentielle Farbpaletten eignen sich für geordnete Daten wie Temperaturen oder Bevölkerungsdichten."
+
+#: app/login/components/color-palettes/profile-color-palette-form.tsx
+msgid "controls.custom-color-palettes.categorical"
+msgstr "Kategorisch"
 
 #: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.categorical-contrast-warning"
@@ -618,7 +620,7 @@ msgstr "Farbpalette erstellen"
 
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.diverging"
-msgstr Sequentiell
+msgstr "Divergierend"
 
 #: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.diverging-contrast-warning"

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -640,7 +640,7 @@ msgstr "Mittlere Farbe"
 
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.sequential"
-msgstr "Divergierend"
+msgstr "Sequentiell"
 
 #: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.sequential-contrast-warning"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -601,15 +601,14 @@ msgstr "Use distinct, high-contrast colors. Avoid using too many colors, maximum
 msgid "controls.custom-color-palettes.caption-diverging"
 msgstr "Choose contrasting colors for the start and end points. These colors will help visually separate extreme values. Diverging palettes are ideal for data with a meaningful midpoint, such as zero or an average."
 
-
-msgid "controls.custom-color-palettes.categorical"
-msgstr "Categorical"
-
 #: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.caption-sequential"
 msgstr "Select a dark endpoint color for a strong contrast between low and high values; the light color is calculated automatically. Sequential color palettes are suitable for ordered data such as temperatures or population densities."
 
+#: app/login/components/color-palettes/profile-color-palette-form.tsx
+msgid "controls.custom-color-palettes.categorical"
+msgstr "Categorical"
 
 #: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.categorical-contrast-warning"
@@ -750,7 +749,6 @@ msgstr "To"
 #: app/configurator/components/filters.tsx
 msgid "controls.filters.show-legend-toggle"
 msgstr "Allow users to change legend titles visibility"
-
 #: app/configurator/components/filters.tsx
 msgid "controls.filters.show-legend.toggle"
 msgstr "Show legend titles"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -605,15 +605,14 @@ msgstr "Sélectionnez une couleur d'extrémité foncée pour obtenir un fort con
 msgid "controls.custom-color-palettes.caption-diverging"
 msgstr "Choisissez des couleurs contrastées pour les points de départ et d'arrivée. Ces couleurs permettent de distinguer visuellement les valeurs extrêmes. Les palettes divergentes sont idéales pour les données comportant un point médian significatif, tel que zéro ou une moyenne. IT Scegliere colori contrastanti per i punti iniziali e finali. Questi colori facilitano la distinzione visiva dei valori estremi. Le palette divergenti sono ideali per dati con un punto medio significativo, come zero o un valore medio."
 
-
-msgid "controls.custom-color-palettes.categorical"
-msgstr "Catégorique"
-
 #: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.caption-sequential"
 msgstr "Sélectionnez une couleur d'extrémité foncée pour obtenir un fort contraste entre les valeurs faibles et élevées ; la couleur claire est calculée automatiquement. Les palettes de couleurs séquentielles conviennent aux données ordonnées telles que les températures ou les densités de population."
 
+#: app/login/components/color-palettes/profile-color-palette-form.tsx
+msgid "controls.custom-color-palettes.categorical"
+msgstr "Catégorique"
 
 #: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.categorical-contrast-warning"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -605,13 +605,14 @@ msgstr "Per ottenere un forte contrasto tra valori bassi e alti, è possibile se
 msgid "controls.custom-color-palettes.caption-diverging"
 msgstr "Scegliere colori contrastanti per i punti iniziali e finali. Questi colori facilitano la distinzione visiva dei valori estremi. Le palette divergenti sono ideali per dati con un punto medio significativo, come zero o un valore medio."
 
-msgid "controls.custom-color-palettes.categorical"
-msgstr "Categorico"
-
 #: app/configurator/components/chart-controls/drawer-color-palette-content.tsx
 #: app/login/components/color-palettes/profile-color-palette-form.tsx
 msgid "controls.custom-color-palettes.caption-sequential"
 msgstr "Per ottenere un forte contrasto tra valori bassi e alti, è possibile selezionare un colore scuro per l'endpoint; il colore chiaro viene calcolato automaticamente. Le tavolozze di colori sequenziali sono adatte per dati ordinati come le temperature o le densità di popolazione."
+
+#: app/login/components/color-palettes/profile-color-palette-form.tsx
+msgid "controls.custom-color-palettes.categorical"
+msgstr "Categorico"
 
 #: app/login/components/color-palettes/color-palette-types.tsx
 msgid "controls.custom-color-palettes.categorical-contrast-warning"


### PR DESCRIPTION
This should finally fix the issue with the translations, please [test](https://visualization-tool-git-fix-color-palette-dynamic-tr-67b330-ixt1.vercel.app/) on google chrome since the issue only happened there, on safari it simply just reverted to English.