### PR TITLE
fix: Image download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Fixes
+  - It's now again possible to download images
 
 # [5.7.1] - 2025-04-25
 

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -76,8 +76,8 @@ module.exports = withPreconstruct(
               // * to allow WMS / WMTS endpoints
               `connect-src 'self' *`,
 
-              // * to allow loading legend images from custom WMS / WMTS endpoints
-              `img-src 'self' *`,
+              // * to allow loading legend images from custom WMS / WMTS endpoints and data: to allow downloading images
+              `img-src 'self' * data:`,
               `script-src-elem 'self' 'unsafe-inline' https://*.admin.ch https://vercel.live https://vercel.com https://*.google-analytics.com https://*.analytics.google.com https://*.googletagmanager.com https://api.mapbox.com https://cdn.jsdelivr.net`,
               `worker-src 'self' blob: https://*.admin.ch`,
             ].join("; "),


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2280 

<!--- Describe the changes -->

This PR fixes image download by allowing local `data` in CSP.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-image-download-ixt1.vercel.app/en/v/9MAMEuKjiPDc?dataSource=Prod).
2. Try to download a chart.
3. ✅ See that it works.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
