### PR TITLE
feat: Future limits support for area charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Features
+  - Display of future limits is now compatible with area charts
 
 # [5.7.0] - 2025-04-16
 

--- a/app/charts/area/areas-state-props.ts
+++ b/app/charts/area/areas-state-props.ts
@@ -81,7 +81,7 @@ export const useAreasStateData = (
   chartProps: ChartProps<AreaConfig> & { limits: ReturnType<typeof useLimits> },
   variables: AreasStateVariables
 ): ChartStateData => {
-  const { chartConfig, observations } = chartProps;
+  const { chartConfig, observations, limits } = chartProps;
   const {
     sortData,
     xDimension,
@@ -98,6 +98,8 @@ export const useAreasStateData = (
   return useChartData(plottableData, {
     sortData,
     chartConfig,
+    axisDimensionId: xDimension.id,
+    limits: limits.limits.map((limit) => limit.measureLimit),
     timeRangeDimensionId: xDimension.id,
     getAxisValueAsDate: getX,
     getSegmentAbbreviationOrLabel,

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -419,9 +419,12 @@ const useAreasState = (
         formatNumber,
       });
       const xAnchor = xScale(getX(datum));
-      const yDesktopAnchor = normalize
-        ? yScale.range()[0] * 0.5
-        : yScale(sum(yValues) * (fields.segment ? 0.5 : 1));
+      const allNaN = yValues.every((d) => Number.isNaN(d));
+      const yDesktopAnchor = allNaN
+        ? NaN
+        : normalize
+          ? yScale.range()[0] * 0.5
+          : yScale(sum(yValues) * (fields.segment ? 0.5 : 1));
       const yAnchor = isMobile ? chartHeight : yDesktopAnchor;
       const placement = isMobile
         ? MOBILE_TOOLTIP_PLACEMENT

--- a/app/charts/area/areas.tsx
+++ b/app/charts/area/areas.tsx
@@ -22,7 +22,13 @@ export const Areas = () => {
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
   const areaGenerator = area<$FixMe>()
-    .defined((d) => d[0] !== null && d[1] !== null)
+    .defined(
+      (d) =>
+        d[0] !== null &&
+        d[1] !== null &&
+        !Number.isNaN(d[0]) &&
+        !Number.isNaN(d[1])
+    )
     .x((d) => xScale(getX(d.data)))
     .y0((d) => yScale(d[0]))
     .y1((d) => yScale(d[1]));


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2254

<!--- Describe the changes -->

This PR adds support for showing future limits for area charts.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-feat-future-limits-area-chart-ixt1.vercel.app/en/v/Z7eFo1DVEV6c?dataSource=Test).
2. ✅ See a non-broken area chart with future limits.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
