### PR TITLE
fix: Multi-filter colors setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ You can also check the
 - Fixes
   - Pie chart's `Measure` field is now correctly labeled (`Measure` instead of
     `Vertical Axis`)
+  - Opening a multi filter field that shouldn't enable setting the colors
+    doesn't longer allow to and doesn't overwrite the colors anymore
+  - It's now again possible to update the symbol layer colors based on
+    categorical dimensions
 - Styles
   - Optimized the custom map legends loading indicator appearance
 

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -58,6 +58,7 @@ import {
   isBarConfig,
   isColorInConfig,
   isComboChartConfig,
+  isMapConfig,
   isTableConfig,
   MapConfig,
   SortingType,
@@ -1750,7 +1751,9 @@ const ChartFieldMultiFilter = ({
 }) => {
   const colorComponentId = get(
     chartConfig,
-    `fields["${field}"].color.componentId`
+    isMapConfig(chartConfig)
+      ? `fields["${field}"].color.componentId`
+      : `fields.segment.componentId`
   );
   const colorComponent = [...dimensions, ...measures].find(
     (d) => d.id === colorComponentId
@@ -1782,7 +1785,7 @@ const ChartFieldMultiFilter = ({
             <DimensionValuesMultiFilter
               dimension={component}
               field={field}
-              colorComponent={colorComponent ?? component}
+              colorComponent={colorComponent}
               // If colorType is defined, we are dealing with color field and
               // not segment.
               colorConfigPath={

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -759,7 +759,7 @@ const useMultiFilterColorPicker = (
           type: "CHART_COLOR_CHANGED",
           value: {
             field: colorField,
-            colorConfigPath: hasColorField ? "" : colorField,
+            colorConfigPath: hasColorField ? "" : "color",
             color,
             value,
           },

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -235,7 +235,7 @@ export const getHasColorMapping = ({
     (colorConfig?.type === "single" ? false : colorConfig?.colorMapping) &&
     (colorComponent !== undefined
       ? filterDimensionId === colorComponent.id
-      : true)
+      : false)
   );
 };
 


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2177

<!--- Describe the changes -->

This PR:
- fixes setting categorical symbol colors,
- makes opening the `Horizontal Axis` field no longer overwrite the colors in case chart has a segment,
- makes it impossible to set colors through multi-filter panel when shouldn't (in places like e.g. `Horizontal Axis`).

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-color-x-segment-overwrite-ixt1.vercel.app/en/create/new?cube=https://health.ld.admin.ch/fsvo/Forschungsbericht_2021-2024_Themengebiete/2&dataSource=Prod).
2. Add a segmentation by `Subject areas`.
3. Open `Horizontal Axis`.
4. ✅ See that the colors were persisted.
5. ✅ See that the colors pickers are not available.
6. Go to [this link](https://visualization-tool-git-fix-color-x-segment-overwrite-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10&dataSource=Prod).
7. Switch to a map chart.
8. Open `Symbols` field.
9. Select a `Kanton` dimension.
10. Add color by `Kanton`.
11. ✅ Change color of a given canton and see that it was correctly applied.

To reproduce the map colors issue, go to PROD (https://visualize.admin.ch/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10&dataSource=Prod) and try to apply the same steps.

<!--- Reproduction steps, in case of a bug -->

---

- [x] Add a CHANGELOG entry
