### PR TITLE
fix: Hash preview text with newlines

### DIFF
--- a/app/utils/hash-utils.spec.ts
+++ b/app/utils/hash-utils.spec.ts
@@ -22,7 +22,7 @@ it("should persist chart configs as is", () => {
         },
         description: {
           de: "",
-          en: "",
+          en: "Very long description with equal sign (=) and new\n\nlines\n\n!",
           fr: "",
           it: "",
         },


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2270

<!--- Describe the changes -->

This PR makes sure we correctly handle newlines in text when previewing the chart via hash params.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-hash-newlines-ixt1.vercel.app/en/create/new?copy=e31bt-AgZKb6).
2. Copy preview link.
3. ✅ Open the link in a new tab and see that new lines were persisted correctly.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
- [x] I wrote tests for the changes (if applicable)
