### PR TITLE
fix: Custom scale domain issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,12 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Fixes
+  - Default min custom scale domain value now defaults to 0 if no negative
+    values are present
+  - Chart area no longer overflows below X or Y axes when setting custom scale
+    domains
+  - Band axis ticks should now be aligned correctly
 
 # 5.7.6 - 2025-05-06
 

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -4,6 +4,7 @@ import { Areas } from "@/charts/area/areas";
 import { AreaChart } from "@/charts/area/areas-state";
 import { ChartDataWrapper } from "@/charts/chart-data-wrapper";
 import { AxisHeightLinear } from "@/charts/shared/axis-height-linear";
+import { AxisHideXOverflowRect } from "@/charts/shared/axis-hide-overflow-rect";
 import { AxisTime, AxisTimeDomain } from "@/charts/shared/axis-width-time";
 import { BrushTime } from "@/charts/shared/brush";
 import {
@@ -40,8 +41,11 @@ const ChartAreas = memo((props: ChartProps<AreaConfig>) => {
     <AreaChart {...props} limits={limits}>
       <ChartContainer>
         <ChartSvg>
-          <AxisTime /> <AxisTimeDomain /> <AxisHeightLinear />
+          <AxisHeightLinear />
           <Areas />
+          <AxisHideXOverflowRect />
+          <AxisTime />
+          <AxisTimeDomain />
           <VerticalLimits {...limits} />
           <InteractionHorizontal />
           {interactiveFiltersConfig?.timeRange.active === true && <BrushTime />}

--- a/app/charts/bar/chart-bar.tsx
+++ b/app/charts/bar/chart-bar.tsx
@@ -15,6 +15,7 @@ import {
   AxisHeightBand,
   AxisHeightBandDomain,
 } from "@/charts/shared/axis-height-band";
+import { AxisHideYOverflowRect } from "@/charts/shared/axis-hide-overflow-rect";
 import { AxisWidthLinear } from "@/charts/shared/axis-width-linear";
 import { BrushTime, shouldShowBrush } from "@/charts/shared/brush";
 import {
@@ -61,9 +62,10 @@ const ChartBars = memo((props: ChartProps<BarConfig>) => {
           <ChartContainer>
             <ChartSvg>
               <AxisWidthLinear />
+              <BarsStacked />
+              <AxisHideYOverflowRect />
               <AxisHeightBand />
               <AxisHeightBandDomain />
-              <BarsStacked />
               <InteractionBars />
               {showTimeBrush && <BrushTime />}
             </ChartSvg>
@@ -91,9 +93,10 @@ const ChartBars = memo((props: ChartProps<BarConfig>) => {
           <ChartContainer>
             <ChartSvg>
               <AxisWidthLinear />
+              <BarsGrouped />
+              <AxisHideYOverflowRect />
               <AxisHeightBand />
               <AxisHeightBandDomain />
-              <BarsGrouped />
               <ErrorWhiskersGrouped />
               <InteractionBars />
               {showTimeBrush && <BrushTime />}
@@ -122,9 +125,10 @@ const ChartBars = memo((props: ChartProps<BarConfig>) => {
           <ChartContainer>
             <ChartSvg>
               <AxisWidthLinear />
+              <Bars />
+              <AxisHideYOverflowRect />
               <AxisHeightBand />
               <AxisHeightBandDomain />
-              <Bars />
               <ErrorWhiskers />
               <HorizontalLimits {...limits} />
               <InteractionBars />

--- a/app/charts/chart-config-ui-options.ts
+++ b/app/charts/chart-config-ui-options.ts
@@ -589,8 +589,10 @@ const getNonStackedDomain = (
   observations: Observation[],
   getValue: (o: Observation) => number
 ) => {
+  const [min, max] = extent(observations.map(getValue)) as [number, number];
+
   return scaleLinear()
-    .domain(extent(observations.map(getValue)) as [number, number])
+    .domain([Math.min(min, 0), max])
     .nice()
     .domain() as [number, number];
 };

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -12,6 +12,7 @@ import { StackedColumnsChart } from "@/charts/column/columns-stacked-state";
 import { ColumnChart } from "@/charts/column/columns-state";
 import { InteractionColumns } from "@/charts/column/overlay-columns";
 import { AxisHeightLinear } from "@/charts/shared/axis-height-linear";
+import { AxisHideXOverflowRect } from "@/charts/shared/axis-hide-overflow-rect";
 import {
   AxisWidthBand,
   AxisWidthBandDomain,
@@ -60,9 +61,11 @@ const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
         <StackedColumnsChart {...props}>
           <ChartContainer>
             <ChartSvg>
-              <AxisHeightLinear /> <AxisWidthBand />
-              <AxisWidthBandDomain />
+              <AxisHeightLinear />
               <ColumnsStacked />
+              <AxisHideXOverflowRect />
+              <AxisWidthBand />
+              <AxisWidthBandDomain />
               <InteractionColumns />
               {showTimeBrush && <BrushTime />}
             </ChartSvg>
@@ -90,9 +93,10 @@ const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
           <ChartContainer>
             <ChartSvg>
               <AxisHeightLinear />
+              <ColumnsGrouped />
+              <AxisHideXOverflowRect />
               <AxisWidthBand />
               <AxisWidthBandDomain />
-              <ColumnsGrouped />
               <ErrorWhiskersGrouped />
               <InteractionColumns />
               {showTimeBrush && <BrushTime />}
@@ -121,9 +125,10 @@ const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
           <ChartContainer>
             <ChartSvg>
               <AxisHeightLinear />
+              <Columns />
+              <AxisHideXOverflowRect />
               <AxisWidthBand />
               <AxisWidthBandDomain />
-              <Columns />
               <ErrorWhiskers />
               <VerticalLimits {...limits} />
               <InteractionColumns />

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -4,6 +4,7 @@ import { ChartDataWrapper } from "@/charts/chart-data-wrapper";
 import { ErrorWhiskers, Lines } from "@/charts/line/lines";
 import { LineChart } from "@/charts/line/lines-state";
 import { AxisHeightLinear } from "@/charts/shared/axis-height-linear";
+import { AxisHideXOverflowRect } from "@/charts/shared/axis-hide-overflow-rect";
 import { AxisTime, AxisTimeDomain } from "@/charts/shared/axis-width-time";
 import { BrushTime, shouldShowBrush } from "@/charts/shared/brush";
 import {
@@ -43,7 +44,7 @@ const ChartLines = memo((props: ChartProps<LineConfig>) => {
     <LineChart {...props} limits={limits}>
       <ChartContainer>
         <ChartSvg>
-          <AxisHeightLinear /> <AxisTime /> <AxisTimeDomain />
+          <AxisHeightLinear />
           <Lines
             dotSize={
               "showDots" in chartConfig.fields.y &&
@@ -53,6 +54,9 @@ const ChartLines = memo((props: ChartProps<LineConfig>) => {
                 : undefined
             }
           />
+          <AxisHideXOverflowRect />
+          <AxisTime />
+          <AxisTimeDomain />
           <ErrorWhiskers />
           <VerticalLimits {...limits} />
           <InteractionHorizontal />

--- a/app/charts/shared/axis-hide-overflow-rect.tsx
+++ b/app/charts/shared/axis-hide-overflow-rect.tsx
@@ -1,0 +1,44 @@
+import { useChartState } from "@/charts/shared/chart-state";
+
+/** Use to hide chart content overflowing below the X axis.
+ * Can happen when user defined a custom domain for the axis. */
+export const AxisHideXOverflowRect = () => {
+  const {
+    bounds: {
+      chartWidth,
+      chartHeight,
+      margins: { top, left, bottom },
+    },
+  } = useChartState();
+
+  return (
+    <rect
+      x={left - 1}
+      y={chartHeight + top}
+      width={chartWidth + 2}
+      height={bottom}
+      fill="white"
+    />
+  );
+};
+
+/** Use to hide chart content overflowing below the X axis.
+ * Can happen when user defined a custom domain for the axis. */
+export const AxisHideYOverflowRect = () => {
+  const {
+    bounds: {
+      chartHeight,
+      margins: { top, left },
+    },
+  } = useChartState();
+
+  return (
+    <rect
+      x={0}
+      y={top - 1}
+      width={left}
+      height={chartHeight + 2}
+      fill="white"
+    />
+  );
+};

--- a/app/charts/shared/axis-width-band.tsx
+++ b/app/charts/shared/axis-width-band.tsx
@@ -84,8 +84,13 @@ export const AxisWidthBand = () => {
       );
       g.selectAll(".tick text")
         .attr("transform", rotation ? "rotate(90)" : "rotate(0)")
-        .attr("x", rotation ? fontSize : 0)
-        .attr("dy", hasNegativeValues ? fontSize + 1 : fontSize * 0.6)
+        .attr("x", rotation ? fontSize + (labelFontSize - fontSize) * 0.6 : 0)
+        .attr(
+          "dy",
+          hasNegativeValues
+            ? fontSize + (labelFontSize - fontSize)
+            : 0.6 * fontSize + (labelFontSize - fontSize) * 0.4
+        )
         .attr("font-size", fontSize)
         .attr("font-family", fontFamily)
         .attr("fill", labelColor)


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #1871

<!--- Describe the changes -->

This PR:
- defaults custom scale domain minimum value to 0 in case no negative values are present,
- hides chart area that overflows X or Y axis when using custom scale domain,
- improves band axis' labels positioning.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-custom-scale-domain-issues-ixt1.vercel.app/en/create/new?cube=https://agriculture.ld.admin.ch/foag/cube/MilkDairyProducts/Consumption_Price_Month&dataSource=Prod&flag__custom-scale-domain=true).
2. ✅ See that the X axis tick labels are aligned correctly with the tick lines.
3. Open Vertical axis field.
4. Click on Adjust scale domain.
5. ✅ See that the min value was set to 0 and chart didn't shift to the bottom.
6. Set the min value to 5.
7. ✅ See that the chart doesn't overflow the X axis.
8. ✅ Repeat the process for grouped and stacked column, line, area and bar charts and see that the behavior is the same for them.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
