### PR TITLE
feat: Improve chart preview table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ You can also check the
 
 - Fixes
   - Text of locale switcher select options is now visible on Windows machines
+- Styles
+  - Header of data preview table is now sticky
+  - Data preview table should now be aligned with the design
 
 # 5.8.0 - 2025-05-20
 

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -37,7 +37,7 @@ import {
 } from "@/components/chart-shared";
 import {
   ChartTablePreviewProvider,
-  TablePreviewWrapper,
+  ChartTablePreviewWrapper,
   useChartTablePreview,
 } from "@/components/chart-table-preview";
 import { ChartWithFilters } from "@/components/chart-with-filters";
@@ -589,7 +589,7 @@ const ChartPreviewInner = ({
                     top: HEADER_HEIGHT_CSS_VAR,
                   }}
                 />
-                <TablePreviewWrapper>
+                <ChartTablePreviewWrapper>
                   {isTable ? (
                     <ChartDataTablePreview
                       dataSource={dataSource}
@@ -605,7 +605,7 @@ const ChartPreviewInner = ({
                       dashboardFilters={state.dashboardFilters}
                     />
                   )}
-                </TablePreviewWrapper>
+                </ChartTablePreviewWrapper>
                 <ChartFootnotes
                   dataSource={dataSource}
                   chartConfig={chartConfig}

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -21,7 +21,7 @@ import {
 } from "@/components/chart-shared";
 import {
   ChartTablePreviewProvider,
-  TablePreviewWrapper,
+  ChartTablePreviewWrapper,
   useChartTablePreview,
 } from "@/components/chart-table-preview";
 import { ChartWithFilters } from "@/components/chart-with-filters";
@@ -466,7 +466,7 @@ const ChartPublishedInnerImpl = ({
                     }
               }
             />
-            <TablePreviewWrapper>
+            <ChartTablePreviewWrapper>
               {isTable ? (
                 <ChartDataTablePreview
                   dataSource={dataSource}
@@ -483,7 +483,7 @@ const ChartPublishedInnerImpl = ({
                   embedParams={embedParams}
                 />
               )}
-            </TablePreviewWrapper>
+            </ChartTablePreviewWrapper>
             <ChartFootnotes
               configKey={configKey}
               dataSource={dataSource}

--- a/app/components/chart-table-preview.tsx
+++ b/app/components/chart-table-preview.tsx
@@ -1,3 +1,4 @@
+import { Box } from "@mui/material";
 import {
   createContext,
   Dispatch,
@@ -106,17 +107,18 @@ export const ChartTablePreviewWrapper = ({
   const { containerRef, containerHeight } = useChartTablePreview();
 
   return (
-    <div
+    <Box
       ref={containerRef}
       className={TABLE_PREVIEW_WRAPPER_CLASS_NAME}
-      style={{
+      sx={{
         minWidth: 0,
         height: containerHeight,
-        marginTop: 16,
+        marginTop: 4,
+        marginBottom: 2,
         flexGrow: 1,
       }}
     >
       {children}
-    </div>
+    </Box>
   );
 };

--- a/app/components/chart-table-preview.tsx
+++ b/app/components/chart-table-preview.tsx
@@ -98,7 +98,11 @@ export const ChartTablePreviewProvider = ({
 
 export const TABLE_PREVIEW_WRAPPER_CLASS_NAME = "table-preview-wrapper";
 
-export const TablePreviewWrapper = ({ children }: { children: ReactNode }) => {
+export const ChartTablePreviewWrapper = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
   const { containerRef, containerHeight } = useChartTablePreview();
 
   return (

--- a/app/themes/components.tsx
+++ b/app/themes/components.tsx
@@ -726,6 +726,11 @@ export const components: Components = {
       },
     },
   },
+  MuiTable: {
+    defaultProps: {
+      stickyHeader: true,
+    },
+  },
   MuiTableCell: {
     styleOverrides: {
       // @ts-ignore

--- a/app/themes/components.tsx
+++ b/app/themes/components.tsx
@@ -730,12 +730,25 @@ export const components: Components = {
     defaultProps: {
       stickyHeader: true,
     },
+    styleOverrides: {
+      root: {
+        borderLeft: `1px solid ${palette.monochrome[300]}`,
+        borderRight: `1px solid ${palette.monochrome[300]}`,
+      },
+      stickyHeader: {
+        "& .MuiTableHead-root": {
+          borderTop: `1px solid ${palette.monochrome[300]}`,
+          borderBottom: `1px solid ${palette.monochrome[300]}`,
+        },
+      },
+    },
   },
   MuiTableCell: {
     styleOverrides: {
       // @ts-ignore
       root: {
         padding: "16px 24px",
+        borderBottom: `1px solid ${palette.monochrome[300]}`,
         color: palette.monochrome[600],
         whiteSpace: "nowrap",
         maxWidth: "unset !important",
@@ -746,18 +759,11 @@ export const components: Components = {
   MuiTableHead: {
     styleOverrides: {
       root: {
-        display: "contents",
-
         "& .MuiTableCell-root": {
+          borderTop: `1px solid ${palette.monochrome[300]}`,
+          borderBottom: `1px solid ${palette.monochrome[300]}`,
           backgroundColor: palette.cobalt[50],
         },
-      },
-    },
-  },
-  MuiTableRow: {
-    styleOverrides: {
-      root: {
-        border: `1px solid ${palette.monochrome[300]}`,
       },
     },
   },


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2321

<!--- Describe the changes -->

This PR improves the data preview table by:
- making the header sticky, as was the case before,
- using correct border styles,
- adding a bit of margin between the table and footnotes.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-feat-improve-chart-table-preview-ixt1.vercel.app/en).
2. Scroll down, to the **Distribution of expenses and income by office** chart.
3. Open `Table view`.
4. ✅ Scroll the table and see that the header is sticky, the border colors are more prominent and include the last row's border, and there's a bit more gap between the table and the footnotes.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
