### PR TITLE
fix: Do not display range limits + fix fetching of related limit values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ You can also check the
 - Fixes
   - Text of locale switcher select options is now visible on Windows machines
   - Total value labels do not overlap with error bars anymore
+  - Fixed the issue of "tandem toggle" of some limits
 - Styles
   - Header of data preview table is now sticky
   - Data preview table should now be aligned with the design

--- a/app/rdf/limits.ts
+++ b/app/rdf/limits.ts
@@ -123,7 +123,7 @@ export const getDimensionLimits = async (
         ${buildLocalizedSubQuery("value", "schema:name", "label", {
           locale,
         })}
-        ?value schema:position ?position .
+        OPTIONAL { ?value schema:position ?position . }
     }`;
 
     const allRelated = (

--- a/app/rdf/limits.ts
+++ b/app/rdf/limits.ts
@@ -54,6 +54,7 @@ export const getDimensionLimits = async (
 
           return {
             ctx,
+            dimensionIri,
             dimensionId: stringifyComponentId({
               unversionedCubeIri,
               unversionedComponentIri: dimensionIri,
@@ -115,10 +116,10 @@ export const getDimensionLimits = async (
   if (baseRelated.length > 0) {
     const allRelatedQuery = `PREFIX schema: <http://schema.org/>
 
-    SELECT ?index ?dimensionId ?value ?label ?position WHERE {
-      VALUES (?index ?dimensionId ?value) { ${baseLimits
+    SELECT ?index ?dimensionIri ?value ?label ?position WHERE {
+      VALUES (?index ?dimensionIri ?value) { ${baseLimits
         .flatMap((l) => l.related.map((r) => ({ ...r, index: l.index })))
-        .map((r) => `(${r.index} <${r.dimensionId}> <${r.value}>)`)
+        .map((r) => `(${r.index} <${r.dimensionIri}> <${r.value}>)`)
         .join(" ")} }
         ${buildLocalizedSubQuery("value", "schema:name", "label", {
           locale,
@@ -132,14 +133,17 @@ export const getDimensionLimits = async (
       })
     ).map((d) => {
       const index = +d.index.value;
-      const dimensionId = d.dimensionId.value;
+      const dimensionIri = d.dimensionIri.value;
       const value = d.value.value;
       const label = d.label.value;
-      const position = d.position.value;
+      const position = d.position?.value;
 
       return {
         index,
-        dimensionId,
+        dimensionId: stringifyComponentId({
+          unversionedCubeIri,
+          unversionedComponentIri: dimensionIri,
+        }),
         value,
         label,
         position,


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2332
Closes #2333

<!--- Describe the changes -->

This PR:
- makes sure we do not display not supposed range limits in the UI, preventing some bugs that come out of this,
- fixes fetching of related limit values (position can be undefined, use dimension iri, not id) to prevent "tandem toggle" issue.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-do-not-display-not-suppo-4da0b7-ixt1.vercel.app/en/create/new?cube=https://environment.ld.admin.ch/foen/test_target/cube/target_soil/1&dataSource=Int).
2. Open `Vertical Axis` field.
3. ✅ See that only limit for current filter (`Cadmium`) is displayed.
4. Change the filter to `Copper`.
5. ✅ Go back to the `Vertical Axis` field and see that only the limit for `Cooper` is displayed.
6. Go to [this link](https://visualization-tool-git-fix-do-not-display-not-suppo-4da0b7-ixt1.vercel.app/en/create/new?cube=https://environment.ld.admin.ch/foen/test_target/cube/target_future_ghg/1&dataSource=Int).
7. Open `Vertical Axis` field.
8. ✅ See that the range limit (2021-2030) is not displayed in the UI, as we do not support this limit type yet.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
