### PR TITLE
fix: Segment value labels margins

### DIFF
--- a/app/charts/shared/render-value-labels.ts
+++ b/app/charts/shared/render-value-labels.ts
@@ -124,6 +124,7 @@ export const setSegmentValueLabelStyles = <
 ) => {
   return g
     .style("overflow", "hidden")
+    .style("margin", 0)
     .style("padding-left", "4px")
     .style("font-size", "12px")
     .style("white-space", "nowrap")


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2182

<!--- Describe the changes -->

This PR aligns paddings of segment value labels across browsers.

<!--- Test instructions -->

## How to test

1. Go to this link on Safari, Chrome and Edge.
2. ✅ See that the paddings are the same in every browser.

<!--- Reproduction steps, in case of a bug -->