### PR TITLE
Support longer HTTP headers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,5 @@
 *Dockerfile*
 # Ignore node_modules to prevent issues with wrong binaries (e.g. sentry cli)
 node_modules
+.DS_Store
+*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Extended maximum URL length in Node to 64KB
 
 # [5.4.1] - 2025-03-18
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN yarn install --frozen-lockfile
 
 ENV NODE_ENV production
 ENV NODE_OPTIONS=--max_old_space_size=2048
+ENV NODE_OPTIONS=--max-http-header-size=65536
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV STORYBOOK_DISABLE_TELEMETRY=1
 ENV PORT 3000


### PR DESCRIPTION
Potentially supports #2064 

This PR includes a Node server configuration parameter for supporting long HTTP headers up to 64KB in length (default is 8K).

## How to test

Currently, there is no possibility of testing the effectiveness of this parameter in our deployment environments, as it is dependent on other configuration changes (load balancer, WAF).

---

- [x] Add a CHANGELOG entry
