### PR TITLE
✓ feat: Add a way to open interactive filters area per default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ You can also check the
     go beyond the data range
   - Limits are now also rendered when the axis dimension is a single filter
   - It's now possible to display limits in map charts
+  - Interactive filters can now be set to be opened by default
 - Fixes
   - Pie chart's `Measure` field is now correctly labeled (`Measure` instead of
     `Vertical Axis`)

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -76,15 +76,21 @@ export const useChartDataFiltersState = ({
   chartConfig: ChartConfig;
   dashboardFilters: DashboardFiltersConfig | undefined;
 }) => {
-  const componentIds =
-    chartConfig.interactiveFiltersConfig?.dataFilters.componentIds;
-  const [open, setOpen] = useState(false);
+  const dataFiltersConfig = chartConfig.interactiveFiltersConfig?.dataFilters;
+  const active = dataFiltersConfig?.active;
+  const defaultOpen = dataFiltersConfig?.defaultOpen;
+  const componentIds = dataFiltersConfig?.componentIds;
+  const [open, setOpen] = useState<boolean>(!!defaultOpen);
 
   useEffect(() => {
     if (componentIds?.length === 0) {
       setOpen(false);
     }
   }, [componentIds?.length]);
+
+  useEffect(() => {
+    setOpen(!!defaultOpen);
+  }, [active, defaultOpen]);
 
   const { loading } = useLoadingState();
   const queryFilters = useQueryFilters({

--- a/app/components/form.tsx
+++ b/app/components/form.tsx
@@ -268,7 +268,7 @@ export const Checkbox = ({
         }}
       />
     }
-    sx={{ display: "flex", whiteSpace: "nowrap" }}
+    sx={{ display: "flex" }}
   />
 );
 

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -140,10 +140,15 @@ export type InteractiveFiltersTimeRange = t.TypeOf<
   typeof InteractiveFiltersTimeRange
 >;
 
-const InteractiveFiltersDataConfig = t.type({
-  active: t.boolean,
-  componentIds: t.array(t.string),
-});
+const InteractiveFiltersDataConfig = t.intersection([
+  t.type({
+    active: t.boolean,
+    componentIds: t.array(t.string),
+  }),
+  t.partial({
+    defaultOpen: t.boolean,
+  }),
+]);
 export type InteractiveFiltersDataConfig = t.TypeOf<
   typeof InteractiveFiltersDataConfig
 >;

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -1,4 +1,4 @@
-import { Trans } from "@lingui/macro";
+import { t, Trans } from "@lingui/macro";
 import {
   Box,
   Button,
@@ -57,6 +57,7 @@ import {
 } from "@/configurator/components/chart-controls/section";
 import { ChartTypeSelector } from "@/configurator/components/chart-type-selector";
 import {
+  ChartOptionCheckboxField,
   ControlTabField,
   DataFilterSelect,
   DataFilterTemporal,
@@ -705,7 +706,21 @@ export const ChartConfigurator = ({
                   No filters
                 </Trans>
               </Typography>
-            ) : null}
+            ) : (
+              <Box sx={{ my: 2 }}>
+                <ChartOptionCheckboxField
+                  label={t({
+                    id: "controls.section.data.filters.default-open",
+                    message: "Show filter area open per default",
+                  })}
+                  field={null}
+                  path="interactiveFiltersConfig.dataFilters.defaultOpen"
+                  disabled={
+                    !chartConfig.interactiveFiltersConfig?.dataFilters.active
+                  }
+                />
+              </Box>
+            )}
             {Object.entries(filterDimensionsByCubeIri).map(
               ([cubeIri, dims], i) => {
                 const cubeTitle = cubes?.find(

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -1023,6 +1023,10 @@ msgid "controls.section.data.filters"
 msgstr "Filter"
 
 #: app/configurator/components/chart-configurator.tsx
+msgid "controls.section.data.filters.default-open"
+msgstr "Filterbereich standardmässig geöffnet anzeigen"
+
+#: app/configurator/components/chart-configurator.tsx
 msgid "controls.section.data.filters.none"
 msgstr "Keine Filter"
 
@@ -1591,6 +1595,7 @@ msgstr "Sie können diese Visualisierung teilen oder sie einbetten. Zudem könne
 
 #: app/components/chart-filters-list.tsx
 #: app/components/form.tsx
+#: app/components/hint.tsx
 #: app/components/hint.tsx
 msgid "hint.loading.data"
 msgstr "Lade Daten …"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -1023,6 +1023,10 @@ msgid "controls.section.data.filters"
 msgstr "Filters"
 
 #: app/configurator/components/chart-configurator.tsx
+msgid "controls.section.data.filters.default-open"
+msgstr "Show filter area open per default"
+
+#: app/configurator/components/chart-configurator.tsx
 msgid "controls.section.data.filters.none"
 msgstr "No filters"
 
@@ -1591,6 +1595,7 @@ msgstr "You can share this visualization by copying the URL or by embedding it o
 
 #: app/components/chart-filters-list.tsx
 #: app/components/form.tsx
+#: app/components/hint.tsx
 #: app/components/hint.tsx
 msgid "hint.loading.data"
 msgstr "Loading data..."

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -1023,6 +1023,10 @@ msgid "controls.section.data.filters"
 msgstr "Filtres"
 
 #: app/configurator/components/chart-configurator.tsx
+msgid "controls.section.data.filters.default-open"
+msgstr "Afficher la zone de filtre ouverte par défaut"
+
+#: app/configurator/components/chart-configurator.tsx
 msgid "controls.section.data.filters.none"
 msgstr "Aucun filtre"
 
@@ -1591,6 +1595,7 @@ msgstr "Vous pouvez partager cette visualisation en copiant l'URL ou en l'intég
 
 #: app/components/chart-filters-list.tsx
 #: app/components/form.tsx
+#: app/components/hint.tsx
 #: app/components/hint.tsx
 msgid "hint.loading.data"
 msgstr "Chargement des données..."

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -1023,6 +1023,10 @@ msgid "controls.section.data.filters"
 msgstr "Filtri"
 
 #: app/configurator/components/chart-configurator.tsx
+msgid "controls.section.data.filters.default-open"
+msgstr "Mostra l'area filtro aperta per impostazione predefinita"
+
+#: app/configurator/components/chart-configurator.tsx
 msgid "controls.section.data.filters.none"
 msgstr "Nessun filtro"
 
@@ -1591,6 +1595,7 @@ msgstr "È possibile condividere questa visualizzazione copiando l'URL o incorpo
 
 #: app/components/chart-filters-list.tsx
 #: app/components/form.tsx
+#: app/components/hint.tsx
 #: app/components/hint.tsx
 msgid "hint.loading.data"
 msgstr "Caricamento dei dati..."


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #1881

<!--- Describe the changes -->

This PR adds a way to display interactive filters panel open by default.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-feat-improve-visibility-of-i-0d6e77-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10&dataSource=Prod).
2. See that there's a "Show filter area open per default" checkbox in the left panel.
3. Make `Kanton` interactive.
4. ✅ Toggle "Show filter area open per default" checkbox and see that the filter area opened.
5. ✅ Publish the chart and see that it's also kept open here.

<!--- Reproduction steps, in case of a bug -->

---

- [x] Add a CHANGELOG entry
