### PR TITLE
fix: Field naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ You can also check the
 - Features
   - Added an option to show all values in area, bar, column, line and pie charts
   - X axis titles are now always displayed
+- Fixes
+  - Pie chart's `Measure` field is now correctly labeled (`Measure` instead of
+    `Vertical Axis`)
 
 # [5.3.1] - 2025-03-04
 

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -467,7 +467,9 @@ const EncodingOptionsPanel = (props: EncodingOptionsPanelProps) => {
       {/* Only show component select if necessary */}
       {encoding.componentTypes.length > 0 && (
         <ControlSection hideTopBorder>
-          <SectionTitle>{getFieldLabel(encoding.field)}</SectionTitle>
+          <SectionTitle>
+            {getFieldLabel(`${chartConfig.chartType}.${encoding.field}`)}
+          </SectionTitle>
           <ControlSectionContent gap="none">
             {!encoding.customComponent && (
               <ChartFieldField


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2173

<!--- Describe the changes -->

This PR makes sure we use correct field labels in the encoding options panel.

<!--- Test instructions -->

## How to test

1. Go to this link.
2. Switch to a pie chart.
3. Open a `Measure` field.
4. See that the section title is correctly set to `Measure` instead of `Vertical Axis`.

<!--- Reproduction steps, in case of a bug -->

---

- [x] Add a CHANGELOG entry
