### PR TITLE
feat: Show limits beyond data range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ You can also check the
 
 - Features
   - It's now possible to show segment value labels in column and bar charts
+  - Axes now adapt dynamically to always show appropriate limits, even when they
+    go beyond the data range
 - Fixes
   - Pie chart's `Measure` field is now correctly labeled (`Measure` instead of
     `Vertical Axis`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ You can also check the
 
 - Features
   - It's now possible to show segment value labels in column and bar charts
+- Fixes
+  - Pie chart's `Measure` field is now correctly labeled (`Measure` instead of
+    `Vertical Axis`)
 - Styles
   - Optimized the custom map legends loading indicator appearance
 
@@ -21,9 +24,6 @@ You can also check the
 - Features
   - Added an option to show all values in area, bar, column, line and pie charts
   - X axis titles are now always displayed
-- Fixes
-  - Pie chart's `Measure` field is now correctly labeled (`Measure` instead of
-    `Vertical Axis`)
 
 # [5.3.1] - 2025-03-04
 

--- a/app/charts/area/areas-state-props.ts
+++ b/app/charts/area/areas-state-props.ts
@@ -1,12 +1,12 @@
 import { ascending } from "d3-array";
 import { useCallback, useMemo } from "react";
 
-import { ChartProps } from "@/charts/shared/ChartProps";
 import { usePlottableData } from "@/charts/shared/chart-helpers";
 import {
   BaseVariables,
   ChartStateData,
   InteractiveFiltersVariables,
+  LimitsVariables,
   NumericalYVariables,
   SegmentVariables,
   SortingVariables,
@@ -14,23 +14,28 @@ import {
   useBaseVariables,
   useChartData,
   useInteractiveFiltersVariables,
+  useLimitsVariables,
   useNumericalYVariables,
   useSegmentVariables,
   useTemporalXVariables,
 } from "@/charts/shared/chart-state";
+import { ChartProps } from "@/charts/shared/ChartProps";
 import { AreaConfig } from "@/config-types";
+import { useLimits } from "@/config-utils";
 
 export type AreasStateVariables = BaseVariables &
   SortingVariables &
   TemporalXVariables &
   NumericalYVariables &
   SegmentVariables &
-  InteractiveFiltersVariables;
+  InteractiveFiltersVariables &
+  LimitsVariables;
 
 export const useAreasStateVariables = (
-  props: ChartProps<AreaConfig>
+  props: ChartProps<AreaConfig> & { limits: ReturnType<typeof useLimits> }
 ): AreasStateVariables => {
-  const { chartConfig, observations, dimensionsById, measuresById } = props;
+  const { chartConfig, observations, dimensionsById, measuresById, limits } =
+    props;
   const { fields } = chartConfig;
   const { x, y, segment } = fields;
 
@@ -49,6 +54,7 @@ export const useAreasStateVariables = (
     chartConfig.interactiveFiltersConfig,
     { dimensionsById }
   );
+  const limitsVariables = useLimitsVariables(limits);
 
   const { getX } = temporalXVariables;
   const sortData: AreasStateVariables["sortData"] = useCallback(
@@ -67,6 +73,7 @@ export const useAreasStateVariables = (
     ...numericalYVariables,
     ...segmentVariables,
     ...interactiveFiltersVariables,
+    ...limitsVariables,
   };
 };
 

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -16,7 +16,7 @@ import {
   stackOrderReverse,
 } from "d3-shape";
 import orderBy from "lodash/orderBy";
-import React, { useCallback, useMemo } from "react";
+import { PropsWithChildren, useCallback, useMemo } from "react";
 
 import {
   AreasStateVariables,
@@ -59,6 +59,7 @@ import {
 import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useSize } from "@/charts/shared/use-size";
+import { useLimits } from "@/config-utils";
 import { AreaConfig } from "@/configurator";
 import { Observation } from "@/domain/data";
 import { useFormatNumber, useTimeFormatUnit } from "@/formatters";
@@ -109,6 +110,8 @@ const useAreasState = (
     getSegmentLabel,
     xAxisLabel,
     yAxisLabel,
+    minLimitValue,
+    maxLimitValue,
   } = variables;
   const getIdentityY = useGetIdentityY(yMeasure.id);
   const {
@@ -311,8 +314,10 @@ const useAreasState = (
       normalize,
       getX: getXAsString,
       getY,
+      minLimitValue,
+      maxLimitValue,
     });
-  }, [scalesData, normalize, getXAsString, getY]);
+  }, [scalesData, normalize, getXAsString, getY, minLimitValue, maxLimitValue]);
 
   const paddingYScale = useMemo(() => {
     //  When the user can toggle between absolute and relative values, we use the
@@ -323,6 +328,8 @@ const useAreasState = (
         normalize: false,
         getX: getXAsString,
         getY,
+        minLimitValue,
+        maxLimitValue,
       });
 
       if (scale.domain()[1] < 100 && scale.domain()[0] > -100) {
@@ -336,13 +343,17 @@ const useAreasState = (
       normalize,
       getX: getXAsString,
       getY,
+      minLimitValue,
+      maxLimitValue,
     });
   }, [
+    interactiveFiltersConfig?.calculation.active,
     paddingData,
+    normalize,
     getXAsString,
     getY,
-    interactiveFiltersConfig?.calculation.active,
-    normalize,
+    minLimitValue,
+    maxLimitValue,
   ]);
 
   /** Dimensions */
