### PR TITLE
feat: Smaller improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ You can also check the
   - Dimension unit labels are now fetched not only in English language, but
     others too – and we fall back to a regular string in case the label is not
     localized
+  - It's now possible to enter www links in text blocks link elements, instead
+    of having to always use https://
 - Fixes
   - Color palette can be changed again
   - Combo charts tooltips now work correctly again

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -441,6 +441,7 @@ export const DataFilterGenericDimension = (
   return (
     <Select
       id="dataFilterBaseDimension"
+      size="sm"
       label={
         <FieldLabel
           label={

--- a/app/components/markdown.tsx
+++ b/app/components/markdown.tsx
@@ -6,6 +6,7 @@ import rehypeSanitize from "rehype-sanitize";
 import remarkGfm from "remark-gfm";
 
 import classes from "@/components/markdown.module.css";
+import { palette } from "@/themes/palette";
 
 const components: ComponentProps<typeof ReactMarkdown>["components"] = {
   h1: ({ children, style, ...props }) => (
@@ -44,7 +45,11 @@ const components: ComponentProps<typeof ReactMarkdown>["components"] = {
     </p>
   ),
   a: ({ children, style, ...props }) => (
-    <a target="_blank" style={{ ...style, marginTop: 0 }} {...props}>
+    <a
+      target="_blank"
+      style={{ ...style, marginTop: 0, color: palette.primary.main }}
+      {...props}
+    >
       {children}
     </a>
   ),
@@ -133,7 +138,7 @@ const componentsInheritFonts: ComponentProps<
     <a
       className={clsx(className, classes.inheritFonts)}
       target="_blank"
-      style={{ ...style, marginTop: 0 }}
+      style={{ ...style, marginTop: 0, color: palette.primary.main }}
       {...props}
     >
       {children}

--- a/app/components/mdx-editor/link-dialog.tsx
+++ b/app/components/mdx-editor/link-dialog.tsx
@@ -367,7 +367,15 @@ const LinkEditForm = ({
       <form
         className={classes.form}
         onSubmit={(e) => {
-          void handleSubmit(onSubmit)(e);
+          void handleSubmit(({ url, text }) => {
+            url = url.trim();
+            if (!/^https?:\/\//i.test(url)) {
+              url = "https://" + url;
+            }
+
+            onSubmit({ url, text });
+          })(e);
+
           e.stopPropagation();
           e.preventDefault();
         }}
@@ -391,12 +399,16 @@ const LinkEditForm = ({
           id="link-url"
           className={classes.input}
           size="sm"
-          type="url"
-          {...register("url")}
+          type="text"
           placeholder={t({
             id: "mdx-editor.link-dialog.url-placeholder",
             message: "URL...",
           })}
+          inputProps={{
+            pattern: "https?://.*|www\\..*",
+            title: "Enter a valid URL starting with https:// or www.",
+          }}
+          {...register("url")}
         />
         <div className={classes.buttonGroup}>
           <Button type="reset" variant="outlined">


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2125
Closes #2126
Closes #2265

<!--- Describe the changes -->

This PR:
- allows entering www links in markdown-based components,
- aligns interactive filter select elements size,
- changes markdown link color to primary.

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
