### PR TITLE
feat: Render limits in maps and when axis dimension is a single filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ You can also check the
   - Axes now adapt dynamically to always show appropriate limits, even when they
     go beyond the data range
   - Limits are now also rendered when the axis dimension is a single filter
+  - It's now possible to display limits in map charts
 - Fixes
   - Pie chart's `Measure` field is now correctly labeled (`Measure` instead of
     `Vertical Axis`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,13 @@ You can also check the
   - It's now possible to show segment value labels in column and bar charts
   - Axes now adapt dynamically to always show appropriate limits, even when they
     go beyond the data range
+  - Limits are now also rendered when the axis dimension is a single filter
 - Fixes
   - Pie chart's `Measure` field is now correctly labeled (`Measure` instead of
     `Vertical Axis`)
 - Styles
   - Optimized the custom map legends loading indicator appearance
+  - Line-based limits now take the full bar / column width
 
 # [5.4.0] - 2025-03-11
 

--- a/app/browser/select-dataset-step.tsx
+++ b/app/browser/select-dataset-step.tsx
@@ -189,6 +189,8 @@ const SelectDatasetStepContent = ({
 }: SelectDatasetStepContentProps) => {
   const locale = useLocale();
   const [configState] = useConfiguratorState();
+  const router = useRouter();
+  const odsIframe = isOdsIframe(router.query);
 
   const browseState = useBrowseContext();
   const {
@@ -203,7 +205,6 @@ const SelectDatasetStepContent = ({
   const [debouncedQuery] = useDebounce(search, 500, {
     leading: true,
   });
-  const router = useRouter();
   const handleHeightChange = useCallback(
     ({ height }: { width: number; height: number }) => {
       window.parent.postMessage({ type: CHART_RESIZE_EVENT_TYPE, height }, "*");
@@ -215,7 +216,7 @@ const SelectDatasetStepContent = ({
   const classes = useStyles({
     datasetPresent: !!dataset,
     variant,
-    isOdsIframe: isOdsIframe(router.query),
+    isOdsIframe: odsIframe,
   });
   const backLink = useMemo(() => {
     return formatBackLink(router.query);
@@ -345,7 +346,7 @@ const SelectDatasetStepContent = ({
   }
 
   return (
-    <Box ref={ref}>
+    <Box ref={odsIframe ? ref : null}>
       <AnimatePresence>
         {!dataset && variant === "page" && (
           <MotionBox key="banner" {...bannerPresenceProps}>
@@ -379,11 +380,11 @@ const SelectDatasetStepContent = ({
         )}
       </AnimatePresence>
       <PanelLayout
-        type={isOdsIframe(router.query) ? "M" : "LM"}
+        type={odsIframe ? "M" : "LM"}
         className={classes.panelLayout}
         key="panel"
       >
-        {!isOdsIframe(router.query) && (
+        {!odsIframe && (
           <PanelBodyWrapper type="L" className={classes.panelLeft}>
             <AnimatePresence mode="wait">
               {dataset ? (
@@ -428,7 +429,7 @@ const SelectDatasetStepContent = ({
         <PanelBodyWrapper
           type="M"
           className={classes.panelMiddle}
-          sx={isOdsIframe(router.query) ? { p: 6 } : { maxWidth: 1040, p: 6 }}
+          sx={odsIframe ? { p: 6 } : { maxWidth: 1040, p: 6 }}
         >
           <AnimatePresence mode="wait">
             {dataset ? (
@@ -521,7 +522,7 @@ const SelectDatasetStepContent = ({
           </AnimatePresence>
         </PanelBodyWrapper>
       </PanelLayout>
-      {variant == "page" && !isOdsIframe(router.query) ? (
+      {variant == "page" && !odsIframe ? (
         <Box
           sx={{
             borderTop: "2px solid rgba(0,0,0,0.05)",

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -17,6 +17,7 @@ import { Cube, MapConfig } from "@/config-types";
 import {
   useChartConfigFilters,
   useDefinitiveTemporalFilterValue,
+  useLimits,
 } from "@/config-utils";
 import { TimeSlider } from "@/configurator/interactive-filters/time-slider";
 import {
@@ -183,15 +184,21 @@ export type ChartMapProps = ChartProps<MapConfig> & {
 };
 
 const ChartMap = memo((props: ChartMapProps) => {
-  const { chartConfig, dimensions, observations } = props;
+  const { chartConfig, dimensions, measures, observations } = props;
   const { fields } = chartConfig;
   const filters = useChartConfigFilters(chartConfig);
   const temporalFilterValue = useDefinitiveTemporalFilterValue({ dimensions });
+  const limits = useLimits({
+    chartConfig,
+    dimensions,
+    measures,
+  });
 
   return (
     <MapChart {...props}>
       <ChartContainer>
         <MapComponent
+          limits={limits}
           customLayers={chartConfig.baseLayer.customLayers}
           value={temporalFilterValue ? +temporalFilterValue : undefined}
         />

--- a/app/charts/map/chart-map.tsx
+++ b/app/charts/map/chart-map.tsx
@@ -220,7 +220,11 @@ const ChartMap = memo((props: ChartMapProps) => {
             flexWrap: "wrap",
           }}
         >
-          <MapLegend chartConfig={chartConfig} observations={observations} />
+          <MapLegend
+            chartConfig={chartConfig}
+            observations={observations}
+            limits={limits.limits}
+          />
           <MapCustomLayersLegend
             chartConfig={chartConfig}
             value={temporalFilterValue ? +temporalFilterValue : undefined}

--- a/app/charts/map/dashed-scatterplot-layer.ts
+++ b/app/charts/map/dashed-scatterplot-layer.ts
@@ -1,0 +1,22 @@
+import { ScatterplotLayer } from "@deck.gl/layers";
+
+export default class DashedScatterplotLayer extends ScatterplotLayer {
+  getShaders() {
+    const shaders = super.getShaders();
+
+    shaders.inject = {
+      "fs:DECKGL_FILTER_COLOR": `
+        float PI = 3.14159265359;
+        float angle = atan(geometry.uv.y, geometry.uv.x); 
+        float dashPattern = mod(angle * 20.0, PI * 2.0);
+        bool isDashed = dashPattern < PI;
+
+        if (!isDashed) {
+          discard;
+        }
+      `,
+    };
+
+    return shaders;
+  }
+}

--- a/app/charts/map/map-legend.tsx
+++ b/app/charts/map/map-legend.tsx
@@ -32,7 +32,7 @@ import { getTextWidth } from "@/utils/get-text-width";
 const MAX_WIDTH = 204;
 const HEIGHT = 40;
 const COLOR_RAMP_HEIGHT = 10;
-const MARGIN = { top: 6, right: 4, bottom: 0, left: 4 };
+const MARGIN = { top: 6, right: 4, bottom: 6, left: 4 };
 const AXIS_TICK_ROTATE_ANGLE = 45;
 const AXIS_LABEL_FONT_SIZE = 10;
 
@@ -228,7 +228,18 @@ export const MapLegend = ({
   );
 };
 
-interface CircleProps {
+const Circle = ({
+  value,
+  label,
+  fill,
+  stroke,
+  radius,
+  maxRadius,
+  fontSize,
+  showLine = true,
+  dashed,
+  center,
+}: {
   value: string;
   label: string;
   fill?: string;
@@ -237,44 +248,35 @@ interface CircleProps {
   maxRadius: number;
   fontSize: number;
   showLine?: boolean;
-}
-
-const Circle = (props: CircleProps) => {
-  const {
-    value,
-    label,
-    fill,
-    stroke,
-    radius,
-    maxRadius,
-    fontSize,
-    showLine = true,
-  } = props;
+  dashed?: boolean;
+  center?: boolean;
+}) => {
+  const cy = center ? -maxRadius + radius : 0;
 
   return (
     <g transform={`translate(0, ${maxRadius - radius})`}>
       <circle
         cx={0}
-        cy={0}
+        cy={cy}
         r={radius}
         fill={fill}
         stroke={stroke}
+        strokeDasharray={dashed ? "4 4" : 0}
         fillOpacity={0.1}
       />
       {showLine && (
         <>
           <line
             x1={0}
-            y1={-radius}
+            y1={cy - radius}
             x2={maxRadius + 4}
-            y2={-radius}
-            stroke={stroke}
+            y2={cy - radius}
+            stroke="black"
           />
           <text
             x={maxRadius + 6}
-            y={-radius}
+            y={cy - radius}
             dy={5}
-            fill={stroke}
             textAnchor="start"
             fontSize={fontSize}
             paintOrder="stroke"

--- a/app/charts/pie/pie.tsx
+++ b/app/charts/pie/pie.tsx
@@ -131,6 +131,7 @@ export const Pie = () => {
             dy: 0,
             fontFamily,
             fontSize: labelFontSize,
+            strokeWidth: 8,
           }),
       });
     }

--- a/app/charts/shared/limits.tsx
+++ b/app/charts/shared/limits.tsx
@@ -46,8 +46,10 @@ export const HorizontalLimits = ({
       .filter(truthy);
 
     return preparedLimits
-      .map((limit, i) => {
-        const key = `${i}`;
+      .map((limit) => {
+        const key = limit.related
+          .map((d) => d.dimensionId + d.dimensionValue)
+          .join();
         const x1 = xScale(limit.x1);
         const x2 = xScale(limit.x2);
         const fill = limit.color;
@@ -150,8 +152,10 @@ export const VerticalLimits = ({
       .filter(truthy);
 
     return preparedLimits
-      .map((limit, i) => {
-        const key = `${i}`;
+      .map((limit) => {
+        const key = limit.related
+          .map((d) => d.dimensionId + d.dimensionValue)
+          .join();
         const y1 = yScale(limit.y1);
         const y2 = yScale(limit.y2);
         const fill = limit.color;

--- a/app/charts/shared/limits.tsx
+++ b/app/charts/shared/limits.tsx
@@ -18,59 +18,60 @@ import { truthy } from "@/domain/types";
 import { useTransitionStore } from "@/stores/transition";
 
 export const HorizontalLimits = ({
-  relatedDimension,
+  axisDimension,
   limits,
 }: ReturnType<typeof useLimits>) => {
   const { yScale, getY, xScale, bounds } = useChartState() as BarsState;
-  const { margins, width, height } = bounds;
+  const { width, height, chartHeight, margins } = bounds;
   const ref = useRef<SVGGElement>(null);
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
   const renderData: RenderHorizontalLimitDatum[] = useMemo(() => {
-    const bandwidth = yScale.bandwidth();
-    const limitHeight = Math.min(yScale.bandwidth(), 15);
+    const limitHeight = yScale.bandwidth();
     const preparedLimits = limits
-      .map(({ configLimit, measureLimit }) => {
-        const relatedDimensionValue = relatedDimension?.values.find(
-          (v) => v.value === configLimit.dimensionValue
-        )?.label;
-
-        if (!relatedDimensionValue) {
-          return;
-        }
-
+      .map(({ configLimit, measureLimit, relatedAxisDimensionValueLabel }) => {
         return {
-          y1:
+          x1:
             measureLimit.type === "single"
               ? measureLimit.value
               : measureLimit.from,
-          y2:
+          x2:
             measureLimit.type === "single"
               ? measureLimit.value
               : measureLimit.to,
           ...configLimit,
-          relatedDimensionValue,
+          relatedAxisDimensionValueLabel,
         };
       })
       .filter(truthy);
 
     return preparedLimits
-      .map((limit) => {
-        const fakeObservation: Observation = {
-          [relatedDimension?.id ?? ""]: limit.relatedDimensionValue,
-        };
-        const y = getY(fakeObservation);
-        const yScaled = yScale(y);
+      .map((limit, i) => {
+        const key = `${i}`;
+        const x1 = xScale(limit.x1);
+        const x2 = xScale(limit.x2);
+        const fill = limit.color;
+        const lineType = limit.lineType;
 
-        return yScaled !== undefined
+        const axisObservation: Observation = {
+          [axisDimension?.id ?? ""]: limit.relatedAxisDimensionValueLabel ?? "",
+        };
+        const axisY = yScale(getY(axisObservation));
+        const y = axisY ?? 0;
+        const height = axisY !== undefined ? limitHeight : chartHeight;
+
+        const hasValidAxis = axisY !== undefined;
+        const hasNoAxis = limit.relatedAxisDimensionValueLabel === undefined;
+
+        return hasValidAxis || hasNoAxis
           ? ({
-              key: limit.relatedDimensionValue,
-              y: yScaled + bandwidth / 2 - limitHeight / 2,
-              x1: xScale(limit.y1),
-              x2: xScale(limit.y2),
-              height: limitHeight,
-              fill: limit.color,
-              lineType: limit.lineType,
+              key,
+              x1,
+              x2,
+              y,
+              height,
+              fill,
+              lineType,
             } as RenderHorizontalLimitDatum)
           : null;
       })
@@ -79,8 +80,8 @@ export const HorizontalLimits = ({
   }, [
     xScale,
     limits,
-    relatedDimension?.values,
-    relatedDimension?.id,
+    axisDimension?.values,
+    axisDimension?.id,
     getY,
     yScale,
     width,
@@ -108,14 +109,14 @@ export const HorizontalLimits = ({
 };
 
 export const VerticalLimits = ({
-  relatedDimension,
+  axisDimension,
   limits,
 }: ReturnType<typeof useLimits>) => {
   const { xScale, getX, yScale, bounds } = useChartState() as
     | AreasState
     | ColumnsState
     | LinesState;
-  const { margins, width, height } = bounds;
+  const { margins, chartWidth, width, height } = bounds;
   const ref = useRef<SVGGElement>(null);
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
@@ -124,7 +125,7 @@ export const VerticalLimits = ({
       "bandwidth" in xScale
         ? {
             bandwidth: xScale.bandwidth(),
-            limitWidth: Math.min(xScale.bandwidth(), 15),
+            limitWidth: xScale.bandwidth(),
           }
         : {
             bandwidth: 0,
@@ -132,15 +133,7 @@ export const VerticalLimits = ({
           };
 
     const preparedLimits = limits
-      .map(({ configLimit, measureLimit }) => {
-        const relatedDimensionValue = relatedDimension?.values.find(
-          (v) => v.value === configLimit.dimensionValue
-        )?.label;
-
-        if (!relatedDimensionValue) {
-          return;
-        }
-
+      .map(({ configLimit, measureLimit, relatedAxisDimensionValueLabel }) => {
         return {
           y1:
             measureLimit.type === "single"
@@ -151,28 +144,39 @@ export const VerticalLimits = ({
               ? measureLimit.value
               : measureLimit.to,
           ...configLimit,
-          relatedDimensionValue,
+          relatedAxisDimensionValueLabel,
         };
       })
       .filter(truthy);
 
     return preparedLimits
-      .map((limit) => {
-        const fakeObservation: Observation = {
-          [relatedDimension?.id ?? ""]: limit.relatedDimensionValue,
-        };
-        const x = getX(fakeObservation) as $IntentionalAny;
-        const xScaled = xScale(x);
+      .map((limit, i) => {
+        const key = `${i}`;
+        const y1 = yScale(limit.y1);
+        const y2 = yScale(limit.y2);
+        const fill = limit.color;
+        const lineType = limit.lineType;
 
-        return xScaled !== undefined
+        const axisObservation: Observation = {
+          [axisDimension?.id ?? ""]: limit.relatedAxisDimensionValueLabel ?? "",
+        };
+        const axisX = xScale(getX(axisObservation) as $IntentionalAny);
+        const x =
+          axisX !== undefined ? axisX + (bandwidth - limitWidth) * 0.5 : 0;
+        const width = axisX !== undefined ? limitWidth : chartWidth;
+
+        const hasValidAxis = axisX !== undefined;
+        const hasNoAxis = limit.relatedAxisDimensionValueLabel === undefined;
+
+        return hasValidAxis || hasNoAxis
           ? ({
-              key: limit.relatedDimensionValue,
-              x: xScaled + bandwidth / 2 - limitWidth / 2,
-              y1: yScale(limit.y1),
-              y2: yScale(limit.y2),
-              width: limitWidth,
-              fill: limit.color,
-              lineType: limit.lineType,
+              key,
+              x,
+              y1,
+              y2,
+              width,
+              fill,
+              lineType,
             } as RenderVerticalLimitDatum)
           : null;
       })
@@ -181,8 +185,8 @@ export const VerticalLimits = ({
   }, [
     xScale,
     limits,
-    relatedDimension?.values,
-    relatedDimension?.id,
+    axisDimension?.values,
+    axisDimension?.id,
     getX,
     yScale,
     width,

--- a/app/charts/shared/render-value-labels.ts
+++ b/app/charts/shared/render-value-labels.ts
@@ -22,6 +22,7 @@ export const renderTotalValueLabels = (
     dy?: number;
     fontSize: number;
     fontFamily: string;
+    strokeWidth?: number;
   }
 ) => {
   const {
@@ -32,6 +33,7 @@ export const renderTotalValueLabels = (
     dy = -8,
     fontFamily,
     fontSize,
+    strokeWidth = 3,
   } = options;
   const textAnchor = _textAnchor ?? getValueLabelTextAnchor(rotate);
 
@@ -46,7 +48,7 @@ export const renderTotalValueLabels = (
           .attr("text-anchor", textAnchor)
           .attr("paint-order", "stroke")
           .attr("stroke", "white")
-          .attr("stroke-width", 8)
+          .attr("stroke-width", strokeWidth)
           .style("transform", (d) =>
             getValueLabelTransform(d, {
               rotate,

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -274,8 +274,12 @@ const Cube = t.intersection([
 export type Cube = t.TypeOf<typeof Cube>;
 
 const Limit = t.type({
-  dimensionId: t.string,
-  dimensionValue: t.string,
+  related: t.array(
+    t.type({
+      dimensionId: t.string,
+      dimensionValue: t.string,
+    })
+  ),
   color: t.string,
   lineType: t.union([t.literal("dashed"), t.literal("solid")]),
 });

--- a/app/config-utils.ts
+++ b/app/config-utils.ts
@@ -323,10 +323,13 @@ const getLimitMeasure = ({
       return measures.find((d) => d.id === chartConfig.fields.y.componentId);
     case "bar":
       return measures.find((d) => d.id === chartConfig.fields.x.componentId);
+    case "map":
+      return measures.find(
+        (d) => d.id === chartConfig.fields.symbolLayer?.measureId
+      );
     case "comboLineColumn":
     case "comboLineDual":
     case "comboLineSingle":
-    case "map":
     case "pie":
     case "scatterplot":
     case "table":

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -589,13 +589,6 @@ const EncodingOptionsPanel = (props: EncodingOptionsPanelProps) => {
           measures={measures}
         />
       )}
-      {limitMeasure ? (
-        <ChartLimits
-          chartConfig={chartConfig}
-          dimensions={dimensions}
-          measure={limitMeasure}
-        />
-      ) : null}
       {encoding.options?.imputation?.shouldShow(chartConfig, observations) && (
         <ChartImputation chartConfig={chartConfig} />
       )}
@@ -631,6 +624,13 @@ const EncodingOptionsPanel = (props: EncodingOptionsPanelProps) => {
           getFieldOptionGroups={getFieldOptionGroups}
         />
       )}
+      {limitMeasure ? (
+        <ChartLimits
+          chartConfig={chartConfig}
+          dimensions={dimensions}
+          measure={limitMeasure}
+        />
+      ) : null}
       {encoding.options?.colorComponent && component && (
         <ChartFieldColorComponent
           chartConfig={chartConfig}

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -452,11 +452,12 @@ const EncodingOptionsPanel = (props: EncodingOptionsPanelProps) => {
 
   const hasSubOptions = encoding.options?.chartSubType ?? false;
 
-  const limitMeasure = isMapConfig(chartConfig)
-    ? measures.find((m) => m.id === chartConfig.fields.symbolLayer?.measureId)
-    : isMeasure(component)
-      ? component
-      : undefined;
+  const limitMeasure =
+    isMapConfig(chartConfig) && chartConfig.activeField === "symbolLayer"
+      ? measures.find((m) => m.id === chartConfig.fields.symbolLayer?.measureId)
+      : isMeasure(component)
+        ? component
+        : undefined;
 
   return (
     <div

--- a/app/configurator/configurator-state/actions.tsx
+++ b/app/configurator/configurator-state/actions.tsx
@@ -281,19 +281,13 @@ export type ConfiguratorStateAction =
       type: "LIMIT_SET";
       value: {
         measureId: string;
-        relatedDimensionId: string;
-        relatedDimensionValue: string;
-        color: string;
-        lineType: Limit["lineType"];
-      };
+      } & Limit;
     }
   | {
       type: "LIMIT_REMOVE";
       value: {
         measureId: string;
-        relatedDimensionId: string;
-        relatedDimensionValue: string;
-      };
+      } & Pick<Limit, "related">;
     }
   | {
       type: "LAYOUT_BLOCK_SWAP";

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -1234,7 +1234,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
         } else {
           chartConfig.limits[measureId] = limits.filter((l) => {
             return l.related.some((lr) => {
-              return related.some((nr) => {
+              return related.every((nr) => {
                 return (
                   lr.dimensionId !== nr.dimensionId ||
                   lr.dimensionValue !== nr.dimensionValue

--- a/app/docs/charts.stories.tsx
+++ b/app/docs/charts.stories.tsx
@@ -89,7 +89,7 @@ const ColumnsStory = {
       <InteractiveFiltersProvider chartConfigs={[chartConfig]}>
         <InteractiveFiltersChartProvider chartConfigKey={chartConfig.key}>
           <ColumnChart
-            limits={{ relatedDimension: undefined, limits: [] }}
+            limits={{ axisDimension: undefined, limits: [] }}
             observations={columnObservations}
             measures={columnMeasures}
             measuresById={keyBy(columnMeasures, (d: Measure) => d.id)}

--- a/app/docs/lines.stories.tsx
+++ b/app/docs/lines.stories.tsx
@@ -67,7 +67,7 @@ const LineChartStory = () => (
     <InteractiveFiltersProvider chartConfigs={[chartConfig]}>
       <InteractiveFiltersChartProvider chartConfigKey={chartConfig.key}>
         <LineChart
-          limits={{ relatedDimension: undefined, limits: [] }}
+          limits={{ axisDimension: undefined, limits: [] }}
           observations={observations}
           dimensions={dimensions}
           dimensionsById={keyBy(dimensions, (d) => d.id)}

--- a/app/docs/tooltip.stories.tsx
+++ b/app/docs/tooltip.stories.tsx
@@ -62,7 +62,7 @@ const TooltipBoxStory = () => (
   <ReactSpecimen>
     <InteractiveFiltersChartProvider chartConfigKey="column-chart">
       <ColumnChart
-        limits={{ relatedDimension: undefined, limits: [] }}
+        limits={{ axisDimension: undefined, limits: [] }}
         observations={observations}
         measures={measures}
         measuresById={keyBy(measures, (d) => d.id)}
@@ -229,7 +229,7 @@ const TooltipContentStory = {
   render: () => (
     <InteractiveFiltersChartProvider chartConfigKey="column-chart">
       <ColumnChart
-        limits={{ relatedDimension: undefined, limits: [] }}
+        limits={{ axisDimension: undefined, limits: [] }}
         observations={observations}
         measures={measures}
         measuresById={keyBy(measures, (d) => d.id)}
@@ -299,7 +299,7 @@ export const TooltipContentStory2 = {
   render: () => (
     <InteractiveFiltersChartProvider chartConfigKey="column-chart">
       <ColumnChart
-        limits={{ relatedDimension: undefined, limits: [] }}
+        limits={{ axisDimension: undefined, limits: [] }}
         observations={observations}
         measures={measures}
         measuresById={keyBy(measures, (d) => d.id)}


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2170
Closes #2180

<!--- Describe the changes -->

This PR:
1. Introduces support for rendering limits when "axis dimension" is not displayed directly in the chart, but is a single filter.
2. Introduces support for rendering limits in map charts.

<!--- Test instructions -->

## How to test

**Rendering limits when "axis dimension" is a single filter**
1. Go to [this link](https://visualization-tool-git-feat-show-limits-in-maps-ixt1.vercel.app/en/create/new?cube=https://environment.ld.admin.ch/foen/test_target/cube/target_1/1&dataSource=Test).
2. Open `Vertical Axis` field.
3. Add limit for thermal fuel (2012).
4. Switch `Horizontal Axis` to `Energy source`.
5. Set `Year` filter to `Year 2012`.
6. ✅ See that the limit is displayed (in contrast to TEST / INT, where it does not appear).
7. Go to [this link](https://visualization-tool-git-feat-show-limits-in-maps-ixt1.vercel.app/en/create/new?cube=https://environment.ld.admin.ch/foen/test_target/cube/target_soil/1&dataSource=Test).
8. Go to `Vertical Axis` and toggle limit for cadmium.
9. ✅ See that the limit displayed itself in the first column.
10. Go to `Horizontal Axis` field and change the component to `Municipality`.
11. ✅ See that the limit for cadmium still displays itself, now in a form of an overarching horizontal line (in contrast to TEST / INT where it does not appear).
12. ✅ Change the `Heavy metals` filter from cadmium to something else and see that the limit disappeared.

**Rendering limits in map charts**
1. Go to [this link](https://visualization-tool-git-feat-show-limits-in-maps-ixt1.vercel.app/en/create/new?cube=https://environment.ld.admin.ch/foen/test_target/cube/target_soil/1&dataSource=Test).
2. Switch to a map chart.
3. Open `Symbols` field and select the `Municipality` dimension.
4. ✅ See that there's a `Targets & limit values` section just below the `Size` section.
5. ✅ See that you can toggle the limit and change its color and that it's rendered on a map and in the legend area.

<!--- Reproduction steps, in case of a bug -->

---

- [x] Add a CHANGELOG entry
