### PR TITLE
feat: New limit styling options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ You can also check the
 
 - Features
   - It's now possible to use triangle symbol for single-value limits
+  - It's now possible to make single-value limit lines dashed when makes sense
 
 # [5.7.0] - 2025-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Features
+  - It's now possible to use triangle symbol for single-value limits
 
 # [5.7.0] - 2025-04-16
 

--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -42,7 +42,13 @@ import useEvent from "@/utils/use-event";
 
 import { DimensionsById } from "./ChartProps";
 
-export type LegendSymbol = "square" | "line" | "circle" | "cross" | "triangle";
+export type LegendSymbol =
+  | "square"
+  | "line"
+  | "dashed-line"
+  | "circle"
+  | "cross"
+  | "triangle";
 
 const useStyles = makeStyles<Theme>((theme) => ({
   legendContainer: {
@@ -165,7 +171,11 @@ export const LegendColor = memo(function LegendColor({
               ? [measureLimit.value]
               : [measureLimit.from, measureLimit.to],
           color: configLimit.color,
-          symbol: !configLimit.symbolType ? "line" : configLimit.symbolType,
+          symbol: !configLimit.symbolType
+            ? configLimit.lineType === "dashed"
+              ? "dashed-line"
+              : "line"
+            : configLimit.symbolType,
         }))}
         getColor={colors}
         getLabel={getColorLabel}
@@ -390,6 +400,21 @@ const LegendIcon = ({
       break;
     case "line":
       node = <rect x={0} y={0.425} width={1} height={0.175} fill={fill} />;
+      break;
+    case "dashed-line":
+      node = (
+        <line
+          x1={0}
+          x2={1}
+          y1={0.5}
+          y2={0.5}
+          stroke={fill}
+          strokeWidth={2.5}
+          vectorEffect="non-scaling-stroke"
+          strokeDashoffset="3"
+          strokeDasharray="2 2"
+        />
+      );
       break;
     case "triangle":
       node = (

--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -399,7 +399,17 @@ const LegendIcon = ({
       );
       break;
     case "line":
-      node = <rect x={0} y={0.425} width={1} height={0.175} fill={fill} />;
+      node = (
+        <line
+          x1={0}
+          x2={1}
+          y1={0.5}
+          y2={0.5}
+          stroke={fill}
+          strokeWidth={2.5}
+          vectorEffect="non-scaling-stroke"
+        />
+      );
       break;
     case "dashed-line":
       node = (

--- a/app/charts/shared/rendering-utils.ts
+++ b/app/charts/shared/rendering-utils.ts
@@ -214,25 +214,35 @@ export const renderVerticalLimits = (
       .attr("stroke-width", LIMIT_SIZE)
       .attr("stroke-dasharray", d.lineType === "dashed" ? "3 3" : "none");
 
-    const isRange = d.symbolType === undefined;
+    const isRange = d.y1 !== d.y2;
 
-    if (isRange) {
+    if (d.symbolType === undefined) {
       group
-        .append("rect")
+        .append("line")
         .attr("class", "top-line")
-        .attr("x", d.x)
-        .attr("y", d.y2 - LIMIT_SIZE / 2)
-        .attr("width", d.width)
-        .attr("height", LIMIT_SIZE)
-        .attr("fill", d.fill);
+        .attr("x1", d.x)
+        .attr("y1", d.y2)
+        .attr("x2", d.x + d.width)
+        .attr("y2", d.y2)
+        .attr("stroke", d.fill)
+        .attr("stroke-width", LIMIT_SIZE)
+        .attr(
+          "stroke-dasharray",
+          isRange || d.lineType === "solid" ? "none" : "3 3"
+        );
       group
-        .append("rect")
+        .append("line")
         .attr("class", "bottom-line")
-        .attr("x", d.x)
-        .attr("y", d.y1 - LIMIT_SIZE / 2)
-        .attr("width", d.width)
-        .attr("height", LIMIT_SIZE)
-        .attr("fill", d.fill);
+        .attr("x1", d.x)
+        .attr("y1", d.y1)
+        .attr("x2", d.x + d.width)
+        .attr("y2", d.y1)
+        .attr("stroke", d.fill)
+        .attr("stroke-width", LIMIT_SIZE)
+        .attr(
+          "stroke-dasharray",
+          isRange || d.lineType === "solid" ? "none" : "3 3"
+        );
     } else {
       const symbolGroup = group.append("g").attr("class", "symbol");
       const { cx, cy } = getMiddle(d);

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -290,7 +290,11 @@ const Limit = t.intersection([
     lineType: t.union([t.literal("dashed"), t.literal("solid")]),
   }),
   t.partial({
-    symbolType: t.union([t.literal("cross"), t.literal("circle")]),
+    symbolType: t.union([
+      t.literal("cross"),
+      t.literal("circle"),
+      t.literal("triangle"),
+    ]),
   }),
 ]);
 export type Limit = t.TypeOf<typeof Limit>;

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -760,14 +760,17 @@ const ChartLimits = ({
   const availableLimitOptions = useMemo(() => {
     return measure.limits
       .map((limit) => {
-        const { limit: maybeLimit, wouldBeValid } =
-          getMaybeValidChartConfigLimit({
-            chartConfig,
-            measureId: measure.id,
-            axisDimension,
-            limit,
-            filters,
-          });
+        const {
+          limit: maybeLimit,
+          wouldBeValid,
+          relatedAxisDimensionValueLabel,
+        } = getMaybeValidChartConfigLimit({
+          chartConfig,
+          measureId: measure.id,
+          axisDimension,
+          limit,
+          filters,
+        });
 
         if (!wouldBeValid) {
           return;
@@ -780,6 +783,7 @@ const ChartLimits = ({
         } = maybeLimit ?? {};
 
         return {
+          relatedAxisDimensionValueLabel,
           limit,
           maybeLimit,
           color,
@@ -808,7 +812,22 @@ const ChartLimits = ({
       </SectionTitle>
       <ControlSectionContent component="fieldset">
         {availableLimitOptions.map(
-          ({ maybeLimit, limit, color, lineType, symbolType }, i) => {
+          (
+            {
+              relatedAxisDimensionValueLabel,
+              maybeLimit,
+              limit,
+              color,
+              lineType,
+              symbolType,
+            },
+            i
+          ) => {
+            /** It means that the limit is rendered as overarching line, not tied
+             * to any axis dimension value. */
+            const hasNoAxisDimension =
+              relatedAxisDimensionValueLabel === undefined;
+
             return (
               <Box key={i} sx={{ mb: 2 }}>
                 <Box
@@ -937,9 +956,11 @@ const ChartLimits = ({
                     </RadioGroup>
                   </div>
                 ) : null}
-                {limit.type === "range" ? (
+                {limit.type === "range" ||
+                !supportsLimitSymbols ||
+                hasNoAxisDimension ? (
                   <div>
-                    <Typography variant="body3" component="p" sx={{ mb: 2 }}>
+                    <Typography variant="body3" component="p" sx={{ my: 2 }}>
                       <Trans id="controls.section.targets-and-limit-values.line-type">
                         Select line type
                       </Trans>

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -912,6 +912,28 @@ const ChartLimits = ({
                         }}
                         disabled={!maybeLimit}
                       />
+                      <Radio
+                        name={`limit-${i}-symbol-type-triangle`}
+                        label={t({
+                          id: "controls.symbol.triangle",
+                          message: "Triangle",
+                        })}
+                        value="triangle"
+                        checked={symbolType === "triangle"}
+                        onChange={() => {
+                          dispatch({
+                            type: "LIMIT_SET",
+                            value: {
+                              measureId: measure.id,
+                              related: limit.related,
+                              color,
+                              lineType,
+                              symbolType: "triangle",
+                            },
+                          });
+                        }}
+                        disabled={!maybeLimit}
+                      />
                     </RadioGroup>
                   </div>
                 ) : null}

--- a/app/configurator/components/chart-options-selector.tsx
+++ b/app/configurator/components/chart-options-selector.tsx
@@ -1,11 +1,5 @@
 import { t, Trans } from "@lingui/macro";
-import {
-  Box,
-  Stack,
-  Switch as MUISwitch,
-  Tooltip,
-  Typography,
-} from "@mui/material";
+import { Box, Stack, Tooltip, Typography } from "@mui/material";
 import { groups } from "d3-array";
 import get from "lodash/get";
 import groupBy from "lodash/groupBy";
@@ -29,9 +23,8 @@ import { getMap } from "@/charts/map/ref";
 import { useQueryFilters } from "@/charts/shared/chart-helpers";
 import { LegendItem, LegendSymbol } from "@/charts/shared/legend-color";
 import Flex from "@/components/flex";
-import { RadioGroup } from "@/components/form";
+import { RadioGroup, Switch } from "@/components/form";
 import {
-  Label,
   Radio,
   Select,
   SelectOption,
@@ -827,18 +820,17 @@ const ChartLimits = ({
                   }}
                 >
                   <Box sx={{ display: "flex", alignItems: "center", gap: 3 }}>
-                    <MUISwitch
+                    <Switch
                       id={`limit-${i}`}
+                      label={t({
+                        id: "controls.section.targets-and-limit-values.show-target",
+                        message: "Show target",
+                      })}
                       checked={!!maybeLimit}
                       onChange={(e) => {
                         onToggle(e.target.checked, limit);
                       }}
                     />
-                    <Label htmlFor={`limit-${i}`}>
-                      <Trans id="controls.section.targets-and-limit-values.show-target">
-                        Show target
-                      </Trans>
-                    </Label>
                   </Box>
                   <Flex
                     sx={{

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -90,11 +90,11 @@ msgid "browse.datasets.description"
 msgstr "Erkunden Sie die vom LINDAS Linked Data Service bereitgestellten Datensätze, indem Sie entweder nach Kategorien oder Organisationen filtern oder direkt nach bestimmten Stichworten suchen. Klicken Sie auf einen Datensatz, um detailliertere Informationen zu erhalten und Ihre eigenen Visualisierungen zu erstellen."
 
 #: app/components/metadata-panel.tsx
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/preview-table.tsx
 msgid "button.back"
 msgstr "Zurück"
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/preview-table.tsx
 msgid "button.confirm"
 msgstr "Bestätigen"
 
@@ -245,11 +245,11 @@ msgstr "Kein Tab-Titel"
 msgid "chart.datasets.add"
 msgstr "Hinzufügen"
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "chart.datasets.add-dataset-dialog.description"
 msgstr "Sie können nur Datensätze kombinieren, die Dimensionen mit derselben Einheit und Auflösung teilen. Standardmässig werden Dimensionen ausgewählt, die zum aktuellen Diagramm passen."
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "chart.datasets.add-dataset-dialog.title"
 msgstr "Wählen Sie einen Datensatz mit gemeinsamen Dimensionen aus"
 
@@ -946,6 +946,7 @@ msgid "controls.scale.type"
 msgstr "Skalierungstyp"
 
 #: app/components/form.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "controls.search.clear"
 msgstr "Suche zurücksetzen"
 
@@ -1357,6 +1358,10 @@ msgstr "Kreuz"
 msgid "controls.symbol.dot"
 msgstr "Punkt"
 
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.symbol.triangle"
+msgstr "Dreieck"
+
 #: app/configurator/table/table-chart-options.tsx
 msgid "controls.table.column.group"
 msgstr "Gruppieren"
@@ -1477,30 +1482,27 @@ msgstr "Achtung, dieser Datensatz ist abgelaufen.<0/><1>Diese Grafik nicht für 
 msgid "dataset.results"
 msgstr "{0, plural, zero {Keine Datensätze} one {# Datensatz} other {# Datensätze}}"
 
-#: app/configurator/components/add-dataset-drawer.tsx
-msgid "dataset.search.add-dataset"
-msgstr "Datensatz hinzufügen"
-
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "dataset.search.at-least-one-compatible-dimension-selected"
 msgstr "Es muss mindestens eine kompatible Dimension ausgewählt werden."
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/caution-alert.tsx
 msgid "dataset.search.caution.acknowledge"
 msgstr "Verstanden, ich werde vorsichtig vorgehen."
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/caution-alert.tsx
 msgid "dataset.search.caution.body"
 msgstr "Die Verknüpfung verschiedener Datensätze birgt Risiken wie Dateninkonsistenzen, Skalierbarkeitsprobleme und unerwartete Korrelationen. Stellen Sie sicher, dass Sie Datensätze nur dann zusammenführen, wenn Sie sicher sind, dass die Daten zusammengeführt werden sollen."
 
 #: app/browser/dataset-browse.tsx
 #: app/components/form.tsx
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "dataset.search.label"
 msgstr "Suchen"
 
 #: app/browser/dataset-browse.tsx
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "dataset.search.placeholder"
 msgstr "Name, Organisation, Stichwort..."
 
@@ -1508,27 +1510,27 @@ msgstr "Name, Organisation, Stichwort..."
 msgid "dataset.search.preview.added-dataset"
 msgstr "Neuer Datensatz hinzugefügt. Sie können die Daten nun in den Diagrammen verwenden."
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/preview-table.tsx
 msgid "dataset.search.preview.datasets"
 msgstr "Datensätze"
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/preview-table.tsx
 msgid "dataset.search.preview.description"
 msgstr "Überprüfen Sie die verfügbaren Dimensionen."
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/preview-table.tsx
 msgid "dataset.search.preview.new-dimension"
 msgstr "Neu"
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/preview-table.tsx
 msgid "dataset.search.preview.title"
 msgstr "Verfügbare Dimensionen"
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "dataset.search.search-options.more-2-options-selected"
 msgstr "{0} weitere"
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "dataset.search.search-options.no-options-selected"
 msgstr "Keine Optionen ausgewählt"
 

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -90,11 +90,11 @@ msgid "browse.datasets.description"
 msgstr "Explore datasets provided by the LINDAS Linked Data Service by either filtering by categories or organizations or search directly for specific keywords. Click on a dataset to see more detailed information and start creating your own visualizations."
 
 #: app/components/metadata-panel.tsx
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/preview-table.tsx
 msgid "button.back"
 msgstr "Back"
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/preview-table.tsx
 msgid "button.confirm"
 msgstr "Confirm"
 
@@ -245,11 +245,11 @@ msgstr "No label"
 msgid "chart.datasets.add"
 msgstr "Add dataset"
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "chart.datasets.add-dataset-dialog.description"
 msgstr "You can only combine datasets that share dimensions with the same unit and resolution. By default, dimensions matching the current chart are selected."
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "chart.datasets.add-dataset-dialog.title"
 msgstr "Select dataset with shared dimensions"
 
@@ -946,6 +946,7 @@ msgid "controls.scale.type"
 msgstr "Scale type"
 
 #: app/components/form.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "controls.search.clear"
 msgstr "Clear search field"
 
@@ -1357,6 +1358,10 @@ msgstr "Cross"
 msgid "controls.symbol.dot"
 msgstr "Dot"
 
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.symbol.triangle"
+msgstr "Triangle"
+
 #: app/configurator/table/table-chart-options.tsx
 msgid "controls.table.column.group"
 msgstr "Use as group"
@@ -1477,30 +1482,27 @@ msgstr "Careful, the data for this chart has expired.<0/><1>Don't use for report
 msgid "dataset.results"
 msgstr "{0, plural, zero {No datasets} one {# dataset} other {# datasets}}"
 
-#: app/configurator/components/add-dataset-drawer.tsx
-msgid "dataset.search.add-dataset"
-msgstr "Add dataset"
-
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "dataset.search.at-least-one-compatible-dimension-selected"
 msgstr "At least one compatible dimension must be selected."
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/caution-alert.tsx
 msgid "dataset.search.caution.acknowledge"
 msgstr "Understood, I'll proceed cautiously."
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/caution-alert.tsx
 msgid "dataset.search.caution.body"
 msgstr "The linking of different datasets carries risks such as data inconsistencies, scalability issues, and unexpected correlations. Be sure to use to merge datasets only when you are confident that data should be merged together."
 
 #: app/browser/dataset-browse.tsx
 #: app/components/form.tsx
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "dataset.search.label"
 msgstr "Search"
 
 #: app/browser/dataset-browse.tsx
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "dataset.search.placeholder"
 msgstr "Name, organization, keyword..."
 
@@ -1508,27 +1510,27 @@ msgstr "Name, organization, keyword..."
 msgid "dataset.search.preview.added-dataset"
 msgstr "New dataset added. You can now use its data in the chart(s)."
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/preview-table.tsx
 msgid "dataset.search.preview.datasets"
 msgstr "Datasets"
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/preview-table.tsx
 msgid "dataset.search.preview.description"
 msgstr "Review data preview of available dimensions and continue to edit visualization."
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/preview-table.tsx
 msgid "dataset.search.preview.new-dimension"
 msgstr "New"
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/preview-table.tsx
 msgid "dataset.search.preview.title"
 msgstr "Available dimensions"
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "dataset.search.search-options.more-2-options-selected"
 msgstr "{0} more"
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "dataset.search.search-options.no-options-selected"
 msgstr "dataset.search.search-options.no-options-selected"
 

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -90,11 +90,11 @@ msgid "browse.datasets.description"
 msgstr "Explorez les jeux de données liés fournis par LINDAS, en filtrant par catégories ou organisations, ou en recherchant par mots-clés. Cliquez sur un ensemble de données pour afficher des informations plus détaillées et commencer à créer vos propres visualisations. "
 
 #: app/components/metadata-panel.tsx
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/preview-table.tsx
 msgid "button.back"
 msgstr "Précédent"
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/preview-table.tsx
 msgid "button.confirm"
 msgstr "Confirmer"
 
@@ -245,11 +245,11 @@ msgstr "Pas de Titre"
 msgid "chart.datasets.add"
 msgstr "Ajouter"
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "chart.datasets.add-dataset-dialog.description"
 msgstr "Vous ne pouvez combiner que des ensembles de données qui partagent des dimensions avec la même unité et résolution. Par défaut, les dimensions correspondant au graphique actuel sont sélectionnées."
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "chart.datasets.add-dataset-dialog.title"
 msgstr "Sélectionner un ensemble de données avec des dimensions partagées"
 
@@ -946,6 +946,7 @@ msgid "controls.scale.type"
 msgstr "Type d'échelle"
 
 #: app/components/form.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "controls.search.clear"
 msgstr "Effacer la recherche"
 
@@ -1357,6 +1358,10 @@ msgstr "Croix"
 msgid "controls.symbol.dot"
 msgstr "Point"
 
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.symbol.triangle"
+msgstr "Triangle"
+
 #: app/configurator/table/table-chart-options.tsx
 msgid "controls.table.column.group"
 msgstr "Grouper selon cette colonne"
@@ -1477,30 +1482,27 @@ msgstr "Attention, ce jeu de données est expiré.<0/><1>Ne l'utilisez pas pour 
 msgid "dataset.results"
 msgstr "{0, plural, zero {Aucun jeu de données} one {# jeu de données} other {# jeux de données}}"
 
-#: app/configurator/components/add-dataset-drawer.tsx
-msgid "dataset.search.add-dataset"
-msgstr "Ajouter la source"
-
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "dataset.search.at-least-one-compatible-dimension-selected"
 msgstr "Au moins une dimension compatible doit être sélectionnée."
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/caution-alert.tsx
 msgid "dataset.search.caution.acknowledge"
 msgstr "Compris, je vais procéder avec prudence."
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/caution-alert.tsx
 msgid "dataset.search.caution.body"
 msgstr "La liaison de différents ensembles de données comporte des risques tels que des incohérences de données, des problèmes d'évolutivité et des corrélations inattendues. Assurez-vous d'utiliser pour fusionner des ensembles de données uniquement lorsque vous êtes sûr que les données doivent être fusionnées."
 
 #: app/browser/dataset-browse.tsx
 #: app/components/form.tsx
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "dataset.search.label"
 msgstr "Chercher"
 
 #: app/browser/dataset-browse.tsx
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "dataset.search.placeholder"
 msgstr "Nom, organisation, mots clés..."
 
@@ -1508,27 +1510,27 @@ msgstr "Nom, organisation, mots clés..."
 msgid "dataset.search.preview.added-dataset"
 msgstr "Nouvel ensemble de données ajouté. Vous pouvez maintenant utiliser ses données dans le(s) graphique(s)."
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/preview-table.tsx
 msgid "dataset.search.preview.datasets"
 msgstr "Ensemble de données"
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/preview-table.tsx
 msgid "dataset.search.preview.description"
 msgstr "Vérifiez les nouvelles dimensions disponibles puis continuez à modifier la visualisation."
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/preview-table.tsx
 msgid "dataset.search.preview.new-dimension"
 msgstr "Nouveau"
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/preview-table.tsx
 msgid "dataset.search.preview.title"
 msgstr "Vérifiez les nouvelles dimensions"
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "dataset.search.search-options.more-2-options-selected"
 msgstr "{0} autres"
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "dataset.search.search-options.no-options-selected"
 msgstr "Aucune option sélectionnée"
 

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -90,11 +90,11 @@ msgid "browse.datasets.description"
 msgstr "Esplora i set di dati forniti dal LINDAS Linked Data Service filtrando per categorie o organizzazioni oppure cercando direttamente per parole chiave specifiche. Clicca su un set di dati per vedere informazioni più dettagliate e iniziare a creare le tue visualizzazioni."
 
 #: app/components/metadata-panel.tsx
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/preview-table.tsx
 msgid "button.back"
 msgstr "Torna indietro"
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/preview-table.tsx
 msgid "button.confirm"
 msgstr "Confermare"
 
@@ -245,11 +245,11 @@ msgstr "Senza etichetta"
 msgid "chart.datasets.add"
 msgstr "Aggiungere"
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "chart.datasets.add-dataset-dialog.description"
 msgstr "Puoi combinare solo set di dati che condividono dimensioni con la stessa unità e risoluzione. Per impostazione predefinita, vengono selezionate le dimensioni corrispondenti al grafico attuale."
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "chart.datasets.add-dataset-dialog.title"
 msgstr "Seleziona il set di dati con dimensioni condivise"
 
@@ -946,6 +946,7 @@ msgid "controls.scale.type"
 msgstr "Tipo di scala"
 
 #: app/components/form.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "controls.search.clear"
 msgstr "Cancella la ricerca"
 
@@ -1357,6 +1358,10 @@ msgstr "Attraverso"
 msgid "controls.symbol.dot"
 msgstr "Punto"
 
+#: app/configurator/components/chart-options-selector.tsx
+msgid "controls.symbol.triangle"
+msgstr "Triangolo"
+
 #: app/configurator/table/table-chart-options.tsx
 msgid "controls.table.column.group"
 msgstr "Raggruppa secondo questa colonna"
@@ -1477,30 +1482,27 @@ msgstr "Attenzione, questo set di dati è scaduto.<0/><1>Non utilizzare questo g
 msgid "dataset.results"
 msgstr "{0, plural, zero {Nessun set di dati} one {# set di dati} other {# set di dati}}"
 
-#: app/configurator/components/add-dataset-drawer.tsx
-msgid "dataset.search.add-dataset"
-msgstr "Aggiungi set di dati"
-
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "dataset.search.at-least-one-compatible-dimension-selected"
 msgstr "È necessario selezionare almeno una dimensione compatibile."
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/caution-alert.tsx
 msgid "dataset.search.caution.acknowledge"
 msgstr "Capito, procederò con cautela."
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/caution-alert.tsx
 msgid "dataset.search.caution.body"
 msgstr "Il collegamento di diversi set di dati comporta rischi quali incoerenze dei dati, problemi di scalabilità e correlazioni impreviste. Assicurati di utilizzare per unire i set di dati solo quando sei sicuro che i dati debbano essere uniti insieme."
 
 #: app/browser/dataset-browse.tsx
 #: app/components/form.tsx
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "dataset.search.label"
 msgstr "Cerca"
 
 #: app/browser/dataset-browse.tsx
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "dataset.search.placeholder"
 msgstr "Nome, organizzazione, parola chiave..."
 
@@ -1508,27 +1510,27 @@ msgstr "Nome, organizzazione, parola chiave..."
 msgid "dataset.search.preview.added-dataset"
 msgstr "Nuovo set di dati aggiunto. Ora puoi utilizzare i suoi dati nei grafici."
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/preview-table.tsx
 msgid "dataset.search.preview.datasets"
 msgstr "Set di dati"
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/preview-table.tsx
 msgid "dataset.search.preview.description"
 msgstr "Esamina le dimensioni disponibili prima di continuare a modificare la visualizzazione."
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/preview-table.tsx
 msgid "dataset.search.preview.new-dimension"
 msgstr "Nuovo"
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/preview-table.tsx
 msgid "dataset.search.preview.title"
 msgstr "Esamina le dimensioni disponibili"
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "dataset.search.search-options.more-2-options-selected"
 msgstr "altre {0}"
 
-#: app/configurator/components/add-dataset-drawer.tsx
+#: app/configurator/components/add-dataset-drawer/add-dataset-drawer.tsx
 msgid "dataset.search.search-options.no-options-selected"
 msgstr "Nessuna opzione selezionata"
 

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -372,10 +372,6 @@ export const getCubeObservations = async ({
   componentIris?: Maybe<string[]>;
   cache: LRUCache | undefined;
 }): Promise<ResolvedObservationsQuery["data"]> => {
-  console.log("getCubeObservations", {
-    cube,
-    filters,
-  });
   const cubeIri = cube.term?.value!;
   const cubeView = View.fromCube(cube, false);
   const unversionedCubeIri =
@@ -387,7 +383,6 @@ export const getCubeObservations = async ({
     unversionedCubeIri,
     cache,
   });
-  console.log({ allResolvedDimensions, cubeIri: cube.term?.value });
   const resolvedDimensions = allResolvedDimensions.filter((d) => {
     if (componentIris) {
       return (
@@ -807,8 +802,6 @@ async function fetchViewObservations({
       projection.addOut(ns.cubeView.limit, limit)
     );
   }
-
-  console.log(observationsView);
 
   const fullQuery = observationsView.observationsQuery({ disableDistinct });
   const query = pragmas


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2218

<!--- Describe the changes -->

This PR:
- introduces a triangle single-value limit symbol,
- allows styling of single-limit line (solid or dashed) when makes sense – either for single-value line limits or overarching limits not tied to any axis dimension value.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-feat-new-limit-symbols-ixt1.vercel.app/en/create/new?cube=https://environment.ld.admin.ch/foen/test_target/cube/target_future_ghg/1&dataSource=Test).
2. Switch to a line chart.
3. Open Vertical Axis.
4. ✅ Toggle a limit and see that you can select a triangle symbol that's also reflected in the legend.
5. Go to [this link](https://visualization-tool-git-feat-new-limit-symbols-ixt1.vercel.app/en/create/new?cube=https://environment.ld.admin.ch/foen/test_target/cube/target_soil/1&dataSource=Test), which leads to a broken test cube – it has not-distinguishable limits, without any related values – but works as a way to showcase dashed lines feature.
6. Open Vertical Axis.
7. Toggle one limit, which will trigger all limits (see above).
8. ✅ Change line type to dashed and see that it works.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
