### PR TITLE
fix: Consolidate multiple Node options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,7 @@ COPY app/package.json ./app/
 RUN yarn install --frozen-lockfile
 
 ENV NODE_ENV production
-ENV NODE_OPTIONS=--max_old_space_size=2048
-ENV NODE_OPTIONS=--max-http-header-size=65536
+ENV NODE_OPTIONS="--max-http-header-size=65536 --max_old_space_size=2048"
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV STORYBOOK_DISABLE_TELEMETRY=1
 ENV PORT 3000


### PR DESCRIPTION
Potentially supports #2064 

Fix for previous PR (#2195) as the GC heap value was being overwritten with the option for long header support.

## How to test

Currently, there is no possibility of testing the effectiveness of this parameter in our deployment environments, as it is dependent on other configuration changes (load balancer, WAF).

