### PR TITLE
feat: Added color palettes to bar charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Nothing yet.
   - Improved filter section styling
   - Removed legend titles tooltip on the toggle switch
   - Fixed Map Symbol Layer custom color palette support for all palette types
+  - Added color palettes to bar chart type
 - Maintenance
   - Added authentication method to e2e tests
   - Added authentication to Vercel previews for easier testing

--- a/app/charts/bar/bars-state-props.ts
+++ b/app/charts/bar/bars-state-props.ts
@@ -10,6 +10,7 @@ import {
   NumericalXErrorVariables,
   NumericalXVariables,
   RenderingVariables,
+  SegmentVariables,
   SortingVariables,
   useBandYVariables,
   useBaseVariables,
@@ -17,6 +18,7 @@ import {
   useInteractiveFiltersVariables,
   useNumericalXErrorVariables,
   useNumericalXVariables,
+  useSegmentVariables,
 } from "@/charts/shared/chart-state";
 import { useRenderingKeyVariable } from "@/charts/shared/rendering-utils";
 import { useChartConfigFilters } from "@/config-utils";
@@ -30,6 +32,7 @@ export type BarsStateVariables = BaseVariables &
   NumericalXVariables &
   BandYVariables &
   NumericalXErrorVariables &
+  SegmentVariables &
   RenderingVariables &
   InteractiveFiltersVariables;
 
@@ -45,7 +48,7 @@ export const useBarsStateVariables = (
     measuresById,
   } = props;
   const { fields, interactiveFiltersConfig } = chartConfig;
-  const { x, y, animation } = fields;
+  const { x, y, animation, segment } = fields;
   const yDimension = dimensionsById[y.componentId];
   const filters = useChartConfigFilters(chartConfig);
 
@@ -92,6 +95,10 @@ export const useBarsStateVariables = (
     [getX, getYAsDate, getY, y.sorting, yDimension]
   );
 
+  const segmentVariables = useSegmentVariables(segment, {
+    dimensionsById,
+    observations,
+  });
   const getRenderingKey = useRenderingKeyVariable(
     dimensions,
     filters,
@@ -100,6 +107,7 @@ export const useBarsStateVariables = (
   );
 
   return {
+    ...segmentVariables,
     ...baseVariables,
     sortData,
     ...bandYVariables,

--- a/app/charts/bar/bars-state.tsx
+++ b/app/charts/bar/bars-state.tsx
@@ -66,6 +66,7 @@ export type BarsState = CommonChartState &
     minY: string;
     getAnnotationInfo: (d: Observation) => TooltipInfo;
     colors: ScaleOrdinal<string, string>;
+    getColorLabel: (segment: string) => string;
   };
 
 const useBarsState = (
@@ -86,6 +87,7 @@ const useBarsState = (
     getMinX,
     getXErrorRange,
     getFormattedXUncertainty,
+    getSegmentLabel,
   } = variables;
   const { chartData, scalesData, timeRangeData, paddingData, allData } = data;
   const { fields, interactiveFiltersConfig } = chartConfig;
@@ -303,6 +305,7 @@ const useBarsState = (
     yScaleInteraction,
     yScale,
     getAnnotationInfo,
+    getColorLabel: getSegmentLabel,
     colors,
     ...variables,
   };

--- a/app/charts/bar/bars-state.tsx
+++ b/app/charts/bar/bars-state.tsx
@@ -4,6 +4,8 @@ import {
   scaleBand,
   ScaleLinear,
   scaleLinear,
+  ScaleOrdinal,
+  scaleOrdinal,
   scaleTime,
 } from "d3-scale";
 import orderBy from "lodash/orderBy";
@@ -45,6 +47,7 @@ import {
   useFormatNumber,
   useTimeFormatUnit,
 } from "@/formatters";
+import { getPalette } from "@/palettes";
 import {
   getSortingOrders,
   makeDimensionValueSorters,
@@ -62,6 +65,7 @@ export type BarsState = CommonChartState &
     yScale: ScaleBand<string>;
     minY: string;
     getAnnotationInfo: (d: Observation) => TooltipInfo;
+    colors: ScaleOrdinal<string, string>;
   };
 
 const useBarsState = (
@@ -272,6 +276,19 @@ const useBarsState = (
     };
   };
 
+  const { colors } = useMemo(() => {
+    const colors = scaleOrdinal<string, string>();
+
+    colors.range(
+      getPalette({
+        paletteId: fields.color.paletteId,
+        colorField: fields.color,
+      })
+    );
+
+    return { colors };
+  }, [fields.color]);
+
   return {
     chartType: "bar",
     bounds: {
@@ -286,6 +303,7 @@ const useBarsState = (
     yScaleInteraction,
     yScale,
     getAnnotationInfo,
+    colors,
     ...variables,
   };
 };

--- a/app/charts/bar/bars.tsx
+++ b/app/charts/bar/bars.tsx
@@ -79,8 +79,16 @@ export const ErrorWhiskers = () => {
 };
 
 export const Bars = () => {
-  const { chartData, bounds, getX, xScale, getY, yScale, getRenderingKey } =
-    useChartState() as BarsState;
+  const {
+    chartData,
+    bounds,
+    getX,
+    xScale,
+    getY,
+    yScale,
+    getRenderingKey,
+    colors,
+  } = useChartState() as BarsState;
   const theme = useTheme();
   const { margins } = bounds;
   const ref = useRef<SVGGElement>(null);
@@ -89,10 +97,6 @@ export const Bars = () => {
   const bandwidth = yScale.bandwidth();
   const x0 = xScale(0);
   const renderData: RenderBarDatum[] = useMemo(() => {
-    const getColor = (d: number) => {
-      return d <= 0 ? theme.palette.secondary.main : schemeCategory10[0];
-    };
-
     return chartData.map((d) => {
       const key = getRenderingKey(d);
       const yScaled = yScale(getY(d)) as number;
@@ -101,7 +105,6 @@ export const Bars = () => {
       const xScaled = xScale(x);
       const xRender = xScale(Math.min(x, 0));
       const width = Math.max(0, Math.abs(xScaled - x0));
-      const color = getColor(x);
 
       return {
         key,
@@ -109,7 +112,7 @@ export const Bars = () => {
         y: yScaled,
         width,
         height: bandwidth,
-        color,
+        color: colors(d.key as string) ?? schemeCategory10[0],
       };
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/charts/chart-config-ui-options.ts
+++ b/app/charts/chart-config-ui-options.ts
@@ -60,7 +60,6 @@ import {
   SEGMENT_ENABLED_COMPONENTS,
 } from "@/domain/data";
 import { getDefaultCategoricalPaletteId, getPalette } from "@/palettes";
-import { theme } from "@/themes/federal";
 
 /**
  * This module controls chart controls displayed in the UI.
@@ -632,8 +631,8 @@ const chartConfigOptionsUISpec: ChartSpecs = {
           calculation: {},
           colorPalette: {
             type: "single",
-            paletteId: "dimension",
-            color: theme.palette.primary.main,
+            paletteId: "schemeCategory10",
+            color: schemeCategory10[0],
           },
           imputation: {
             shouldShow: (chartConfig, data) => {
@@ -676,8 +675,8 @@ const chartConfigOptionsUISpec: ChartSpecs = {
         options: {
           colorPalette: {
             type: "single",
-            paletteId: "dimension",
-            color: theme.palette.primary.main,
+            paletteId: "schemeCategory10",
+            color: schemeCategory10[0],
           },
           showStandardError: {},
           showConfidenceInterval: {},
@@ -797,8 +796,8 @@ const chartConfigOptionsUISpec: ChartSpecs = {
           },
           colorPalette: {
             type: "single",
-            paletteId: "dimension",
-            color: theme.palette.primary.main,
+            paletteId: "schemeCategory10",
+            color: schemeCategory10[0],
           },
           useAbbreviations: {},
         },
@@ -837,6 +836,11 @@ const chartConfigOptionsUISpec: ChartSpecs = {
         options: {
           showStandardError: {},
           showConfidenceInterval: {},
+          colorPalette: {
+            type: "single",
+            paletteId: "schemeCategory10",
+            color: schemeCategory10[0],
+          },
         },
       },
       {
@@ -972,8 +976,8 @@ const chartConfigOptionsUISpec: ChartSpecs = {
         options: {
           colorPalette: {
             type: "single",
-            paletteId: "dimension",
-            color: theme.palette.primary.main,
+            paletteId: "schemeCategory10",
+            color: schemeCategory10[0],
           },
           showStandardError: {},
           showConfidenceInterval: {},
@@ -999,8 +1003,8 @@ const chartConfigOptionsUISpec: ChartSpecs = {
         options: {
           colorPalette: {
             type: "single",
-            paletteId: "dimension",
-            color: theme.palette.primary.main,
+            paletteId: "schemeCategory10",
+            color: schemeCategory10[0],
           },
           useAbbreviations: {},
         },
@@ -1096,8 +1100,8 @@ const chartConfigOptionsUISpec: ChartSpecs = {
         options: {
           colorPalette: {
             type: "single",
-            paletteId: "dimension",
-            color: theme.palette.primary.main,
+            paletteId: "schemeCategory10",
+            color: schemeCategory10[0],
           },
           useAbbreviations: {},
         },
@@ -1133,8 +1137,8 @@ const chartConfigOptionsUISpec: ChartSpecs = {
         options: {
           colorPalette: {
             type: "single",
-            paletteId: "dimension",
-            color: theme.palette.primary.main,
+            paletteId: "schemeCategory10",
+            color: schemeCategory10[0],
           },
           useAbbreviations: {},
         },

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -1078,7 +1078,8 @@ export const isColorInConfig = (
   | ColumnConfig
   | LineConfig
   | PieConfig
-  | ScatterPlotConfig => {
+  | ScatterPlotConfig
+  | BarConfig => {
   return !isTableConfig(chartConfig) && !isMapConfig(chartConfig);
 };
 

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -55,6 +55,7 @@ import {
   ImputationType,
   imputationTypes,
   isAnimationInConfig,
+  isBarConfig,
   isColorInConfig,
   isComboChartConfig,
   isTableConfig,
@@ -670,10 +671,23 @@ const ChartLayoutOptions = ({
   hasSubOptions: boolean;
   measures: Measure[];
 }) => {
+  const activeField = chartConfig.activeField as EncodingFieldType | undefined;
+
+  if (!activeField) {
+    return null;
+  }
+
   const hasColorField = isColorInConfig(chartConfig);
   const values: { id: string; symbol: LegendSymbol }[] = hasColorField
     ? chartConfig.fields.color.type === "single"
-      ? [{ id: chartConfig.fields.y.componentId, symbol: "line" }]
+      ? [
+          {
+            id: isBarConfig(chartConfig)
+              ? chartConfig.fields.x.componentId
+              : chartConfig.fields.y.componentId,
+            symbol: "line",
+          },
+        ]
       : Object.keys(chartConfig.fields.color.colorMapping).map((key) => ({
           id: key,
           symbol: "line",
@@ -695,7 +709,7 @@ const ChartLayoutOptions = ({
           />
         )}
         <ColorPalette
-          field="y"
+          field={activeField}
           // Faking a component here, because we don't have a real one.
           // We use measure iris as dimension values, because that's how
           // the color mapping is done.


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

**What changes?**
This PR adds custom color palettes bar chart types

<!--- Test instructions -->

## How to test

1. Go to this [link](https://visualization-tool-git-fix-add-color-palettes-to-barchart-ixt1.vercel.app/)
2. Create a visualization 
3. Select bars
4. Select X Axis
5. See how there is a color selector ✅

<!--- Reproduction steps, in case of a bug -->

## How to reproduce

1. Go to this [link](https://test.visualize.admin.ch)
2. Create a visualization 
3. Select bars
4. Select X Axis
5. See how there is no color selector ❌

---

- [x] Add a CHANGELOG entry
