### PR TITLE
fix: Temporal entity dimension column-line charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Fixes
+  - Column line combo charts now work correctly with temporal entity X dimension
 
 # 5.7.6 - 2025-05-06
 

--- a/app/charts/column/overlay-columns.tsx
+++ b/app/charts/column/overlay-columns.tsx
@@ -3,26 +3,27 @@ import { ComboLineColumnState } from "@/charts/combo/combo-line-column-state";
 import { useChartState } from "@/charts/shared/chart-state";
 import { useInteraction } from "@/charts/shared/use-interaction";
 import { Observation } from "@/domain/data";
+import useEvent from "@/utils/use-event";
 
 export const InteractionColumns = () => {
   const [, dispatch] = useInteraction();
-
-  const { chartData, bounds, getX, xScaleInteraction } = useChartState() as
-    | ColumnsState
-    | ComboLineColumnState;
-  const { margins, chartHeight } = bounds;
-
-  const showTooltip = (d: Observation) => {
+  const {
+    chartData,
+    bounds: { margins, chartHeight },
+    getX,
+    xScaleInteraction,
+  } = useChartState() as ColumnsState | ComboLineColumnState;
+  const showTooltip = useEvent((d: Observation) => {
     dispatch({
       type: "INTERACTION_UPDATE",
       value: { interaction: { visible: true, d } },
     });
-  };
-  const hideTooltip = () => {
+  });
+  const hideTooltip = useEvent(() => {
     dispatch({
       type: "INTERACTION_HIDE",
     });
-  };
+  });
   return (
     <g transform={`translate(${margins.left} ${margins.top})`}>
       {chartData.map((d, i) => (

--- a/app/charts/column/overlay-columns.tsx
+++ b/app/charts/column/overlay-columns.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from "react";
+
 import { ColumnsState } from "@/charts/column/columns-state";
 import { ComboLineColumnState } from "@/charts/combo/combo-line-column-state";
 import { useChartState } from "@/charts/shared/chart-state";
@@ -5,12 +7,14 @@ import { useInteraction } from "@/charts/shared/use-interaction";
 import { Observation } from "@/domain/data";
 import useEvent from "@/utils/use-event";
 
-export const InteractionColumns = () => {
+export const InteractionColumns = ({ temporal }: { temporal?: boolean }) => {
   const [, dispatch] = useInteraction();
   const {
     chartData,
     bounds: { margins, chartHeight },
     getX,
+    getXAsDate,
+    formatXDate,
     xScaleInteraction,
   } = useChartState() as ColumnsState | ComboLineColumnState;
   const showTooltip = useEvent((d: Observation) => {
@@ -24,22 +28,34 @@ export const InteractionColumns = () => {
       type: "INTERACTION_HIDE",
     });
   });
+  const getXValue = useCallback(
+    (d: Observation) => {
+      return temporal ? formatXDate(getXAsDate(d)) : getX(d);
+    },
+    [formatXDate, getX, getXAsDate, temporal]
+  );
+
   return (
     <g transform={`translate(${margins.left} ${margins.top})`}>
-      {chartData.map((d, i) => (
-        <rect
-          key={i}
-          x={xScaleInteraction(getX(d)) as number}
-          y={0}
-          width={xScaleInteraction.bandwidth()}
-          height={Math.max(0, chartHeight)}
-          fill="hotpink"
-          fillOpacity={0}
-          stroke="none"
-          onMouseOut={hideTooltip}
-          onMouseOver={() => showTooltip(d)}
-        />
-      ))}
+      {chartData.map((d, i) => {
+        const x = getXValue(d);
+        const xScaled = xScaleInteraction(x) as number;
+
+        return (
+          <rect
+            key={i}
+            x={xScaled}
+            y={0}
+            width={xScaleInteraction.bandwidth()}
+            height={Math.max(0, chartHeight)}
+            fill="hotpink"
+            fillOpacity={0}
+            stroke="none"
+            onMouseOut={hideTooltip}
+            onMouseOver={() => showTooltip(d)}
+          />
+        );
+      })}
     </g>
   );
 };

--- a/app/charts/combo/chart-combo-line-column.tsx
+++ b/app/charts/combo/chart-combo-line-column.tsx
@@ -36,7 +36,7 @@ const ChartComboLineColumn = memo(
             <AxisHeightLinearDual orientation="right" />
             <AxisWidthBand />
             <ComboLineColumn />
-            <InteractionColumns />
+            <InteractionColumns temporal />
             {shouldShowBrush(
               interactiveFiltersConfig,
               dashboardFilters?.timeRange

--- a/app/charts/combo/combo-line-column-state.tsx
+++ b/app/charts/combo/combo-line-column-state.tsx
@@ -74,6 +74,7 @@ export type ComboLineColumnState = CommonChartState &
     maxRightTickWidth: number;
     leftAxisLabelSize: AxisLabelSizeVariables;
     bottomAxisLabelSize: AxisLabelSizeVariables;
+    bypassXAxisTickFormat: true;
   };
 
 const useComboLineColumnState = (
@@ -257,6 +258,10 @@ const useComboLineColumnState = (
       offset: Math.max(leftAxisLabelSize.offset, rightAxisLabelSize.offset),
     },
     bottomAxisLabelSize,
+    // We need to bypass the default formatting, as we already need
+    // to format the x-axis labels upfront in the scale domain for
+    // properly build "temporal band" axis.
+    bypassXAxisTickFormat: true,
     ...variables,
   };
 };

--- a/app/charts/combo/combo-line-column-state.tsx
+++ b/app/charts/combo/combo-line-column-state.tsx
@@ -47,7 +47,6 @@ import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { ComboLineColumnConfig } from "@/configurator";
 import { Observation } from "@/domain/data";
 import { truthy } from "@/domain/types";
-import { useFormatFullDateAuto } from "@/formatters";
 import { TimeUnit } from "@/graphql/resolver-types";
 import { getTimeInterval } from "@/intervals";
 import { getTextWidth } from "@/utils/get-text-width";
@@ -83,7 +82,7 @@ const useComboLineColumnState = (
   data: ChartStateData
 ): ComboLineColumnState => {
   const { chartConfig } = chartProps;
-  const { getX, getXAsDate, xAxisLabel } = variables;
+  const { getX, getXAsDate, xAxisLabel, formatXDate } = variables;
   const { chartData, scalesData, timeRangeData, paddingData, allData } = data;
   const { fields, interactiveFiltersConfig } = chartConfig;
   const xKey = fields.x.componentId;
@@ -107,11 +106,10 @@ const useComboLineColumnState = (
   });
 
   // x
-  // We can only use TemporalDimension in ComboLineColumn chart (see UI encodings).
-  const interval = getTimeInterval(variables.xTimeUnit as TimeUnit);
-  const formatDate = useFormatFullDateAuto();
+  const xTimeUnit = variables.xTimeUnit as TimeUnit;
+  const interval = getTimeInterval(xTimeUnit);
   const [xMin, xMax] = xScaleTime.domain() as [Date, Date];
-  const xDomain = interval.range(xMin, xMax).concat(xMax).map(formatDate);
+  const xDomain = interval.range(xMin, xMax).concat(xMax).map(formatXDate);
   const xScale = scaleBand()
     .domain(xDomain)
     .paddingInner(PADDING_INNER)
@@ -195,15 +193,18 @@ const useComboLineColumnState = (
 
   // Tooltip
   const getAnnotationInfo = (d: Observation): TooltipInfo => {
-    const x = getX(d);
-    const xScaled = (xScale(x) as number) + xScale.bandwidth() * 0.5;
+    const x = getXAsDate(d);
+    const xScaled =
+      (xScale(formatXDate(x)) as number) + xScale.bandwidth() * 0.5;
     const values = [variables.y.left, variables.y.right]
       .map(({ orientation, getY, id, label, chartType }) => {
         const y = getY(d);
         const yPos = yOrientationScales[orientation](y ?? 0);
+
         if (!Number.isFinite(y) || y === null) {
           return null;
         }
+
         return {
           label,
           value: `${y}`,

--- a/app/charts/combo/combo-line-column-state.tsx
+++ b/app/charts/combo/combo-line-column-state.tsx
@@ -259,7 +259,7 @@ const useComboLineColumnState = (
     },
     bottomAxisLabelSize,
     // We need to bypass the default formatting, as we already need
-    // to format the x-axis labels upfront in the scale domain for
+    // to format the x-axis labels upfront in the scale domain to
     // properly build "temporal band" axis.
     bypassXAxisTickFormat: true,
     ...variables,

--- a/app/charts/combo/combo-line-column.tsx
+++ b/app/charts/combo/combo-line-column.tsx
@@ -16,7 +16,8 @@ const Columns = () => {
     chartData,
     bounds,
     xScale,
-    getX,
+    getXAsDate,
+    formatXDate,
     y,
     yOrientationScales,
     colors,
@@ -36,7 +37,8 @@ const Columns = () => {
   const renderData: RenderColumnDatum[] = useMemo(() => {
     return chartData.map((d) => {
       const key = getRenderingKey(d);
-      const xScaled = xScale(getX(d)) as number;
+      const xDate = getXAsDate(d);
+      const xScaled = xScale(formatXDate(xDate)) as number;
       const y = yColumn.getY(d) ?? NaN;
       const yScaled = yScale(y);
       const yRender = yScale(Math.max(y, 0));
@@ -57,7 +59,8 @@ const Columns = () => {
     chartData,
     getRenderingKey,
     xScale,
-    getX,
+    getXAsDate,
+    formatXDate,
     yColumn,
     yScale,
     y0,
@@ -87,8 +90,16 @@ const Columns = () => {
 };
 
 const Lines = () => {
-  const { chartData, xScale, getX, yOrientationScales, y, colors, bounds } =
-    useChartState() as ComboLineColumnState;
+  const {
+    chartData,
+    xScale,
+    getXAsDate,
+    formatXDate,
+    yOrientationScales,
+    y,
+    colors,
+    bounds,
+  } = useChartState() as ComboLineColumnState;
   const yLine = y.left.chartType === "line" ? y.left : y.right;
   const yScale =
     y.left.chartType === "line"
@@ -101,7 +112,11 @@ const Lines = () => {
       const y = yLine.getY(d);
       return y !== null && !isNaN(y);
     })
-    .x((d) => (xScale(getX(d)) as number) + xScale.bandwidth() * 0.5)
+    .x(
+      (d) =>
+        (xScale(formatXDate(getXAsDate(d))) as number) +
+        xScale.bandwidth() * 0.5
+    )
     .y((d) => yScale(yLine.getY(d) as number));
 
   return (

--- a/app/charts/shared/axis-width-band.tsx
+++ b/app/charts/shared/axis-width-band.tsx
@@ -13,7 +13,6 @@ import {
 } from "@/charts/shared/rendering-utils";
 import { useChartTheme } from "@/charts/shared/use-chart-theme";
 import { OpenMetadataPanelWrapper } from "@/components/metadata-panel";
-import { useTimeFormatUnit } from "@/formatters";
 import { useTransitionStore } from "@/stores/transition";
 
 export const AxisWidthBand = () => {
@@ -23,8 +22,9 @@ export const AxisWidthBand = () => {
     getXLabel,
     xDimension,
     xTimeUnit,
+    formatXDate,
     yScale,
-    bounds,
+    bounds: { chartHeight, chartWidth, margins },
     xAxisLabel,
     bottomAxisLabelSize,
   } = useChartState() as
@@ -34,11 +34,7 @@ export const AxisWidthBand = () => {
     | ComboLineColumnState;
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
-  const formatDate = useTimeFormatUnit();
-  const { chartHeight, chartWidth, margins } = bounds;
-
   const xAxisTitleOffset = useXAxisTitleOffset(xScale, getXLabel, xTimeUnit);
-
   const {
     labelColor,
     gridColor,
@@ -60,7 +56,7 @@ export const AxisWidthBand = () => {
         .tickPadding(rotation ? -10 : 0);
 
       if (xTimeUnit) {
-        axis.tickFormat((d) => formatDate(d, xTimeUnit));
+        axis.tickFormat((d) => formatXDate(d));
       } else {
         axis.tickFormat((d) => getXLabel(d));
       }
@@ -96,7 +92,6 @@ export const AxisWidthBand = () => {
     domainColor,
     enableTransition,
     fontFamily,
-    formatDate,
     getXLabel,
     gridColor,
     labelColor,
@@ -107,6 +102,7 @@ export const AxisWidthBand = () => {
     xScale,
     xTimeUnit,
     yScale,
+    formatXDate,
   ]);
 
   return (

--- a/app/charts/shared/axis-width-band.tsx
+++ b/app/charts/shared/axis-width-band.tsx
@@ -32,6 +32,7 @@ export const AxisWidthBand = () => {
     | StackedColumnsState
     | GroupedColumnsState
     | ComboLineColumnState;
+  const { bypassXAxisTickFormat } = useChartState() as ComboLineColumnState;
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
   const xAxisTitleOffset = useXAxisTitleOffset(xScale, getXLabel, xTimeUnit);
@@ -55,10 +56,12 @@ export const AxisWidthBand = () => {
         .tickSizeInner(hasNegativeValues ? -chartHeight : 6)
         .tickPadding(rotation ? -10 : 0);
 
-      if (xTimeUnit) {
-        axis.tickFormat((d) => formatXDate(d));
-      } else {
-        axis.tickFormat((d) => getXLabel(d));
+      if (!bypassXAxisTickFormat) {
+        if (xTimeUnit) {
+          axis.tickFormat((d) => formatXDate(d));
+        } else {
+          axis.tickFormat((d) => getXLabel(d));
+        }
       }
 
       const g = renderContainer(ref.current, {
@@ -103,6 +106,7 @@ export const AxisWidthBand = () => {
     xTimeUnit,
     yScale,
     formatXDate,
+    bypassXAxisTickFormat,
   ]);
 
   return (

--- a/app/charts/shared/chart-state.ts
+++ b/app/charts/shared/chart-state.ts
@@ -171,16 +171,6 @@ export type BandYVariables = {
   getYAsDate: TemporalValueGetter;
 };
 
-export type BandXVariables = {
-  xAxisLabel: string;
-  xDimension: Dimension;
-  getX: StringValueGetter;
-  getXLabel: (d: string) => string;
-  getXAbbreviationOrLabel: (d: Observation) => string;
-  xTimeUnit: TimeUnit | undefined;
-  getXAsDate: TemporalValueGetter;
-};
-
 export const useBandYVariables = (
   y: GenericField,
   {
@@ -196,9 +186,10 @@ export const useBandYVariables = (
     throw Error(`No dimension <${y.componentId}> in cube! (useBandXVariables)`);
   }
 
-  const yTimeUnit = isTemporalDimension(yDimension)
-    ? yDimension.timeUnit
-    : undefined;
+  const yTimeUnit =
+    isTemporalDimension(yDimension) || isTemporalEntityDimension(yDimension)
+      ? yDimension.timeUnit
+      : undefined;
 
   const {
     getAbbreviationOrLabelByValue: getYAbbreviationOrLabel,
@@ -229,6 +220,16 @@ export const useBandYVariables = (
   };
 };
 
+export type BandXVariables = {
+  xAxisLabel: string;
+  xDimension: Dimension;
+  getX: StringValueGetter;
+  getXLabel: (d: string) => string;
+  getXAbbreviationOrLabel: (d: Observation) => string;
+  xTimeUnit: TimeUnit | undefined;
+  getXAsDate: TemporalValueGetter;
+};
+
 export const useBandXVariables = (
   x: GenericField,
   {
@@ -244,9 +245,10 @@ export const useBandXVariables = (
     throw Error(`No dimension <${x.componentId}> in cube! (useBandXVariables)`);
   }
 
-  const xTimeUnit = isTemporalDimension(xDimension)
-    ? xDimension.timeUnit
-    : undefined;
+  const xTimeUnit =
+    isTemporalDimension(xDimension) || isTemporalEntityDimension(xDimension)
+      ? xDimension.timeUnit
+      : undefined;
 
   const {
     getAbbreviationOrLabelByValue: getXAbbreviationOrLabel,


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2300

<!--- Describe the changes -->

This PR makes the column-line chart work correctly with temporal entity X dimensions.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-merged-column-line-charts-ixt1.vercel.app/en/v/JQZnJZT2Nj84?dataSource=Int).
2. ✅ See that the column-line chart works correctly for merged BLW cubes (joined X temporal entity dimension).

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
