### PR TITLE
fix: Locale switcher text color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Fixes
+  - Text of locale switcher select options is now visible on Windows machines
 
 # 5.8.0 - 2025-05-20
 

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -81,7 +81,9 @@ export const Header = ({
             }}
           >
             {localeConfig.locales.map((locale) => (
-              <option key={locale} value={locale}>
+              // Color override is needed to make sure the text is visible on
+              // Windows machines.
+              <option key={locale} value={locale} style={{ color: "initial" }}>
                 {locale.toUpperCase()}
               </option>
             ))}


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2310

<!--- Describe the changes -->

This PR makes sure the text color is correctly displayed on Windows machines.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-invisible-windows-locale-c798a2-ixt1.vercel.app/en) on a Windows machine and use e.g. Edge browser.
2. ✅ Open the locale switcher menu and see that the text is visible.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
