### PR TITLE
fix: Basic iri validation for statistics query

### DIFF
--- a/app/statistics/prisma.ts
+++ b/app/statistics/prisma.ts
@@ -214,7 +214,7 @@ export const fetchChartsMetadata = async () => {
     WHERE NOT EXISTS (
       SELECT 1
       FROM jsonb_array_elements_text(iris) AS iri
-      WHERE NOT (iri LIKE 'http%://%')
+      WHERE NOT (iri LIKE 'http://%' OR iri LIKE 'https://%')
     );
   `.then((rows) => {
     return rows.map((row) => ({


### PR DESCRIPTION
Should close #2196 

This PR adds (very) basic validation that cube `iri`s conform to the form of a URL, i.e. beginning with `http://` or `https://`. For sure, more robust logic could be added, however, this would be at the expense of performance and fundamentally, the longer-term fix would be to not write malformed `iri`s to the DB in the first place.

## How to test

_Note:_ The intended, fixed behaviour can only be tested on INT.

1. https://int.visualize.admin.ch/statistics
2. There should be no error reported and statistics should be displayed as expected

---

- [ ] I added a CHANGELOG entry
