### PR TITLE
feat: Fetch unit labels in more languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Features
+  - Dimension unit labels are now fetched not only in English language, but
+    others too – and we fall back to a regular string in case the label is not
+    localized
 
 # [5.7.0] - 2025-04-16
 

--- a/app/rdf/queries.ts
+++ b/app/rdf/queries.ts
@@ -90,7 +90,7 @@ export const getCubeDimensions = async ({
     const dimensionUnitIndex = index(
       await loadUnits({
         ids: dimensionUnits,
-        locale: "en", // No other locales exist yet
+        locale,
         sparqlClient,
         cache,
       }),

--- a/app/rdf/query-cube-preview.ts
+++ b/app/rdf/query-cube-preview.ts
@@ -87,7 +87,7 @@ CONSTRUCT {
       OPTIONAL { ?dimensionUnit ?dimensionUnitIsCurrency qudt:CurrencyUnit . }
       OPTIONAL { ?dimensionUnit qudt:currencyExponent ?dimensionUnitCurrencyExponent . }
       BIND(STR(COALESCE(STR(?dimensionUnitSymbol), STR(?dimensionUnitUcumCode), STR(?dimensionUnitExpression), STR(?dimensionUnitRdfsLabel))) AS ?dimensionUnitLabel)
-      FILTER (LANG(?dimensionUnitRdfsLabel) = "en")
+      FILTER (LANG(?dimensionUnitRdfsLabel) = "${locale}" || LANG(?dimensionUnitRdfsLabel) = "en" || datatype(?dimensionUnitRdfsLabel) = xsd:string)
     }
     OPTIONAL { ?dimension sh:order ?dimensionOrder . }
     OPTIONAL {

--- a/app/rdf/query-unit-labels.ts
+++ b/app/rdf/query-unit-labels.ts
@@ -8,10 +8,10 @@ import batchLoad from "./batch-load";
 import { pragmas } from "./create-source";
 import * as ns from "./namespace";
 
-interface ResourceLabel {
+type ResourceLabel = {
   iri: Term;
   label?: Term;
-}
+};
 
 const buildUnitsQuery = (values: Term[], locale: string) => {
   const uniqueValues = uniqBy(values, (v) => v.value);
@@ -30,8 +30,8 @@ const buildUnitsQuery = (values: Term[], locale: string) => {
         OPTIONAL { ?iri ${ns.qudt.currencyExponent} ?currencyExponent }
 
         BIND(str(coalesce(str(?symbol), str(?ucumCode), str(?expression), str(?rdfsLabel), "?")) AS ?label)
-        
-        FILTER ( lang(?rdfsLabel) = "${locale}" )
+
+        FILTER ( lang(?rdfsLabel) = "${locale}" || lang(?rdfsLabel) = "en" || datatype(?rdfsLabel) = ${ns.xsd.string} )
       `.prologue`${pragmas}`;
 };
 


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2251

<!--- Describe the changes -->

This PR adds support for fetching unit labels in more languages, falling back to non-localized strings if unit label is not localized.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-feat-fetch-unit-labels-in-mo-7eb547-ixt1.vercel.app/en/browse?previous=%7B%22order%22%3A%22SCORE%22%2C%22search%22%3A%22future%22%2C%22includeDrafts%22%3Atrue%7D&dataset=https%3A%2F%2Fenvironment.ld.admin.ch%2Ffoen%2Ftest_target%2Fcube%2Ftarget_future%2F1&dataSource=Int).
2. ✅ See that the `Mt` unit is displayed in the column.
3. Create a chart.
4. ✅ See that the `Mt` unit is displayed in the y axis label.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
