### PR TITLE
fix: Show value labels when segment label equals value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ You can also check the
     to collapse it
   - Valid cube iris in Statistics page (coming from the same data source as the
     environment's default one) are now pointing to Visualize dataset previews
+- Fixes
+  - Showing segmented values was fixed for some cubes
 - Maintenance
   - Extended maximum URL length in Node to 64KB
 

--- a/app/charts/bar/bars-stacked.tsx
+++ b/app/charts/bar/bars-stacked.tsx
@@ -29,7 +29,8 @@ export const BarsStacked = () => {
   const renderData: RenderBarDatum[] = useMemo(() => {
     return series.flatMap((s) => {
       const segmentLabel = s.key;
-      const segment = segmentsByAbbreviationOrLabel.get(segmentLabel)?.value;
+      const segment =
+        segmentsByAbbreviationOrLabel.get(segmentLabel)?.value ?? segmentLabel;
       const color = colors(segmentLabel);
 
       return s.map((d) => {

--- a/app/charts/column/columns-stacked.tsx
+++ b/app/charts/column/columns-stacked.tsx
@@ -32,7 +32,8 @@ export const ColumnsStacked = () => {
   const renderData: RenderColumnDatum[] = useMemo(() => {
     return series.flatMap((s) => {
       const segmentLabel = s.key;
-      const segment = segmentsByAbbreviationOrLabel.get(segmentLabel)?.value;
+      const segment =
+        segmentsByAbbreviationOrLabel.get(segmentLabel)?.value ?? segmentLabel;
       const color = colors(segmentLabel);
 
       return s.map((d) => {


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2202

<!--- Describe the changes -->

This PR fixes a rare scenario when showing value labels for segmented charts was not working – the only reproduction was possible with an INT cube, so I assume there was an issue with cube definitions. The fix to try to treat segment label as segment, in case it doesn't return a value when we try to retrie a segment value by label.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-segment-vs-segment-label-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/19&dataSource=Int).
2. Add segmentation by Kanton.
3. ✅ Toggle some value labels and see that they show on a chart.

<!--- Reproduction steps, in case of a bug -->

## How to reproduce

1. Go to [this link](https://test.visualize.admin.ch/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/19&dataSource=Int) (TEST).
2. Add segmentation by Kanton.
3. ❌ Toggle some value labels and see that they do not show on a chart.

---

- [x] Add a CHANGELOG entry
