### PR TITLE
feat: Reverse custom layers order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Features
+  - Reversed the order of custom layers in the custom layers selector, so that
+    the topmost layer is displayed first
 
 # 5.7.7 - 2025-05-13
 

--- a/app/configurator/components/custom-layers-selector.tsx
+++ b/app/configurator/components/custom-layers-selector.tsx
@@ -99,8 +99,8 @@ export const CustomLayersSelector = () => {
     dispatch({
       type: "CUSTOM_LAYER_SWAP",
       value: {
-        oldIndex,
-        newIndex,
+        oldIndex: configLayers.length - 1 - oldIndex,
+        newIndex: configLayers.length - 1 - newIndex,
       },
     });
   });
@@ -223,7 +223,7 @@ export const CustomLayersSelector = () => {
             <Droppable droppableId="layers">
               {(provided) => (
                 <div {...provided.droppableProps} ref={provided.innerRef}>
-                  {configLayers.map((configLayer, i) => {
+                  {[...configLayers].reverse().map((configLayer, i) => {
                     return (
                       <DraggableLayer
                         key={`${configLayer.type}-${configLayer.id}`}

--- a/app/configurator/components/custom-layers-selector.tsx
+++ b/app/configurator/components/custom-layers-selector.tsx
@@ -241,12 +241,12 @@ export const CustomLayersSelector = () => {
         ) : null}
 
         {layersStatus === "fetching" ? (
-          <Box sx={{ width: "100%" }}>
+          <div style={{ width: "100%" }}>
             <ControlSectionSkeleton />
-          </Box>
+          </div>
         ) : null}
 
-        <Box>
+        <div>
           <Button
             variant="contained"
             color="cobalt"
@@ -254,7 +254,7 @@ export const CustomLayersSelector = () => {
           >
             Add layer
           </Button>
-        </Box>
+        </div>
       </ControlSectionContent>
     </ControlSection>
   );


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2298

<!--- Describe the changes -->

This PR reverses the order of displaying the custom layers in the UI, so that the topmost layer is the topmost layer on the map.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-feat-layers-order-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10&dataSource=Prod).
2. Switch to a map chart.
3. Add a few custom layers.
4. ✅ See that new layers are added on top of the list.
5. ✅ See that the topmost layer in the list is also the topmost layer on the map.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
