### PR TITLE
feat: Add units to limit legend items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ You can also check the
 
 # Unreleased
 
+- Features
+  - Limit values displayed in the legend now include the unit if it's available
 - Fixes
   - Default min custom scale domain value now defaults to 0 if no negative
     values are present

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -61,7 +61,7 @@ const ChartAreas = memo((props: ChartProps<AreaConfig>) => {
             interactive={interactiveFiltersConfig?.legend.active}
             showTitle={fields.segment?.showTitle}
             dimensionsById={dimensionsById}
-            limits={limits.limits}
+            limits={limits}
           />
         </ChartControlsContainer>
       )}

--- a/app/charts/bar/chart-bar.tsx
+++ b/app/charts/bar/chart-bar.tsx
@@ -140,7 +140,7 @@ const ChartBars = memo((props: ChartProps<BarConfig>) => {
             <ChartControlsContainer>
               {limits.limits.length > 0 && (
                 <LegendColor
-                  limits={limits.limits}
+                  limits={limits}
                   dimensionsById={dimensionsById}
                   chartConfig={chartConfig}
                   symbol="square"

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -140,7 +140,7 @@ const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
             <ChartControlsContainer>
               {limits.limits.length > 0 && (
                 <LegendColor
-                  limits={limits.limits}
+                  limits={limits}
                   dimensionsById={dimensionsById}
                   chartConfig={chartConfig}
                   symbol="square"

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -77,7 +77,7 @@ const ChartLines = memo((props: ChartProps<LineConfig>) => {
             symbol="line"
             interactive={interactiveFiltersConfig?.legend.active}
             showTitle={fields.segment?.showTitle}
-            limits={limits.limits}
+            limits={limits}
           />
         </ChartControlsContainer>
       )}

--- a/app/charts/shared/legend-color.tsx
+++ b/app/charts/shared/legend-color.tsx
@@ -136,7 +136,7 @@ export const LegendColor = memo(function LegendColor({
   interactive?: boolean;
   showTitle?: boolean;
   dimensionsById?: DimensionsById;
-  limits?: ReturnType<typeof useLimits>["limits"];
+  limits?: ReturnType<typeof useLimits>;
 }) {
   const { colors, getColorLabel } = useChartState() as ColorsChartState;
   const values =
@@ -164,7 +164,7 @@ export const LegendColor = memo(function LegendColor({
       )}
       <LegendColorContent
         groups={groups}
-        limits={limits?.map(({ configLimit, measureLimit }) => ({
+        limits={limits?.limits.map(({ configLimit, measureLimit }) => ({
           label: measureLimit.name,
           values:
             measureLimit.type === "single"
@@ -176,6 +176,7 @@ export const LegendColor = memo(function LegendColor({
               ? "dashed-line"
               : "line"
             : configLimit.symbolType,
+          unit: limits.limitMeasure?.unit,
         }))}
         getColor={colors}
         getLabel={getColorLabel}
@@ -272,6 +273,7 @@ const LegendColorContent = ({
     values: number[];
     color: string;
     symbol: LegendSymbol;
+    unit?: string;
   }[];
   getColor: (d: string) => string;
   getLabel: (d: string) => string;
@@ -355,10 +357,10 @@ const LegendColorContent = ({
                   );
                 })}
                 {isLastGroup && limits
-                  ? limits.map(({ label, values, color, symbol }, i) => (
+                  ? limits.map(({ label, values, color, symbol, unit }, i) => (
                       <LegendItem
                         key={i}
-                        label={`${label}: ${values.map(formatNumber).join("-")}`}
+                        label={`${label}: ${values.map(formatNumber).join("-")}${unit ? ` ${unit}` : ""}`}
                         color={color}
                         symbol={symbol}
                       />

--- a/app/config-utils.ts
+++ b/app/config-utils.ts
@@ -347,6 +347,7 @@ export const useLimits = ({
   measures: Measure[];
 }): {
   axisDimension: Dimension | undefined;
+  limitMeasure: Measure | undefined;
   limits: {
     configLimit: ConfigLimit;
     measureLimit: Limit;
@@ -354,25 +355,27 @@ export const useLimits = ({
   }[];
 } => {
   const filters = useDefinitiveFilters();
-  const measure = getLimitMeasure({ chartConfig, measures });
+  const limitMeasure = getLimitMeasure({ chartConfig, measures });
   const axisDimension = getAxisDimension({ chartConfig, dimensions });
 
   return useMemo(() => {
-    if (!measure) {
+    if (!limitMeasure) {
       return {
         axisDimension,
+        limitMeasure,
         limits: [],
       };
     }
 
     return {
       axisDimension,
-      limits: measure.limits
+      limitMeasure,
+      limits: limitMeasure.limits
         .map((limit) => {
           const { limit: maybeLimit, relatedAxisDimensionValueLabel } =
             getMaybeValidChartConfigLimit({
               chartConfig,
-              measureId: measure.id,
+              measureId: limitMeasure.id,
               limit,
               axisDimension,
               filters,
@@ -395,7 +398,7 @@ export const useLimits = ({
         })
         .filter(truthy),
     };
-  }, [chartConfig, filters, measure, axisDimension]);
+  }, [chartConfig, filters, limitMeasure, axisDimension]);
 };
 
 export const getSupportsLimitSymbols = (chartConfig: ChartConfig) => {

--- a/app/docs/charts.stories.tsx
+++ b/app/docs/charts.stories.tsx
@@ -91,7 +91,11 @@ const ColumnsStory = {
         <InteractiveFiltersChartProvider chartConfigKey={chartConfig.key}>
           <Observer>
             <ColumnChart
-              limits={{ axisDimension: undefined, limits: [] }}
+              limits={{
+                axisDimension: undefined,
+                limitMeasure: undefined,
+                limits: [],
+              }}
               observations={columnObservations}
               measures={columnMeasures}
               measuresById={keyBy(columnMeasures, (d: Measure) => d.id)}

--- a/app/docs/lines.stories.tsx
+++ b/app/docs/lines.stories.tsx
@@ -69,7 +69,11 @@ const LineChartStory = () => (
       <InteractiveFiltersChartProvider chartConfigKey={chartConfig.key}>
         <Observer>
           <LineChart
-            limits={{ axisDimension: undefined, limits: [] }}
+            limits={{
+              axisDimension: undefined,
+              limitMeasure: undefined,
+              limits: [],
+            }}
             observations={observations}
             dimensions={dimensions}
             dimensionsById={keyBy(dimensions, (d) => d.id)}

--- a/app/docs/tooltip.stories.tsx
+++ b/app/docs/tooltip.stories.tsx
@@ -62,7 +62,11 @@ const TooltipBoxStory = () => (
   <ReactSpecimen>
     <InteractiveFiltersChartProvider chartConfigKey="column-chart">
       <ColumnChart
-        limits={{ axisDimension: undefined, limits: [] }}
+        limits={{
+          axisDimension: undefined,
+          limitMeasure: undefined,
+          limits: [],
+        }}
         observations={observations}
         measures={measures}
         measuresById={keyBy(measures, (d) => d.id)}
@@ -229,7 +233,11 @@ const TooltipContentStory = {
   render: () => (
     <InteractiveFiltersChartProvider chartConfigKey="column-chart">
       <ColumnChart
-        limits={{ axisDimension: undefined, limits: [] }}
+        limits={{
+          axisDimension: undefined,
+          limitMeasure: undefined,
+          limits: [],
+        }}
         observations={observations}
         measures={measures}
         measuresById={keyBy(measures, (d) => d.id)}
@@ -299,7 +307,11 @@ export const TooltipContentStory2 = {
   render: () => (
     <InteractiveFiltersChartProvider chartConfigKey="column-chart">
       <ColumnChart
-        limits={{ axisDimension: undefined, limits: [] }}
+        limits={{
+          axisDimension: undefined,
+          limitMeasure: undefined,
+          limits: [],
+        }}
         observations={observations}
         measures={measures}
         measuresById={keyBy(measures, (d) => d.id)}


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2301

<!--- Describe the changes -->

This PR adds units to limit legend items if they are available.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-feat-add-units-to-limit-lege-7d57f3-ixt1.vercel.app/en/v/Bkq9xccvieTR?dataSource=Int).
2. ✅ See that the legend limit contains a unit.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
