### PR TITLE
feat: Support limits with Literal related values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ You can also check the
   - Added support for time range limits
   - Symbol limits are now supported in bar charts
   - Pie charts now display the "Y" axis title
+  - Application now supports limits based on Literal related values
 - Fixes
   - Text of locale switcher select options is now visible on Windows machines
   - Total value labels do not overlap with error bars anymore


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2337

<!--- Describe the changes -->

This PR makes sure we can display limits with `Literal` related values (regular dates).

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-feat-support-literal-related-f348d6-ixt1.vercel.app/en/v/6byHMR3sTBFl?dataSource=Int).
2. ✅ See that the limits are displayed (temporal entity based related limit values).
3. Go to [this link](https://visualization-tool-git-feat-support-literal-related-f348d6-ixt1.vercel.app/en/v/eu-rXJBdhixR?dataSource=Int).
4. ✅ See that the limits are displayed (non temporal entity based related limit values).

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