@@ -491,7 +502,9 @@ const useAreasState = (
 };
 
 const AreaChartProvider = (
-  props: React.PropsWithChildren<ChartProps<AreaConfig>>
+  props: PropsWithChildren<
+    ChartProps<AreaConfig> & { limits: ReturnType<typeof useLimits> }
+  >
 ) => {
   const { children, ...chartProps } = props;
   const variables = useAreasStateVariables(chartProps);
@@ -504,7 +517,9 @@ const AreaChartProvider = (
 };
 
 export const AreaChart = (
-  props: React.PropsWithChildren<ChartProps<AreaConfig>>
+  props: PropsWithChildren<
+    ChartProps<AreaConfig> & { limits: ReturnType<typeof useLimits> }
+  >
 ) => {
   return (
     <InteractionProvider>

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -37,7 +37,7 @@ const ChartAreas = memo((props: ChartProps<AreaConfig>) => {
   });
 
   return (
-    <AreaChart {...props}>
+    <AreaChart {...props} limits={limits}>
       <ChartContainer>
         <ChartSvg>
           <AxisTime /> <AxisHeightLinear />

--- a/app/charts/bar/bars-state-props.ts
+++ b/app/charts/bar/bars-state-props.ts
@@ -7,6 +7,7 @@ import {
   BaseVariables,
   ChartStateData,
   InteractiveFiltersVariables,
+  LimitsVariables,
   NumericalXErrorVariables,
   NumericalXVariables,
   RenderingVariables,
@@ -16,12 +17,13 @@ import {
   useBaseVariables,
   useChartData,
   useInteractiveFiltersVariables,
+  useLimitsVariables,
   useNumericalXErrorVariables,
   useNumericalXVariables,
   useSegmentVariables,
 } from "@/charts/shared/chart-state";
 import { useRenderingKeyVariable } from "@/charts/shared/rendering-utils";
-import { useChartConfigFilters } from "@/config-utils";
+import { useChartConfigFilters, useLimits } from "@/config-utils";
 import { BarConfig } from "@/configurator";
 import { isTemporalEntityDimension } from "@/domain/data";
 
@@ -34,10 +36,11 @@ export type BarsStateVariables = BaseVariables &
   NumericalXErrorVariables &
   SegmentVariables &
   RenderingVariables &
-  InteractiveFiltersVariables;
+  InteractiveFiltersVariables &
+  LimitsVariables;
 
 export const useBarsStateVariables = (
-  props: ChartProps<BarConfig>
+  props: ChartProps<BarConfig> & { limits: ReturnType<typeof useLimits> }
 ): BarsStateVariables => {
   const {
     chartConfig,
@@ -46,6 +49,7 @@ export const useBarsStateVariables = (
     dimensionsById,
     measures,
     measuresById,
+    limits,
   } = props;
   const { fields, interactiveFiltersConfig } = chartConfig;
   const { x, y, animation, segment } = fields;
@@ -69,6 +73,7 @@ export const useBarsStateVariables = (
     interactiveFiltersConfig,
     { dimensionsById }
   );
+  const limitsVariables = useLimitsVariables(limits);
 
   const { getY, getYAsDate } = bandYVariables;
   const { getX } = numericalXVariables;
@@ -114,6 +119,7 @@ export const useBarsStateVariables = (
     ...numericalXVariables,
     ...numericalXErrorVariables,
     ...interactiveFiltersVariables,
+    ...limitsVariables,
     getRenderingKey,
   };
 };

--- a/app/charts/bar/chart-bar.tsx
+++ b/app/charts/bar/chart-bar.tsx
@@ -118,7 +118,7 @@ const ChartBars = memo((props: ChartProps<BarConfig>) => {
           </ChartControlsContainer>
         </GroupedBarChart>
       ) : (
-        <BarChart {...props}>
+        <BarChart {...props} limits={limits}>
           <ChartContainer>
             <ChartSvg>
               <AxisWidthLinear />

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -116,7 +116,7 @@ const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
           </ChartControlsContainer>
         </GroupedColumnChart>
       ) : (
-        <ColumnChart {...props}>
+        <ColumnChart {...props} limits={limits}>
           <ChartContainer>
             <ChartSvg>
               <AxisHeightLinear />

--- a/app/charts/column/columns-state-props.ts
+++ b/app/charts/column/columns-state-props.ts
@@ -7,6 +7,7 @@ import {
   BaseVariables,
   ChartStateData,
   InteractiveFiltersVariables,
+  LimitsVariables,
   NumericalYErrorVariables,
   NumericalYVariables,
   RenderingVariables,
@@ -16,12 +17,13 @@ import {
   useBaseVariables,
   useChartData,
   useInteractiveFiltersVariables,
+  useLimitsVariables,
   useNumericalYErrorVariables,
   useNumericalYVariables,
   useSegmentVariables,
 } from "@/charts/shared/chart-state";
 import { useRenderingKeyVariable } from "@/charts/shared/rendering-utils";
-import { useChartConfigFilters } from "@/config-utils";
+import { useChartConfigFilters, useLimits } from "@/config-utils";
 import { ColumnConfig } from "@/configurator";
 import { isTemporalEntityDimension } from "@/domain/data";
 
@@ -34,10 +36,11 @@ export type ColumnsStateVariables = BaseVariables &
   NumericalYErrorVariables &
   SegmentVariables &
   RenderingVariables &
-  InteractiveFiltersVariables;
+  InteractiveFiltersVariables &
+  LimitsVariables;
 
 export const useColumnsStateVariables = (
-  props: ChartProps<ColumnConfig>
+  props: ChartProps<ColumnConfig> & { limits: ReturnType<typeof useLimits> }
 ): ColumnsStateVariables => {
   const {
     chartConfig,
@@ -46,6 +49,7 @@ export const useColumnsStateVariables = (
     dimensionsById,
     measures,
     measuresById,
+    limits,
   } = props;
   const { fields, interactiveFiltersConfig } = chartConfig;
   const { x, y, animation } = fields;
@@ -73,6 +77,7 @@ export const useColumnsStateVariables = (
     interactiveFiltersConfig,
     { dimensionsById }
   );
+  const limitsVariables = useLimitsVariables(limits);
 
   const { getX, getXAsDate } = bandXVariables;
   const { getY } = numericalYVariables;
@@ -114,6 +119,7 @@ export const useColumnsStateVariables = (
     ...numericalYErrorVariables,
     ...segmentVariables,
     ...interactiveFiltersVariables,
+    ...limitsVariables,
     getRenderingKey,
   };
 };

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -40,7 +40,7 @@ const ChartLines = memo((props: ChartProps<LineConfig>) => {
   });
 
   return (
-    <LineChart {...props}>
+    <LineChart {...props} limits={limits}>
       <ChartContainer>
         <ChartSvg>
           <AxisHeightLinear /> <AxisTime /> <AxisTimeDomain />

--- a/app/charts/line/lines-state-props.ts
+++ b/app/charts/line/lines-state-props.ts
@@ -6,6 +6,7 @@ import {
   BaseVariables,
   ChartStateData,
   InteractiveFiltersVariables,
+  LimitsVariables,
   NumericalYErrorVariables,
   NumericalYVariables,
   SegmentVariables,
@@ -14,11 +15,13 @@ import {
   useBaseVariables,
   useChartData,
   useInteractiveFiltersVariables,
+  useLimitsVariables,
   useNumericalYErrorVariables,
   useNumericalYVariables,
   useSegmentVariables,
   useTemporalXVariables,
 } from "@/charts/shared/chart-state";
+import { useLimits } from "@/config-utils";
 import { LineConfig } from "@/configurator";
 
 import { ChartProps } from "../shared/ChartProps";
@@ -29,10 +32,11 @@ export type LinesStateVariables = BaseVariables &
   NumericalYVariables &
   NumericalYErrorVariables &
   SegmentVariables &
-  InteractiveFiltersVariables;
+  InteractiveFiltersVariables &
+  LimitsVariables;
 
 export const useLinesStateVariables = (
-  props: ChartProps<LineConfig>
+  props: ChartProps<LineConfig> & { limits: ReturnType<typeof useLimits> }
 ): LinesStateVariables => {
   const {
     chartConfig,
@@ -41,6 +45,7 @@ export const useLinesStateVariables = (
     dimensionsById,
     measures,
     measuresById,
+    limits,
   } = props;
   const { fields } = chartConfig;
   const { x, y, segment } = fields;
@@ -65,6 +70,7 @@ export const useLinesStateVariables = (
     chartConfig.interactiveFiltersConfig,
     { dimensionsById }
   );
+  const limitsVariables = useLimitsVariables(limits);
 
   const { getX } = temporalXVariables;
   const sortData: LinesStateVariables["sortData"] = useCallback(
@@ -84,6 +90,7 @@ export const useLinesStateVariables = (
     ...numericalYErrorVariables,
     ...segmentVariables,
     ...interactiveFiltersVariables,
+    ...limitsVariables,
   };
 };
 

--- a/app/charts/shared/chart-state.ts
+++ b/app/charts/shared/chart-state.ts
@@ -1,4 +1,4 @@
-import { min } from "d3-array";
+import { max, min } from "d3-array";
 import { ScaleTime } from "d3-scale";
 import get from "lodash/get";
 import overEvery from "lodash/overEvery";
@@ -29,6 +29,7 @@ import {
 import { DimensionsById, MeasuresById } from "@/charts/shared/ChartProps";
 import { Bounds } from "@/charts/shared/use-size";
 import { TableChartState } from "@/charts/table/table-state";
+import { useLimits } from "@/config-utils";
 import {
   AreaFields,
   ChartConfig,
@@ -742,6 +743,30 @@ export type SymbolLayerVariables = {
     | undefined;
   getSymbol: StringValueGetter;
   getSymbolLabel: (d: string) => string;
+};
+
+export type LimitsVariables = {
+  minLimitValue: number | undefined;
+  maxLimitValue: number | undefined;
+};
+
+export const useLimitsVariables = (limits: ReturnType<typeof useLimits>) => {
+  const values = limits.limits.flatMap((d) => {
+    switch (d.measureLimit.type) {
+      case "single":
+        return d.measureLimit.value;
+      case "range":
+        return [d.measureLimit.from, d.measureLimit.to];
+      default:
+        const _exhaustiveCheck: never = d.measureLimit;
+        return _exhaustiveCheck;
+    }
+  });
+
+  return {
+    minLimitValue: min(values),
+    maxLimitValue: max(values),
+  };
 };
 
 export type ChartStateData = {

--- a/app/charts/shared/rendering-utils.ts
+++ b/app/charts/shared/rendering-utils.ts
@@ -181,7 +181,7 @@ export const renderVerticalLimits = (
               .append("rect")
               .attr("class", "top")
               .attr("x", (d) => d.x)
-              .attr("y", (d) => d.y2)
+              .attr("y", (d) => d.y2 - LIMIT_SIZE / 2)
               .attr("width", (d) => d.width)
               .attr("height", LIMIT_SIZE)
               .attr("fill", (d) => d.fill)
@@ -193,8 +193,8 @@ export const renderVerticalLimits = (
               .attr("class", "middle")
               .attr("x1", (d) => d.x + d.width / 2)
               .attr("x2", (d) => d.x + d.width / 2)
-              .attr("y1", (d) => d.y1)
-              .attr("y2", (d) => d.y2)
+              .attr("y1", (d) => d.y1 - LIMIT_SIZE / 2)
+              .attr("y2", (d) => d.y2 - LIMIT_SIZE / 2)
               .attr("stroke", (d) => d.fill)
               .attr("stroke-width", LIMIT_SIZE)
               .attr("stroke-dasharray", (d) =>
@@ -206,7 +206,7 @@ export const renderVerticalLimits = (
               .append("rect")
               .attr("class", "bottom")
               .attr("x", (d) => d.x)
-              .attr("y", (d) => d.y1)
+              .attr("y", (d) => d.y1 - LIMIT_SIZE / 2)
               .attr("width", (d) => d.width)
               .attr("height", LIMIT_SIZE)
               .attr("fill", (d) => d.fill)
@@ -227,7 +227,7 @@ export const renderVerticalLimits = (
                 g
                   .select(".top")
                   .attr("x", (d) => d.x)
-                  .attr("y", (d) => d.y2)
+                  .attr("y", (d) => d.y2 - LIMIT_SIZE / 2)
                   .attr("width", (d) => d.width)
                   .attr("fill", (d) => d.fill)
               )
@@ -236,8 +236,8 @@ export const renderVerticalLimits = (
                   .select(".middle")
                   .attr("x1", (d) => d.x + d.width / 2)
                   .attr("x2", (d) => d.x + d.width / 2)
-                  .attr("y1", (d) => d.y1)
-                  .attr("y2", (d) => d.y2)
+                  .attr("y1", (d) => d.y1 - LIMIT_SIZE / 2)
+                  .attr("y2", (d) => d.y2 - LIMIT_SIZE / 2)
                   .attr("stroke", (d) => d.fill)
                   .attr("stroke-width", LIMIT_SIZE)
                   .attr("stroke-dasharray", (d) =>
@@ -248,7 +248,7 @@ export const renderVerticalLimits = (
                 g
                   .select(".bottom")
                   .attr("x", (d) => d.x)
-                  .attr("y", (d) => d.y1)
+                  .attr("y", (d) => d.y1 - LIMIT_SIZE / 2)
                   .attr("width", (d) => d.width)
                   .attr("fill", (d) => d.fill)
               ),
@@ -290,7 +290,7 @@ export const renderHorizontalLimits = (
             g
               .append("rect")
               .attr("class", "left")
-              .attr("x", (d) => d.x1)
+              .attr("x", (d) => d.x1 - LIMIT_SIZE / 2)
               .attr("y", (d) => d.y)
               .attr("width", LIMIT_SIZE)
               .attr("height", (d) => d.height)
@@ -301,8 +301,8 @@ export const renderHorizontalLimits = (
             g
               .append("line")
               .attr("class", "middle")
-              .attr("x1", (d) => d.x1)
-              .attr("x2", (d) => d.x2)
+              .attr("x1", (d) => d.x1 - LIMIT_SIZE / 2)
+              .attr("x2", (d) => d.x2 - LIMIT_SIZE / 2)
               .attr("y1", (d) => d.y + d.height / 2)
               .attr("y2", (d) => d.y + d.height / 2)
               .attr("stroke", (d) => d.fill)
@@ -315,7 +315,7 @@ export const renderHorizontalLimits = (
             g
               .append("rect")
               .attr("class", "right")
-              .attr("x", (d) => d.x2)
+              .attr("x", (d) => d.x2 - LIMIT_SIZE / 2)
               .attr("y", (d) => d.y)
               .attr("width", LIMIT_SIZE)
               .attr("height", (d) => d.height)
@@ -336,7 +336,7 @@ export const renderHorizontalLimits = (
               .call((g) =>
                 g
                   .select(".left")
-                  .attr("x", (d) => d.x1)
+                  .attr("x", (d) => d.x1 - LIMIT_SIZE / 2)
                   .attr("y", (d) => d.y)
                   .attr("height", (d) => d.height)
                   .attr("fill", (d) => d.fill)
@@ -344,8 +344,8 @@ export const renderHorizontalLimits = (
               .call((g) =>
                 g
                   .select(".middle")
-                  .attr("x1", (d) => d.x1)
-                  .attr("x2", (d) => d.x2)
+                  .attr("x1", (d) => d.x1 - LIMIT_SIZE / 2)
+                  .attr("x2", (d) => d.x2 - LIMIT_SIZE / 2)
                   .attr("y1", (d) => d.y + d.height / 2)
                   .attr("y2", (d) => d.y + d.height / 2)
                   .attr("stroke", (d) => d.fill)
@@ -357,7 +357,7 @@ export const renderHorizontalLimits = (
               .call((g) =>
                 g
                   .select(".right")
-                  .attr("x", (d) => d.x2)
+                  .attr("x", (d) => d.x2 - LIMIT_SIZE / 2)
                   .attr("y", (d) => d.y)
                   .attr("height", (d) => d.height)
                   .attr("fill", (d) => d.fill)

--- a/app/charts/shared/stacked-helpers.ts
+++ b/app/charts/shared/stacked-helpers.ts
@@ -17,9 +17,12 @@ export const getStackedYScale = (
     getX: StringValueGetter;
     getY: NumericalValueGetter;
     getTime?: StringValueGetter;
+    minLimitValue?: number;
+    maxLimitValue?: number;
   }
 ): ScaleLinear<number, number> => {
-  const { normalize, getX, getY, getTime } = options;
+  const { normalize, getX, getY, getTime, minLimitValue, maxLimitValue } =
+    options;
   const yScale = scaleLinear();
 
   if (normalize) {
@@ -43,7 +46,12 @@ export const getStackedYScale = (
       }
     }
 
-    yScale.domain([yMin, yMax]).nice();
+    yScale
+      .domain([
+        minLimitValue !== undefined ? Math.min(minLimitValue, yMin) : yMin,
+        maxLimitValue !== undefined ? Math.max(maxLimitValue, yMax) : yMax,
+      ])
+      .nice();
   }
 
   return yScale;

--- a/app/docs/charts.stories.tsx
+++ b/app/docs/charts.stories.tsx
@@ -89,6 +89,7 @@ const ColumnsStory = {
       <InteractiveFiltersProvider chartConfigs={[chartConfig]}>
         <InteractiveFiltersChartProvider chartConfigKey={chartConfig.key}>
           <ColumnChart
+            limits={{ relatedDimension: undefined, limits: [] }}
             observations={columnObservations}
             measures={columnMeasures}
             measuresById={keyBy(columnMeasures, (d: Measure) => d.id)}

--- a/app/docs/lines.stories.tsx
+++ b/app/docs/lines.stories.tsx
@@ -67,6 +67,7 @@ const LineChartStory = () => (
     <InteractiveFiltersProvider chartConfigs={[chartConfig]}>
       <InteractiveFiltersChartProvider chartConfigKey={chartConfig.key}>
         <LineChart
+          limits={{ relatedDimension: undefined, limits: [] }}
           observations={observations}
           dimensions={dimensions}
           dimensionsById={keyBy(dimensions, (d) => d.id)}

--- a/app/docs/tooltip.stories.tsx
+++ b/app/docs/tooltip.stories.tsx
@@ -62,6 +62,7 @@ const TooltipBoxStory = () => (
   <ReactSpecimen>
     <InteractiveFiltersChartProvider chartConfigKey="column-chart">
       <ColumnChart
+        limits={{ relatedDimension: undefined, limits: [] }}
         observations={observations}
         measures={measures}
         measuresById={keyBy(measures, (d) => d.id)}
@@ -95,7 +96,7 @@ const TooltipBoxStory = () => (
           chartType: "column",
           fields,
           interactiveFiltersConfig: {
-            legend: { active: false, componentId: "", },
+            legend: { active: false, componentId: "" },
             timeRange: {
               active: false,
               componentId: "",
@@ -228,6 +229,7 @@ const TooltipContentStory = {
   render: () => (
     <InteractiveFiltersChartProvider chartConfigKey="column-chart">
       <ColumnChart
+        limits={{ relatedDimension: undefined, limits: [] }}
         observations={observations}
         measures={measures}
         measuresById={keyBy(measures, (d) => d.id)}
@@ -261,7 +263,7 @@ const TooltipContentStory = {
           chartType: "column",
           fields,
           interactiveFiltersConfig: {
-            legend: { active: false, componentId: "",  },
+            legend: { active: false, componentId: "" },
             timeRange: {
               active: false,
               componentId: "",
@@ -297,6 +299,7 @@ export const TooltipContentStory2 = {
   render: () => (
     <InteractiveFiltersChartProvider chartConfigKey="column-chart">
       <ColumnChart
+        limits={{ relatedDimension: undefined, limits: [] }}
         observations={observations}
         measures={measures}
         measuresById={keyBy(measures, (d) => d.id)}
@@ -330,7 +333,7 @@ export const TooltipContentStory2 = {
           chartType: "column",
           fields,
           interactiveFiltersConfig: {
-            legend: { active: false, componentId: "",},
+            legend: { active: false, componentId: "" },
             timeRange: {
               active: false,
               componentId: "",


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2169

<!--- Describe the changes -->

This PR makes sure we always display appropriate limits, even when they go beyond the data range. It also correctly centers limits by offsetting half of line stroke width.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-feat-show-limits-beyond-chart-range-ixt1.vercel.app/en/v/TD_3oSQPBtj2?dataSource=Test).
2. ✅ See that all limits are visible, even these far beyond the data range.

<!--- Reproduction steps, in case of a bug -->

---

- [x] Add a CHANGELOG entry
