### PR TITLE
feat: Improve DebugPanel & flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ You can also check the
   - Data preview table should now be aligned with the design
 - Maintenance
   - Split the chart options selector into multiple files
+  - Improved the CI / CD implementation by aligning the names better with the
+    design file
 - Documentation
   - Aligned and updated for new Parametrized URLs functionality
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ You can also check the
   - Added support for time range limits
   - Symbol limits are now supported in bar charts
   - Pie charts now display the "Y" axis title
+  - Debug panel is not open by default on non-production environments
+  - All available flags are now displayed in the debug panel
+  - All deprecated flags are now removed from localStorage
+  - Improved the debug panel UI
 - Fixes
   - Text of locale switcher select options is now visible on Windows machines
   - Total value labels do not overlap with error bars anymore

--- a/app/browser/dataset-browse.tsx
+++ b/app/browser/dataset-browse.tsx
@@ -614,7 +614,7 @@ const NavSection = ({
         {topItems.length !== items.length ? (
           <Button
             variant="text"
-            color="blue"
+            color="primary"
             size="sm"
             onClick={isOpen ? close : open}
             endIcon={<Icon name={isOpen ? "arrowUp" : "arrowDown"} size={20} />}

--- a/app/browser/dataset-preview.tsx
+++ b/app/browser/dataset-preview.tsx
@@ -12,7 +12,7 @@ import { CubeDataTablePreview } from "@/browse/cube-data-table-preview";
 import { useFootnotesStyles } from "@/components/chart-footnotes";
 import { DataDownloadMenu } from "@/components/data-download";
 import Flex from "@/components/flex";
-import { HintRed, Loading, LoadingDataError } from "@/components/hint";
+import { HintError, Loading, LoadingDataError } from "@/components/hint";
 import { DataSource } from "@/config-types";
 import {
   DataCubeMetadataQuery,
@@ -116,13 +116,13 @@ export const DataSetPreview = ({
         {dataCubeMetadata.publicationStatus ===
           DataCubePublicationStatus.Draft && (
           <Box sx={{ mb: 4 }}>
-            <HintRed>
+            <HintError>
               <Trans id="dataset.publicationStatus.draft.warning">
                 Careful, this dataset is only a draft.
                 <br />
                 <strong>Don&apos;t use for reporting!</strong>
               </Trans>
-            </HintRed>
+            </HintError>
           </Box>
         )}
         <Flex

--- a/app/charts/map/wms-wmts-provider-info.tsx
+++ b/app/charts/map/wms-wmts-provider-info.tsx
@@ -86,7 +86,7 @@ const ProviderInfoAlert = ({ extraInfo }: { extraInfo: ProviderExtraInfo }) => {
 
   return (
     <Alert
-      severity="blue"
+      severity="info"
       className={classes.alert}
       elevation={0}
       sx={{

--- a/app/charts/map/wms-wmts-selector.tsx
+++ b/app/charts/map/wms-wmts-selector.tsx
@@ -27,7 +27,7 @@ import {
 } from "@/charts/map/wms-wmts-endpoint-utils";
 import ProviderAutocomplete from "@/charts/map/wms-wmts-providers-autocomplete";
 import { RemoteWMTSLayer } from "@/charts/map/wmts-utils";
-import { HintRed, Spinner } from "@/components/hint";
+import { HintError, Spinner } from "@/components/hint";
 import { Tree, useSelectTree } from "@/components/select-tree";
 import { Icon } from "@/icons";
 import SvgIcChevronRight from "@/icons/components/IcChevronRight";
@@ -375,7 +375,7 @@ const WMTSSelector = ({
       flexDirection="column"
       width="100%"
     >
-      {error ? <HintRed>{error.message}</HintRed> : null}
+      {error ? <HintError>{error.message}</HintError> : null}
       <ProviderAutocomplete
         value={provider}
         onChange={(newValue) => setProvider(newValue)}

--- a/app/charts/shared/chart-data-filters.tsx
+++ b/app/charts/shared/chart-data-filters.tsx
@@ -170,7 +170,7 @@ export const ChartDataFiltersToggle = ({
         {componentIds && componentIds.length > 0 && (
           <Button
             variant="text"
-            color="blue"
+            color="primary"
             size="sm"
             endIcon={
               <Icon

--- a/app/components/chart-preview.tsx
+++ b/app/components/chart-preview.tsx
@@ -47,7 +47,7 @@ import { DragHandle, useDragOverClasses } from "@/components/drag-handle";
 import Flex from "@/components/flex";
 import { Checkbox } from "@/components/form";
 import { HEADER_HEIGHT_CSS_VAR } from "@/components/header-constants";
-import { HintOrange } from "@/components/hint";
+import { HintWarning } from "@/components/hint";
 import {
   createMetadataPanelStore,
   MetadataPanelStoreContext,
@@ -570,13 +570,13 @@ const ChartPreviewInner = ({
                       d.publicationStatus === DataCubePublicationStatus.Draft
                   ) && (
                     <Box sx={{ mb: 4 }}>
-                      <HintOrange>
+                      <HintWarning>
                         <Trans id="dataset.publicationStatus.draft.warning">
                           Careful, this dataset is only a draft.
                           <br />
                           <strong>Don&apos;t use for reporting!</strong>
                         </Trans>
-                      </HintOrange>
+                      </HintWarning>
                     </Box>
                   )}
                 </Box>

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -28,7 +28,7 @@ import { ChartWithFilters } from "@/components/chart-with-filters";
 import { DashboardInteractiveFilters } from "@/components/dashboard-interactive-filters";
 import { EmbedQueryParams } from "@/components/embed-params";
 import Flex from "@/components/flex";
-import { HintBlue, HintOrange, HintRed } from "@/components/hint";
+import { HintInfo, HintWarning, HintError } from "@/components/hint";
 import {
   createMetadataPanelStore,
   MetadataPanelStoreContext,
@@ -376,43 +376,43 @@ const ChartPublishedInnerImpl = ({
             (d) => d.publicationStatus === DataCubePublicationStatus.Draft
           ) && (
             <Box sx={{ mb: 4 }}>
-              <HintRed>
+              <HintError>
                 <Trans id="dataset.publicationStatus.draft.warning">
                   Careful, this dataset is only a draft.
                   <br />
                   <strong>Don&apos;t use for reporting!</strong>
                 </Trans>
-              </HintRed>
+              </HintError>
             </Box>
           )}
           {metadata?.some((d) => d.expires) && (
             <Box sx={{ mb: 4 }}>
-              <HintRed>
+              <HintError>
                 <Trans id="dataset.publicationStatus.expires.warning">
                   Careful, the data for this chart has expired.
                   <br />
                   <strong>Don&apos;t use for reporting!</strong>
                 </Trans>
-              </HintRed>
+              </HintError>
             </Box>
           )}
           {!isTrustedDataSource && (
             <Box sx={{ mb: 4 }}>
-              <HintOrange>
+              <HintWarning>
                 <Trans id="data.source.notTrusted">
                   This chart is not using a trusted data source.
                 </Trans>
-              </HintOrange>
+              </HintWarning>
             </Box>
           )}
           {isUsingImputation(chartConfig) && (
             <Box sx={{ mb: 4 }}>
-              <HintBlue>
+              <HintInfo>
                 <Trans id="dataset.hasImputedValues">
                   Some data in this dataset is missing and has been interpolated
                   to fill the gaps.
                 </Trans>
-              </HintBlue>
+              </HintInfo>
             </Box>
           )}
         </div>

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -28,7 +28,7 @@ import { ChartWithFilters } from "@/components/chart-with-filters";
 import { DashboardInteractiveFilters } from "@/components/dashboard-interactive-filters";
 import { EmbedQueryParams } from "@/components/embed-params";
 import Flex from "@/components/flex";
-import { HintInfo, HintWarning, HintError } from "@/components/hint";
+import { HintError, HintInfo, HintWarning } from "@/components/hint";
 import {
   createMetadataPanelStore,
   MetadataPanelStoreContext,

--- a/app/components/chart-selection-tabs.tsx
+++ b/app/components/chart-selection-tabs.tsx
@@ -288,7 +288,7 @@ const TabsEditable = (props: TabsEditableProps) => {
               type="button"
               leadingIconName="trash"
               label={<Trans id="chart-controls.delete">Delete</Trans>}
-              color="red.main"
+              color="red"
               requireConfirmation
               confirmationTitle={t({
                 id: "chat-preview.delete.title",

--- a/app/components/chart-shared.tsx
+++ b/app/components/chart-shared.tsx
@@ -271,7 +271,7 @@ export const ChartMoreButton = ({
               <MenuActionItem
                 type="button"
                 as="menuitem"
-                color="red.main"
+                color="red"
                 requireConfirmation
                 confirmationTitle={t({
                   id: "chart-controls.delete.title",

--- a/app/components/dashboard-shared.tsx
+++ b/app/components/dashboard-shared.tsx
@@ -99,7 +99,7 @@ export const BlockMoreButton = ({ blockKey }: { blockKey: string }) => {
           <MenuActionItem
             type="button"
             as="menuitem"
-            color="red.main"
+            color="red"
             requireConfirmation
             confirmationTitle={t({
               id: "block-controls.delete.title",

--- a/app/components/data-download.tsx
+++ b/app/components/data-download.tsx
@@ -224,7 +224,7 @@ const DataDownloadInnerMenu = ({
     <>
       <Button
         variant="text"
-        color="blue"
+        color="primary"
         size="sm"
         startIcon={
           state.isDownloading ? (

--- a/app/components/debug-panel/DebugPanel.tsx
+++ b/app/components/debug-panel/DebugPanel.tsx
@@ -113,7 +113,7 @@ const DebugConfigurator = () => {
         <Stack key={cube.iri} spacing={2} sx={{ pl: 5, py: 3 }}>
           <Button
             component="a"
-            color="blue"
+            color="primary"
             variant="text"
             size="sm"
             href={`https://cube-viewer.zazuko.com/?endpointUrl=${encodeURIComponent(
@@ -129,7 +129,7 @@ const DebugConfigurator = () => {
           </Button>
           <Button
             component="a"
-            color="blue"
+            color="primary"
             variant="text"
             size="sm"
             href={`${sparqlEditorUrl}#query=${encodeURIComponent(

--- a/app/components/hint.tsx
+++ b/app/components/hint.tsx
@@ -186,7 +186,7 @@ export const LoadingOverlay = () => {
 
 export const NoDataHint = () => {
   return (
-    <HintBlue>
+    <HintInfo>
       <AlertTitle>
         <Trans id="hint.nodata.title">
           No data available for current filter selection
@@ -195,26 +195,26 @@ export const NoDataHint = () => {
       <Trans id="hint.nodata.message">
         Please try with another geographical dimension.
       </Trans>
-    </HintBlue>
+    </HintInfo>
   );
 };
 
 export const NoGeometriesHint = () => {
   return (
-    <HintBlue>
+    <HintInfo>
       <AlertTitle>
         <Trans id="hint.nogeometries.title">No geometries available</Trans>
       </AlertTitle>
       <Trans id="hint.nogeometries.message">
         Please try with another geographical dimension.
       </Trans>
-    </HintBlue>
+    </HintInfo>
   );
 };
 
 export const LoadingDataError = ({ message }: { message?: string }) => {
   return (
-    <HintRed>
+    <HintError>
       <AlertTitle>
         <Trans id="hint.dataloadingerror.title">Data loading error</Trans>
       </AlertTitle>
@@ -243,13 +243,13 @@ export const LoadingDataError = ({ message }: { message?: string }) => {
           {message}
         </pre>
       ) : null}
-    </HintRed>
+    </HintError>
   );
 };
 
 export const LoadingGeoDimensionsError = () => {
   return (
-    <HintRed>
+    <HintError>
       <AlertTitle>
         <Trans id="hint.coordinatesloadingerror.title">
           Coordinates loading error
@@ -259,13 +259,13 @@ export const LoadingGeoDimensionsError = () => {
         There was a problem with loading the coordinates from geographical
         dimensions.
       </Trans>
-    </HintRed>
+    </HintError>
   );
 };
 
 export const ChartUnexpectedError = ({ error }: { error?: Error }) => {
   return (
-    <HintRed>
+    <HintError>
       <AlertTitle>
         <Trans id="hint.chartunexpected.title">Unexpected error</Trans>
       </AlertTitle>
@@ -277,39 +277,39 @@ export const ChartUnexpectedError = ({ error }: { error?: Error }) => {
           {error.message}
         </Typography>
       ) : null}
-    </HintRed>
+    </HintError>
   );
 };
 
 export const OnlyNegativeDataHint = () => {
   return (
-    <HintOrange>
+    <HintWarning>
       <AlertTitle>
         <Trans id="hint.only.negative.data.title">Negative Values</Trans>
       </AlertTitle>
       <Trans id="hint.only.negative.data.message">
         Negative data values cannot be displayed with this chart type.
       </Trans>
-    </HintOrange>
+    </HintWarning>
   );
 };
 
 export const PublishSuccess = () => {
   return (
-    <HintGreen>
+    <HintSuccess>
       <Trans id="hint.publication.success">
         Your visualization is now published. You can share and embed it using
         the URL or the options below.
       </Trans>
-    </HintGreen>
+    </HintSuccess>
   );
 };
 
 const colorToIcon: Record<NonNullable<AlertProps["color"]>, IconName> = {
-  red: "infoCircle",
-  green: "checkmarkCircle",
-  blue: "infoCircle",
-  orange: "infoCircle",
+  error: "infoCircle",
+  success: "checkmarkCircle",
+  info: "infoCircle",
+  warning: "infoCircle",
 };
 
 const mkHint = (
@@ -350,10 +350,10 @@ const mkHint = (
 };
 
 /** Use to highlight errors. */
-export const HintRed = mkHint("red", "HintRed");
+export const HintError = mkHint("error", "HintError");
 /** Use to highlight successes. */
-const HintGreen = mkHint("green", "HintGreen");
+const HintSuccess = mkHint("success", "HintSuccess");
 /** Use to highlight information. */
-export const HintBlue = mkHint("blue", "HintBlue");
+export const HintInfo = mkHint("info", "HintInfo");
 /** Use to highlight warnings. */
-export const HintOrange = mkHint("orange", "HintOrange");
+export const HintWarning = mkHint("warning", "HintWarning");

--- a/app/components/menu-action-item.tsx
+++ b/app/components/menu-action-item.tsx
@@ -17,12 +17,10 @@ const StyledMenuItem = styled(MenuItem)(({ theme, color }) => ({
   display: "flex",
   alignItems: "flex-start",
   gap: theme.spacing(2),
-  color:
-    color === "blue" || color === "red"
-      ? theme.palette[color].main
-      : theme.palette.primary.main,
+  color: color === "red" ? theme.palette.red.main : theme.palette.text.primary,
   whiteSpace: "normal",
 })) as typeof MenuItem;
+
 export type MenuActionProps = {
   disabled?: boolean;
   label: string | NonNullable<React.ReactNode>;
@@ -30,7 +28,7 @@ export type MenuActionProps = {
   leadingIconName?: IconName;
   priority?: number;
   stayOpen?: boolean;
-  color?: "text.primary" | "red.main";
+  color?: "red";
   onClick?: (e: MouseEvent<HTMLElement>) => Promise<unknown> | void;
 } & (
   | {
@@ -69,7 +67,6 @@ export const MenuActionItem = (
     leadingIcon,
     trailingIcon,
     label,
-    color = "text.primary",
     ...rest
   }: {
     leadingIcon?: IconName;
@@ -121,7 +118,7 @@ export const MenuActionItem = (
           disabled={disabled}
           component={props.type === "link" ? Link : "div"}
           {...forwardedProps}
-          sx={{ display: "flex", alignItems: "center", minHeight: 0, color }}
+          sx={{ display: "flex", alignItems: "center", minHeight: 0 }}
         >
           {leadingIcon && <Icon name={leadingIcon} />}
           <Typography variant="body3">{label}</Typography>

--- a/app/components/menu-action-item.tsx
+++ b/app/components/menu-action-item.tsx
@@ -67,6 +67,7 @@ export const MenuActionItem = (
     leadingIcon,
     trailingIcon,
     label,
+    color,
     ...rest
   }: {
     leadingIcon?: IconName;
@@ -118,6 +119,7 @@ export const MenuActionItem = (
           disabled={disabled}
           component={props.type === "link" ? Link : "div"}
           {...forwardedProps}
+          color={color}
           sx={{ display: "flex", alignItems: "center", minHeight: 0 }}
         >
           {leadingIcon && <Icon name={leadingIcon} />}

--- a/app/components/metadata-panel.tsx
+++ b/app/components/metadata-panel.tsx
@@ -248,7 +248,7 @@ export const OpenMetadataPanelWrapper = ({
       className={classes.openComponentInteractive}
       variant="text"
       size="sm"
-      color="blue"
+      color="primary"
       onClick={handleClick}
     >
       {children}
@@ -394,7 +394,7 @@ const ToggleButton = ({
       data-testid="panel-metadata-toggle"
       className={classes.toggleButton}
       variant="text"
-      color="blue"
+      color="primary"
       size={smaller ? "xs" : "sm"}
       onClick={onClick}
     >
@@ -868,7 +868,7 @@ const ComponentTabPanel = ({
           component="a"
           variant="text"
           size="sm"
-          color="blue"
+          color="primary"
           onClick={handleClick}
           endIcon={<SvgIcArrowRight />}
           sx={{ p: 0 }}

--- a/app/configurator/components/add-dataset-drawer/caution-alert.tsx
+++ b/app/configurator/components/add-dataset-drawer/caution-alert.tsx
@@ -2,7 +2,7 @@ import { Trans } from "@lingui/macro";
 import { Box, Link } from "@mui/material";
 import { useCallback } from "react";
 
-import { HintOrange } from "@/components/hint";
+import { HintWarning } from "@/components/hint";
 import useLocalState from "@/utils/use-local-state";
 
 export const useCautionAlert = () => {
@@ -17,7 +17,7 @@ export const useCautionAlert = () => {
 
 export const CautionAlert = ({ onConfirm }: { onConfirm: () => void }) => {
   return (
-    <HintOrange>
+    <HintWarning>
       <Trans id="dataset.search.caution.body">
         The linking of different datasets carries risks such as data
         inconsistencies, scalability issues, and unexpected correlations. Be
@@ -37,6 +37,6 @@ export const CautionAlert = ({ onConfirm }: { onConfirm: () => void }) => {
           </Trans>
         </Link>
       </Box>
-    </HintOrange>
+    </HintWarning>
   );
 };

--- a/app/configurator/components/chart-controls/color-palette.tsx
+++ b/app/configurator/components/chart-controls/color-palette.tsx
@@ -273,10 +273,10 @@ export const ColorPalette = ({
               <Button
                 variant="text"
                 size="sm"
-                color="blue"
+                color="primary"
                 sx={{
                   "&:hover": {
-                    color: "blue.main",
+                    color: "primary.main",
                   },
                 }}
               >
@@ -533,12 +533,12 @@ const ColorPaletteControls = ({
           alignItems: "center",
           columnGap: 2,
           flexWrap: "wrap",
-          color: "blue.main",
+          color: "primary.main",
         }}
       >
         <Button
           variant="text"
-          color="blue"
+          color="primary"
           size="xs"
           disabled={same}
           onClick={resetColorPalette}
@@ -546,7 +546,12 @@ const ColorPaletteControls = ({
           <Trans id="controls.color.palette.reset">Reset color palette</Trans>
         </Button>
         •
-        <Button variant="text" color="blue" size="xs" onClick={shuffleColors}>
+        <Button
+          variant="text"
+          color="primary"
+          size="xs"
+          onClick={shuffleColors}
+        >
           <Trans id="controls.filters.select.refresh-colors">
             Shuffle colors
           </Trans>

--- a/app/configurator/components/chart-type-selector.tsx
+++ b/app/configurator/components/chart-type-selector.tsx
@@ -8,7 +8,7 @@ import {
   regularChartTypes,
 } from "@/charts";
 import Flex from "@/components/flex";
-import { HintRed } from "@/components/hint";
+import { HintError } from "@/components/hint";
 import { InfoIconTooltip } from "@/components/info-icon-tooltip";
 import { MaybeTooltip } from "@/components/maybe-tooltip";
 import { ChartType, ConfiguratorStatePublished } from "@/config-types";
@@ -103,11 +103,11 @@ export const ChartTypeSelector = ({
       )}
       <div>
         {enabledChartTypes.length === 0 ? (
-          <HintRed smaller>
+          <HintError smaller>
             <Trans id="hint.no.visualization.with.dataset">
               No visualization can be created with the selected dataset.
             </Trans>
-          </HintRed>
+          </HintError>
         ) : (
           <Flex sx={{ flexDirection: "column", gap: 4 }}>
             <ChartTypeSelectorMenu

--- a/app/configurator/components/custom-layers-selector.tsx
+++ b/app/configurator/components/custom-layers-selector.tsx
@@ -247,11 +247,7 @@ export const CustomLayersSelector = () => {
         ) : null}
 
         <div>
-          <Button
-            variant="contained"
-            color="cobalt"
-            onClick={() => setAddingLayer(true)}
-          >
+          <Button variant="contained" onClick={() => setAddingLayer(true)}>
             Add layer
           </Button>
         </div>

--- a/app/configurator/components/dataset-control-section.tsx
+++ b/app/configurator/components/dataset-control-section.tsx
@@ -119,7 +119,7 @@ const DatasetRow = ({
         >
           <Button
             variant="text"
-            color="blue"
+            color="primary"
             size="sm"
             onClick={handleDatasetClick}
           >
@@ -240,7 +240,7 @@ export const DatasetsControlSection = () => {
           <Button
             variant="text"
             size="sm"
-            color="blue"
+            color="primary"
             startIcon={<Icon name="plus" size={20} />}
             onClick={openDatasetDialog}
           >

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -448,7 +448,7 @@ const MultiFilterContent = ({
         <Flex gap={2} alignItems="center" sx={{ color: "primary.main" }}>
           <Button
             variant="text"
-            color="blue"
+            color="primary"
             size="xs"
             disabled={
               sum(showValuesMappingBooleans, (d) => +d) === values.length
@@ -470,7 +470,7 @@ const MultiFilterContent = ({
           •
           <Button
             variant="text"
-            color="blue"
+            color="primary"
             size="xs"
             disabled={showValuesMappingBooleans.every((d) => !d)}
             onClick={() => {

--- a/app/configurator/table/table-chart-options.tsx
+++ b/app/configurator/table/table-chart-options.tsx
@@ -5,7 +5,7 @@ import { ChangeEvent, useCallback } from "react";
 
 import { EncodingFieldType } from "@/charts/chart-config-ui-options";
 import { Checkbox } from "@/components/form";
-import { HintRed } from "@/components/hint";
+import { HintError } from "@/components/hint";
 import {
   ColumnStyle,
   ConfiguratorStateConfiguringChart,
@@ -184,7 +184,7 @@ export const TableColumnOptions = ({
   const component = allComponents.find((d) => d.id === activeField);
 
   if (!component) {
-    return <HintRed smaller>No component {activeField}</HintRed>;
+    return <HintError smaller>No component {activeField}</HintError>;
   }
 
   const { isGroup, isHidden } = chartConfig.fields[activeField];

--- a/app/docs/theme.stories.tsx
+++ b/app/docs/theme.stories.tsx
@@ -334,13 +334,13 @@ export const Components: React.FC = () => {
         </StorybookSection>
         <StorybookSection>
           <StorybookSectionTitle>Alerts</StorybookSectionTitle>
-          {(["red", "green", "blue", "orange"] as AlertProps["color"][]).map(
-            (color) => (
-              <Alert key={color} color={color} sx={{ mb: 1 }}>
-                Here is an Alert of color {color}.
-              </Alert>
-            )
-          )}
+          {(
+            ["error", "success", "info", "warning"] as AlertProps["color"][]
+          ).map((color) => (
+            <Alert key={color} color={color} sx={{ mb: 1 }}>
+              Here is an Alert of color {color}.
+            </Alert>
+          ))}
         </StorybookSection>
         <StorybookSection>
           <StorybookSectionTitle>Cards</StorybookSectionTitle>
@@ -481,10 +481,10 @@ const SnackbarExample = () => {
 
   return (
     <Stack gap="1rem" direction="row">
-      {renderButton("red")}
-      {renderButton("green")}
-      {renderButton("blue")}
-      {renderButton("orange")}
+      {renderButton("error")}
+      {renderButton("success")}
+      {renderButton("info")}
+      {renderButton("warning")}
     </Stack>
   );
 };

--- a/app/flags/flag.tsx
+++ b/app/flags/flag.tsx
@@ -28,13 +28,29 @@ const listFlagNames = () => {
   return store.keys().sort();
 };
 
-/** List all flags from the store */
+/** List all available flags */
 const listFlags = () => {
-  return listFlagNames().map((name) => ({
-    name,
-    description: FLAGS.find((flag) => flag.name === name)?.description,
-    value: store.get(name as FlagName),
+  const allDefinedFlags = FLAGS.map((flagDef) => ({
+    name: flagDef.name,
+    description: flagDef.description,
+    value: store.get(flagDef.name),
   }));
+
+  return allDefinedFlags;
+};
+
+/** Find and remove deprecated flags (flags in store but not in FLAGS) */
+const removeDeprecatedFlags = () => {
+  const storeFlags = listFlagNames();
+  const deprecatedFlags = storeFlags.filter(
+    (name) => !FLAGS.some((flagDef) => flagDef.name === name)
+  );
+
+  deprecatedFlags.forEach((name) => {
+    store.remove(name as FlagName);
+  });
+
+  return deprecatedFlags;
 };
 
 /** Resets all the flags */
@@ -66,6 +82,7 @@ flag.listNames = listFlagNames;
 flag.list = listFlags;
 flag.reset = resetFlags;
 flag.enable = enable;
+flag.removeDeprecated = removeDeprecatedFlags;
 
 const initFromSearchParams = (locationSearch: string) => {
   locationSearch = locationSearch.startsWith("?")

--- a/app/flags/flag.tsx
+++ b/app/flags/flag.tsx
@@ -17,6 +17,12 @@ export const flag = function flag(...args: [FlagName] | [FlagName, FlagValue]) {
     return store.get(args[0]);
   } else {
     const [name, value] = args;
+
+    if (value === false) {
+      store.remove(name);
+      return false;
+    }
+
     store.set(name, value);
 
     return value;

--- a/app/flags/flag.tsx
+++ b/app/flags/flag.tsx
@@ -103,6 +103,7 @@ const initFromHost = (host: string) => {
   const shouldSetDefaultFlags =
     host.includes("localhost") ||
     host.includes("test.visualize.admin.ch") ||
+    host.includes("int.visualize.admin.ch") ||
     isVercelPreviewHost(host);
 
   if (shouldSetDefaultFlags) {

--- a/app/flags/flag.tsx
+++ b/app/flags/flag.tsx
@@ -91,15 +91,15 @@ export const isVercelPreviewHost = (host: string) => {
   return !!/visualization\-tool.*ixt1\.vercel\.app/.exec(host);
 };
 
-const initFromHost = (host: string) => {
-  // @ts-ignore
-  const setDefaultFlag = (name: FlagName, value: FlagValue) => {
-    const flagValue = flag(name);
+const setDefaultFlag = (name: FlagName, value: FlagValue) => {
+  const flagValue = flag(name);
 
-    if (flagValue === null) {
-      flag(name, value);
-    }
-  };
+  if (flagValue === null) {
+    flag(name, value);
+  }
+};
+
+const initFromHost = (host: string) => {
   const shouldSetDefaultFlags =
     host.includes("localhost") ||
     host.includes("test.visualize.admin.ch") ||
@@ -107,7 +107,7 @@ const initFromHost = (host: string) => {
     isVercelPreviewHost(host);
 
   if (shouldSetDefaultFlags) {
-    flag("wmts-show-extra-info", true);
+    setDefaultFlag("debug", true);
   }
 };
 

--- a/app/flags/types.ts
+++ b/app/flags/types.ts
@@ -4,6 +4,7 @@ export const FLAGS = [
     name: "debug" as const,
     description:
       "Controls whether debug elements are shown, e.g. ConfiguratorState viewer or this debug panel.",
+    priority: 1,
   },
   {
     name: "server-side-cache.disable" as const,
@@ -15,7 +16,7 @@ export const FLAGS = [
   },
   {
     name: "easter-eggs" as const,
-    description: "Enables easter eggs",
+    description: "Enables easter eggs.",
   },
   {
     name: "enable-experimental-features" as const,
@@ -24,7 +25,7 @@ export const FLAGS = [
   },
   {
     name: "wmts-show-extra-info" as const,
-    description: "Show extra debug info in WMTS provider autocomplete",
+    description: "Show extra debug info in WMTS provider autocomplete.",
   },
   {
     name: "custom-scale-domain" as const,
@@ -34,7 +35,10 @@ export const FLAGS = [
     name: "convert-units" as const,
     description: "Enables unit conversion.",
   },
-];
+].sort(
+  (a, b) =>
+    (b.priority ?? 0) - (a.priority ?? 0) || a.name.localeCompare(b.name)
+);
 export const FLAG_NAMES = FLAGS.map((flag) => flag.name);
 type Flag = (typeof FLAGS)[number];
 export type FlagName = Flag["name"];

--- a/app/flags/types.ts
+++ b/app/flags/types.ts
@@ -10,38 +10,39 @@ export const FLAGS = [
   {
     name: "debug" as const,
     description:
-      "Controls whether debug elements are shown, e.g. ConfiguratorState viewer or this debug panel.",
+      "Shows debug elements such as ConfiguratorState viewer and debug panel.",
     priority: 1,
     type: "boolean" as FlagType,
   },
   {
     name: "server-side-cache.disable" as const,
-    description: "Disables server side cache.",
+    description: "Disables server-side cache functionality.",
     type: "boolean" as FlagType,
   },
   {
     name: "graphql.endpoint" as const,
-    description: "GraphQL endpoint, can be used for testing.",
+    description: "Specifies custom GraphQL endpoint for testing purposes.",
     type: "text" as FlagType,
   },
   {
     name: "easter-eggs" as const,
-    description: "Enables easter eggs.",
+    description: "Enables hidden easter egg features.",
     type: "boolean" as FlagType,
   },
   {
     name: "wmts-show-extra-info" as const,
-    description: "Show extra debug info in WMTS provider autocomplete.",
+    description:
+      "Displays additional debug information in WMTS provider autocomplete.",
     type: "boolean" as FlagType,
   },
   {
     name: "custom-scale-domain" as const,
-    description: "Allows users to set custom numerical scale domains.",
+    description: "Enables setting custom numerical scale domains.",
     type: "boolean" as FlagType,
   },
   {
     name: "convert-units" as const,
-    description: "Enables unit conversion.",
+    description: "Enables unit conversion functionality.",
     type: "boolean" as FlagType,
   },
 ].sort(

--- a/app/flags/types.ts
+++ b/app/flags/types.ts
@@ -3,7 +3,7 @@ export const FLAGS = [
   {
     name: "debug" as const,
     description:
-      "Controls whether debug elements are shown, e.g. ConfiguratorState viewer or GraphQL debug panel.",
+      "Controls whether debug elements are shown, e.g. ConfiguratorState viewer or this debug panel.",
   },
   {
     name: "server-side-cache.disable" as const,
@@ -11,7 +11,7 @@ export const FLAGS = [
   },
   {
     name: "graphql.endpoint" as const,
-    description: "The GraphQL endpoint, can be used for testing purposes.",
+    description: "GraphQL endpoint, can be used for testing.",
   },
   {
     name: "easter-eggs" as const,

--- a/app/flags/types.ts
+++ b/app/flags/types.ts
@@ -1,43 +1,60 @@
 export type FlagValue = any;
+export type FlagType = "boolean" | "text";
+
+const TYPE_PRIORITY: Record<FlagType, number> = {
+  boolean: 0,
+  text: 1,
+};
+
 export const FLAGS = [
   {
     name: "debug" as const,
     description:
       "Controls whether debug elements are shown, e.g. ConfiguratorState viewer or this debug panel.",
     priority: 1,
+    type: "boolean" as FlagType,
   },
   {
     name: "server-side-cache.disable" as const,
     description: "Disables server side cache.",
+    type: "boolean" as FlagType,
   },
   {
     name: "graphql.endpoint" as const,
     description: "GraphQL endpoint, can be used for testing.",
+    type: "text" as FlagType,
   },
   {
     name: "easter-eggs" as const,
     description: "Enables easter eggs.",
+    type: "boolean" as FlagType,
   },
   {
     name: "enable-experimental-features" as const,
     description:
       "Enables experimental features, including dashboard text blocks, Markdown editor and bar charts.",
+    type: "boolean" as FlagType,
   },
   {
     name: "wmts-show-extra-info" as const,
     description: "Show extra debug info in WMTS provider autocomplete.",
+    type: "boolean" as FlagType,
   },
   {
     name: "custom-scale-domain" as const,
     description: "Allows users to set custom numerical scale domains.",
+    type: "boolean" as FlagType,
   },
   {
     name: "convert-units" as const,
     description: "Enables unit conversion.",
+    type: "boolean" as FlagType,
   },
 ].sort(
   (a, b) =>
-    (b.priority ?? 0) - (a.priority ?? 0) || a.name.localeCompare(b.name)
+    (b.priority ?? 0) - (a.priority ?? 0) ||
+    TYPE_PRIORITY[a.type] - TYPE_PRIORITY[b.type] ||
+    a.name.localeCompare(b.name)
 );
 export const FLAG_NAMES = FLAGS.map((flag) => flag.name);
 type Flag = (typeof FLAGS)[number];

--- a/app/flags/types.ts
+++ b/app/flags/types.ts
@@ -30,12 +30,6 @@ export const FLAGS = [
     type: "boolean" as FlagType,
   },
   {
-    name: "enable-experimental-features" as const,
-    description:
-      "Enables experimental features, including dashboard text blocks, Markdown editor and bar charts.",
-    type: "boolean" as FlagType,
-  },
-  {
     name: "wmts-show-extra-info" as const,
     description: "Show extra debug info in WMTS provider autocomplete.",
     type: "boolean" as FlagType,

--- a/app/flags/useFlag.ts
+++ b/app/flags/useFlag.ts
@@ -24,7 +24,10 @@ export default function useFlagValue(name: FlagName) {
 }
 
 export function useFlags() {
-  const [flags, setFlags] = useState(flag.list());
+  const [flags, setFlags] = useState(() => {
+    flag.removeDeprecated();
+    return flag.list();
+  });
 
   useEffect(() => {
     const handleChange = () => {

--- a/app/gql-flamegraph/devtool.tsx
+++ b/app/gql-flamegraph/devtool.tsx
@@ -552,7 +552,7 @@ const FlagList = () => {
           <Box sx={{ display: "flex" }}>
             <FlagSwitch flagName={flag.name as FlagName} />
           </Box>
-          <Typography variant="caption" style={{ paddingLeft: "0.5rem" }}>
+          <Typography variant="body3" style={{ paddingLeft: "0.5rem" }}>
             {flag.description}
           </Typography>
         </Fragment>
@@ -569,7 +569,6 @@ const FlagSwitch = ({ flagName }: { flagName: FlagName }) => {
 
   return (
     <Switch
-      size="sm"
       checked={!!flagValue}
       onChange={handleChange}
       label={flagName.toUpperCase()}

--- a/app/gql-flamegraph/devtool.tsx
+++ b/app/gql-flamegraph/devtool.tsx
@@ -13,8 +13,6 @@ import {
   IconButtonProps,
   Link,
   LinkProps,
-  Switch,
-  SwitchProps,
   Tab,
   Typography,
 } from "@mui/material";
@@ -29,6 +27,7 @@ import uniqBy from "lodash/uniqBy";
 import mitt from "mitt";
 import React, {
   ChangeEvent,
+  Fragment,
   MouseEvent,
   ReactNode,
   useEffect,
@@ -44,6 +43,8 @@ import { flag, useFlag, useFlags } from "@/flags";
 import { FlagName } from "@/flags/types";
 import { RequestQueryMeta } from "@/graphql/query-meta";
 import useEvent from "@/utils/use-event";
+import { Switch } from "@/components/form";
+import { Icon } from "@/icons";
 
 type Timings = Record<
   string,
@@ -363,13 +364,13 @@ const EmojiIconButton = ({
 }: { children: ReactNode } & IconButtonProps) => {
   return (
     <IconButton
-      size="small"
       sx={{
-        display: "inline-flex",
+        display: "flex",
         justifyContent: "center",
         alignItems: "center",
         width: 32,
         height: 32,
+        mr: 2,
       }}
       {...props}
     >
@@ -496,25 +497,29 @@ const DebugPanel = () => {
 
   return (
     <>
-      <Box sx={{ position: "fixed", bottom: 0, right: 0, zIndex: 10 }}>
+      <Box sx={{ position: "fixed", bottom: 8, right: 8, zIndex: 10 }}>
         <Grow in>
-          <IconButton
-            data-testid="debug-panel-toggle"
-            size="small"
-            onClick={open}
-          >
+          <IconButton data-testid="debug-panel-toggle" onClick={open}>
             🛠
           </IconButton>
         </Grow>
       </Box>
       <Drawer open={isOpen} anchor="bottom" elevation={2} onClose={close}>
         <TabContext value={tab}>
-          <Box sx={{ display: "flex", justifyContent: "space-between" }}>
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+            }}
+          >
             <TabList onChange={(_, tab) => setTab(tab)}>
               <Tab value="graphql" label="GraphQL" />
               <Tab value="flags" label="🚩 Flags" />
             </TabList>
-            <EmojiIconButton onClick={close}>⨯</EmojiIconButton>
+            <EmojiIconButton onClick={close}>
+              <Icon name="close" />
+            </EmojiIconButton>
           </Box>
           <Divider />
           <TabPanel value="graphql">
@@ -533,38 +538,43 @@ const FlagList = () => {
   const flags = useFlags();
 
   return (
-    <>
-      {flags.map((flag) => {
-        return (
-          <Box
-            key={flag.name}
-            sx={{ display: "flex", alignItems: "center", gap: "0.5rem" }}
-          >
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "auto 1fr",
+        columnGap: "1rem",
+        rowGap: "0.5rem",
+        alignItems: "center",
+      }}
+    >
+      {flags.map((flag) => (
+        <Fragment key={flag.name}>
+          <Box sx={{ display: "flex" }}>
             <FlagSwitch flagName={flag.name as FlagName} />
-            <Typography variant="body2">{flag.name}</Typography>
-            <Typography variant="caption">{flag.description}</Typography>
           </Box>
-        );
-      })}
-    </>
+          <Typography variant="caption" style={{ paddingLeft: "0.5rem" }}>
+            {flag.description}
+          </Typography>
+        </Fragment>
+      ))}
+    </div>
   );
 };
 
-const FlagSwitch = ({
-  flagName,
-  onChange,
-  ...props
-}: {
-  flagName: FlagName;
-  onChange?: (value: boolean) => void;
-} & Omit<SwitchProps, "onChange">) => {
+const FlagSwitch = ({ flagName }: { flagName: FlagName }) => {
   const flagValue = useFlag(flagName);
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const handleChange = useEvent((e: ChangeEvent<HTMLInputElement>) => {
     flag(flagName, e.target.checked);
-    onChange?.(e.target.checked);
-  };
+  });
 
-  return <Switch checked={!!flagValue} onChange={handleChange} {...props} />;
+  return (
+    <Switch
+      size="sm"
+      checked={!!flagValue}
+      onChange={handleChange}
+      label={flagName.toUpperCase()}
+    />
+  );
 };
 
 export default DebugPanel;

--- a/app/gql-flamegraph/devtool.tsx
+++ b/app/gql-flamegraph/devtool.tsx
@@ -40,11 +40,12 @@ import { pipe, tap } from "wonka";
 
 import useDisclosure from "@/components/use-disclosure";
 import { flag, useFlag, useFlags } from "@/flags";
-import { FlagName } from "@/flags/types";
+import { FlagName, FLAGS } from "@/flags/types";
 import { RequestQueryMeta } from "@/graphql/query-meta";
 import useEvent from "@/utils/use-event";
 import { Switch } from "@/components/form";
 import { Icon } from "@/icons";
+import { MaybeTooltip } from "@/components/maybe-tooltip";
 
 type Timings = Record<
   string,
@@ -563,16 +564,28 @@ const FlagList = () => {
 
 const FlagSwitch = ({ flagName }: { flagName: FlagName }) => {
   const flagValue = useFlag(flagName);
+  const isTextFlag = useMemo(() => {
+    return FLAGS.find((f) => f.name === flagName)?.type === "text";
+  }, [flagName]);
   const handleChange = useEvent((e: ChangeEvent<HTMLInputElement>) => {
     flag(flagName, e.target.checked);
   });
 
   return (
-    <Switch
-      checked={!!flagValue}
-      onChange={handleChange}
-      label={flagName.toUpperCase()}
-    />
+    <MaybeTooltip
+      title={
+        isTextFlag ? "This flag can only be set through the URL" : undefined
+      }
+    >
+      <div>
+        <Switch
+          label={flagName.toUpperCase()}
+          checked={!!flagValue}
+          disabled={isTextFlag}
+          onChange={handleChange}
+        />
+      </div>
+    </MaybeTooltip>
   );
 };
 

--- a/app/gql-flamegraph/devtool.tsx
+++ b/app/gql-flamegraph/devtool.tsx
@@ -30,6 +30,7 @@ import mitt from "mitt";
 import React, {
   ChangeEvent,
   MouseEvent,
+  ReactNode,
   useEffect,
   useMemo,
   useRef,
@@ -359,16 +360,16 @@ const Queries = ({ queries }: { queries: RequestQueryMeta[] }) => {
 const EmojiIconButton = ({
   children,
   ...props
-}: { children: React.ReactNode } & IconButtonProps) => {
+}: { children: ReactNode } & IconButtonProps) => {
   return (
     <IconButton
       size="small"
       sx={{
-        width: 32,
-        height: 32,
         display: "inline-flex",
         justifyContent: "center",
         alignItems: "center",
+        width: 32,
+        height: 32,
       }}
       {...props}
     >
@@ -510,8 +511,8 @@ const DebugPanel = () => {
         <TabContext value={tab}>
           <Box sx={{ display: "flex", justifyContent: "space-between" }}>
             <TabList onChange={(_, tab) => setTab(tab)}>
-              <Tab value="graphql" label="graphql" />
-              <Tab value="flags" label="flags" />
+              <Tab value="graphql" label="GraphQL" />
+              <Tab value="flags" label="🚩 Flags" />
             </TabList>
             <EmojiIconButton onClick={close}>⨯</EmojiIconButton>
           </Box>

--- a/app/graphql/client.tsx
+++ b/app/graphql/client.tsx
@@ -6,11 +6,16 @@ import { flag } from "@/flags/flag";
 import { devtoolsExchanges } from "@/graphql/devtools";
 
 const graphqlEndpointFlag = flag("graphql.endpoint");
+
 if (graphqlEndpointFlag) {
   console.log("ℹ️ Using custom GraphQL endpoint:", graphqlEndpointFlag);
 }
+
 export const client = createClient({
-  url: graphqlEndpointFlag ?? GRAPHQL_ENDPOINT,
+  url:
+    typeof graphqlEndpointFlag === "string"
+      ? graphqlEndpointFlag
+      : GRAPHQL_ENDPOINT,
   exchanges: [...devtoolsExchanges, ...defaultExchanges],
   fetchOptions: {
     headers: getHeaders(),

--- a/app/jest.setup.ts
+++ b/app/jest.setup.ts
@@ -161,10 +161,19 @@ jest.mock("@zazuko/cube-hierarchy-query/index", () => ({}));
 jest.mock("@interactivethings/swiss-federal-ci", () => ({
   c: {
     cobalt: {
-      700: "#fff",
+      400: "#fff",
+      600: "#fff",
     },
     monochrome: {},
-    red: {},
+    red: {
+      50: "#fff",
+      800: "#fff",
+    },
+    green: {
+      50: "#fff",
+      500: "#fff",
+      700: "#fff",
+    },
   },
   e: {},
   t: {},

--- a/app/login/components/profile-header.tsx
+++ b/app/login/components/profile-header.tsx
@@ -44,7 +44,7 @@ export const ProfileHeader = (props: { user: User }) => {
             component="a"
             href={ADFS_PROFILE_URL}
             variant="text"
-            color="blue"
+            color="primary"
             size="sm"
             sx={{ mr: 2 }}
           >
@@ -54,7 +54,7 @@ export const ProfileHeader = (props: { user: User }) => {
         <Button
           className={classes.button}
           variant="text"
-          color="blue"
+          color="primary"
           size="sm"
           onClick={async () => await signOut()}
         >

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -287,7 +287,7 @@ const ProfileVisualizationsRow = (props: {
       {
         type: "button",
         label: t({ id: "login.chart.delete", message: "Delete" }),
-        color: "red.main",
+        color: "red",
         leadingIconName:
           removeConfigMut.status === "fetching" ? "refresh" : "trash",
         requireConfirmation: true,

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -147,7 +147,7 @@ export const ProfileVisualizationsTable = (
           {preview && (
             <Button
               variant="text"
-              color="blue"
+              color="primary"
               size="sm"
               endIcon={<Icon name="arrowDown" size={20} />}
               onClick={onShowAll}

--- a/app/pages/v/[chartId].tsx
+++ b/app/pages/v/[chartId].tsx
@@ -19,7 +19,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 import { ChartPublished } from "@/components/chart-published";
 import { useEmbedQueryParams } from "@/components/embed-params";
-import { HintOrange, PublishSuccess } from "@/components/hint";
+import { HintWarning, PublishSuccess } from "@/components/hint";
 import { ContentLayout } from "@/components/layout";
 import { PublishActions } from "@/components/publish-actions";
 import { ConfiguratorStatePublished } from "@/config-types";
@@ -184,7 +184,7 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
             )}
             {config.published_state === PUBLISHED_STATE.DRAFT && (
               <Box mt={2} mb={5}>
-                <HintOrange
+                <HintWarning
                   sx={{
                     flexDirection: "row",
                     alignItems: "center",
@@ -211,7 +211,7 @@ const VisualizationPage = (props: Serialized<PageProps>) => {
                       <Trans id="login.chart.edit">Edit</Trans>
                     </Button>
                   ) : null}
-                </HintOrange>
+                </HintWarning>
               </Box>
             )}
             <Box ref={chartWrapperRef}>

--- a/app/themes/components.tsx
+++ b/app/themes/components.tsx
@@ -146,14 +146,24 @@ export const components: Components = {
         })();
 
         const variant = ownerState.variant ?? "contained";
-        const color =
-          ownerState.color === "inherit"
-            ? "inherit"
-            : palette[
-                ownerState.color === "secondary"
-                  ? "cobalt"
-                  : (ownerState.color ?? "cobalt")
-              ];
+        const getPaletteColor = (
+          color: "primary" | "secondary" | "monochrome" | "red" | "inherit"
+        ) => {
+          if (color === "primary") {
+            return palette.blue;
+          }
+
+          if (color === "secondary") {
+            return palette.cobalt;
+          }
+
+          if (color === "inherit") {
+            return "inherit";
+          }
+
+          return palette[color];
+        };
+        const color = getPaletteColor(ownerState.color ?? "secondary");
 
         const variantColorStyles = (() => {
           if (!color) {

--- a/app/themes/components.tsx
+++ b/app/themes/components.tsx
@@ -121,7 +121,7 @@ export const components: Components = {
   MuiButton: {
     defaultProps: {
       variant: "contained",
-      color: "cobalt",
+      color: "secondary",
       size: "md",
     },
     styleOverrides: {
@@ -149,7 +149,11 @@ export const components: Components = {
         const color =
           ownerState.color === "inherit"
             ? "inherit"
-            : palette[ownerState.color ?? "cobalt"];
+            : palette[
+                ownerState.color === "secondary"
+                  ? "cobalt"
+                  : (ownerState.color ?? "cobalt")
+              ];
 
         const variantColorStyles = (() => {
           if (!color) {

--- a/app/themes/components.tsx
+++ b/app/themes/components.tsx
@@ -51,19 +51,34 @@ export const components: Components = {
     },
     styleOverrides: {
       root: ({ ownerState }) => {
-        const color = ownerState.color ?? "blue";
+        const color = ownerState.color ?? "info";
+        const getPalette = (
+          color: "info" | "success" | "warning" | "error"
+        ) => {
+          switch (color) {
+            case "info":
+              return palette.blue;
+            case "success":
+              return palette.green;
+            case "warning":
+              return palette.orange;
+            case "error":
+              return palette.red;
+          }
+        };
+        const basePalette = getPalette(color);
 
         return {
           display: "flex",
           alignItems: "center",
           width: "100%",
           padding: 0,
-          backgroundColor: palette[color][50],
+          backgroundColor: palette[color].light,
           color: palette[color].main,
           boxShadow: shadows[2],
 
           "& .MuiIconButton-root:hover": {
-            backgroundColor: palette[color][100],
+            backgroundColor: basePalette[100],
           },
         };
       },

--- a/app/themes/components.tsx
+++ b/app/themes/components.tsx
@@ -162,7 +162,7 @@ export const components: Components = {
 
         const variant = ownerState.variant ?? "contained";
         const getPaletteColor = (
-          color: "primary" | "secondary" | "monochrome" | "red" | "inherit"
+          color: "primary" | "secondary" | "red" | "inherit"
         ) => {
           if (color === "primary") {
             return palette.blue;

--- a/app/themes/index.ts
+++ b/app/themes/index.ts
@@ -24,7 +24,6 @@ declare module "@mui/material/Button" {
     info: false;
     warning: false;
 
-    monochrome: true;
     red: true;
     inherit: true;
   }

--- a/app/themes/index.ts
+++ b/app/themes/index.ts
@@ -32,13 +32,12 @@ declare module "@mui/material/Alert" {
 declare module "@mui/material/Button" {
   interface ButtonPropsColorOverrides {
     primary: false;
-    secondary: false;
+    secondary: true;
     success: false;
     error: false;
     info: false;
     warning: false;
 
-    cobalt: true;
     monochrome: true;
     blue: true;
     red: true;

--- a/app/themes/index.ts
+++ b/app/themes/index.ts
@@ -19,13 +19,12 @@ declare module "@mui/material/Button" {
   interface ButtonPropsColorOverrides {
     primary: true;
     secondary: true;
+    inherit: true;
+
     success: false;
     error: false;
     info: false;
     warning: false;
-
-    red: true;
-    inherit: true;
   }
 
   interface ButtonPropsSizeOverrides {

--- a/app/themes/index.ts
+++ b/app/themes/index.ts
@@ -15,20 +15,6 @@ declare module "@mui/material" {
     extends FederalTypographyVariantsOptions {}
 }
 
-declare module "@mui/material/Alert" {
-  interface AlertPropsColorOverrides {
-    error: false;
-    warning: false;
-    info: false;
-    success: false;
-
-    red: true;
-    orange: true;
-    blue: true;
-    green: true;
-  }
-}
-
 declare module "@mui/material/Button" {
   interface ButtonPropsColorOverrides {
     primary: true;

--- a/app/themes/index.ts
+++ b/app/themes/index.ts
@@ -31,7 +31,7 @@ declare module "@mui/material/Alert" {
 
 declare module "@mui/material/Button" {
   interface ButtonPropsColorOverrides {
-    primary: false;
+    primary: true;
     secondary: true;
     success: false;
     error: false;
@@ -39,7 +39,6 @@ declare module "@mui/material/Button" {
     warning: false;
 
     monochrome: true;
-    blue: true;
     red: true;
     inherit: true;
   }

--- a/app/themes/palette.ts
+++ b/app/themes/palette.ts
@@ -16,6 +16,20 @@ const blue: PaletteOptions["blue"] = {
   900: "#1E3A8A",
 };
 
+const orange: PaletteOptions["orange"] = {
+  main: "#9A3412",
+  50: "#FFF7ED",
+  100: "#FFEDD5",
+  200: "#FED7AA",
+  300: "#FDBA74",
+  400: "#FB923C",
+  500: "#F97316",
+  600: "#EA580C",
+  700: "#C2410C",
+  800: "#9A3412",
+  900: "#7C2D12",
+};
+
 export const palette = {
   primary: {
     main: blue[700],
@@ -34,11 +48,10 @@ export const palette = {
   success: colors.success,
   error: colors.error,
   warning: {
-    // BLW colors
-    main: "#EDD15A",
-    light: "#F7EBB6",
+    main: orange[800],
+    // contrastText in Bund Library
+    light: orange[50],
   },
-
   cobalt: {
     main: colors.cobalt[700],
     ...colors.cobalt,
@@ -51,19 +64,7 @@ export const palette = {
     main: colors.red[700],
     ...colors.red,
   },
-  orange: {
-    main: "#9A3412",
-    50: "#FFF7ED",
-    100: "#FFEDD5",
-    200: "#FED7AA",
-    300: "#FDBA74",
-    400: "#FB923C",
-    500: "#F97316",
-    600: "#EA580C",
-    700: "#C2410C",
-    800: "#9A3412",
-    900: "#7C2D12",
-  },
+  orange,
   yellow: {
     main: "#92400E",
     50: "#FFFBEB",

--- a/app/themes/palette.ts
+++ b/app/themes/palette.ts
@@ -60,12 +60,25 @@ export const palette = {
     secondary: colors.monochrome[500],
   },
   divider: colors.cobalt[100],
-  success: colors.success,
-  error: colors.error,
+  error: {
+    main: colors.red[800],
+    light: colors.red[50],
+    contrastText: "#fff",
+  },
   warning: {
     main: orange[800],
-    // contrastText in Bund Library
     light: orange[50],
+    contrastText: "#fff",
+  },
+  info: {
+    main: blue[700],
+    light: blue[50],
+    contrastText: "#fff",
+  },
+  success: {
+    main: green[700],
+    light: green[50],
+    contrastText: "#fff",
   },
   cobalt: {
     main: colors.cobalt[700],

--- a/app/themes/palette.ts
+++ b/app/themes/palette.ts
@@ -37,7 +37,8 @@ export const palette = {
     contrastText: "#fff",
   },
   secondary: {
-    main: colors.cobalt[700],
+    main: colors.cobalt[400],
+    dark: colors.cobalt[600],
     contrastText: "#fff",
   },
   text: {

--- a/app/themes/palette.ts
+++ b/app/themes/palette.ts
@@ -30,6 +30,20 @@ const orange: PaletteOptions["orange"] = {
   900: "#7C2D12",
 };
 
+const green: PaletteOptions["green"] = {
+  main: "#047857",
+  50: "#ECFDF5",
+  100: "#D1FAE5",
+  200: "#A7F3D0",
+  300: "#6EE7B7",
+  400: "#34D399",
+  500: "#10B981",
+  600: "#059669",
+  700: "#047857",
+  800: "#065F46",
+  900: "#064E3B",
+};
+
 export const palette = {
   primary: {
     main: blue[700],
@@ -79,18 +93,6 @@ export const palette = {
     800: "#92400E",
     900: "#78350F",
   },
-  green: {
-    main: "#047857",
-    50: "#ECFDF5",
-    100: "#D1FAE5",
-    200: "#A7F3D0",
-    300: "#6EE7B7",
-    400: "#34D399",
-    500: "#10B981",
-    600: "#059669",
-    700: "#047857",
-    800: "#065F46",
-    900: "#064E3B",
-  },
+  green,
   blue,
 } satisfies ThemeOptions["palette"];

--- a/app/utils/flashes.tsx
+++ b/app/utils/flashes.tsx
@@ -4,7 +4,7 @@ import { AnimatePresence, motion } from "framer-motion";
 import { useRouter } from "next/router";
 import React, { useMemo, useState } from "react";
 
-import { HintRed } from "@/components/hint";
+import { HintError } from "@/components/hint";
 import { Icon } from "@/icons";
 
 const flashes = {
@@ -69,7 +69,7 @@ const Flashes = () => {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: "1rem" }}
           >
-            <HintRed
+            <HintError
               smaller
               onClose={() =>
                 setDismissed((dismissed) => ({
@@ -84,7 +84,7 @@ const Flashes = () => {
               ) : (
                 <Trans id={`flashes.error.${errorId}`} />
               )}
-            </HintRed>
+            </HintError>
           </motion.div>
         ) : null}
       </AnimatePresence>

--- a/e2e/chart-actions.spec.ts
+++ b/e2e/chart-actions.spec.ts
@@ -41,7 +41,6 @@ test.skip("it should be possible to make a screenshot of a chart", async ({
   await actions.chart.createFrom({
     iri: "https://agriculture.ld.admin.ch/foag/cube/MilkDairyProducts/Consumption_Price_Month",
     dataSource: "Prod",
-    createURLParams: "flag__enable-experimental-features=true",
   });
   await selectors.chart.loaded();
   await actions.editor.changeRegularChartType("Bars");

--- a/e2e/tooltip.spec.ts
+++ b/e2e/tooltip.spec.ts
@@ -59,7 +59,6 @@ test("should keep correct position after scrolling", async ({
   await actions.chart.createFrom({
     iri: "https://agriculture.ld.admin.ch/foag/cube/MilkDairyProducts/Consumption_Price_Month",
     dataSource: "Prod",
-    createURLParams: "flag__enable-experimental-features=true",
   });
   await actions.editor.changeRegularChartType("Bars");
   const chart = page.locator("[data-chart-loaded]");


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #1992
Closes #2105

<!--- Describe the changes -->

This PR:
- makes the `DebugPanel` always shown by default when not on visualize.admin.ch,
- improves the flags section by:
  - always listing all available flags,
  - removing deprecated flags from `localStorage`,
  - enhancing the UI.

<!--- Test instructions -->

## How to test

1. Go to this link.
2. ...

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [ ] I added a CHANGELOG entry
- [ ] I made a self-review of my own code
- [ ] I wrote tests for the changes (if applicable)
- [ ] I wrote configurator and chart config migrations (if applicable)
