### PR TITLE
feat: Make it possible to preview chart via iframe with query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ You can also check the
 # Unreleased
 
 - Features
+  - It's now possible to preview charts by passing configurator state as a query
+    parameter
   - It's now possible to add custom WMS layers coming from wms.geo.admin.ch to
     map charts
 - Fixes

--- a/app/charts/shared/limits.tsx
+++ b/app/charts/shared/limits.tsx
@@ -59,7 +59,7 @@ export const HorizontalLimits = ({
         const fakeObservation: Observation = {
           [relatedDimension?.id ?? ""]: limit.relatedDimensionValue,
         };
-        const y = getY(fakeObservation) as (Date | number) & string;
+        const y = getY(fakeObservation);
         const yScaled = yScale(y);
 
         return yScaled !== undefined
@@ -161,7 +161,7 @@ export const VerticalLimits = ({
         const fakeObservation: Observation = {
           [relatedDimension?.id ?? ""]: limit.relatedDimensionValue,
         };
-        const x = getX(fakeObservation) as (Date | number) & string;
+        const x = getX(fakeObservation) as $IntentionalAny;
         const xScaled = xScale(x);
 
         return xScaled !== undefined

--- a/app/docs/catalog/chart-preview-via-api.mdx
+++ b/app/docs/catalog/chart-preview-via-api.mdx
@@ -30,12 +30,29 @@ While usually you'll want to publish your chart, sometimes you might want to
 simply preview it, without going through the publishing process. This could be
 especially helpful to programmatically generate charts based on many different
 configuration options. Visualize offers a way to preview charts without
-publishing them, by using a custom API.
+publishing them, by using a custom API or iframe query parameter.
 
-## iframe
+## iframe preview via query parameter
 
 **Demo**: Visit <a href="/_preview" target="_blank">`/_preview`</a> to see a
-page with an iframe containing a chart preview.
+page with two iframes containing chart previews. The first iframe gets the chart
+state a `state` query parameter.
+
+```html
+<iframe
+  id="chart"
+  src="https://visualize.admin.ch/it/preview?state={JSON.stringify(photovoltaikanlagenState)}"
+  width="100%"
+  height="500"
+  frameborder="0"
+/>
+```
+
+## iframe preview via API
+
+**Demo**: Visit <a href="/_preview" target="_blank">`/_preview`</a> to see a
+page with two iframes containing chart previews. The second iframe gets the
+chart state from posting a message to the iframe window.
 
 This method works by pointing an iframe to the `/preview` page, and posting a
 message with the chart state to the iframe window on load.

--- a/app/pages/_preview.tsx
+++ b/app/pages/_preview.tsx
@@ -19,7 +19,6 @@ const Page = () => {
   const locale = useLocale();
 
   useEffect(() => {
-    loadIframe("chart-column", CONFIGURATOR_STATE_COLUMN);
     loadIframe("chart-map", CONFIGURATOR_STATE_MAP);
   }, []);
 
@@ -36,7 +35,10 @@ const Page = () => {
         },
       }}
     >
-      <iframe id="chart-column" src={`/${locale}/preview`} />
+      <iframe
+        id="chart-column"
+        src={`/${locale}/preview?state=${JSON.stringify(CONFIGURATOR_STATE_COLUMN)}`}
+      />
       <iframe id="chart-map" src={`/${locale}/preview`} />
     </Box>
   );

--- a/app/pages/docs/index.tsx
+++ b/app/pages/docs/index.tsx
@@ -83,7 +83,7 @@ const pages: ConfigPageOrGroup[] = [
       },
       {
         path: "/charts/preview-via-api",
-        title: "Preview via API",
+        title: "Previewing charts",
         content: require("@/docs/catalog/chart-preview-via-api.mdx"),
       },
     ],


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2064

<!--- Describe the changes -->

This PR makes it possible to set chart state in` /preview` chart preview via a `state` query parameter.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_Iframe).
2. Remove all the content from the left editor and paste the below.

```html
<!DOCTYPE html>
<html>
<body>

<h1>The iframe element</h1>

<iframe src="https://visualization-tool-git-feat-parametrisable-url-ixt1.vercel.app/preview?state={%22state%22:%22CONFIGURING_CHART%22,%22dataSet%22:%22https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/2%22,%22dataSource%22:{%22type%22:%22sparql%22,%22url%22:%22https://lindas-cached.cluster.ldbar.ch/query%22},%22meta%22:{%22title%22:{%22de%22:%22%22,%22fr%22:%22%22,%22it%22:%22%22,%22en%22:%22%22},%22description%22:{%22de%22:%22%22,%22fr%22:%22%22,%22it%22:%22%22,%22en%22:%22%22}},%22chartConfig%22:{%22version%22:%221.4.2%22,%22chartType%22:%22column%22,%22filters%22:{%22https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Kanton%22:{%22type%22:%22single%22,%22value%22:%22https://ld.admin.ch/canton/1%22}},%22interactiveFiltersConfig%22:{%22legend%22:{%22active%22:false,%22componentIri%22:%22%22},%22timeRange%22:{%22active%22:false,%22componentIri%22:%22https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr%22,%22presets%22:{%22type%22:%22range%22,%22from%22:%22%22,%22to%22:%22%22}},%22dataFilters%22:{%22active%22:false,%22componentIris%22:[]},%22calculation%22:{%22active%22:false,%22type%22:%22identity%22}},%22fields%22:{%22x%22:{%22componentIri%22:%22https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr%22,%22sorting%22:{%22sortingType%22:%22byAuto%22,%22sortingOrder%22:%22asc%22}},%22y%22:{%22componentIri%22:%22https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/AnzahlAnlagen%22}}}}" width="100%" height="1000">
</iframe>

</body>
</html>
```

3. ✅ See that the chart loaded and that you used a query parameter to pass the state to the iframe.

<!--- Reproduction steps, in case of a bug -->

---

- [x] Add a CHANGELOG entry
