### PR TITLE
fix: Merging of cubes problems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ You can also check the
     environment's default one) are now pointing to Visualize dataset previews
 - Fixes
   - Showing segmented values was fixed for some cubes
+  - Changing filter values when using merged cubes with dimensions with the same
+    iris doesn't change both filters at the same time
+  - Multi-line charts now correctly separate legend items by cube in case
+    working with merged cubes that have dimensions with the same iris
 - Maintenance
   - Extended maximum URL length in Node to 64KB
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ You can also check the
   - Showing segmented values was fixed for some cubes
   - Changing filter values when using merged cubes with dimensions with the same
     iris doesn't change both filters at the same time
+  - Interactive filters for merged cubes should now works correctly, as we scope
+    them per cube now
   - Multi-line charts now correctly separate legend items by cube in case
     working with merged cubes that have dimensions with the same iris
 - Maintenance

--- a/app/charts/combo/combo-line-column-state.tsx
+++ b/app/charts/combo/combo-line-column-state.tsx
@@ -198,7 +198,7 @@ const useComboLineColumnState = (
     const x = getX(d);
     const xScaled = (xScale(x) as number) + xScale.bandwidth() * 0.5;
     const values = [variables.y.left, variables.y.right]
-      .map(({ orientation, getY, label, chartType }) => {
+      .map(({ orientation, getY, id, label, chartType }) => {
         const y = getY(d);
         const yPos = yOrientationScales[orientation](y ?? 0);
         if (!Number.isFinite(y) || y === null) {
@@ -207,7 +207,7 @@ const useComboLineColumnState = (
         return {
           label,
           value: `${y}`,
-          color: colors(label),
+          color: colors(id),
           hide: y === null,
           yPos,
           symbol: chartType === "line" ? "line" : "square",

--- a/app/charts/combo/combo-line-column.tsx
+++ b/app/charts/combo/combo-line-column.tsx
@@ -41,7 +41,7 @@ const Columns = () => {
       const yScaled = yScale(y);
       const yRender = yScale(Math.max(y, 0));
       const height = Math.max(0, Math.abs(yScaled - y0));
-      const color = colors(yColumn.label);
+      const color = colors(yColumn.id);
 
       return {
         key,

--- a/app/charts/combo/combo-line-dual-state.tsx
+++ b/app/charts/combo/combo-line-dual-state.tsx
@@ -183,7 +183,7 @@ const useComboLineDualState = (
     const xScaled = xScale(x);
 
     const values = [variables.y.left, variables.y.right]
-      .map(({ orientation, getY, label }) => {
+      .map(({ orientation, getY, id, label }) => {
         const y = getY(d);
         const yPos = yOrientationScales[orientation](y ?? 0);
         if (!Number.isFinite(y) || y === null) {
@@ -193,7 +193,7 @@ const useComboLineDualState = (
         return {
           label,
           value: `${y}`,
-          color: colors(label),
+          color: colors(id),
           hide: y === null,
           yPos: yPos,
           symbol: "line",

--- a/app/charts/combo/combo-line-dual.tsx
+++ b/app/charts/combo/combo-line-dual.tsx
@@ -11,7 +11,7 @@ export const ComboLineDual = () => {
 
   return (
     <g transform={`translate(${bounds.margins.left} ${bounds.margins.top})`}>
-      {[y.left, y.right].map(({ orientation, id, label, getY }) => {
+      {[y.left, y.right].map(({ orientation, id, getY }) => {
         const pathGenerator = line<Observation>()
           .defined((d) => {
             const y = getY(d);
@@ -24,7 +24,7 @@ export const ComboLineDual = () => {
           <Line
             key={id}
             path={pathGenerator(chartData) as string}
-            color={colors(label)}
+            color={colors(id)}
           />
         );
       })}

--- a/app/charts/combo/combo-line-single-state.tsx
+++ b/app/charts/combo/combo-line-single-state.tsx
@@ -144,7 +144,7 @@ const useComboLineSingleState = (
     const x = getX(d);
     const xScaled = xScale(x);
     const values = variables.y.lines
-      .map(({ getY, label }) => {
+      .map(({ getY, id, label }) => {
         const y = getY(d);
         if (!Number.isFinite(y) || y === null) {
           return null;
@@ -153,7 +153,7 @@ const useComboLineSingleState = (
         return {
           label,
           value: `${y}`,
-          color: colors(label),
+          color: colors(id),
           hide: y === null,
           yPos: yScale(y ?? 0),
           symbol: "line",

--- a/app/charts/combo/combo-line-single.tsx
+++ b/app/charts/combo/combo-line-single.tsx
@@ -11,7 +11,7 @@ export const ComboLineSingle = () => {
 
   return (
     <g transform={`translate(${bounds.margins.left} ${bounds.margins.top})`}>
-      {y.lines.map(({ id, label, getY }) => {
+      {y.lines.map(({ id, getY }) => {
         const pathGenerator = line<Observation>()
           .defined((d) => {
             const y = getY(d);
@@ -24,7 +24,7 @@ export const ComboLineSingle = () => {
           <Line
             key={id}
             path={pathGenerator(chartData) as string}
-            color={colors(label)}
+            color={colors(id)}
           />
         );
       })}

--- a/app/charts/combo/combo-state.ts
+++ b/app/charts/combo/combo-state.ts
@@ -45,8 +45,13 @@ export const useCommonComboState = (options: UseCommonComboStateOptions) => {
   const timeFormatUnit = useTimeFormatUnit();
 
   const chartDataByX = useMemo(() => {
-    return groups(chartData, getXAsString).sort();
-  }, [chartData, getXAsString]);
+    return groups(
+      chartData.sort(
+        (a, b) => getXAsDate(a).getTime() - getXAsDate(b).getTime()
+      ),
+      getXAsString
+    );
+  }, [chartData, getXAsDate, getXAsString]);
 
   const chartWideData = useMemo(() => {
     const chartWideData: Observation[] = [];

--- a/app/charts/combo/combo-state.ts
+++ b/app/charts/combo/combo-state.ts
@@ -9,6 +9,7 @@ import {
 } from "d3-scale";
 import { useMemo } from "react";
 
+import { BaseYGetter } from "@/charts/combo/combo-state-props";
 import {
   SINGLE_LINE_AXIS_LABEL_HEIGHT,
   useAxisTitleSize,
@@ -24,11 +25,7 @@ type UseCommonComboStateOptions = {
   xKey: string;
   getXAsDate: (d: Observation) => Date;
   getXAsString: (d: Observation) => string;
-  yGetters: {
-    label: string;
-    getY: (d: Observation) => number | null;
-    color: string;
-  }[];
+  yGetters: BaseYGetter[];
   computeTotal: boolean;
 };
 
@@ -86,7 +83,7 @@ export const useCommonComboState = (options: UseCommonComboStateOptions) => {
   }, [getXAsDate, timeRangeData]);
 
   const colors = useMemo(() => {
-    const domain = yGetters.map((d) => d.label);
+    const domain = yGetters.map((d) => d.id);
     const range = yGetters.map((d) => d.color);
 
     return scaleOrdinal<string, string>().domain(domain).range(range);

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -273,7 +273,7 @@ const DataFilter = ({
   disabled: boolean;
 }) => {
   const locale = useLocale();
-  const filters = useChartConfigFilters(chartConfig);
+  const filters = useChartConfigFilters(chartConfig, { cubeIri });
   const chartLoadingState = useLoadingState();
   const updateDataFilter = useChartInteractiveFilters(
     (d) => d.updateDataFilter

--- a/app/components/chart-footnotes.tsx
+++ b/app/components/chart-footnotes.tsx
@@ -209,6 +209,7 @@ const ChartFootnotesLegend = ({
         <ChartFootnotesComboLineSingle
           chartConfig={chartConfig}
           components={components}
+          cubeIri={cubeIri}
         />
       );
     }
@@ -324,9 +325,11 @@ const ChartFootnotesComboLineDual = ({
 const ChartFootnotesComboLineSingle = ({
   chartConfig,
   components,
+  cubeIri,
 }: {
   chartConfig: ComboLineSingleConfig;
   components: Component[];
+  cubeIri: string;
 }) => {
   const {
     y: { componentIds },
@@ -335,7 +338,10 @@ const ChartFootnotesComboLineSingle = ({
   return componentIds.length ? (
     <ChartFootnotesLegendContainer>
       {componentIds.map((id) => {
-        const component = components.find((d) => d.id === id);
+        const component = components.find(
+          (d) => d.id === id && d.cubeIri === cubeIri
+        );
+
         return component ? (
           <LegendItem
             key={component.id}

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -144,7 +144,10 @@ export const DataFilterSelectGeneric = ({
     keepPreviousData: true,
   });
 
-  const dimension = data?.dataCubesComponents?.dimensions?.[0] ?? rawDimension;
+  const dimension =
+    data?.dataCubesComponents?.dimensions.find(
+      (d) => d.cubeIri === rawDimension.cubeIri
+    ) ?? rawDimension;
   const controls = dimension.isKeyDimension ? null : (
     <Box sx={{ display: "flex", flexGrow: 1 }}>
       <IconButton
@@ -766,6 +769,7 @@ export const ChartConfigurator = ({
                                         key={dim.id}
                                         rawDimension={dim}
                                         filterDimensionIds={filterDimensions
+                                          .filter((d) => d.cubeIri === cubeIri)
                                           .slice(0, i)
                                           .map((d) => d.id)}
                                         index={i}

--- a/app/configurator/components/dataset-control-section.tsx
+++ b/app/configurator/components/dataset-control-section.tsx
@@ -129,7 +129,7 @@ const DatasetRow = ({
             component="span"
             onClick={handleDatasetClick}
           >
-            Datasets
+            <Trans id="dataset.footnotes.dataset">Dataset</Trans>
           </MuiLink>
           <br />
           <Typography variant="caption">{cube.title}</Typography>

--- a/e2e/filter-position.spec.ts
+++ b/e2e/filter-position.spec.ts
@@ -4,7 +4,7 @@ const { test, expect } = setup();
 
 test("Filters should be sorted by position", async ({ selectors, actions }) => {
   await actions.chart.createFrom({
-    iri: "https://environment.ld.admin.ch/foen/ubd003001_colors_jan2024",
+    iri: "https://environment.ld.admin.ch/foen/UBD003002/6",
     dataSource: "Int",
   });
 
@@ -45,5 +45,6 @@ test("Filters should be sorted by position", async ({ selectors, actions }) => {
     "Endangered",
     "Critically endangered",
     "Regionally extinct",
+    "Extinct in the world",
   ]);
 });

--- a/e2e/fixtures/hierarchy-test-13-municipality-population.json
+++ b/e2e/fixtures/hierarchy-test-13-municipality-population.json
@@ -1,6 +1,6 @@
 {
   "state": "CONFIGURING_CHART",
-  "dataSet": "https://environment.ld.admin.ch/foen/fab_hierarchy_test13_switzerland_canton_municipality/3",
+  "dataSet": "https://environment.ld.admin.ch/foen/fab_hierarchy_test12_switzerland_canton_municipality/5",
   "dataSource": {
     "type": "sparql",
     "url": "https://lindas-cached.int.cluster.ldbar.ch/query"
@@ -13,11 +13,11 @@
     "version": "1.3.0",
     "chartType": "column",
     "filters": {
-      "https://environment.ld.admin.ch/foen/fab_hierarchy_test13_switzerland_canton_municipality/date": {
+      "https://environment.ld.admin.ch/foen/fab_hierarchy_test12_switzerland_canton_municipality/date": {
         "type": "single",
         "value": "2022-01-01"
       },
-      "https://environment.ld.admin.ch/foen/fab_hierarchy_test13_switzerland_canton_municipality/BFSIdentifier": {
+      "https://environment.ld.admin.ch/foen/fab_hierarchy_test12_switzerland_canton_municipality/BFSIdentifier": {
         "type": "multi",
         "values": {
           "https://ld.admin.ch/municipality/261": true,
@@ -37,10 +37,10 @@
     },
     "fields": {
       "x": {
-        "componentIri": "https://environment.ld.admin.ch/foen/fab_hierarchy_test13_switzerland_canton_municipality/BFSIdentifier"
+        "componentIri": "https://environment.ld.admin.ch/foen/fab_hierarchy_test12_switzerland_canton_municipality/BFSIdentifier"
       },
       "y": {
-        "componentIri": "https://environment.ld.admin.ch/foen/fab_hierarchy_test13_switzerland_canton_municipality/population"
+        "componentIri": "https://environment.ld.admin.ch/foen/fab_hierarchy_test12_switzerland_canton_municipality/population"
       }
     }
   },


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #1922

<!--- Describe the changes -->

This PR:
- fixes the problem with changing one filter value that made two filters change when using merged cubes with dimensions with the same iris,
- fixes the problem with interactive filters displaying no values when enabling them in merged cubes context,
- fixes the problem with not separating dimensions per cubes in multi-line chart when using merged cubes with dimensions with the same iris (and also misaligned colors in the same cases),
- makes the legend items break words, which prevent the labels from overlapping.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-merged-cubes-filters-tandem-ixt1.vercel.app/en/create/new?cube=https://agriculture.ld.admin.ch/foag/cube/MilkDairyProducts/Consumption_Price_Month&dataSource=Prod).
2. Add a new dataset.
3. Select `Market figures milk and dairy products - Monthly producer prices` and confirm.
4. ✅ See that the values in the single filters are different per cube, contrary to what's happening currently on `main`.
5. ✅ Change one filter value and see that it doesn't affect the other cube.
6. ✅ Enable both `Product` interactive filters and see that they show values and are usable, contrary to `main`, where they show up empty.

<!--- Reproduction steps, in case of a bug -->

---

- [x] Add a CHANGELOG entry
