### PR TITLE
fix: Translations of color names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ You can also check the
     doesn't longer allow to and doesn't overwrite the colors anymore
   - It's now again possible to update the symbol layer colors based on
     categorical dimensions
+  - Color palette names are now correctly translated in user profile (instead of
+    always displaying in German)
 - Styles
   - Optimized the custom map legends loading indicator appearance
 

--- a/app/login/components/color-palettes/profile-color-palette-form.tsx
+++ b/app/login/components/color-palettes/profile-color-palette-form.tsx
@@ -264,21 +264,6 @@ type ColorPaletteTypeSelectorProps = {
   selectedType: CustomPaletteType["type"];
 };
 
-const colorTypes: Record<CustomPaletteType["type"], string> = {
-  sequential: t({
-    id: "controls.custom-color-palettes.sequential",
-    message: "Sequential",
-  }),
-  diverging: t({
-    id: "controls.custom-color-palettes.diverging",
-    message: "Diverging",
-  }),
-  categorical: t({
-    id: "controls.custom-color-palettes.categorical",
-    message: "Categorical",
-  }),
-};
-
 const ColorPaletteTypeSelector = ({
   onChange,
   selectedType,
@@ -288,6 +273,17 @@ const ColorPaletteTypeSelector = ({
     "sequential",
     "diverging",
   ];
+  const colorTypes: Record<CustomPaletteType["type"], string> = {
+    sequential: t({
+      id: "controls.custom-color-palettes.sequential",
+    }),
+    diverging: t({
+      id: "controls.custom-color-palettes.diverging",
+    }),
+    categorical: t({
+      id: "controls.custom-color-palettes.categorical",
+    }),
+  };
 
   const handleChange = useEvent((e: React.ChangeEvent<HTMLInputElement>) => {
     onChange(e.target.value as CustomPaletteType["type"]);


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2098 

<!--- Describe the changes -->

This PR makes sure the color type names are correctly translated, instead of always displaying German labels. This was fixed by moving the type labels mapping to a component, instead of being defined at the file-level.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-color-ui-copy-ixt1.vercel.app/en).
2. Log in.
3. Go to user profile.
4. ✅ Try to define a new color palette and see that the palette names are correctly translated.
5. ✅ Change language and repeat to see that the labels are correct.

<!--- Reproduction steps, in case of a bug -->

---

- [x] Add a CHANGELOG entry
