### PR TITLE
Display of layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,22 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- WMTS / WMS layers
+  - Features
+    - Add a warning icon next to a layer if its CRS is unsupported (not CRS:84 /
+      ESPG:3857)
+  - Fixes on
+    - Nested layers appear on the map
+    - Attributions are no longer coming from all layers of the endpoint
 
-# 5.7.4
+# 5.7.4 - 2025-04-29
 
 - Smaller improvements
   - OK button in "Text object" settings
   - Better spacing/line-height for title & description of dashboards
   - Better spacing for tick label of time animation slider
 
-# 5.7.3
+# 5.7.3 - 2025-04-29
 
 - Features
   - Color settings are now persisted across chart type changes

--- a/app/charts/map/map-custom-layers-legend.tsx
+++ b/app/charts/map/map-custom-layers-legend.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography } from "@mui/material";
+import { Box, Typography, useTheme } from "@mui/material";
 import uniq from "lodash/uniq";
 import NextImage from "next/image";
 
@@ -28,7 +28,7 @@ export const MapCustomLayersLegend = ({
 }) => {
   const customLayers = chartConfig.baseLayer.customLayers;
   const { data: legendsData, error } = useLegendsData({ customLayers });
-
+  const theme = useTheme();
   return error ? (
     <Error>{error.message}</Error>
   ) : !legendsData ? (
@@ -68,7 +68,13 @@ export const MapCustomLayersLegend = ({
                 {layer.description ? (
                   <InfoIconTooltip
                     title={
-                      <div
+                      <Box
+                        sx={{
+                          "& > *": {
+                            // We do not let the tooltip HTML override the font size
+                            fontSize: `${theme.typography.caption.fontSize} !important`,
+                          },
+                        }}
                         dangerouslySetInnerHTML={{ __html: layer.description }}
                       />
                     }

--- a/app/charts/map/map-custom-layers-legend.tsx
+++ b/app/charts/map/map-custom-layers-legend.tsx
@@ -67,7 +67,11 @@ export const MapCustomLayersLegend = ({
                 </Typography>
                 {layer.description ? (
                   <InfoIconTooltip
-                    title={layer.description}
+                    title={
+                      <div
+                        dangerouslySetInnerHTML={{ __html: layer.description }}
+                      />
+                    }
                     sx={{ width: "fit-content" }}
                   />
                 ) : null}

--- a/app/charts/map/map.tsx
+++ b/app/charts/map/map.tsx
@@ -131,16 +131,17 @@ export const MapComponent = ({
     ...wmsEndpoints,
     ...wmtsEndpoints,
   ]);
-  const { wms: wmsLayers, wmts: wmtsLayers } = groupedLayers ?? {
+  const { byKey: layersByKey } = groupedLayers ?? {
     wms: [],
     wmts: [],
   };
 
   const attribution = useMemo(() => {
-    return Array.from(
-      new Set([...wmtsLayers, ...wmsLayers].map((x) => x.attribution))
-    ).join(", ");
-  }, [wmsLayers, wmtsLayers]);
+    const attributions = customLayers.map(
+      (layer) => layersByKey?.[getLayerKey(layer)]?.attribution
+    );
+    return Array.from(new Set(attributions)).join(", ");
+  }, [customLayers, layersByKey]);
 
   const { behindAreaCustomLayers, afterAreaCustomLayers } = useMemo(() => {
     return {

--- a/app/charts/map/map.tsx
+++ b/app/charts/map/map.tsx
@@ -31,9 +31,20 @@ import {
 import { MapState } from "@/charts/map/map-state";
 import { HoverObjectType, useMapTooltip } from "@/charts/map/map-tooltip";
 import { getMap, setMap } from "@/charts/map/ref";
-import { DEFAULT_WMS_URL, getWMSTile } from "@/charts/map/wms-utils";
-import { useWMTSorWMSLayers } from "@/charts/map/wms-wmts-endpoint-utils";
-import { DEFAULT_WMTS_URL, getWMTSTile } from "@/charts/map/wmts-utils";
+import {
+  DEFAULT_WMS_URL,
+  getWMSTile,
+  RemoteWMSLayer,
+} from "@/charts/map/wms-utils";
+import {
+  getLayerKey,
+  useWMTSorWMSLayers,
+} from "@/charts/map/wms-wmts-endpoint-utils";
+import {
+  DEFAULT_WMTS_URL,
+  getWMTSTile,
+  RemoteWMTSLayer,
+} from "@/charts/map/wmts-utils";
 import { useChartState } from "@/charts/shared/chart-state";
 import { useInteraction } from "@/charts/shared/use-interaction";
 import { useLimits } from "@/config-utils";
@@ -42,6 +53,8 @@ import {
   BBox,
   getWMSCustomLayers,
   getWMTSCustomLayers,
+  WMSCustomLayer,
+  WMTSCustomLayer,
 } from "@/configurator";
 import { GeoFeature, GeoPoint } from "@/domain/data";
 import { Icon, IconName } from "@/icons";
@@ -144,51 +157,39 @@ export const MapComponent = ({
   }, [customLayers, layersByKey]);
 
   const { behindAreaCustomLayers, afterAreaCustomLayers } = useMemo(() => {
+    const getDeckGLLayerBefore = (
+      customLayer: WMTSCustomLayer | WMSCustomLayer,
+      beforeId?: string | undefined
+    ) => {
+      const layer = layersByKey?.[getLayerKey(customLayer)];
+      switch (customLayer.type) {
+        case "wms":
+          return getWMSTile({
+            wmsLayer: layer as RemoteWMSLayer | undefined,
+            customLayer,
+            beforeId,
+          });
+        case "wmts":
+          return getWMTSTile({
+            wmtsLayer: layer as RemoteWMTSLayer | undefined,
+            customLayer,
+            beforeId,
+            value,
+          });
+        default:
+          const _exhaustiveCheck: never = customLayer;
+          return _exhaustiveCheck;
+      }
+    };
     return {
       behindAreaCustomLayers: customLayers
         .filter((customLayer) => customLayer.isBehindAreaLayer)
-        .map((customLayer) => {
-          switch (customLayer.type) {
-            case "wms":
-              return getWMSTile({
-                wmsLayers,
-                customLayer,
-                beforeId: "areaLayer",
-              });
-            case "wmts":
-              return getWMTSTile({
-                remoteWmtsLayers: wmtsLayers,
-                customLayer,
-                beforeId: "areaLayer",
-                value,
-              });
-            default:
-              const _exhaustiveCheck: never = customLayer;
-              return _exhaustiveCheck;
-          }
-        }),
+        .map((l) => getDeckGLLayerBefore(l, "areaLayer")),
       afterAreaCustomLayers: customLayers
         .filter((customLayer) => !customLayer.isBehindAreaLayer)
-        .map((customLayer) => {
-          switch (customLayer.type) {
-            case "wms":
-              return getWMSTile({
-                wmsLayers,
-                customLayer,
-              });
-            case "wmts":
-              return getWMTSTile({
-                remoteWmtsLayers: wmtsLayers,
-                customLayer,
-                value,
-              });
-            default:
-              const _exhaustiveCheck: never = customLayer;
-              return _exhaustiveCheck;
-          }
-        }),
+        .map((l) => getDeckGLLayerBefore(l)),
     };
-  }, [customLayers, value, wmsLayers, wmtsLayers]);
+  }, [customLayers, layersByKey, value]);
 
   const [{ interaction }, dispatchInteraction] = useInteraction();
   const [, setMapTooltipType] = useMapTooltip();

--- a/app/charts/map/wms-wmts-endpoint-utils.ts
+++ b/app/charts/map/wms-wmts-endpoint-utils.ts
@@ -150,6 +150,25 @@ const indexByKey = ({
   return layersByKey;
 };
 
+/**
+ * Right now we only support EPSG:3857 (same as CRS:84) for remote layers
+ * Maybe we could support other projections system but not sure if
+ * DeckGL TileLayer could support it or if we should tweak projection
+ * when querying or when displaying.
+ * @see https://github.com/visgl/deck.gl/discussions/6885#discussioncomment-2703052
+ */
+export const isRemoteLayerCRSSupported = (
+  remoteLayer: RemoteWMTSLayer | RemoteWMSLayer
+) => {
+  const supportedCRS = remoteLayer.crs;
+  if (!supportedCRS) {
+    return false;
+  }
+  return supportedCRS.some(
+    (crs) => crs.includes("EPSG:3857") || crs.includes("CRS:84")
+  );
+};
+
 export const useWMTSorWMSLayers = (
   endpoints: string[],
   { pause }: { pause?: boolean } = { pause: false }

--- a/app/charts/map/wms-wmts-selector.tsx
+++ b/app/charts/map/wms-wmts-selector.tsx
@@ -351,8 +351,7 @@ const WMTSSelector = ({
     [
       treeItemClasses,
       defaultExpanded,
-      classes.treeRow,
-      classes.label,
+      classes,
       layersByPath,
       onLayerCheck,
       selectedSet,

--- a/app/charts/map/wms-wmts-selector.tsx
+++ b/app/charts/map/wms-wmts-selector.tsx
@@ -8,6 +8,7 @@ import {
   Input,
   Popover,
   Theme,
+  Tooltip,
   Typography,
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
@@ -19,7 +20,10 @@ import createStore from "zustand";
 
 import { RemoteLayer } from "@/charts/map/types";
 import { RemoteWMSLayer } from "@/charts/map/wms-utils";
-import { useWMTSorWMSLayers } from "@/charts/map/wms-wmts-endpoint-utils";
+import {
+  isRemoteLayerCRSSupported,
+  useWMTSorWMSLayers,
+} from "@/charts/map/wms-wmts-endpoint-utils";
 import ProviderAutocomplete from "@/charts/map/wms-wmts-providers-autocomplete";
 import { RemoteWMTSLayer } from "@/charts/map/wmts-utils";
 import { HintRed, Spinner } from "@/components/hint";
@@ -88,6 +92,9 @@ const useStyles = makeStyles<Theme>((theme) => ({
     whiteSpace: "nowrap",
     lineHeight: "1.5rem",
   },
+  warnIcon: {
+    color: theme.palette.warning.main,
+  },
 }));
 
 const LegendButton = ({
@@ -146,7 +153,7 @@ const LegendButton = ({
 const TreeRow = ({
   layer,
   className,
-  labelClassName,
+  classes,
   label,
   value,
   initialChecked,
@@ -154,7 +161,7 @@ const TreeRow = ({
 }: {
   layer: RemoteLayer;
   className?: string;
-  labelClassName?: string;
+  classes: ReturnType<typeof useStyles>;
   label: string;
   value: string;
   initialChecked?: boolean;
@@ -181,10 +188,22 @@ const TreeRow = ({
           checked={checked}
         />
       ) : null}
-      <div className={labelClassName} onClick={handleChangeCheckbox}>
+      <div className={classes.label} onClick={handleChangeCheckbox}>
         {label}
       </div>
       {layer && layer.legendUrl ? <LegendButton layer={layer} /> : null}
+      {isRemoteLayerCRSSupported(layer) ? null : (
+        <Tooltip
+          title={t({
+            id: "wmts.layer-not-supported-crs",
+            message: "Layer not supported, no supported CRS",
+          })}
+        >
+          <span>
+            <Icon name="warningCircleFilled" className={classes.warnIcon} />
+          </span>
+        </Tooltip>
+      )}
     </div>
   );
 };
@@ -303,7 +322,7 @@ const WMTSSelector = ({
                 label={
                   <TreeRow
                     className={classes.treeRow}
-                    labelClassName={classes.label}
+                    classes={classes}
                     layer={layersByPath[value]}
                     label={label}
                     value={value}

--- a/app/charts/map/wms-wmts-utils.spec.ts
+++ b/app/charts/map/wms-wmts-utils.spec.ts
@@ -60,6 +60,11 @@ Array [
     "children": Array [
       Object {
         "attribution": "EUNIS Ecosystems",
+        "crs": Array [
+          "CRS:84",
+          "EPSG:4326",
+          "EPSG:3035",
+        ],
         "dataUrl": "https://bio.discomap.eea.europa.eu/arcgis/services/Ecosystem/Ecosystems/MapServer/WMSServer?",
         "description": "",
         "endpoint": "http://example.com/wms",
@@ -71,6 +76,11 @@ Array [
       },
       Object {
         "attribution": "EUNIS Ecosystems",
+        "crs": Array [
+          "CRS:84",
+          "EPSG:4326",
+          "EPSG:3035",
+        ],
         "dataUrl": "https://bio.discomap.eea.europa.eu/arcgis/services/Ecosystem/Ecosystems/MapServer/WMSServer?",
         "description": "",
         "endpoint": "http://example.com/wms",
@@ -82,6 +92,11 @@ Array [
       },
       Object {
         "attribution": "EUNIS Ecosystems",
+        "crs": Array [
+          "CRS:84",
+          "EPSG:4326",
+          "EPSG:3035",
+        ],
         "dataUrl": "https://bio.discomap.eea.europa.eu/arcgis/services/Ecosystem/Ecosystems/MapServer/WMSServer?",
         "description": "",
         "endpoint": "http://example.com/wms",
@@ -93,6 +108,11 @@ Array [
       },
       Object {
         "attribution": "EUNIS Ecosystems",
+        "crs": Array [
+          "CRS:84",
+          "EPSG:4326",
+          "EPSG:3035",
+        ],
         "dataUrl": "https://bio.discomap.eea.europa.eu/arcgis/services/Ecosystem/Ecosystems/MapServer/WMSServer?",
         "description": "",
         "endpoint": "http://example.com/wms",
@@ -104,6 +124,11 @@ Array [
       },
       Object {
         "attribution": "EUNIS Ecosystems",
+        "crs": Array [
+          "CRS:84",
+          "EPSG:4326",
+          "EPSG:3035",
+        ],
         "dataUrl": "https://bio.discomap.eea.europa.eu/arcgis/services/Ecosystem/Ecosystems/MapServer/WMSServer?",
         "description": "",
         "endpoint": "http://example.com/wms",
@@ -115,6 +140,11 @@ Array [
       },
       Object {
         "attribution": "EUNIS Ecosystems",
+        "crs": Array [
+          "CRS:84",
+          "EPSG:4326",
+          "EPSG:3035",
+        ],
         "dataUrl": "https://bio.discomap.eea.europa.eu/arcgis/services/Ecosystem/Ecosystems/MapServer/WMSServer?",
         "description": "",
         "endpoint": "http://example.com/wms",
@@ -126,6 +156,11 @@ Array [
       },
       Object {
         "attribution": "EUNIS Ecosystems",
+        "crs": Array [
+          "CRS:84",
+          "EPSG:4326",
+          "EPSG:3035",
+        ],
         "dataUrl": "https://bio.discomap.eea.europa.eu/arcgis/services/Ecosystem/Ecosystems/MapServer/WMSServer?",
         "description": "",
         "endpoint": "http://example.com/wms",
@@ -135,6 +170,11 @@ Array [
         "title": "D - Mires, bogs and fens",
         "type": "wms",
       },
+    ],
+    "crs": Array [
+      "CRS:84",
+      "EPSG:4326",
+      "EPSG:3035",
     ],
     "dataUrl": "https://bio.discomap.eea.europa.eu/arcgis/services/Ecosystem/Ecosystems/MapServer/WMSServer?",
     "description": "",
@@ -150,6 +190,11 @@ Array [
     "children": Array [
       Object {
         "attribution": "EUNIS Ecosystems",
+        "crs": Array [
+          "CRS:84",
+          "EPSG:4326",
+          "EPSG:3035",
+        ],
         "dataUrl": "https://bio.discomap.eea.europa.eu/arcgis/services/Ecosystem/Ecosystems/MapServer/WMSServer?",
         "description": "",
         "endpoint": "http://example.com/wms",
@@ -159,6 +204,11 @@ Array [
         "title": "C - Inland surface waters",
         "type": "wms",
       },
+    ],
+    "crs": Array [
+      "CRS:84",
+      "EPSG:4326",
+      "EPSG:3035",
     ],
     "dataUrl": "https://bio.discomap.eea.europa.eu/arcgis/services/Ecosystem/Ecosystems/MapServer/WMSServer?",
     "description": "",
@@ -174,6 +224,11 @@ Array [
     "children": Array [
       Object {
         "attribution": "EUNIS Ecosystems",
+        "crs": Array [
+          "CRS:84",
+          "EPSG:4326",
+          "EPSG:3035",
+        ],
         "dataUrl": "https://bio.discomap.eea.europa.eu/arcgis/services/Ecosystem/Ecosystems/MapServer/WMSServer?",
         "description": "",
         "endpoint": "http://example.com/wms",
@@ -185,6 +240,11 @@ Array [
       },
       Object {
         "attribution": "EUNIS Ecosystems",
+        "crs": Array [
+          "CRS:84",
+          "EPSG:4326",
+          "EPSG:3035",
+        ],
         "dataUrl": "https://bio.discomap.eea.europa.eu/arcgis/services/Ecosystem/Ecosystems/MapServer/WMSServer?",
         "description": "",
         "endpoint": "http://example.com/wms",
@@ -194,6 +254,11 @@ Array [
         "title": "A - Marine habitats",
         "type": "wms",
       },
+    ],
+    "crs": Array [
+      "CRS:84",
+      "EPSG:4326",
+      "EPSG:3035",
     ],
     "dataUrl": "https://bio.discomap.eea.europa.eu/arcgis/services/Ecosystem/Ecosystems/MapServer/WMSServer?",
     "description": "",
@@ -238,6 +303,9 @@ describe("parseWMTSContent", () => {
 Object {
   "attribution": "GIS-Zentrum Stadt Zuerich",
   "availableDimensionValues": undefined,
+  "crs": Array [
+    "EPSG:2056",
+  ],
   "defaultDimensionValue": undefined,
   "description": "",
   "dimensionIdentifier": undefined,
@@ -406,6 +474,9 @@ Object {
   "attribution": "Federal Office of Topography swisstopo",
   "availableDimensionValues": Array [
     "current",
+  ],
+  "crs": Array [
+    "urn:ogc:def:crs:EPSG:3857",
   ],
   "defaultDimensionValue": "current",
   "description": "-",
@@ -647,6 +718,9 @@ Object {
 Object {
   "attribution": undefined,
   "availableDimensionValues": undefined,
+  "crs": Array [
+    "urn:ogc:def:crs:EPSG::2056",
+  ],
   "defaultDimensionValue": undefined,
   "description": undefined,
   "dimensionIdentifier": undefined,

--- a/app/charts/map/wmts-playground.stories.tsx
+++ b/app/charts/map/wmts-playground.stories.tsx
@@ -51,8 +51,8 @@ const WMTSPlayground = () => {
   const deckglLayers = useMemo(() => {
     return layers.map((x) => {
       return x.type === "wms"
-        ? getWMSTile({ wmsLayers: [x], customLayer: x })
-        : getWMTSTile({ remoteWmtsLayers: [x], customLayer: x });
+        ? getWMSTile({ wmsLayer: x, customLayer: x })
+        : getWMTSTile({ wmtsLayer: x, customLayer: x });
     });
   }, [layers]);
 


### PR DESCRIPTION
I do not know how I missed that lists were still used to find the remote layer from the config layer in the map. It was preventing nested layers to appear.

- **fix: Support html description for external layers**
- **feat: Add CRS and expose isCRS supported function for both WMS and WMTS tiles**
- **fix: Get attributions only from added layers**
- **fix: Correctly get deckgl layers from tree**
- **feat: Add mention of unsupported CRS**

## How to test

- Correctly added layers

1. Open Photovoltaik
2. Add a custom layer with endpoint https://www.geoservice.apps.be.ch/geoservice3/services/a42geo/of_boundaries01_de_ms_wms/MapServer/WMSServer
3. Add layer from "Steininventare" : Stundensteine, historiziche grensteine
4. See that it works

- Add mention of unsupported CRS

Open the endpoint "https://wmts.geo.admin.ch/1.0.0/WMTSCapabilities.xml", see that every layer under it have a yellow exclamation point with "Layer not supported".
