### PR TITLE
feat: Add Statistics page link to the footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ You can also check the
     go beyond the data range
   - Limits are now also rendered when the axis dimension is a single filter
   - It's now possible to display limits in map charts
+  - Statistics page is now linked in the footer
 - Fixes
   - Pie chart's `Measure` field is now correctly labeled (`Measure` instead of
     `Vertical Axis`)

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -87,7 +87,6 @@ export const Footer = ({ sx }: { sx?: FlexProps["sx"] }) => {
           </Trans>
         </FooterLink>
       </Box>
-
       <Flex
         sx={{
           width: ["100%", "auto"],
@@ -106,7 +105,6 @@ export const Footer = ({ sx }: { sx?: FlexProps["sx"] }) => {
         >
           <Logo />
         </Box>
-
         <Flex
           sx={{
             justifyContent: "flex-end",
@@ -133,10 +131,14 @@ export const Footer = ({ sx }: { sx?: FlexProps["sx"] }) => {
           <FooterLinkBottom href="https://www.youtube.com/channel/UCNK0uJTJ74kbv3jmNtZfgOw">
             <Trans id="footer.tutorials">Tutorials</Trans>
           </FooterLinkBottom>
-
           <FooterLinkBottom href="https://visualization-tool.status.interactivethings.io/">
             <Trans id="footer.status">Status</Trans>
           </FooterLinkBottom>
+          <NextLink href="/statistics" passHref legacyBehavior>
+            <FooterLinkBottom>
+              <Trans id="footer.statistics">Statistics</Trans>
+            </FooterLinkBottom>
+          </NextLink>
           <NextLink
             href={contentRoutes.legal[locale].path}
             passHref

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -1544,6 +1544,10 @@ msgid "footer.institution.url"
 msgstr "https://www.bafu.admin.ch/bafu/de/home.html"
 
 #: app/components/footer.tsx
+msgid "footer.statistics"
+msgstr "Statistiken"
+
+#: app/components/footer.tsx
 msgid "footer.status"
 msgstr "Status"
 
@@ -1591,6 +1595,7 @@ msgstr "Sie können diese Visualisierung teilen oder sie einbetten. Zudem könne
 
 #: app/components/chart-filters-list.tsx
 #: app/components/form.tsx
+#: app/components/hint.tsx
 #: app/components/hint.tsx
 msgid "hint.loading.data"
 msgstr "Lade Daten …"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -1544,6 +1544,10 @@ msgid "footer.institution.url"
 msgstr "https://www.bafu.admin.ch/bafu/en/home.html"
 
 #: app/components/footer.tsx
+msgid "footer.statistics"
+msgstr "Statistics"
+
+#: app/components/footer.tsx
 msgid "footer.status"
 msgstr "Status"
 
@@ -1591,6 +1595,7 @@ msgstr "You can share this visualization by copying the URL or by embedding it o
 
 #: app/components/chart-filters-list.tsx
 #: app/components/form.tsx
+#: app/components/hint.tsx
 #: app/components/hint.tsx
 msgid "hint.loading.data"
 msgstr "Loading data..."

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -1544,6 +1544,10 @@ msgid "footer.institution.url"
 msgstr "https://www.bafu.admin.ch/bafu/fr/home.html"
 
 #: app/components/footer.tsx
+msgid "footer.statistics"
+msgstr "Statistiques"
+
+#: app/components/footer.tsx
 msgid "footer.status"
 msgstr "Statut"
 
@@ -1591,6 +1595,7 @@ msgstr "Vous pouvez partager cette visualisation en copiant l'URL ou en l'intég
 
 #: app/components/chart-filters-list.tsx
 #: app/components/form.tsx
+#: app/components/hint.tsx
 #: app/components/hint.tsx
 msgid "hint.loading.data"
 msgstr "Chargement des données..."

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -1544,6 +1544,10 @@ msgid "footer.institution.url"
 msgstr "https://www.bafu.admin.ch/bafu/it/home.html"
 
 #: app/components/footer.tsx
+msgid "footer.statistics"
+msgstr "Statistiche"
+
+#: app/components/footer.tsx
 msgid "footer.status"
 msgstr "Stato"
 
@@ -1591,6 +1595,7 @@ msgstr "È possibile condividere questa visualizzazione copiando l'URL o incorpo
 
 #: app/components/chart-filters-list.tsx
 #: app/components/form.tsx
+#: app/components/hint.tsx
 #: app/components/hint.tsx
 msgid "hint.loading.data"
 msgstr "Caricamento dei dati..."


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #1795

<!--- Describe the changes -->

This PR adds a link to Statistics page to the footer.

<!--- Test instructions -->

## How to test

1. ✅ Go to [this link](https://visualization-tool-git-feat-add-stats-page-to-footer-ixt1.vercel.app/en) and see that there's a Statistics link in the footer that once clicked, opens Statistics page.

<!--- Reproduction steps, in case of a bug -->

---

- [x] Add a CHANGELOG entry
