### PR TITLE
feat: Smaller improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ You can also check the
   - Fixes on
     - Nested layers appear on the map
     - Attributions are no longer coming from all layers of the endpoint
+- Other features
+  - Value labels in bar and column charts are now centered both horizontally and
+    vertically
+  - ODS iframe dataset preview now uses official ODS color for new chart button
 
 # 5.7.4 - 2025-04-29
 

--- a/app/browser/select-dataset-step.tsx
+++ b/app/browser/select-dataset-step.tsx
@@ -1,6 +1,6 @@
 import { ContentWrapper } from "@interactivethings/swiss-federal-ci/dist/components";
 import { Trans } from "@lingui/macro";
-import { Box, Button, Theme, Typography } from "@mui/material";
+import { Box, Button, darken, Theme, Typography } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import { AnimatePresence } from "framer-motion";
 import sortBy from "lodash/sortBy";
@@ -471,6 +471,17 @@ const SelectDatasetStepContent = ({
                           ) : (
                             <Icon name="arrowRight" size={20} />
                           )
+                        }
+                        sx={
+                          odsIframe
+                            ? {
+                                backgroundColor: "#009688",
+
+                                "&:hover": {
+                                  backgroundColor: darken("#009688", 0.2),
+                                },
+                              }
+                            : null
                         }
                       >
                         {!odsIframe ? (

--- a/app/browser/select-dataset-step.tsx
+++ b/app/browser/select-dataset-step.tsx
@@ -473,6 +473,8 @@ const SelectDatasetStepContent = ({
                           )
                         }
                         sx={
+                          // Could be extracted in case we have more
+                          // openData.swiss dependencies
                           odsIframe
                             ? {
                                 backgroundColor: "#009688",

--- a/app/charts/bar/rendering-utils.ts
+++ b/app/charts/bar/rendering-utils.ts
@@ -66,14 +66,8 @@ export const renderBars = (
                 })
               )
               .append("xhtml:div")
-              .style("display", "flex")
-              .style("align-items", "center")
-              .style("width", "100%")
-              .style("height", "100%")
-              .append("xhtml:p")
               .call(setSegmentValueLabelProps)
-              .style("padding-left", "2px")
-              .style("padding-right", "2px")
+              .append("xhtml:p")
               .style("color", function (d) {
                 return d.valueLabelColor ?? select(this).style("color");
               })

--- a/app/charts/bar/rendering-utils.ts
+++ b/app/charts/bar/rendering-utils.ts
@@ -1,6 +1,9 @@
 import { select, Selection } from "d3-selection";
 
-import { setSegmentValueLabelProps } from "@/charts/shared/render-value-labels";
+import {
+  setSegmentValueLabelProps,
+  setSegmentWrapperValueLabelProps,
+} from "@/charts/shared/render-value-labels";
 import {
   maybeTransition,
   RenderOptions,
@@ -66,8 +69,9 @@ export const renderBars = (
                 })
               )
               .append("xhtml:div")
-              .call(setSegmentValueLabelProps)
+              .call(setSegmentWrapperValueLabelProps)
               .append("xhtml:p")
+              .call(setSegmentValueLabelProps)
               .style("color", function (d) {
                 return d.valueLabelColor ?? select(this).style("color");
               })

--- a/app/charts/column/rendering-utils.ts
+++ b/app/charts/column/rendering-utils.ts
@@ -61,11 +61,9 @@ export const renderColumns = (
                   s: (g) => g.attr("y", (d) => d.y),
                 })
               )
-              .append("xhtml:p")
+              .append("xhtml:div")
               .call(setSegmentValueLabelProps)
-              .style("padding-top", "4px")
-              .style("padding-left", "2px")
-              .style("padding-right", "2px")
+              .append("xhtml:p")
               .style("color", function (d) {
                 return d.valueLabelColor ?? select(this).style("color");
               })

--- a/app/charts/column/rendering-utils.ts
+++ b/app/charts/column/rendering-utils.ts
@@ -1,6 +1,9 @@
 import { select, Selection } from "d3-selection";
 
-import { setSegmentValueLabelProps } from "@/charts/shared/render-value-labels";
+import {
+  setSegmentValueLabelProps,
+  setSegmentWrapperValueLabelProps,
+} from "@/charts/shared/render-value-labels";
 import {
   maybeTransition,
   RenderOptions,
@@ -62,8 +65,9 @@ export const renderColumns = (
                 })
               )
               .append("xhtml:div")
-              .call(setSegmentValueLabelProps)
+              .call(setSegmentWrapperValueLabelProps)
               .append("xhtml:p")
+              .call(setSegmentValueLabelProps)
               .style("color", function (d) {
                 return d.valueLabelColor ?? select(this).style("color");
               })

--- a/app/charts/shared/render-value-labels.ts
+++ b/app/charts/shared/render-value-labels.ts
@@ -117,20 +117,28 @@ const getValueLabelTextAnchor = (rotate: boolean) => {
   return rotate ? "start" : "middle";
 };
 
-export const setSegmentValueLabelProps = <
+export const setSegmentWrapperValueLabelProps = <
   T extends { valueLabel?: string; valueLabelColor?: string },
 >(
   g: Selection<BaseType, T, SVGGElement, null>
 ) => {
   return g
     .attr(DISABLE_SCREENSHOT_COLOR_WIPE_KEY, true)
-    .style("overflow", "hidden")
     .style("display", "flex")
     .style("justify-content", "center")
     .style("align-items", "center")
     .style("width", "100%")
     .style("height", "100%")
-    .style("padding", "2px")
+    .style("padding", "2px");
+};
+
+export const setSegmentValueLabelProps = <
+  T extends { valueLabel?: string; valueLabelColor?: string },
+>(
+  g: Selection<BaseType, T, SVGGElement, null>
+) => {
+  return g
+    .style("overflow", "hidden")
     .style("font-size", "12px")
     .style("white-space", "nowrap")
     .style("text-overflow", "ellipsis");

--- a/app/charts/shared/render-value-labels.ts
+++ b/app/charts/shared/render-value-labels.ts
@@ -125,9 +125,12 @@ export const setSegmentValueLabelProps = <
   return g
     .attr(DISABLE_SCREENSHOT_COLOR_WIPE_KEY, true)
     .style("overflow", "hidden")
+    .style("display", "flex")
+    .style("justify-content", "center")
+    .style("align-items", "center")
     .style("width", "100%")
-    .style("margin", 0)
-    .style("text-align", "center")
+    .style("height", "100%")
+    .style("padding", "2px")
     .style("font-size", "12px")
     .style("white-space", "nowrap")
     .style("text-overflow", "ellipsis");


### PR DESCRIPTION
This PR:
- centers value labels both horizontally and vertically,
- makes the Create new visualization button use ODS color when in ODS iframe preview.

## How to test
1. Go to [this link](https://visualization-tool-git-feat-smaller-improvements-2-ixt1.vercel.app/en/browse?previous=%7B%22order%22%3A%22SCORE%22%2C%22search%22%3A%22photo%22%7D&dataset=https%3A%2F%2Fenergy.ld.admin.ch%2Fsfoe%2Fbfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen%2F10&dataSource=Prod&odsiframe=true).
2. ✅ See that the button uses ODS color.
3. Go to [this link](https://visualization-tool-git-feat-smaller-improvements-2-ixt1.vercel.app/en/v/SVlWo1_b0PR-?dataSource=Prod) and [this link](https://visualization-tool-git-feat-smaller-improvements-2-ixt1.vercel.app/en/v/2KJrIDDjPN3H?dataSource=Prod).
4. ✅ See that the values are consistently centered.

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
