### PR TITLE
feat: Add InlineLoading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ You can also check the
 
 - Features
   - It's now possible to show segment value labels in column and bar charts
+- Styles
+  - Optimized the custom map legends loading indicator appearance
 
 # [5.4.0] - 2025-03-11
 

--- a/app/charts/map/map-custom-layers-legend.tsx
+++ b/app/charts/map/map-custom-layers-legend.tsx
@@ -7,7 +7,7 @@ import {
   ParsedWMTSLayer,
   useWMTSLayers,
 } from "@/charts/map/wmts-utils";
-import { Error, Loading } from "@/components/hint";
+import { Error, InlineLoading } from "@/components/hint";
 import { InfoIconTooltip } from "@/components/info-icon-tooltip";
 import { BaseLayer, MapConfig } from "@/config-types";
 import { truthy } from "@/domain/types";
@@ -27,7 +27,7 @@ export const MapCustomLayersLegend = ({
   return error ? (
     <Error>{error.message}</Error>
   ) : !legendsData ? (
-    <Loading />
+    <InlineLoading />
   ) : (
     <>
       {legendsData.map(({ layer, dataUrl, width, height }) => {

--- a/app/components/hint.tsx
+++ b/app/components/hint.tsx
@@ -3,13 +3,13 @@ import {
   Alert,
   AlertProps,
   AlertTitle,
+  alpha,
   Box,
   BoxProps,
+  keyframes,
   Link,
   Theme,
   Typography,
-  alpha,
-  keyframes,
   useTheme,
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
@@ -109,15 +109,15 @@ export const Loading = ({ delayMs = 1000 }: { delayMs?: number }) => {
       setVariant("long");
     }, 7500);
 
-    return () => clearTimeout(timeout);
+    return () => {
+      clearTimeout(timeout);
+    };
   }, []);
 
   return (
     <Flex
       className={classes.root}
-      sx={{
-        animation: `0s linear ${delayMs}ms forwards ${delayedShow}`,
-      }}
+      sx={{ animation: `0s linear ${delayMs}ms forwards ${delayedShow}` }}
     >
       <Spinner />
 
@@ -136,6 +136,31 @@ export const Loading = ({ delayMs = 1000 }: { delayMs?: number }) => {
         )}
       </Box>
     </Flex>
+  );
+};
+
+const useInlineLoadingStyles = makeStyles({
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+});
+
+export const InlineLoading = ({ delayMs = 1000 }: { delayMs?: number }) => {
+  const classes = useInlineLoadingStyles();
+
+  return (
+    <Box
+      className={classes.root}
+      sx={{ animation: `0s linear ${delayMs}ms forwards ${delayedShow}` }}
+    >
+      <Spinner />
+      <Typography>
+        <Trans id="hint.loading.data">Loading data…</Trans>
+      </Typography>
+    </Box>
   );
 };
 


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2164

<!--- Describe the changes -->

This PR improves the styles of custom map legends loading indicator.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-feat-optimize-custom-map-leg-2393c5-ixt1.vercel.app/en/v/dMuqmcsH31D8?dataSource=Prod).
2. ✅ See that the loading indicator doesn't take the full width, doesn't switch to "loading this dataset may require additional time" after 7.5s and that it's positioned further away from the footnotes.

<!--- Reproduction steps, in case of a bug -->

---

- [x] Add a CHANGELOG entry
