### PR TITLE
style: Improve ODS dataset preview iframe's appearance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ You can also check the
 
 - Features
   - Added a way to preview charts using hash parameters through `/preview` page
+- Styles
+  - Improved ODS dataset preview iframe's appearance
 
 # [5.6.0] - 2025-04-15
 

--- a/app/browse/datatable.tsx
+++ b/app/browse/datatable.tsx
@@ -132,7 +132,7 @@ export const PreviewTable = ({
   );
 
   return (
-    <div ref={tooltipContainerRef}>
+    <div ref={tooltipContainerRef} style={{ width: "100%" }}>
       <Table>
         <caption style={{ display: "none" }}>{title}</caption>
         <TableHead

--- a/app/browser/dataset-preview.tsx
+++ b/app/browser/dataset-preview.tsx
@@ -45,8 +45,7 @@ const useStyles = makeStyles<
     marginBottom: theme.spacing(6),
   },
   tableOuterWrapper: {
-    width: "fit-content",
-    maxWidth: "100%",
+    width: "100%",
     boxShadow: theme.shadows[4],
   },
   tableInnerWrapper: {

--- a/app/browser/select-dataset-step.tsx
+++ b/app/browser/select-dataset-step.tsx
@@ -391,7 +391,11 @@ const SelectDatasetStepContent = ({
         }}
       >
         <ContentWrapper
-          sx={odsIframe ? { maxWidth: "unset !important", px: 8 } : {}}
+          sx={
+            odsIframe
+              ? { maxWidth: "unset !important", px: "8px !important" }
+              : {}
+          }
         >
           <AnimatePresence mode="wait">
             {dataset ? (
@@ -488,7 +492,11 @@ const SelectDatasetStepContent = ({
         </ContentWrapper>
       </Box>
       <ContentWrapper
-        sx={odsIframe ? { maxWidth: "unset !important", px: 8 } : {}}
+        sx={
+          odsIframe
+            ? { maxWidth: "unset !important", px: "8px !important" }
+            : {}
+        }
       >
         <PanelLayout
           type={odsIframe ? "M" : "LM"}


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2249

<!--- Describe the changes -->

This PR improves the appearance of ODS dataset preview iframe by extending the table width to 100% even if we have few columns. It also optimizes horizontal padding to align more closely with surrounding content on target pages (didn't set it to 0 to avoid cut off shadows).

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-feat-improve-ods-iframe-ixt1.vercel.app/en/browse?previous=%7B%22order%22%3A%22SCORE%22%2C%22search%22%3A%22NOx%22%7D&dataset=https%3A%2F%2Fenvironment.ld.admin.ch%2Ffoen%2Fubd010702%2F14&dataSource=Int&odsiframe=true).
2. ✅ See that the table takes the full width of the page and that horizontal paddings are smaller than before.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
