### PR TITLE
fix: fixed odsiframe based on requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ You can also check the
 - Fixes
   - Limits that are connected to values that are filtered out do not render in
     the chart anymore
+  - Removed title & description on open data swiss iframes.
 - Maintenance
   - Updated documentation
 

--- a/app/browser/dataset-preview.tsx
+++ b/app/browser/dataset-preview.tsx
@@ -36,7 +36,7 @@ const useStyles = makeStyles<Theme, { descriptionPresent: boolean }>(
       paddingLeft: theme.spacing(4),
     },
     header: {
-      justifyContent: "space-between",
+      justifyContent: "end",
       marginBottom: theme.spacing(5),
       [theme.breakpoints.up("md")]: {
         flexDirection: "row",
@@ -166,9 +166,11 @@ export const DataSetPreview = ({
               {dataCubeMetadata.title} - visualize.admin.ch
             </title>
           </Head>
-          <Typography className={classes.title} component="div" variant="h1">
-            {dataCubeMetadata.title}
-          </Typography>
+          {!isOdsIframe(router.query) && (
+            <Typography className={classes.title} component="div" variant="h1">
+              {dataCubeMetadata.title}
+            </Typography>
+          )}
           {onCreateChartFromDataset ? (
             <Button
               onClick={(ev) => onCreateChartFromDataset?.(ev, dataSetIri)}
@@ -217,7 +219,7 @@ export const DataSetPreview = ({
           )}
         </Flex>
         <Paper className={classes.paper} elevation={5}>
-          {dataCubeMetadata.description && (
+          {dataCubeMetadata.description && !isOdsIframe(router.query) && (
             <Typography
               className={classes.description}
               component="div"


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2159

<!--- Describe the changes -->

**What changes?**
This PR removes the title and description on dataset previews when odsiframe is active.

<!--- Test instructions -->

## How to test

1. Go to this link
2. Create a Visualization w/ a Dataset
3. Go until the preview page 
4. add `&odsiframe=true` to the end of the `url` 
5. See how view is stripped of title and description as well 

<!--- Reproduction steps, in case of a bug -->

---

- [x] Add a CHANGELOG entry

---

@sosiology 
