### PR TITLE
feat: Add limit symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ You can also check the
     go beyond the data range
   - Limits are now also rendered when the axis dimension is a single filter
   - It's now possible to display limits in map charts
+  - Added a way to set different limit symbols for area and line charts
 - Fixes
   - Pie chart's `Measure` field is now correctly labeled (`Measure` instead of
     `Vertical Axis`)

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -3,6 +3,7 @@ import { ascending, descending, group, rollup, rollups } from "d3-array";
 import produce from "immer";
 import get from "lodash/get";
 import sortBy from "lodash/sortBy";
+import mapValues from "lodash/mapValues";
 
 import {
   AREA_SEGMENT_SORTING,
@@ -995,7 +996,9 @@ const chartConfigsAdjusters: ChartConfigsAdjusters = {
     },
     limits: ({ oldValue, newChartConfig }) => {
       return produce(newChartConfig, (draft) => {
-        draft.limits = oldValue;
+        draft.limits = mapValues(oldValue, (limits) =>
+          limits.map(({ symbolType, ...rest }) => rest)
+        );
       });
     },
     fields: {
@@ -1113,7 +1116,9 @@ const chartConfigsAdjusters: ChartConfigsAdjusters = {
     },
     limits: ({ oldValue, newChartConfig }) => {
       return produce(newChartConfig, (draft) => {
-        draft.limits = oldValue;
+        draft.limits = mapValues(oldValue, (limits) =>
+          limits.map(({ symbolType, ...rest }) => rest)
+        );
       });
     },
     fields: {
@@ -1240,7 +1245,12 @@ const chartConfigsAdjusters: ChartConfigsAdjusters = {
     },
     limits: ({ oldValue, newChartConfig }) => {
       return produce(newChartConfig, (draft) => {
-        draft.limits = oldValue;
+        draft.limits = mapValues(oldValue, (limits) =>
+          limits.map(({ symbolType = "dot", ...rest }) => ({
+            ...rest,
+            symbolType,
+          }))
+        );
       });
     },
     fields: {
@@ -1339,7 +1349,12 @@ const chartConfigsAdjusters: ChartConfigsAdjusters = {
     },
     limits: ({ oldValue, newChartConfig }) => {
       return produce(newChartConfig, (draft) => {
-        draft.limits = oldValue;
+        draft.limits = mapValues(oldValue, (limits) =>
+          limits.map(({ symbolType = "dot", ...rest }) => ({
+            ...rest,
+            symbolType,
+          }))
+        );
       });
     },
     fields: {
@@ -1450,7 +1465,9 @@ const chartConfigsAdjusters: ChartConfigsAdjusters = {
     },
     limits: ({ oldValue, newChartConfig }) => {
       return produce(newChartConfig, (draft) => {
-        draft.limits = oldValue;
+        draft.limits = mapValues(oldValue, (limits) =>
+          limits.map(({ symbolType, ...rest }) => rest)
+        );
       });
     },
     fields: {
@@ -1524,7 +1541,9 @@ const chartConfigsAdjusters: ChartConfigsAdjusters = {
     },
     limits: ({ oldValue, newChartConfig }) => {
       return produce(newChartConfig, (draft) => {
-        draft.limits = oldValue;
+        draft.limits = mapValues(oldValue, (limits) =>
+          limits.map(({ symbolType, ...rest }) => rest)
+        );
       });
     },
     fields: {
@@ -1645,7 +1664,9 @@ const chartConfigsAdjusters: ChartConfigsAdjusters = {
     },
     limits: ({ oldValue, newChartConfig }) => {
       return produce(newChartConfig, (draft) => {
-        draft.limits = oldValue;
+        draft.limits = mapValues(oldValue, (limits) =>
+          limits.map(({ symbolType, ...rest }) => rest)
+        );
       });
     },
     fields: {
@@ -1695,7 +1716,9 @@ const chartConfigsAdjusters: ChartConfigsAdjusters = {
     },
     limits: ({ oldValue, newChartConfig }) => {
       return produce(newChartConfig, (draft) => {
-        draft.limits = oldValue;
+        draft.limits = mapValues(oldValue, (limits) =>
+          limits.map(({ symbolType, ...rest }) => rest)
+        );
       });
     },
     fields: {
@@ -1766,7 +1789,9 @@ const chartConfigsAdjusters: ChartConfigsAdjusters = {
     },
     limits: ({ oldValue, newChartConfig }) => {
       return produce(newChartConfig, (draft) => {
-        draft.limits = oldValue;
+        draft.limits = mapValues(oldValue, (limits) =>
+          limits.map(({ symbolType, ...rest }) => rest)
+        );
       });
     },
     fields: {
@@ -1887,7 +1912,9 @@ const chartConfigsAdjusters: ChartConfigsAdjusters = {
     },
     limits: ({ oldValue, newChartConfig }) => {
       return produce(newChartConfig, (draft) => {
-        draft.limits = oldValue;
+        draft.limits = mapValues(oldValue, (limits) =>
+          limits.map(({ symbolType, ...rest }) => rest)
+        );
       });
     },
     fields: {

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -1246,7 +1246,7 @@ const chartConfigsAdjusters: ChartConfigsAdjusters = {
     limits: ({ oldValue, newChartConfig }) => {
       return produce(newChartConfig, (draft) => {
         draft.limits = mapValues(oldValue, (limits) =>
-          limits.map(({ symbolType = "dot", ...rest }) => ({
+          limits.map(({ symbolType = "circle", ...rest }) => ({
             ...rest,
             symbolType,
           }))
@@ -1350,7 +1350,7 @@ const chartConfigsAdjusters: ChartConfigsAdjusters = {
     limits: ({ oldValue, newChartConfig }) => {
       return produce(newChartConfig, (draft) => {
         draft.limits = mapValues(oldValue, (limits) =>
-          limits.map(({ symbolType = "dot", ...rest }) => ({
+          limits.map(({ symbolType = "circle", ...rest }) => ({
             ...rest,
             symbolType,
           }))

--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -398,6 +398,7 @@ const LegendColorContent = ({
                       onToggle={handleToggle}
                       checked={interactive && active}
                       disabled={soleItemChecked && active}
+                      usage="legend"
                     />
                   );
                 })}
@@ -441,11 +442,12 @@ export const LegendItem = (props: LegendItemProps) => {
     onToggle,
     checked,
     disabled,
-    usage = "legend",
+    usage: _usage,
   } = props;
+  const usage = _usage ?? "legend";
   const classes = useItemStyles({ symbol, color, usage });
   const shouldBeBigger =
-    (symbol === "circle" && usage !== "legend") || usage === "colorPicker";
+    (symbol === "circle" && _usage !== "legend") || usage === "colorPicker";
 
   return interactive && onToggle ? (
     <MaybeTooltip

--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -40,10 +40,11 @@ import { useChartInteractiveFilters } from "@/stores/interactive-filters";
 import { interlace } from "@/utils/interlace";
 import { makeDimensionValueSorters } from "@/utils/sorting-values";
 import useEvent from "@/utils/use-event";
+import { Icon } from "@/icons";
 
 import { DimensionsById } from "./ChartProps";
 
-export type LegendSymbol = "square" | "line" | "circle";
+export type LegendSymbol = "square" | "line" | "circle" | "cross";
 
 type LegendItemUsage = "legend" | "tooltip" | "colorPicker";
 
@@ -99,7 +100,7 @@ const useItemStyles = makeStyles<Theme, ItemStyleProps>((theme) => {
       "&::before": {
         content: "''",
         position: "relative",
-        display: "block",
+        display: ({ symbol }) => (symbol === "cross" ? "none" : "block"),
         width: `calc(0.5rem * var(--size-adjust, 1))`,
         height: ({ symbol }) =>
           `calc(${["square", "circle"].includes(symbol) ? "0.5rem" : "2px"} * var(--size-adjust, 1))`,
@@ -221,6 +222,7 @@ export const LegendColor = memo(function LegendColor({
               ? [measureLimit.value]
               : [measureLimit.from, measureLimit.to],
           color: configLimit.color,
+          symbol: !configLimit.symbolType ? "line" : configLimit.symbolType,
         }))}
         getColor={colors}
         getLabel={getColorLabel}
@@ -312,7 +314,12 @@ const LegendColorContent = ({
   numberOfOptions,
 }: {
   groups: ReturnType<typeof useLegendGroups>;
-  limits?: { label: string; values: number[]; color: string }[];
+  limits?: {
+    label: string;
+    values: number[];
+    color: string;
+    symbol: LegendSymbol;
+  }[];
   getColor: (d: string) => string;
   getLabel: (d: string) => string;
   getItemDimension?: (dimensionLabel: string) => Measure | undefined;
@@ -395,12 +402,12 @@ const LegendColorContent = ({
                   );
                 })}
                 {isLastGroup && limits
-                  ? limits.map(({ label, values, color }, i) => (
+                  ? limits.map(({ label, values, color, symbol }, i) => (
                       <LegendItem
                         key={i}
                         item={`${label}: ${values.map(formatNumber).join("-")}`}
                         color={color}
-                        symbol="line"
+                        symbol={symbol}
                       />
                     ))
                   : null}
@@ -437,7 +444,8 @@ export const LegendItem = (props: LegendItemProps) => {
     usage = "legend",
   } = props;
   const classes = useItemStyles({ symbol, color, usage });
-  const shouldBeBigger = symbol === "circle" || usage === "colorPicker";
+  const shouldBeBigger =
+    (symbol === "circle" && usage !== "legend") || usage === "colorPicker";
 
   return interactive && onToggle ? (
     <MaybeTooltip
@@ -472,7 +480,14 @@ export const LegendItem = (props: LegendItemProps) => {
     <Flex
       data-testid="legendItem"
       className={clsx(classes.legendItem, shouldBeBigger && classes.bigger)}
+      sx={{
+        alignItems: symbol === "cross" ? "center !important" : "flex-start",
+      }}
     >
+      {/* TODO: Use icons instead of ::before when migrating to new CI / CD */}
+      {symbol === "cross" ? (
+        <Icon size={16} name="close" color={color} />
+      ) : null}
       {dimension ? (
         <OpenMetadataPanelWrapper component={dimension}>
           {/* Account for the added space, to align the symbol and label. */}

--- a/app/charts/shared/limits.tsx
+++ b/app/charts/shared/limits.tsx
@@ -160,6 +160,7 @@ export const VerticalLimits = ({
         const y2 = yScale(limit.y2);
         const fill = limit.color;
         const lineType = limit.lineType;
+        const symbolType = limit.symbolType;
 
         const axisObservation: Observation = {
           [axisDimension?.id ?? ""]: limit.relatedAxisDimensionValueLabel ?? "",
@@ -181,6 +182,7 @@ export const VerticalLimits = ({
               width,
               fill,
               lineType,
+              symbolType,
             } as RenderVerticalLimitDatum)
           : null;
       })

--- a/app/charts/shared/rendering-utils.ts
+++ b/app/charts/shared/rendering-utils.ts
@@ -177,7 +177,7 @@ const getBottomRotate = (d: RenderVerticalLimitDatum) => {
   return d.symbolType === "cross" ? "rotate(-45deg)" : "rotate(0deg)";
 };
 const getMiddleRadius = (d: RenderVerticalLimitDatum) => {
-  return d.symbolType === "dot" ? LIMIT_SIZE * 1.5 : 0;
+  return d.symbolType === "circle" ? LIMIT_SIZE * 1.5 : 0;
 };
 
 export const renderVerticalLimits = (

--- a/app/charts/shared/rendering-utils.ts
+++ b/app/charts/shared/rendering-utils.ts
@@ -160,6 +160,24 @@ export type RenderVerticalLimitDatum = {
   width: number;
   fill: string;
   lineType: Limit["lineType"];
+  symbolType: Limit["symbolType"];
+};
+
+const getTopBottomLineHeight = (d: RenderVerticalLimitDatum) => {
+  return d.symbolType
+    ? d.symbolType === "cross"
+      ? LIMIT_SIZE
+      : 0
+    : LIMIT_SIZE;
+};
+const getTopRotate = (d: RenderVerticalLimitDatum) => {
+  return d.symbolType === "cross" ? "rotate(45deg)" : "rotate(0deg)";
+};
+const getBottomRotate = (d: RenderVerticalLimitDatum) => {
+  return d.symbolType === "cross" ? "rotate(-45deg)" : "rotate(0deg)";
+};
+const getMiddleRadius = (d: RenderVerticalLimitDatum) => {
+  return d.symbolType === "dot" ? LIMIT_SIZE * 1.5 : 0;
 };
 
 export const renderVerticalLimits = (
@@ -183,14 +201,17 @@ export const renderVerticalLimits = (
               .attr("x", (d) => d.x)
               .attr("y", (d) => d.y2 - LIMIT_SIZE / 2)
               .attr("width", (d) => d.width)
-              .attr("height", LIMIT_SIZE)
+              .attr("height", getTopBottomLineHeight)
               .attr("fill", (d) => d.fill)
               .attr("stroke", "none")
+              .style("transform-box", "fill-box")
+              .style("transform-origin", "center")
+              .style("transform", getTopRotate)
           )
           .call((g) =>
             g
               .append("line")
-              .attr("class", "middle")
+              .attr("class", "middle-line")
               .attr("x1", (d) => d.x + d.width / 2)
               .attr("x2", (d) => d.x + d.width / 2)
               .attr("y1", (d) => d.y1 - LIMIT_SIZE / 2)
@@ -203,14 +224,26 @@ export const renderVerticalLimits = (
           )
           .call((g) =>
             g
+              .append("circle")
+              .attr("class", "middle-dot")
+              .attr("cx", (d) => d.x + d.width / 2)
+              .attr("cy", (d) => (d.y1 + d.y2) / 2)
+              .attr("r", getMiddleRadius)
+              .attr("fill", (d) => d.fill)
+          )
+          .call((g) =>
+            g
               .append("rect")
               .attr("class", "bottom")
               .attr("x", (d) => d.x)
               .attr("y", (d) => d.y1 - LIMIT_SIZE / 2)
               .attr("width", (d) => d.width)
-              .attr("height", LIMIT_SIZE)
+              .attr("height", getTopBottomLineHeight)
               .attr("fill", (d) => d.fill)
               .attr("stroke", "none")
+              .style("transform-box", "fill-box")
+              .style("transform-origin", "center")
+              .style("transform", getBottomRotate)
           )
           .call((enter) =>
             maybeTransition(enter, {
@@ -229,11 +262,13 @@ export const renderVerticalLimits = (
                   .attr("x", (d) => d.x)
                   .attr("y", (d) => d.y2 - LIMIT_SIZE / 2)
                   .attr("width", (d) => d.width)
+                  .attr("height", getTopBottomLineHeight)
                   .attr("fill", (d) => d.fill)
+                  .style("transform", getTopRotate)
               )
               .call((g) =>
                 g
-                  .select(".middle")
+                  .select(".middle-line")
                   .attr("x1", (d) => d.x + d.width / 2)
                   .attr("x2", (d) => d.x + d.width / 2)
                   .attr("y1", (d) => d.y1 - LIMIT_SIZE / 2)
@@ -246,11 +281,21 @@ export const renderVerticalLimits = (
               )
               .call((g) =>
                 g
+                  .select(".middle-dot")
+                  .attr("cx", (d) => d.x + d.width / 2)
+                  .attr("cy", (d) => (d.y1 + d.y2) / 2)
+                  .attr("r", getMiddleRadius)
+                  .attr("fill", (d) => d.fill)
+              )
+              .call((g) =>
+                g
                   .select(".bottom")
                   .attr("x", (d) => d.x)
                   .attr("y", (d) => d.y1 - LIMIT_SIZE / 2)
                   .attr("width", (d) => d.width)
+                  .attr("height", getTopBottomLineHeight)
                   .attr("fill", (d) => d.fill)
+                  .style("transform", getBottomRotate)
               ),
           transition,
         }),

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -285,7 +285,7 @@ const Limit = t.intersection([
     lineType: t.union([t.literal("dashed"), t.literal("solid")]),
   }),
   t.partial({
-    symbolType: t.union([t.literal("cross"), t.literal("dot")]),
+    symbolType: t.union([t.literal("cross"), t.literal("circle")]),
   }),
 ]);
 export type Limit = t.TypeOf<typeof Limit>;

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -273,16 +273,21 @@ const Cube = t.intersection([
 ]);
 export type Cube = t.TypeOf<typeof Cube>;
 
-const Limit = t.type({
-  related: t.array(
-    t.type({
-      dimensionId: t.string,
-      dimensionValue: t.string,
-    })
-  ),
-  color: t.string,
-  lineType: t.union([t.literal("dashed"), t.literal("solid")]),
-});
+const Limit = t.intersection([
+  t.type({
+    related: t.array(
+      t.type({
+        dimensionId: t.string,
+        dimensionValue: t.string,
+      })
+    ),
+    color: t.string,
+    lineType: t.union([t.literal("dashed"), t.literal("solid")]),
+  }),
+  t.partial({
+    symbolType: t.union([t.literal("cross"), t.literal("dot")]),
+  }),
+]);
 export type Limit = t.TypeOf<typeof Limit>;
 
 const GenericChartConfig = t.type({

--- a/app/config-utils.ts
+++ b/app/config-utils.ts
@@ -388,7 +388,7 @@ export const useLimits = ({
                   symbolType:
                     limit.type === "single" &&
                     getSupportsLimitSymbols(chartConfig)
-                      ? (maybeLimit.symbolType ?? "dot")
+                      ? (maybeLimit.symbolType ?? "circle")
                       : undefined,
                 },
                 measureLimit: limit,

--- a/app/config-utils.ts
+++ b/app/config-utils.ts
@@ -383,7 +383,14 @@ export const useLimits = ({
 
           return maybeLimit
             ? {
-                configLimit: maybeLimit,
+                configLimit: {
+                  ...maybeLimit,
+                  symbolType:
+                    limit.type === "single" &&
+                    getSupportsLimitSymbols(chartConfig)
+                      ? (maybeLimit.symbolType ?? "dot")
+                      : undefined,
+                },
                 measureLimit: limit,
                 relatedAxisDimensionValueLabel,
               }
@@ -392,4 +399,8 @@ export const useLimits = ({
         .filter(truthy),
     };
   }, [chartConfig, filters, measure, axisDimension]);
+};
+
+export const getSupportsLimitSymbols = (chartConfig: ChartConfig) => {
+  return chartConfig.chartType === "area" || chartConfig.chartType === "line";
 };

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -816,7 +816,7 @@ const ChartLimits = ({
         const {
           color = "#ffffff",
           lineType = "solid",
-          symbolType = "dot",
+          symbolType = "circle",
         } = maybeLimit ?? {};
 
         return {
@@ -916,7 +916,7 @@ const ChartLimits = ({
                       name={`limit-${i}-symbol-type-dot`}
                       label={t({ id: "controls.symbol.dot", message: "Dot" })}
                       value="dot"
-                      checked={symbolType === "dot"}
+                      checked={symbolType === "circle"}
                       onChange={() => {
                         dispatch({
                           type: "LIMIT_SET",
@@ -925,7 +925,7 @@ const ChartLimits = ({
                             related: limit.related,
                             color,
                             lineType,
-                            symbolType: "dot",
+                            symbolType: "circle",
                           },
                         });
                       }}

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -67,6 +67,7 @@ import {
   getAxisDimension,
   getChartConfig,
   getMaybeValidChartConfigLimit,
+  getSupportsLimitSymbols,
   useChartConfigFilters,
 } from "@/config-utils";
 import { ColorPalette } from "@/configurator/components/chart-controls/color-palette";
@@ -812,13 +813,18 @@ const ChartLimits = ({
           return;
         }
 
-        const { color = "#ffffff", lineType = "solid" } = maybeLimit ?? {};
+        const {
+          color = "#ffffff",
+          lineType = "solid",
+          symbolType = "dot",
+        } = maybeLimit ?? {};
 
         return {
           limit,
           maybeLimit,
           color,
           lineType,
+          symbolType,
         };
       })
       .filter(truthy);
@@ -831,6 +837,7 @@ const ChartLimits = ({
     fallbackPalette: userPalettes?.find((d) => d.paletteId === paletteId)
       ?.colors,
   });
+  const supportsLimitSymbols = getSupportsLimitSymbols(chartConfig);
 
   return availableLimitOptions.length > 0 ? (
     <ControlSection collapse>
@@ -841,7 +848,7 @@ const ChartLimits = ({
       </SubsectionTitle>
       <ControlSectionContent component="fieldset">
         {availableLimitOptions.map(
-          ({ maybeLimit, limit, color, lineType }, i) => {
+          ({ maybeLimit, limit, color, lineType, symbolType }, i) => {
             return (
               <Box key={i} sx={{ mb: 2 }}>
                 <Box
@@ -849,7 +856,7 @@ const ChartLimits = ({
                     display: "flex",
                     flexDirection: "column",
                     gap: 4,
-                    mb: limit.type === "range" ? 4 : 0,
+                    mb: limit.type === "range" || supportsLimitSymbols ? 4 : 0,
                   }}
                 >
                   <Box sx={{ display: "flex", alignItems: "center", gap: 3 }}>
@@ -890,6 +897,7 @@ const ChartLimits = ({
                             related: limit.related,
                             color,
                             lineType,
+                            symbolType,
                           },
                         });
                       }}
@@ -897,6 +905,56 @@ const ChartLimits = ({
                     />
                   </Flex>
                 </Box>
+                {limit.type === "single" && supportsLimitSymbols ? (
+                  <div>
+                    <Typography variant="body2" sx={{ mb: 2 }}>
+                      <Trans id="controls.section.targets-and-limit-values.symbol-type">
+                        Select symbol type
+                      </Trans>
+                    </Typography>
+                    <Radio
+                      name={`limit-${i}-symbol-type-dot`}
+                      label={t({ id: "controls.symbol.dot", message: "Dot" })}
+                      value="dot"
+                      checked={symbolType === "dot"}
+                      onChange={() => {
+                        dispatch({
+                          type: "LIMIT_SET",
+                          value: {
+                            measureId: measure.id,
+                            related: limit.related,
+                            color,
+                            lineType,
+                            symbolType: "dot",
+                          },
+                        });
+                      }}
+                      disabled={!maybeLimit}
+                    />
+                    <Radio
+                      name={`limit-${i}-symbol-type-cross`}
+                      label={t({
+                        id: "controls.symbol.cross",
+                        message: "Cross",
+                      })}
+                      value="cross"
+                      checked={symbolType === "cross"}
+                      onChange={() => {
+                        dispatch({
+                          type: "LIMIT_SET",
+                          value: {
+                            measureId: measure.id,
+                            related: limit.related,
+                            color,
+                            lineType,
+                            symbolType: "cross",
+                          },
+                        });
+                      }}
+                      disabled={!maybeLimit}
+                    />
+                  </div>
+                ) : null}
                 {limit.type === "range" ? (
                   <div>
                     <Typography variant="body2" sx={{ mb: 2 }}>
@@ -917,6 +975,7 @@ const ChartLimits = ({
                             related: limit.related,
                             color,
                             lineType: "solid",
+                            symbolType,
                           },
                         });
                       }}
@@ -938,6 +997,7 @@ const ChartLimits = ({
                             related: limit.related,
                             color,
                             lineType: "dashed",
+                            symbolType,
                           },
                         });
                       }}

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -47,7 +47,6 @@ import {
   isMapConfig,
   isSegmentInConfig,
   isTableConfig,
-  Limit,
   ReactGridLayoutType,
   SingleColorField,
 } from "@/config-types";
@@ -1181,20 +1180,15 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
 
     case "LIMIT_SET":
       if (isConfiguring(draft)) {
-        const { measureId, related, color, lineType } = action.value;
+        const { measureId, ...limit } = action.value;
         const chartConfig = getChartConfig(draft);
-        const newLimit: Limit = {
-          related,
-          color,
-          lineType,
-        };
 
         if (!chartConfig.limits[measureId]) {
-          chartConfig.limits[measureId] = [newLimit];
+          chartConfig.limits[measureId] = [limit];
         } else {
           const maybeLimitIndex = chartConfig.limits[measureId].findIndex((d) =>
             d.related.every((r) =>
-              newLimit.related.some(
+              limit.related.some(
                 (nr) =>
                   r.dimensionId === nr.dimensionId &&
                   r.dimensionValue === nr.dimensionValue
@@ -1203,9 +1197,9 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
           );
 
           if (maybeLimitIndex !== -1) {
-            chartConfig.limits[measureId][maybeLimitIndex] = newLimit;
+            chartConfig.limits[measureId][maybeLimitIndex] = limit;
           } else {
-            chartConfig.limits[measureId].push(newLimit);
+            chartConfig.limits[measureId].push(limit);
           }
         }
       }

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -1194,7 +1194,7 @@ const reducer_: Reducer<ConfiguratorState, ConfiguratorStateAction> = (
         } else {
           const maybeLimitIndex = chartConfig.limits[measureId].findIndex((d) =>
             d.related.every((r) =>
-              newLimit.related.every(
+              newLimit.related.some(
                 (nr) =>
                   r.dimensionId === nr.dimensionId &&
                   r.dimensionValue === nr.dimensionValue

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -1149,6 +1149,10 @@ msgstr "Linientyp auswählen"
 msgid "controls.section.targets-and-limit-values.show-target"
 msgstr "Zielvorgabe anzeigen"
 
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.section.targets-and-limit-values.symbol-type"
+msgstr "Symboltyp auswählen"
+
 #: app/configurator/components/annotators.tsx
 #: app/configurator/components/annotators.tsx
 msgid "controls.section.title.warning"
@@ -1327,6 +1331,14 @@ msgstr "Sortieren nach"
 #: app/configurator/components/chart-type-selector.tsx
 msgid "controls.switch.chart.type"
 msgstr "Wechseln Sie zu einem anderen Diagrammtyp unter Beibehaltung der meisten Filtereinstellungen"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.symbol.cross"
+msgstr "Kreuz"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.symbol.dot"
+msgstr "Punkt"
 
 #: app/configurator/table/table-chart-options.tsx
 msgid "controls.table.column.group"
@@ -1591,6 +1603,7 @@ msgstr "Sie können diese Visualisierung teilen oder sie einbetten. Zudem könne
 
 #: app/components/chart-filters-list.tsx
 #: app/components/form.tsx
+#: app/components/hint.tsx
 #: app/components/hint.tsx
 msgid "hint.loading.data"
 msgstr "Lade Daten …"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -1149,6 +1149,10 @@ msgstr "Select line type"
 msgid "controls.section.targets-and-limit-values.show-target"
 msgstr "Show target"
 
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.section.targets-and-limit-values.symbol-type"
+msgstr "Select symbol type"
+
 #: app/configurator/components/annotators.tsx
 #: app/configurator/components/annotators.tsx
 msgid "controls.section.title.warning"
@@ -1327,6 +1331,14 @@ msgstr "Sort by"
 #: app/configurator/components/chart-type-selector.tsx
 msgid "controls.switch.chart.type"
 msgstr "Switch to another chart type while maintaining most filter settings."
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.symbol.cross"
+msgstr "Cross"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.symbol.dot"
+msgstr "Dot"
 
 #: app/configurator/table/table-chart-options.tsx
 msgid "controls.table.column.group"
@@ -1591,6 +1603,7 @@ msgstr "You can share this visualization by copying the URL or by embedding it o
 
 #: app/components/chart-filters-list.tsx
 #: app/components/form.tsx
+#: app/components/hint.tsx
 #: app/components/hint.tsx
 msgid "hint.loading.data"
 msgstr "Loading data..."

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -1149,6 +1149,10 @@ msgstr "Sélectionner le type de ligne"
 msgid "controls.section.targets-and-limit-values.show-target"
 msgstr "Afficher la cible"
 
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.section.targets-and-limit-values.symbol-type"
+msgstr "Sélectionnez le type de symbole"
+
 #: app/configurator/components/annotators.tsx
 #: app/configurator/components/annotators.tsx
 msgid "controls.section.title.warning"
@@ -1327,6 +1331,14 @@ msgstr "Trier par"
 #: app/configurator/components/chart-type-selector.tsx
 msgid "controls.switch.chart.type"
 msgstr "Passer à une autre visualisation tout en conservant la plupart des filtres"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.symbol.cross"
+msgstr "Croix"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.symbol.dot"
+msgstr "Point"
 
 #: app/configurator/table/table-chart-options.tsx
 msgid "controls.table.column.group"
@@ -1591,6 +1603,7 @@ msgstr "Vous pouvez partager cette visualisation en copiant l'URL ou en l'intég
 
 #: app/components/chart-filters-list.tsx
 #: app/components/form.tsx
+#: app/components/hint.tsx
 #: app/components/hint.tsx
 msgid "hint.loading.data"
 msgstr "Chargement des données..."

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -1149,6 +1149,10 @@ msgstr "Selezionare il tipo di linea"
 msgid "controls.section.targets-and-limit-values.show-target"
 msgstr "Mostra bersaglio"
 
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.section.targets-and-limit-values.symbol-type"
+msgstr "Seleziona il tipo di simbolo"
+
 #: app/configurator/components/annotators.tsx
 #: app/configurator/components/annotators.tsx
 msgid "controls.section.title.warning"
@@ -1327,6 +1331,14 @@ msgstr "Ordina per"
 #: app/configurator/components/chart-type-selector.tsx
 msgid "controls.switch.chart.type"
 msgstr "Passa a un altro tipo di grafico mantenendo la maggior parte delle impostazioni dei filtri"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.symbol.cross"
+msgstr "Attraverso"
+
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.symbol.dot"
+msgstr "Punto"
 
 #: app/configurator/table/table-chart-options.tsx
 msgid "controls.table.column.group"
@@ -1591,6 +1603,7 @@ msgstr "È possibile condividere questa visualizzazione copiando l'URL o incorpo
 
 #: app/components/chart-filters-list.tsx
 #: app/components/form.tsx
+#: app/components/hint.tsx
 #: app/components/hint.tsx
 msgid "hint.loading.data"
 msgstr "Caricamento dei dati..."


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2181

<!--- Describe the changes -->

This PR adds support for setting circle and cross symbol types for area and line charts.

To make the implementation simpler, I decided to not introduce a new type (to keep track of e.g. `single` or `range` limits in chart config) and avoid a need to check the types everywhere to access `symbolType` or `lineType` properties.

I am not happy how the color legend code looks like now; but this could be cleaned when we migrate to new CI / CD, as the symbols and styles will change anyway then.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-feat-add-limit-symbols-ixt1.vercel.app/en/create/new?cube=https://environment.ld.admin.ch/foen/test_target/cube/target_1/1&dataSource=Test).
2. Go to `Vertical Axis` field and toggle all targets.
3. ✅ Switch to a line chart and see that you can control symbol types for single targets.
4. Go back to the column chart and see that the symbols converted back to lines.

<!--- Reproduction steps, in case of a bug -->

---

- [x] Add a CHANGELOG entry
