### PR TITLE
fix: Total value labels and error whiskers overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ You can also check the
 
 - Fixes
   - Text of locale switcher select options is now visible on Windows machines
+  - Total value labels do not overlap with error bars anymore
 - Styles
   - Header of data preview table is now sticky
   - Data preview table should now be aligned with the design

--- a/app/charts/bar/bars-state.tsx
+++ b/app/charts/bar/bars-state.tsx
@@ -267,13 +267,14 @@ const useBarsState = (
     left,
   };
 
-  const barCount = yScale.domain().length;
   const { offset: xValueLabelsOffset, ...showValuesVariables } =
     useShowBandValueLabelsVariables(x, {
       chartData,
       dimensions,
       measures,
       getValue: getX,
+      getErrorRange: getXErrorRange,
+      scale: xScale,
     });
 
   const chartWidth = getChartWidth({ width, left, right });
@@ -281,6 +282,7 @@ const useBarsState = (
   const { chartHeight } = bounds;
 
   // Here we adjust the height to make sure the bars have a minimum height and are legible
+  const barCount = yScale.domain().length;
   const adjustedChartHeight =
     barCount * MIN_BAR_HEIGHT > chartHeight
       ? barCount * MIN_BAR_HEIGHT

--- a/app/charts/bar/show-values-utils.ts
+++ b/app/charts/bar/show-values-utils.ts
@@ -17,6 +17,7 @@ export const useBarValueLabelsData = () => {
     yScale,
     getY,
     valueLabelFormatter,
+    getValueOffset,
   } = useChartState() as BarsState;
   const bandwidth = yScale.bandwidth();
   const valueLabelsData: RenderTotalValueLabelDatum[] = useMemo(() => {
@@ -35,10 +36,11 @@ export const useBarValueLabelsData = () => {
         const value = valueRaw === null || isNaN(valueRaw) ? 0 : valueRaw;
         const xScaled = xScale(Math.max(value, 0));
         const yRender = yScale(getY(d)) as number;
+        const valueOffset = getValueOffset(d);
 
         return {
           key,
-          x: xScaled,
+          x: xScaled + valueOffset,
           y: yRender + bandwidth / 2,
           valueLabel: valueLabelFormatter(value),
         };
@@ -57,6 +59,7 @@ export const useBarValueLabelsData = () => {
     getY,
     bandwidth,
     valueLabelFormatter,
+    getValueOffset,
   ]);
 
   return valueLabelsData;

--- a/app/charts/column/columns-state.tsx
+++ b/app/charts/column/columns-state.tsx
@@ -278,6 +278,8 @@ const useColumnsState = (
       dimensions,
       measures,
       getValue: getY,
+      getErrorRange: getYErrorRange,
+      scale: yScale,
       bandwidth: xScale.bandwidth(),
     });
   const margins = {

--- a/app/charts/column/show-values-utils.ts
+++ b/app/charts/column/show-values-utils.ts
@@ -9,6 +9,7 @@ export const useColumnValueLabelsData = () => {
   const {
     bounds: { width, height },
     showValues,
+    getValueOffset,
     renderEveryNthValue,
     chartData,
     getRenderingKey,
@@ -35,11 +36,12 @@ export const useColumnValueLabelsData = () => {
         const xScaled = xScale(getX(d)) as number;
         const value = valueRaw === null || isNaN(valueRaw) ? 0 : valueRaw;
         const yRender = yScale(Math.max(value, 0));
+        const valueOffset = getValueOffset(d);
 
         return {
           key,
           x: xScaled + bandwidth / 2,
-          y: yRender,
+          y: yRender + valueOffset,
           valueLabel: valueLabelFormatter(value),
         };
       })
@@ -57,6 +59,7 @@ export const useColumnValueLabelsData = () => {
     yScale,
     bandwidth,
     valueLabelFormatter,
+    getValueOffset,
   ]);
 
   return valueLabelsData;

--- a/app/charts/shared/show-values-utils.ts
+++ b/app/charts/shared/show-values-utils.ts
@@ -1,9 +1,12 @@
+import { ScaleLinear } from "d3-scale";
 import { useCallback, useMemo } from "react";
 
 import { AreasState } from "@/charts/area/areas-state";
 import { LinesState } from "@/charts/line/lines-state";
 import {
   NumericalValueGetter,
+  NumericalXErrorVariables,
+  NumericalYErrorVariables,
   useChartState,
 } from "@/charts/shared/chart-state";
 import { RenderTotalValueLabelDatum } from "@/charts/shared/render-value-labels";
@@ -22,6 +25,7 @@ import { getTextWidth } from "@/utils/get-text-width";
 
 export type ShowBandValueLabelsVariables = {
   offset: number;
+  getValueOffset: (observation: Observation) => number;
   showValues: boolean;
   rotateValues: boolean;
   renderEveryNthValue: number;
@@ -35,12 +39,18 @@ export const useShowBandValueLabelsVariables = (
     dimensions,
     measures,
     getValue,
+    getErrorRange,
+    scale,
     bandwidth,
   }: {
     chartData: Observation[];
     dimensions: Dimension[];
     measures: Measure[];
     getValue: NumericalValueGetter;
+    getErrorRange?:
+      | NumericalXErrorVariables["getXErrorRange"]
+      | NumericalYErrorVariables["getYErrorRange"];
+    scale: ScaleLinear<number, number>;
     bandwidth?: number;
   }
 ): ShowBandValueLabelsVariables => {
@@ -54,6 +64,7 @@ export const useShowBandValueLabelsVariables = (
   }
 
   const disableRotation = !bandwidth;
+  const horizontal = disableRotation;
   const { labelFontSize: fontSize } = useChartTheme();
   const renderEveryNthValue =
     disableRotation || bandwidth > fontSize
@@ -66,6 +77,30 @@ export const useShowBandValueLabelsVariables = (
     measures,
   });
 
+  const getValueOffset: ShowBandValueLabelsVariables["getValueOffset"] =
+    useCallback(
+      (observation: Observation) => {
+        const value = getValue(observation);
+
+        if (value === null) {
+          return 0;
+        }
+
+        const errorEnd = getErrorRange?.(observation)[1];
+
+        if (errorEnd === undefined) {
+          return 0;
+        }
+
+        if (horizontal) {
+          return scale(errorEnd - value);
+        }
+
+        return scale(errorEnd) - scale(value);
+      },
+      [getValue, getErrorRange, horizontal, scale]
+    );
+
   const { offset, rotateValues } = useMemo(() => {
     let offset = 0;
     let rotateValues = false;
@@ -74,7 +109,8 @@ export const useShowBandValueLabelsVariables = (
       let maxWidth = 0;
 
       chartData.forEach((d) => {
-        const formattedValue = valueLabelFormatter(getValue(d));
+        const value = getValue(d);
+        const formattedValue = valueLabelFormatter(value);
         const width = getTextWidth(formattedValue, { fontSize });
 
         if (!disableRotation && width - 2 > bandwidth) {
@@ -101,14 +137,15 @@ export const useShowBandValueLabelsVariables = (
     showValues,
     chartData,
     disableRotation,
-    valueLabelFormatter,
     getValue,
+    valueLabelFormatter,
     fontSize,
     bandwidth,
   ]);
 
   return {
     offset,
+    getValueOffset,
     showValues,
     rotateValues,
     renderEveryNthValue,


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2328

<!--- Describe the changes -->

This PR makes sure there are no overlaps when total value labels and error whiskers are enabled at the same time.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-show-all-values-error-wh-c2b469-ixt1.vercel.app/en/create/new?cube=https://environment.ld.admin.ch/foen/nfi/nfi_T-changes/cube/2024-1&dataSource=Prod).
2. Open Vertical Axis field.
3. Enable `Always show total values` option.
4. ✅ See that the value labels do not overlap with the error whiskers.
5. ✅ Switch to a bar chart and see that the overlap is also not here.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
