### PR TITLE
fix: Correctly set showValuesMapping when segment changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ You can also check the
     to collapse it
   - Valid cube iris in Statistics page (coming from the same data source as the
     environment's default one) are now pointing to Visualize dataset previews
+- Fixes
+  - Changing segmentation dimension now correctly sets underlying chart
+    parameters, which prevents saving wrong chart configuration in a database
+  - Very long words in legend items and multi-filter panel now correctly break
 - Maintenance
   - Extended maximum URL length in Node to 64KB
 

--- a/app/charts/chart-config-ui-options.ts
+++ b/app/charts/chart-config-ui-options.ts
@@ -19,6 +19,7 @@ import {
   AreaConfig,
   BarConfig,
   ChartConfig,
+  ChartSegmentField,
   ChartSubType,
   ChartType,
   ColorScaleType,
@@ -529,7 +530,8 @@ export const defaultSegmentOnChange: OnEncodingChange<
   });
 
   if (chartConfig.fields.segment) {
-    chartConfig.fields.segment.componentId = id;
+    (chartConfig.fields.segment as ChartSegmentField).componentId = id;
+    (chartConfig.fields.segment as ChartSegmentField).showValuesMapping = {};
   } else {
     chartConfig.fields.segment = {
       componentId: id,

--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -96,6 +96,7 @@ const useItemStyles = makeStyles<Theme, ItemStyleProps>((theme) => {
           : theme.typography.caption.fontSize,
       fontWeight: theme.typography.fontWeightRegular,
       color: theme.palette.grey[700],
+      wordBreak: "break-word",
 
       "&::before": {
         content: "''",


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2201

<!--- Describe the changes -->

This PR makes sure we re-initialize `showValuesMapping` when segment is changed. This won't fix existing TEST / INT charts that were made before the fix, but will make sure new ones are saved correctly.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-value-mapping-copy-ixt1.vercel.app/en/create/new?cube=https://environment.ld.admin.ch/foen/ubd01041prod/4&dataSource=Prod).
2. Add segmentation by `Observation location`.
3. Change segmentation to `Parameter`.
4. Refresh the page.
5. ✅ See that you still see the chart.

<!--- Reproduction steps, in case of a bug -->

## How to reproduce

1. Go to [this link](https://test.visualize.admin.ch/en/create/new?cube=https://environment.ld.admin.ch/foen/ubd01041prod/4&dataSource=Prod) (TEST).
2. Add segmentation by `Observation location`.
3. Change segmentation to `Parameter`.
4. Refresh the page.
5. ❌ See that you were redirected to the browse page.

---

- [x] Add a CHANGELOG entry
