### PR TITLE
fix: BLW cube issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Fixes
+  - X and Y band axes have now correctly formatted ticks in case of being based
+    on temporal entity dimension
 
 # 5.7.7 - 2025-05-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ You can also check the
 - Fixes
   - X and Y band axes have now correctly formatted ticks in case of being based
     on temporal entity dimension
+  - Dimensions with multiple termsets are now displayed correctly in the dataset
+    browse view (no more duplicates)
 
 # 5.7.7 - 2025-05-13
 

--- a/app/charts/bar/bars-grouped-state.tsx
+++ b/app/charts/bar/bars-grouped-state.tsx
@@ -10,7 +10,7 @@ import {
 } from "d3-scale";
 import { schemeCategory10 } from "d3-scale-chromatic";
 import orderBy from "lodash/orderBy";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 import {
   BarsGroupedStateVariables,
@@ -394,6 +394,13 @@ const useBarsGroupedState = (
 
   const isMobile = useIsMobile();
 
+  const maybeFormatDate = useCallback(
+    (tick: string) => {
+      return isTemporalDimension(yDimension) ? formatYDate(tick) : tick;
+    },
+    [yDimension, formatYDate]
+  );
+
   // Tooltip
   const getAnnotationInfo = (datum: Observation): TooltipInfo => {
     const bw = yScale.bandwidth();
@@ -432,7 +439,7 @@ const useBarsGroupedState = (
       yAnchor: yAnchorRaw + (placement.y === "bottom" ? 0.5 : -0.5) * bw,
       xAnchor,
       placement,
-      value: isTemporalDimension(yDimension) ? formatYDate(yLabel) : yLabel,
+      value: maybeFormatDate(yLabel),
       datum: {
         label: fields.segment && getSegmentAbbreviationOrLabel(datum),
         value: xValueFormatter(getX(datum)),
@@ -468,9 +475,7 @@ const useBarsGroupedState = (
     leftAxisLabelSize,
     leftAxisLabelOffsetTop: top,
     bottomAxisLabelSize,
-    formatYAxisTick: isTemporalDimension(yDimension)
-      ? (tick) => formatYDate(tick)
-      : undefined,
+    formatYAxisTick: maybeFormatDate,
     ...variables,
   };
 };

--- a/app/charts/bar/bars-grouped-state.tsx
+++ b/app/charts/bar/bars-grouped-state.tsx
@@ -45,7 +45,7 @@ import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useSize } from "@/charts/shared/use-size";
 import { BarConfig } from "@/configurator";
-import { Observation } from "@/domain/data";
+import { isTemporalDimension, Observation } from "@/domain/data";
 import { formatNumberWithUnit, useFormatNumber } from "@/formatters";
 import { getPalette } from "@/palettes";
 import { sortByIndex } from "@/utils/array";
@@ -73,6 +73,7 @@ export type GroupedBarsState = CommonChartState &
     leftAxisLabelSize: AxisLabelSizeVariables;
     leftAxisLabelOffsetTop: number;
     bottomAxisLabelSize: AxisLabelSizeVariables;
+    formatYAxisTick?: (tick: string) => string;
   };
 
 const useBarsGroupedState = (
@@ -89,6 +90,7 @@ const useBarsGroupedState = (
     getYLabel,
     xMeasure,
     getY,
+    formatYDate,
     getMinX,
     getXErrorRange,
     getFormattedXUncertainty,
@@ -424,12 +426,13 @@ const useBarsGroupedState = (
           xAnchor,
           topAnchor: !fields.segment,
         });
+    const yLabel = getYAbbreviationOrLabel(datum);
 
     return {
       yAnchor: yAnchorRaw + (placement.y === "bottom" ? 0.5 : -0.5) * bw,
       xAnchor,
       placement,
-      value: getYAbbreviationOrLabel(datum),
+      value: isTemporalDimension(yDimension) ? formatYDate(yLabel) : yLabel,
       datum: {
         label: fields.segment && getSegmentAbbreviationOrLabel(datum),
         value: xValueFormatter(getX(datum)),
@@ -465,6 +468,9 @@ const useBarsGroupedState = (
     leftAxisLabelSize,
     leftAxisLabelOffsetTop: top,
     bottomAxisLabelSize,
+    formatYAxisTick: isTemporalDimension(yDimension)
+      ? (tick) => formatYDate(tick)
+      : undefined,
     ...variables,
   };
 };

--- a/app/charts/bar/bars-stacked-state.tsx
+++ b/app/charts/bar/bars-stacked-state.tsx
@@ -66,7 +66,7 @@ import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useSize } from "@/charts/shared/use-size";
 import { BarConfig } from "@/configurator";
-import { Observation } from "@/domain/data";
+import { isTemporalDimension, Observation } from "@/domain/data";
 import { useFormatNumber } from "@/formatters";
 import { getPalette } from "@/palettes";
 import { useChartInteractiveFilters } from "@/stores/interactive-filters";
@@ -99,6 +99,7 @@ export type StackedBarsState = CommonChartState &
     leftAxisLabelOffsetTop: number;
     bottomAxisLabelSize: AxisLabelSizeVariables;
     valueLabelFormatter: ValueLabelFormatter;
+    formatYAxisTick?: (tick: string) => string;
   };
 
 const useBarsStackedState = (
@@ -115,6 +116,7 @@ const useBarsStackedState = (
     getYLabel,
     xMeasure,
     getY,
+    formatYDate,
     segmentDimension,
     segmentsByAbbreviationOrLabel,
     getSegment,
@@ -497,12 +499,13 @@ const useBarsStackedState = (
             xAnchor,
             topAnchor: !fields.segment,
           });
+      const yLabel = getYAbbreviationOrLabel(datum);
 
       return {
         yAnchor: yAnchorRaw + (placement.y === "top" ? 0.5 : -0.5) * bw,
         xAnchor,
         placement,
-        value: getYAbbreviationOrLabel(datum),
+        value: isTemporalDimension(yDimension) ? formatYDate(yLabel) : yLabel,
         datum: {
           label: fields.segment && getSegmentAbbreviationOrLabel(datum),
           value: xValueFormatter(getX(datum), getIdentityX(datum)),
@@ -536,6 +539,8 @@ const useBarsStackedState = (
       isMobile,
       normalize,
       yScale,
+      formatYDate,
+      yDimension,
     ]
   );
 
@@ -568,6 +573,9 @@ const useBarsStackedState = (
     leftAxisLabelOffsetTop: top,
     bottomAxisLabelSize,
     valueLabelFormatter,
+    formatYAxisTick: isTemporalDimension(yDimension)
+      ? (tick) => formatYDate(tick)
+      : undefined,
     ...variables,
   };
 };

--- a/app/charts/bar/bars-stacked-state.tsx
+++ b/app/charts/bar/bars-stacked-state.tsx
@@ -465,6 +465,13 @@ const useBarsStackedState = (
 
   const isMobile = useIsMobile();
 
+  const maybeFormatDate = useCallback(
+    (tick: string) => {
+      return isTemporalDimension(yDimension) ? formatYDate(tick) : tick;
+    },
+    [yDimension, formatYDate]
+  );
+
   // Tooltips
   const getAnnotationInfo = useCallback(
     (datum: Observation): TooltipInfo => {
@@ -505,7 +512,7 @@ const useBarsStackedState = (
         yAnchor: yAnchorRaw + (placement.y === "top" ? 0.5 : -0.5) * bw,
         xAnchor,
         placement,
-        value: isTemporalDimension(yDimension) ? formatYDate(yLabel) : yLabel,
+        value: maybeFormatDate(yLabel),
         datum: {
           label: fields.segment && getSegmentAbbreviationOrLabel(datum),
           value: xValueFormatter(getX(datum), getIdentityX(datum)),
@@ -539,8 +546,7 @@ const useBarsStackedState = (
       isMobile,
       normalize,
       yScale,
-      formatYDate,
-      yDimension,
+      maybeFormatDate,
     ]
   );
 
@@ -573,9 +579,7 @@ const useBarsStackedState = (
     leftAxisLabelOffsetTop: top,
     bottomAxisLabelSize,
     valueLabelFormatter,
-    formatYAxisTick: isTemporalDimension(yDimension)
-      ? (tick) => formatYDate(tick)
-      : undefined,
+    formatYAxisTick: maybeFormatDate,
     ...variables,
   };
 };

--- a/app/charts/bar/bars-state.tsx
+++ b/app/charts/bar/bars-state.tsx
@@ -49,12 +49,8 @@ import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useSize } from "@/charts/shared/use-size";
 import { useLimits } from "@/config-utils";
 import { BarConfig } from "@/configurator";
-import { Observation } from "@/domain/data";
-import {
-  formatNumberWithUnit,
-  useFormatNumber,
-  useTimeFormatUnit,
-} from "@/formatters";
+import { isTemporalDimension, Observation } from "@/domain/data";
+import { formatNumberWithUnit, useFormatNumber } from "@/formatters";
 import { getPalette } from "@/palettes";
 import {
   getSortingOrders,
@@ -79,6 +75,7 @@ export type BarsState = CommonChartState &
     leftAxisLabelSize: AxisLabelSizeVariables;
     leftAxisLabelOffsetTop: number;
     bottomAxisLabelSize: AxisLabelSizeVariables;
+    formatYAxisTick?: (tick: string) => string;
   };
 
 const useBarsState = (
@@ -93,7 +90,7 @@ const useBarsState = (
     getYAsDate,
     getYAbbreviationOrLabel,
     getYLabel,
-    yTimeUnit,
+    formatYDate,
     xMeasure,
     getY,
     getMinX,
@@ -112,7 +109,6 @@ const useBarsState = (
   const { width, height } = useSize();
   const formatNumber = useFormatNumber({ decimals: "auto" });
   const formatters = useChartFormatters(chartProps);
-  const timeFormatUnit = useTimeFormatUnit();
 
   const sumsByY = useMemo(() => {
     return Object.fromEntries(
@@ -326,7 +322,7 @@ const useBarsState = (
       xAnchor,
       yAnchor,
       placement,
-      value: yTimeUnit ? timeFormatUnit(yLabel, yTimeUnit) : yLabel,
+      value: isTemporalDimension(yDimension) ? formatYDate(yLabel) : yLabel,
       datum: {
         label: undefined,
         value: x !== null && isNaN(x) ? "-" : `${xValueFormatter(getX(d))}`,
@@ -369,6 +365,9 @@ const useBarsState = (
     leftAxisLabelSize,
     leftAxisLabelOffsetTop: top,
     bottomAxisLabelSize,
+    formatYAxisTick: isTemporalDimension(yDimension)
+      ? (tick) => formatYDate(tick)
+      : undefined,
     ...showValuesVariables,
     ...variables,
   };

--- a/app/charts/bar/bars-state.tsx
+++ b/app/charts/bar/bars-state.tsx
@@ -9,7 +9,7 @@ import {
   scaleTime,
 } from "d3-scale";
 import orderBy from "lodash/orderBy";
-import { PropsWithChildren, useMemo } from "react";
+import { PropsWithChildren, useCallback, useMemo } from "react";
 
 import {
   BarsStateVariables,
@@ -293,6 +293,13 @@ const useBarsState = (
 
   const isMobile = useIsMobile();
 
+  const maybeFormatDate = useCallback(
+    (tick: string) => {
+      return isTemporalDimension(yDimension) ? formatYDate(tick) : tick;
+    },
+    [yDimension, formatYDate]
+  );
+
   // Tooltip
   const getAnnotationInfo = (d: Observation): TooltipInfo => {
     const yAnchor = (yScale(getY(d)) as number) + yScale.bandwidth() * 0.5;
@@ -322,7 +329,7 @@ const useBarsState = (
       xAnchor,
       yAnchor,
       placement,
-      value: isTemporalDimension(yDimension) ? formatYDate(yLabel) : yLabel,
+      value: maybeFormatDate(yLabel),
       datum: {
         label: undefined,
         value: x !== null && isNaN(x) ? "-" : `${xValueFormatter(getX(d))}`,
@@ -365,9 +372,7 @@ const useBarsState = (
     leftAxisLabelSize,
     leftAxisLabelOffsetTop: top,
     bottomAxisLabelSize,
-    formatYAxisTick: isTemporalDimension(yDimension)
-      ? (tick) => formatYDate(tick)
-      : undefined,
+    formatYAxisTick: maybeFormatDate,
     ...showValuesVariables,
     ...variables,
   };

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -10,7 +10,7 @@ import {
 } from "d3-scale";
 import { schemeCategory10 } from "d3-scale-chromatic";
 import orderBy from "lodash/orderBy";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 
 import {
   ColumnsGroupedStateVariables,
@@ -395,6 +395,13 @@ const useColumnsGroupedState = (
 
   const isMobile = useIsMobile();
 
+  const maybeFormatDate = useCallback(
+    (tick: string) => {
+      return isTemporalDimension(xDimension) ? formatXDate(tick) : tick;
+    },
+    [xDimension, formatXDate]
+  );
+
   // Tooltip
   const getAnnotationInfo = (datum: Observation): TooltipInfo => {
     const bw = xScale.bandwidth();
@@ -433,7 +440,7 @@ const useColumnsGroupedState = (
       xAnchor: xAnchorRaw + (placement.x === "right" ? 0.5 : -0.5) * bw,
       yAnchor,
       placement,
-      value: isTemporalDimension(xDimension) ? formatXDate(xLabel) : xLabel,
+      value: maybeFormatDate(xLabel),
       datum: {
         label: fields.segment && getSegmentAbbreviationOrLabel(datum),
         value: yValueFormatter(getY(datum)),
@@ -469,9 +476,7 @@ const useColumnsGroupedState = (
     leftAxisLabelSize,
     leftAxisLabelOffsetTop: top,
     bottomAxisLabelSize,
-    formatXAxisTick: isTemporalDimension(xDimension)
-      ? (tick) => formatXDate(tick)
-      : undefined,
+    formatXAxisTick: maybeFormatDate,
     ...variables,
   };
 };

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -45,7 +45,7 @@ import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useSize } from "@/charts/shared/use-size";
 import { ColumnConfig } from "@/configurator";
-import { Observation } from "@/domain/data";
+import { isTemporalDimension, Observation } from "@/domain/data";
 import { formatNumberWithUnit, useFormatNumber } from "@/formatters";
 import { getPalette } from "@/palettes";
 import { sortByIndex } from "@/utils/array";
@@ -73,6 +73,7 @@ export type GroupedColumnsState = CommonChartState &
     leftAxisLabelSize: AxisLabelSizeVariables;
     leftAxisLabelOffsetTop: number;
     bottomAxisLabelSize: AxisLabelSizeVariables;
+    formatXAxisTick?: (d: string) => string;
   };
 
 const useColumnsGroupedState = (
@@ -87,6 +88,7 @@ const useColumnsGroupedState = (
     getXAsDate,
     getXAbbreviationOrLabel,
     getXLabel,
+    formatXDate,
     yMeasure,
     getY,
     getMinY,
@@ -425,12 +427,13 @@ const useColumnsGroupedState = (
           xAnchor: xAnchorRaw,
           topAnchor: !fields.segment,
         });
+    const xLabel = getXAbbreviationOrLabel(datum);
 
     return {
       xAnchor: xAnchorRaw + (placement.x === "right" ? 0.5 : -0.5) * bw,
       yAnchor,
       placement,
-      value: getXAbbreviationOrLabel(datum),
+      value: isTemporalDimension(xDimension) ? formatXDate(xLabel) : xLabel,
       datum: {
         label: fields.segment && getSegmentAbbreviationOrLabel(datum),
         value: yValueFormatter(getY(datum)),
@@ -466,6 +469,9 @@ const useColumnsGroupedState = (
     leftAxisLabelSize,
     leftAxisLabelOffsetTop: top,
     bottomAxisLabelSize,
+    formatXAxisTick: isTemporalDimension(xDimension)
+      ? (tick) => formatXDate(tick)
+      : undefined,
     ...variables,
   };
 };

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -62,7 +62,7 @@ import useChartFormatters from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useSize } from "@/charts/shared/use-size";
 import { ColumnConfig } from "@/configurator";
-import { Observation } from "@/domain/data";
+import { isTemporalDimension, Observation } from "@/domain/data";
 import { useFormatNumber } from "@/formatters";
 import { getPalette } from "@/palettes";
 import { useChartInteractiveFilters } from "@/stores/interactive-filters";
@@ -95,6 +95,7 @@ export type StackedColumnsState = CommonChartState &
     leftAxisLabelOffsetTop: number;
     bottomAxisLabelSize: AxisLabelSizeVariables;
     valueLabelFormatter: ValueLabelFormatter;
+    formatXAxisTick?: (d: string) => string;
   };
 
 const useColumnsStackedState = (
@@ -109,6 +110,7 @@ const useColumnsStackedState = (
     getXAsDate,
     getXAbbreviationOrLabel,
     getXLabel,
+    formatXDate,
     yMeasure,
     getY,
     segmentDimension,
@@ -484,12 +486,13 @@ const useColumnsStackedState = (
             xAnchor: xAnchorRaw,
             topAnchor: !fields.segment,
           });
+      const xLabel = getXAbbreviationOrLabel(datum);
 
       return {
         xAnchor: xAnchorRaw + (placement.x === "right" ? 0.5 : -0.5) * bw,
         yAnchor,
         placement,
-        value: getXAbbreviationOrLabel(datum),
+        value: isTemporalDimension(xDimension) ? formatXDate(xLabel) : xLabel,
         datum: {
           label: fields.segment && getSegmentAbbreviationOrLabel(datum),
           value: yValueFormatter(getY(datum), getIdentityY(datum)),
@@ -523,6 +526,8 @@ const useColumnsStackedState = (
       isMobile,
       normalize,
       yScale,
+      xDimension,
+      formatXDate,
     ]
   );
 
@@ -552,6 +557,9 @@ const useColumnsStackedState = (
     leftAxisLabelOffsetTop: top,
     bottomAxisLabelSize,
     valueLabelFormatter,
+    formatXAxisTick: isTemporalDimension(xDimension)
+      ? (tick) => formatXDate(tick)
+      : undefined,
     ...variables,
   };
 };

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -453,6 +453,13 @@ const useColumnsStackedState = (
 
   const isMobile = useIsMobile();
 
+  const maybeFormatDate = useCallback(
+    (tick: string) => {
+      return isTemporalDimension(xDimension) ? formatXDate(tick) : tick;
+    },
+    [xDimension, formatXDate]
+  );
+
   // Tooltips
   const getAnnotationInfo = useCallback(
     (datum: Observation): TooltipInfo => {
@@ -492,7 +499,7 @@ const useColumnsStackedState = (
         xAnchor: xAnchorRaw + (placement.x === "right" ? 0.5 : -0.5) * bw,
         yAnchor,
         placement,
-        value: isTemporalDimension(xDimension) ? formatXDate(xLabel) : xLabel,
+        value: maybeFormatDate(xLabel),
         datum: {
           label: fields.segment && getSegmentAbbreviationOrLabel(datum),
           value: yValueFormatter(getY(datum), getIdentityY(datum)),
@@ -526,8 +533,7 @@ const useColumnsStackedState = (
       isMobile,
       normalize,
       yScale,
-      xDimension,
-      formatXDate,
+      maybeFormatDate,
     ]
   );
 
@@ -557,9 +563,7 @@ const useColumnsStackedState = (
     leftAxisLabelOffsetTop: top,
     bottomAxisLabelSize,
     valueLabelFormatter,
-    formatXAxisTick: isTemporalDimension(xDimension)
-      ? (tick) => formatXDate(tick)
-      : undefined,
+    formatXAxisTick: maybeFormatDate,
     ...variables,
   };
 };

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -45,12 +45,8 @@ import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useSize } from "@/charts/shared/use-size";
 import { useLimits } from "@/config-utils";
 import { ColumnConfig } from "@/configurator";
-import { Observation } from "@/domain/data";
-import {
-  formatNumberWithUnit,
-  useFormatNumber,
-  useTimeFormatUnit,
-} from "@/formatters";
+import { isTemporalDimension, Observation } from "@/domain/data";
+import { formatNumberWithUnit, useFormatNumber } from "@/formatters";
 import { getPalette } from "@/palettes";
 import {
   getSortingOrders,
@@ -74,6 +70,7 @@ export type ColumnsState = CommonChartState &
     leftAxisLabelSize: AxisLabelSizeVariables;
     leftAxisLabelOffsetTop: number;
     bottomAxisLabelSize: AxisLabelSizeVariables;
+    formatXAxisTick?: (d: string) => string;
   };
 
 const useColumnsState = (
@@ -88,7 +85,7 @@ const useColumnsState = (
     getXAsDate,
     getXAbbreviationOrLabel,
     getXLabel,
-    xTimeUnit,
+    formatXDate,
     yMeasure,
     getY,
     getMinY,
@@ -107,7 +104,6 @@ const useColumnsState = (
   const { width, height } = useSize();
   const formatNumber = useFormatNumber({ decimals: "auto" });
   const formatters = useChartFormatters(chartProps);
-  const timeFormatUnit = useTimeFormatUnit();
 
   const sumsByX = useMemo(() => {
     return Object.fromEntries(
@@ -322,7 +318,7 @@ const useColumnsState = (
       xAnchor,
       yAnchor,
       placement,
-      value: xTimeUnit ? timeFormatUnit(xLabel, xTimeUnit) : xLabel,
+      value: isTemporalDimension(xDimension) ? formatXDate(xLabel) : xLabel,
       datum: {
         label: undefined,
         value: y !== null && isNaN(y) ? "-" : `${yValueUnitFormatter(getY(d))}`,
@@ -348,6 +344,9 @@ const useColumnsState = (
     leftAxisLabelSize,
     leftAxisLabelOffsetTop: top,
     bottomAxisLabelSize,
+    formatXAxisTick: isTemporalDimension(xDimension)
+      ? (tick) => formatXDate(tick)
+      : undefined,
     ...showValuesVariables,
     ...variables,
   };

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -9,7 +9,7 @@ import {
   scaleTime,
 } from "d3-scale";
 import orderBy from "lodash/orderBy";
-import { PropsWithChildren, useMemo } from "react";
+import { PropsWithChildren, useCallback, useMemo } from "react";
 
 import {
   ColumnsStateVariables,
@@ -292,6 +292,13 @@ const useColumnsState = (
   yScale.range([chartHeight, 0]);
   const isMobile = useIsMobile();
 
+  const maybeFormatDate = useCallback(
+    (tick: string) => {
+      return isTemporalDimension(xDimension) ? formatXDate(tick) : tick;
+    },
+    [xDimension, formatXDate]
+  );
+
   // Tooltip
   const getAnnotationInfo = (d: Observation): TooltipInfo => {
     const xAnchor = (xScale(getX(d)) as number) + xScale.bandwidth() * 0.5;
@@ -318,7 +325,7 @@ const useColumnsState = (
       xAnchor,
       yAnchor,
       placement,
-      value: isTemporalDimension(xDimension) ? formatXDate(xLabel) : xLabel,
+      value: maybeFormatDate(xLabel),
       datum: {
         label: undefined,
         value: y !== null && isNaN(y) ? "-" : `${yValueUnitFormatter(getY(d))}`,
@@ -344,9 +351,7 @@ const useColumnsState = (
     leftAxisLabelSize,
     leftAxisLabelOffsetTop: top,
     bottomAxisLabelSize,
-    formatXAxisTick: isTemporalDimension(xDimension)
-      ? (tick) => formatXDate(tick)
-      : undefined,
+    formatXAxisTick: maybeFormatDate,
     ...showValuesVariables,
     ...variables,
   };

--- a/app/charts/combo/combo-line-column-state.tsx
+++ b/app/charts/combo/combo-line-column-state.tsx
@@ -74,7 +74,7 @@ export type ComboLineColumnState = CommonChartState &
     maxRightTickWidth: number;
     leftAxisLabelSize: AxisLabelSizeVariables;
     bottomAxisLabelSize: AxisLabelSizeVariables;
-    bypassXAxisTickFormat: true;
+    formatXAxisTick?: (tick: string) => string;
   };
 
 const useComboLineColumnState = (
@@ -258,10 +258,6 @@ const useComboLineColumnState = (
       offset: Math.max(leftAxisLabelSize.offset, rightAxisLabelSize.offset),
     },
     bottomAxisLabelSize,
-    // We need to bypass the default formatting, as we already need
-    // to format the x-axis labels upfront in the scale domain to
-    // properly build "temporal band" axis.
-    bypassXAxisTickFormat: true,
     ...variables,
   };
 };

--- a/app/charts/shared/axis-height-band.tsx
+++ b/app/charts/shared/axis-height-band.tsx
@@ -25,6 +25,7 @@ export const AxisHeightBand = () => {
     yDimension,
     leftAxisLabelSize,
     leftAxisLabelOffsetTop,
+    formatYAxisTick,
   } = useChartState() as BarsState | GroupedBarsState | StackedBarsState;
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
@@ -46,13 +47,8 @@ export const AxisHeightBand = () => {
       const hasNegativeValues = xScale.domain()[0] < 0;
       const axis = axisLeft(yScale)
         .tickSizeOuter(0)
-        .tickSizeInner(hasNegativeValues ? -chartHeight : 6);
-
-      if (yTimeUnit) {
-        axis.tickFormat((d) => formatDate(d, yTimeUnit));
-      } else {
-        axis.tickFormat((d) => getYLabel(d));
-      }
+        .tickSizeInner(hasNegativeValues ? -chartHeight : 6)
+        .tickFormat(formatYAxisTick ?? ((tick) => tick));
 
       const g = renderContainer(ref.current, {
         id: "axis-height-band",
@@ -94,6 +90,7 @@ export const AxisHeightBand = () => {
     yTimeUnit,
     yScale,
     fontSize,
+    formatYAxisTick,
   ]);
 
   return (

--- a/app/charts/shared/axis-width-band.tsx
+++ b/app/charts/shared/axis-width-band.tsx
@@ -27,12 +27,12 @@ export const AxisWidthBand = () => {
     bounds: { chartHeight, chartWidth, margins },
     xAxisLabel,
     bottomAxisLabelSize,
+    formatXAxisTick,
   } = useChartState() as
     | ColumnsState
     | StackedColumnsState
     | GroupedColumnsState
     | ComboLineColumnState;
-  const { bypassXAxisTickFormat } = useChartState() as ComboLineColumnState;
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
   const xAxisTitleOffset = useXAxisTitleOffset(xScale, getXLabel, xTimeUnit);
@@ -54,15 +54,8 @@ export const AxisWidthBand = () => {
       const axis = axisBottom(xScale)
         .tickSizeOuter(0)
         .tickSizeInner(hasNegativeValues ? -chartHeight : 6)
-        .tickPadding(rotation ? -10 : 0);
-
-      if (!bypassXAxisTickFormat) {
-        if (xTimeUnit) {
-          axis.tickFormat((d) => formatXDate(d));
-        } else {
-          axis.tickFormat((d) => getXLabel(d));
-        }
-      }
+        .tickPadding(rotation ? -10 : 0)
+        .tickFormat(formatXAxisTick ?? ((tick) => tick));
 
       const g = renderContainer(ref.current, {
         id: "axis-width-band",
@@ -111,7 +104,7 @@ export const AxisWidthBand = () => {
     xTimeUnit,
     yScale,
     formatXDate,
-    bypassXAxisTickFormat,
+    formatXAxisTick,
   ]);
 
   return (

--- a/app/charts/shared/chart-state.ts
+++ b/app/charts/shared/chart-state.ts
@@ -170,6 +170,7 @@ export type BandYVariables = {
   getYAbbreviationOrLabel: (d: Observation) => string;
   yTimeUnit: TimeUnit | undefined;
   getYAsDate: TemporalValueGetter;
+  formatYDate: (d: Date | string) => string;
 };
 
 export const useBandYVariables = (
@@ -191,6 +192,21 @@ export const useBandYVariables = (
     isTemporalDimension(yDimension) || isTemporalEntityDimension(yDimension)
       ? yDimension.timeUnit
       : undefined;
+  const timeFormatUnit = useTimeFormatUnit();
+  const formatYDate = useCallback(
+    (d: Date | string) => {
+      if (yTimeUnit) {
+        return timeFormatUnit(d, yTimeUnit);
+      }
+
+      if (typeof d === "string") {
+        return d;
+      }
+
+      return d.toISOString();
+    },
+    [timeFormatUnit, yTimeUnit]
+  );
 
   const {
     getAbbreviationOrLabelByValue: getYAbbreviationOrLabel,
@@ -218,6 +234,7 @@ export const useBandYVariables = (
     getYAsDate: isTemporalEntityDimension(yDimension)
       ? getYTemporalEntity
       : getYAsDate,
+    formatYDate,
   };
 };
 

--- a/app/rdf/query-search.ts
+++ b/app/rdf/query-search.ts
@@ -56,10 +56,52 @@ export const mergeSearchCubes = (
   a: SearchCube | undefined,
   b: SearchCube
 ): SearchCube => {
+  const deduplicateDimensions = (dimensions: SearchCube["dimensions"] = []) => {
+    const seen = new Set<string>();
+
+    return dimensions.filter((d) => {
+      if (seen.has(d.id)) {
+        return false;
+      }
+
+      seen.add(d.id);
+
+      return true;
+    });
+  };
+
+  const deduplicateTermsets = (termsets: { iri: string; label: string }[]) => {
+    const seen = new Set<string>();
+
+    return termsets.filter((termset) => {
+      if (seen.has(termset.iri)) {
+        return false;
+      }
+
+      seen.add(termset.iri);
+
+      return true;
+    });
+  };
+
+  const mergedDimensions = deduplicateDimensions([
+    ...(a?.dimensions ?? []),
+    ...(b.dimensions ?? []),
+  ]).map((d) => ({
+    ...d,
+    termsets: deduplicateTermsets(d.termsets),
+  }));
+
+  const mergedTermsets = deduplicateTermsets([
+    ...(a?.termsets ?? []),
+    ...(b.termsets ?? []),
+  ]);
+
   return {
     ...a,
     ...b,
-    dimensions: [...(a?.dimensions ?? []), ...(b.dimensions ?? [])],
+    dimensions: mergedDimensions,
+    termsets: mergedTermsets,
   };
 };
 

--- a/app/rdf/query-search.ts
+++ b/app/rdf/query-search.ts
@@ -1,5 +1,6 @@
 import { descending } from "d3-array";
 import groupBy from "lodash/groupBy";
+import uniqBy from "lodash/uniqBy";
 import ParsingClient from "sparql-http-client/ParsingClient";
 
 import { SearchCube } from "@/domain/data";
@@ -56,46 +57,18 @@ export const mergeSearchCubes = (
   a: SearchCube | undefined,
   b: SearchCube
 ): SearchCube => {
-  const deduplicateDimensions = (dimensions: SearchCube["dimensions"] = []) => {
-    const seen = new Set<string>();
-
-    return dimensions.filter((d) => {
-      if (seen.has(d.id)) {
-        return false;
-      }
-
-      seen.add(d.id);
-
-      return true;
-    });
-  };
-
-  const deduplicateTermsets = (termsets: { iri: string; label: string }[]) => {
-    const seen = new Set<string>();
-
-    return termsets.filter((termset) => {
-      if (seen.has(termset.iri)) {
-        return false;
-      }
-
-      seen.add(termset.iri);
-
-      return true;
-    });
-  };
-
-  const mergedDimensions = deduplicateDimensions([
-    ...(a?.dimensions ?? []),
-    ...(b.dimensions ?? []),
-  ]).map((d) => ({
+  const mergedDimensions = uniqBy(
+    [...(a?.dimensions ?? []), ...(b.dimensions ?? [])],
+    "id"
+  ).map((d) => ({
     ...d,
-    termsets: deduplicateTermsets(d.termsets),
+    termsets: uniqBy(d.termsets, "iri"),
   }));
 
-  const mergedTermsets = deduplicateTermsets([
-    ...(a?.termsets ?? []),
-    ...(b.termsets ?? []),
-  ]);
+  const mergedTermsets = uniqBy(
+    [...(a?.termsets ?? []), ...(b.termsets ?? [])],
+    "iri"
+  );
 
   return {
     ...a,


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Fixes #2304
Fixes #2313

<!--- Describe the changes -->

This PR fixes:
- an issue with NaN values in X axis and tooltip title for temporal entity dimensions,
- an issue with duplicated termset tags when search for cubes to merge.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-blw-cubes-issues-ixt1.vercel.app/browse?dataset=https%3A%2F%2Fagriculture.ld.admin.ch%2Ffoag%2Fcube%2FOilseeds%2FProduction_Quantity_Year&dataSource=Int).
2. ✅ See that X axis tick labels and tooltip title are formatted correctly (no NaNs).
3. ✅ Switch to a bar chart and see that it looks ok too.
4. Click on Hinzufügen.
5. Search for `Marktzahlen Ölsaaten - Jährliche Konsumentenpreise`.
6. ✅ See that the tags are not duplicated.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
