### PR TITLE
feat: Add axis title to pie charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ You can also check the
 
 # Unreleased
 
-- Documentation
-  - Aligned and updated for new Parametrized URLs functionality
+- Features
+  - Pie charts now display the "Y" axis title
 - Fixes
   - Text of locale switcher select options is now visible on Windows machines
   - Total value labels do not overlap with error bars anymore
@@ -21,6 +21,8 @@ You can also check the
   - Data preview table should now be aligned with the design
 - Maintenance
   - Split the chart options selector into multiple files
+- Documentation
+  - Aligned and updated for new Parametrized URLs functionality
 
 # 5.8.0 - 2025-05-20
 

--- a/app/charts/pie/chart-pie.tsx
+++ b/app/charts/pie/chart-pie.tsx
@@ -3,6 +3,7 @@ import { memo } from "react";
 import { ChartDataWrapper } from "@/charts/chart-data-wrapper";
 import { Pie } from "@/charts/pie/pie";
 import { PieChart } from "@/charts/pie/pie-state";
+import { AxisHeightTitle } from "@/charts/shared/axis-height-title";
 import {
   ChartContainer,
   ChartControlsContainer,
@@ -37,6 +38,7 @@ const ChartPie = memo((props: ChartProps<PieConfig>) => {
     <PieChart {...props}>
       <ChartContainer>
         <ChartSvg>
+          <AxisHeightTitle />
           <Pie />
         </ChartSvg>
         <Tooltip type="single" />

--- a/app/charts/pie/pie-state.tsx
+++ b/app/charts/pie/pie-state.tsx
@@ -49,6 +49,7 @@ export type PieState = CommonChartState &
     getColorLabel: (segment: string) => string;
     getAnnotationInfo: (d: PieArcDatum<Observation>) => TooltipInfo;
     leftAxisLabelSize: AxisLabelSizeVariables;
+    leftAxisLabelOffsetTop: number;
   };
 
 const usePieState = (
@@ -272,6 +273,7 @@ const usePieState = (
     getColorLabel: getSegmentLabel,
     getAnnotationInfo,
     leftAxisLabelSize,
+    leftAxisLabelOffsetTop: 0,
     ...showValuesVariables,
     ...variables,
   };

--- a/app/charts/shared/axis-height-linear.tsx
+++ b/app/charts/shared/axis-height-linear.tsx
@@ -9,6 +9,7 @@ import type { ColumnsState } from "@/charts/column/columns-state";
 import { ComboLineSingleState } from "@/charts/combo/combo-line-single-state";
 import type { LinesState } from "@/charts/line/lines-state";
 import type { ScatterplotState } from "@/charts/scatterplot/scatterplot-state";
+import { AxisHeightTitle } from "@/charts/shared/axis-height-title";
 import { useChartState } from "@/charts/shared/chart-state";
 import {
   maybeTransition,
@@ -16,31 +17,25 @@ import {
 } from "@/charts/shared/rendering-utils";
 import { getTickNumber } from "@/charts/shared/ticks";
 import { useChartTheme } from "@/charts/shared/use-chart-theme";
-import { OpenMetadataPanelWrapper } from "@/components/metadata-panel";
 import { useFormatNumber } from "@/formatters";
 import { useChartInteractiveFilters } from "@/stores/interactive-filters";
 import { useTransitionStore } from "@/stores/transition";
 
+export type AxisHeightLinearChartState =
+  | AreasState
+  | ColumnsState
+  | GroupedColumnsState
+  | StackedColumnsState
+  | LinesState
+  | ScatterplotState
+  | ComboLineSingleState;
+
 export const TICK_PADDING = 6;
 
 export const AxisHeightLinear = () => {
-  const { gridColor, labelColor, axisLabelFontSize } = useChartTheme();
+  const { gridColor, labelColor } = useChartTheme();
   const [ref, setRef] = useState<SVGGElement | null>(null);
-  const {
-    yScale,
-    bounds,
-    yAxisLabel,
-    leftAxisLabelSize,
-    leftAxisLabelOffsetTop,
-    ...rest
-  } = useChartState() as
-    | AreasState
-    | ColumnsState
-    | GroupedColumnsState
-    | StackedColumnsState
-    | LinesState
-    | ScatterplotState
-    | ComboLineSingleState;
+  const { yScale, bounds } = useChartState() as AxisHeightLinearChartState;
 
   useRenderAxisHeightLinear(ref, {
     id: "axis-height-linear",
@@ -55,27 +50,7 @@ export const AxisHeightLinear = () => {
 
   return (
     <>
-      {rest.chartType === "comboLineSingle" ? (
-        <text
-          y={axisLabelFontSize}
-          style={{ fontSize: axisLabelFontSize, fill: "black" }}
-        >
-          {yAxisLabel}
-        </text>
-      ) : (
-        <foreignObject
-          y={leftAxisLabelOffsetTop}
-          width={leftAxisLabelSize.width}
-          height={leftAxisLabelSize.height}
-          style={{ display: "flex" }}
-        >
-          <OpenMetadataPanelWrapper component={rest.yMeasure}>
-            <span style={{ fontSize: axisLabelFontSize, lineHeight: 1.5 }}>
-              {yAxisLabel}
-            </span>
-          </OpenMetadataPanelWrapper>
-        </foreignObject>
-      )}
+      <AxisHeightTitle />
       <g ref={(newRef) => setRef(newRef)} />
     </>
   );

--- a/app/charts/shared/axis-height-title.tsx
+++ b/app/charts/shared/axis-height-title.tsx
@@ -1,0 +1,41 @@
+import { AxisHeightLinearChartState } from "@/charts/shared/axis-height-linear";
+import { useChartState } from "@/charts/shared/chart-state";
+import { useChartTheme } from "@/charts/shared/use-chart-theme";
+import { OpenMetadataPanelWrapper } from "@/components/metadata-panel";
+
+export const AxisHeightTitle = () => {
+  const { axisLabelFontSize } = useChartTheme();
+  const { chartType, yAxisLabel, leftAxisLabelSize, leftAxisLabelOffsetTop } =
+    useChartState() as AxisHeightLinearChartState;
+  // Axis title can also be used in combo line single charts.
+  const { yMeasure } = useChartState() as Exclude<
+    AxisHeightLinearChartState,
+    { chartType: "comboLineSingle" }
+  >;
+
+  return (
+    <>
+      {chartType === "comboLineSingle" ? (
+        <text
+          y={axisLabelFontSize}
+          style={{ fontSize: axisLabelFontSize, fill: "black" }}
+        >
+          {yAxisLabel}
+        </text>
+      ) : (
+        <foreignObject
+          y={leftAxisLabelOffsetTop}
+          width={leftAxisLabelSize.width}
+          height={leftAxisLabelSize.height}
+          style={{ display: "flex" }}
+        >
+          <OpenMetadataPanelWrapper component={yMeasure}>
+            <span style={{ fontSize: axisLabelFontSize, lineHeight: 1.5 }}>
+              {yAxisLabel}
+            </span>
+          </OpenMetadataPanelWrapper>
+        </foreignObject>
+      )}
+    </>
+  );
+};

--- a/app/charts/shared/axis-height-title.tsx
+++ b/app/charts/shared/axis-height-title.tsx
@@ -1,15 +1,19 @@
+import { PieState } from "@/charts/pie/pie-state";
 import { AxisHeightLinearChartState } from "@/charts/shared/axis-height-linear";
 import { useChartState } from "@/charts/shared/chart-state";
 import { useChartTheme } from "@/charts/shared/use-chart-theme";
 import { OpenMetadataPanelWrapper } from "@/components/metadata-panel";
 
+// Axis title can be used in both "linear" and pie charts.
+type AxisHeightTitleChartState = AxisHeightLinearChartState | PieState;
+
 export const AxisHeightTitle = () => {
   const { axisLabelFontSize } = useChartTheme();
   const { chartType, yAxisLabel, leftAxisLabelSize, leftAxisLabelOffsetTop } =
-    useChartState() as AxisHeightLinearChartState;
+    useChartState() as AxisHeightTitleChartState;
   // Axis title can also be used in combo line single charts.
   const { yMeasure } = useChartState() as Exclude<
-    AxisHeightLinearChartState,
+    AxisHeightTitleChartState,
     { chartType: "comboLineSingle" }
   >;
 


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2223

<!--- Describe the changes -->

This PR adds "Y" axis title to pie charts.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-feat-add-axis-title-to-pie-charts-ixt1.vercel.app/en/v/8kQrrwRMsl-u?dataSource=Prod).
2. ✅ See that the pie chart has an "Y" axis title.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
