### PR TITLE
fix: fixed color on dimensions change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ You can also check the
 - Fixes
   - Limits that are connected to values that are filtered out do not render in
     the chart anymore
+  - Persisting and showing colors on dimension changes
 
 # [5.3.0] - 2025-02-25
 

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -1732,10 +1732,6 @@ const ChartFieldMultiFilter = ({
   const colorComponent = [...dimensions, ...measures].find(
     (d) => d.id === colorComponentId
   );
-  const colorType = get(chartConfig, `fields["${field}"].color.type`) as
-    | ColorFieldType
-    | undefined;
-
   return encoding.filters && component ? (
     <ControlSection data-testid="chart-edition-multi-filters" collapse>
       <SubsectionTitle
@@ -1766,7 +1762,9 @@ const ChartFieldMultiFilter = ({
               colorComponent={colorComponent ?? component}
               // If colorType is defined, we are dealing with color field and
               // not segment.
-              colorConfigPath={colorType ? "color" : "colorMapping"}
+              colorConfigPath={
+                isColorInConfig(chartConfig) ? undefined : "colorMapping"
+              }
             />
           )
         )}

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -770,11 +770,11 @@ const useMultiFilterColorPicker = (
     [dispatch, colorField, value, hasColorField]
   );
 
-  const path = colorConfigPath ? colorConfigPath : "";
+  const path = colorConfigPath ? `color.${colorConfigPath}` : "";
 
   const color = get(
     chartConfig,
-    `fields["${colorField}"].${path}${!hasColorField ? ".colorMapping" : ""}["${value}"]`
+    `fields["${colorField}"].${path}${hasColorField ? "colorMapping" : ""}["${value}"]`
   );
 
   const palette = useMemo(() => {

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -358,6 +358,8 @@ const MultiFilterContent = ({
   const visibleLegendProps = useLegendTitleVisibility();
   const chartSymbol = getChartSymbol(chartConfig.chartType);
 
+  console.log(valueGroups);
+
   return (
     <Box sx={{ position: "relative" }}>
       <Box mb={4}>

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -358,8 +358,6 @@ const MultiFilterContent = ({
   const visibleLegendProps = useLegendTitleVisibility();
   const chartSymbol = getChartSymbol(chartConfig.chartType);
 
-  console.log(valueGroups);
-
   return (
     <Box sx={{ position: "relative" }}>
       <Box mb={4}>
@@ -533,27 +531,24 @@ const useEnsureUpToDateColorMapping = ({
       : false;
   }, [colorComponentValues, colorMapping]);
 
+  const field = isColorInConfig(chartConfig) ? "color" : activeField;
+
   useEffect(() => {
-    if (
-      hasOutdatedMapping &&
-      colorMapping &&
-      colorComponentValues &&
-      activeField
-    ) {
+    if (hasOutdatedMapping && colorMapping && colorComponentValues && field) {
       dispatch({
         type: "CHART_CONFIG_UPDATE_COLOR_MAPPING",
         value: {
           dimensionId,
           colorConfigPath,
           colorMapping,
-          field: isColorInConfig(chartConfig) ? "color" : activeField,
+          field,
           values: colorComponentValues,
           random: false,
         },
       });
     }
   }, [
-    activeField,
+    field,
     chartConfig,
     hasOutdatedMapping,
     dispatch,

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -533,10 +533,10 @@ const useEnsureUpToDateColorMapping = ({
 
   useEffect(() => {
     if (
-      activeField &&
       hasOutdatedMapping &&
       colorMapping &&
-      colorComponentValues
+      colorComponentValues &&
+      activeField
     ) {
       dispatch({
         type: "CHART_CONFIG_UPDATE_COLOR_MAPPING",
@@ -544,20 +544,21 @@ const useEnsureUpToDateColorMapping = ({
           dimensionId,
           colorConfigPath,
           colorMapping,
-          field: activeField,
+          field: isColorInConfig(chartConfig) ? "color" : activeField,
           values: colorComponentValues,
           random: false,
         },
       });
     }
   }, [
+    activeField,
+    chartConfig,
     hasOutdatedMapping,
     dispatch,
     dimensionId,
     colorConfigPath,
     colorMapping,
     colorComponentValues,
-    activeField,
   ]);
 };
 

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -548,8 +548,9 @@ export const updateColorMapping = (
         });
       }
     } else {
+      const { paletteId } = get(chartConfig, path);
       colorMapping = mapValueIrisToColor({
-        paletteId: "dimension",
+        paletteId,
         dimensionValues: values,
         colorMapping: oldColorMapping,
         random,


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2149 

<!--- Describe the changes -->

**What changes?**
This PR fixes the color palette selection to persist and map correctly when changing dimensions

<!--- Test instructions -->

## How to test

1. Go to this link 
2. Create a chart (e.g : Bodenbelastung durch Schwermetalle)
3. Add Segmentation select (Bemerkungen)
4. Select a color palette
5. Change Dimension to (Gemeinde)
6. See how colors persist ✅

<!--- Reproduction steps, in case of a bug -->

## How to reproduce
1. Go to this [link](https://test.visualize.admin.ch) 
2. Create a chart (e.g : Bodenbelastung durch Schwermetalle)
3. Add Segmentation select (Bemerkungen)
4. Select a color palette
5. Change Dimension to (Gemeinde)
6. See how colors don't persist ❌

---

- [x] Add a CHANGELOG entry
