### PR TITLE
fix: Do not keep open wmts autocomplete

### DIFF
--- a/app/charts/map/wms-wmts-providers-autocomplete.tsx
+++ b/app/charts/map/wms-wmts-providers-autocomplete.tsx
@@ -84,7 +84,6 @@ const ProviderAutocomplete = ({
         value={value}
         freeSolo
         groupBy={(option) => option.group}
-        open
         // @ts-ignore
         getOptionLabel={(option) =>
           typeof option === "string" ? (


### PR DESCRIPTION
Inadvertently kept the "open" attribute on the wmts autocomplete, preventing
the autocomplete popover to be closed.
This PR fixes this problem.

## How to test

- Add a custom layer to a map
- See that the WMTS provider autocomplete is not open by default

