### PR TITLE
feat: Interactive filters toggle changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ You can also check the
 
 # Unreleased
 
-- Extended maximum URL length in Node to 64KB
+- Features
+  - Interactive filters area is now open by default
+  - When interactive filters area is initialized open, it's no longer possible
+    to collapse it
+- Maintenance
+  - Extended maximum URL length in Node to 64KB
 
 # [5.4.1] - 2025-03-18
 

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -2,8 +2,8 @@ import { t } from "@lingui/macro";
 import { ascending, descending, group, rollup, rollups } from "d3-array";
 import produce from "immer";
 import get from "lodash/get";
-import sortBy from "lodash/sortBy";
 import mapValues from "lodash/mapValues";
+import sortBy from "lodash/sortBy";
 
 import {
   AREA_SEGMENT_SORTING,
@@ -204,6 +204,7 @@ const getInitialInteractiveFiltersConfig = (options?: {
     dataFilters: {
       active: false,
       componentIds: [],
+      defaultOpen: true,
     },
     calculation: {
       active: false,

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -133,6 +133,7 @@ export const useChartDataFiltersState = ({
   return {
     open,
     setOpen,
+    defaultOpen,
     dataSource,
     chartConfig,
     loading,
@@ -142,11 +143,14 @@ export const useChartDataFiltersState = ({
   };
 };
 
-export const ChartDataFiltersToggle = (
-  props: ReturnType<typeof useChartDataFiltersState>
-) => {
-  const { open, setOpen, loading, error, componentIds } = props;
-
+export const ChartDataFiltersToggle = ({
+  open,
+  setOpen,
+  defaultOpen,
+  loading,
+  error,
+  componentIds,
+}: ReturnType<typeof useChartDataFiltersState>) => {
   return error ? (
     <Typography variant="body2" color="error">
       <Trans id="controls.section.data.filters.possible-filters-error">
@@ -154,7 +158,7 @@ export const ChartDataFiltersToggle = (
         reload the page.
       </Trans>
     </Typography>
-  ) : (
+  ) : defaultOpen ? null : (
     <Flex sx={{ flexDirection: "column", width: "100%" }}>
       <Flex
         sx={{

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -711,7 +711,7 @@ export const ChartConfigurator = ({
                 <ChartOptionCheckboxField
                   label={t({
                     id: "controls.section.data.filters.default-open",
-                    message: "Show filter area open per default",
+                    message: "Show filter area open",
                   })}
                   field={null}
                   path="interactiveFiltersConfig.dataFilters.defaultOpen"

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -1024,7 +1024,7 @@ msgstr "Filter"
 
 #: app/configurator/components/chart-configurator.tsx
 msgid "controls.section.data.filters.default-open"
-msgstr "Filterbereich standardmässig geöffnet anzeigen"
+msgstr "Filterbereich anzeigen geöffnet"
 
 #: app/configurator/components/chart-configurator.tsx
 msgid "controls.section.data.filters.none"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -1024,7 +1024,7 @@ msgstr "Filters"
 
 #: app/configurator/components/chart-configurator.tsx
 msgid "controls.section.data.filters.default-open"
-msgstr "Show filter area open per default"
+msgstr "Show filter area open"
 
 #: app/configurator/components/chart-configurator.tsx
 msgid "controls.section.data.filters.none"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -1024,7 +1024,7 @@ msgstr "Filtres"
 
 #: app/configurator/components/chart-configurator.tsx
 msgid "controls.section.data.filters.default-open"
-msgstr "Afficher la zone de filtre ouverte par défaut"
+msgstr "Afficher la zone de filtre ouverte"
 
 #: app/configurator/components/chart-configurator.tsx
 msgid "controls.section.data.filters.none"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -1024,7 +1024,7 @@ msgstr "Filtri"
 
 #: app/configurator/components/chart-configurator.tsx
 msgid "controls.section.data.filters.default-open"
-msgstr "Mostra l'area filtro aperta per impostazione predefinita"
+msgstr "Mostra area filtro aperta"
 
 #: app/configurator/components/chart-configurator.tsx
 msgid "controls.section.data.filters.none"


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2192
Closes #2193

<!--- Describe the changes -->

This PR sets the state of interactive filters to open by default. It also removes the function to collapse filters when this option is active.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-feat-interactive-filters-tog-5be719-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10&dataSource=Prod).
2. Enable `Kanton` interactive filter.
3. ✅ See that it's shown open and that `Hide filters` toggle is missing.

@KerstinFaye @sosiology I know the client has already decided about removing `Hide filters` toggle, if I understood correctly, to save some space – I just wanted to point that removing it doesn't save any space, as it's rendered in the same row as `Details` panel button (and not having a way to hide a long list of filters could be frustrating).

See opened mobile views in both cases:

Open panel with hide toggle removed             |  Open panel with hide toggle shown
:-------------------------:|:-------------------------:
<img width="1728" alt="Screenshot 2025-03-20 at 12 32 16" src="https://github.com/user-attachments/assets/326f6431-3c94-46a5-b759-ab0b1c2733d8" />  |  <img width="1728" alt="Screenshot 2025-03-20 at 12 32 19" src="https://github.com/user-attachments/assets/0c271134-b29e-43f0-a5bc-794c93a77cab" />


<!--- Reproduction steps, in case of a bug -->

---

- [x] Add a CHANGELOG entry
