### PR TITLE
fix: Correctly filter out undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Fixes
+  - Limits that are connected to values that are filtered out do not render in
+    the chart anymore
 
 # [5.3.0] - 2025-02-25
 

--- a/app/charts/shared/limits.tsx
+++ b/app/charts/shared/limits.tsx
@@ -54,23 +54,27 @@ export const HorizontalLimits = ({
       })
       .filter(truthy);
 
-    return preparedLimits.map((limit) => {
-      const fakeObservation: Observation = {
-        [relatedDimension?.id ?? ""]: limit.relatedDimensionValue,
-      };
-      const y = getY(fakeObservation) as (Date | number) & string;
+    return preparedLimits
+      .map((limit) => {
+        const fakeObservation: Observation = {
+          [relatedDimension?.id ?? ""]: limit.relatedDimensionValue,
+        };
+        const y = getY(fakeObservation) as (Date | number) & string;
+        const yScaled = yScale(y);
 
-      return {
-        key: limit.relatedDimensionValue,
-        y: yScale(y)! + bandwidth / 2 - limitHeight / 2,
-        x1: xScale(limit.y1),
-        x2: xScale(limit.y2),
-        height: limitHeight,
-        fill: limit.color,
-        lineType: limit.lineType,
-      } as RenderHorizontalLimitDatum;
-    });
-
+        return yScaled !== undefined
+          ? ({
+              key: limit.relatedDimensionValue,
+              y: yScaled + bandwidth / 2 - limitHeight / 2,
+              x1: xScale(limit.y1),
+              x2: xScale(limit.y2),
+              height: limitHeight,
+              fill: limit.color,
+              lineType: limit.lineType,
+            } as RenderHorizontalLimitDatum)
+          : null;
+      })
+      .filter(truthy);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     xScale,
@@ -152,23 +156,27 @@ export const VerticalLimits = ({
       })
       .filter(truthy);
 
-    return preparedLimits.map((limit) => {
-      const fakeObservation: Observation = {
-        [relatedDimension?.id ?? ""]: limit.relatedDimensionValue,
-      };
-      const x = getX(fakeObservation) as (Date | number) & string;
+    return preparedLimits
+      .map((limit) => {
+        const fakeObservation: Observation = {
+          [relatedDimension?.id ?? ""]: limit.relatedDimensionValue,
+        };
+        const x = getX(fakeObservation) as (Date | number) & string;
+        const xScaled = xScale(x);
 
-      return {
-        key: limit.relatedDimensionValue,
-        x: xScale(x)! + bandwidth / 2 - limitWidth / 2,
-        y1: yScale(limit.y1),
-        y2: yScale(limit.y2),
-        width: limitWidth,
-        fill: limit.color,
-        lineType: limit.lineType,
-      } as RenderVerticalLimitDatum;
-    });
-
+        return xScaled !== undefined
+          ? ({
+              key: limit.relatedDimensionValue,
+              x: xScaled + bandwidth / 2 - limitWidth / 2,
+              y1: yScale(limit.y1),
+              y2: yScale(limit.y2),
+              width: limitWidth,
+              fill: limit.color,
+              lineType: limit.lineType,
+            } as RenderVerticalLimitDatum)
+          : null;
+      })
+      .filter(truthy);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     xScale,


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes https://github.com/visualize-admin/visualization-tool/issues/1894#issuecomment-2682331086

<!--- Describe the changes -->

This PR makes sure we don't render limits that have undefined X or Y values.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-filtering-of-limits-ixt1.vercel.app/en/v/sYiShrTs0WNn?dataSource=Test).
2. ✅ See that there are no limits on the left side of the chart.

<!--- Reproduction steps, in case of a bug -->

---

- [x] Add a CHANGELOG entry
