### PR TITLE
feat: Merging of cubes improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ You can also check the
   - Fixes on
     - Nested layers appear on the map
     - Attributions are no longer coming from all layers of the endpoint
+- Fixes
+  - It's now possible to add non-key dimensions when all key dimensions of a
+    cube are joined
+  - Improved cut-off and overlapping labels in combo charts
 
 # 5.7.4 - 2025-04-29
 

--- a/app/charts/combo/combo-state.ts
+++ b/app/charts/combo/combo-state.ts
@@ -149,11 +149,11 @@ type GetMarginsOptions = {
 };
 
 export const getMargins = (options: GetMarginsOptions) => {
-  const { left, top = 50, right = 40, bottom } = options;
+  const { left, top, right, bottom } = options;
 
   return {
-    top,
-    right,
+    top: top || 50,
+    right: right || 40,
     bottom,
     left,
   };
@@ -189,7 +189,7 @@ export const useDualAxisMargins = ({
   return getMargins({
     left,
     right,
-    bottom: bottom - SINGLE_LINE_AXIS_LABEL_HEIGHT / 2,
+    bottom,
     top,
   });
 };

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -564,8 +564,6 @@ const useStyles = makeStyles<Theme, { fetching: boolean }>((theme) => ({
     },
   },
   addDimensionContainer: {
-    marginTop: theme.spacing(5),
-
     "& .menu-button": {
       background: "transparent",
       border: 0,

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -95,6 +95,7 @@ import {
   useDataCubesMetadataQuery,
   useDataCubesObservationsQuery,
 } from "@/graphql/hooks";
+import { isJoinByCube } from "@/graphql/join";
 import {
   PossibleFiltersDocument,
   PossibleFiltersQuery,
@@ -740,8 +741,15 @@ export const ChartConfigurator = ({
                 />
               </Box>
             )}
-            {Object.entries(filterDimensionsByCubeIri).map(
-              ([cubeIri, dims]) => {
+            {Object.entries(filterDimensionsByCubeIri)
+              .sort((a, b) =>
+                isJoinByCube(a[0])
+                  ? -1
+                  : isJoinByCube(b[0])
+                    ? 1
+                    : a[0].localeCompare(b[0])
+              )
+              .map(([cubeIri, dims]) => {
                 const cubeTitle = cubes?.find(
                   (cube) => cube.iri === cubeIri
                 )?.title;
@@ -809,8 +817,7 @@ export const ChartConfigurator = ({
                     ) : null}
                   </Fragment>
                 );
-              }
-            )}
+              })}
           </ControlSectionContent>
         </ControlSection>
       )}

--- a/app/configurator/components/chart-configurator.tsx
+++ b/app/configurator/components/chart-configurator.tsx
@@ -15,6 +15,7 @@ import isEmpty from "lodash/isEmpty";
 import isEqual from "lodash/isEqual";
 import pickBy from "lodash/pickBy";
 import sortBy from "lodash/sortBy";
+import uniq from "lodash/uniq";
 import React, {
   Fragment,
   ReactNode,
@@ -496,6 +497,17 @@ const useFilterReorder = ({
       filterDimensions,
       (d) => d.cubeIri
     );
+    const allCubeIris = uniq(dimensions?.map((d) => d.cubeIri));
+
+    // Make sure we don't forget about merged cubes that have non-key-dimensions
+    // available, but no key dimension available (might be the case when merging)
+    // cubes by a lot of key dimensions that get joinBy cube iri then.
+    for (const iri of allCubeIris) {
+      if (!filterDimensionsByCubeIri[iri]) {
+        filterDimensionsByCubeIri[iri] = [];
+      }
+    }
+
     const addableDimensions =
       dimensions?.filter(
         (dim) =>


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #

<!--- Describe the changes -->

This PR introduces some enhancements to merging of cubes and combo charts.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-feat-merging-of-cubes-improv-8b67c9-ixt1.vercel.app/en/create/new?cube=https://agriculture.ld.admin.ch/foag/cube/BreadCerealsFlourBakedGoods/Consumption_Price_Month&dataSource=Int).
2. Add a **Market figures milk and dairy products - Monthly consumer prices** dataset.
3. ✅ See that it's possible to add non key dimensions for both datasets.
4. ✅ See that joined dimensions are shown first.
5. ✅ See that the Y axis label is not overlapping with Y axis ticks.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
