### PR TITLE
feat: Improve conversion unit input UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ You can also check the
 
 - Features
   - Invalid URL error message is now translated
+  - Improved UX of interacting with conversion units multiplier input
 - Fixes
   - Fixed an infinite render loop when adding a custom map layer
 

--- a/app/configurator/components/chart-options-selector/conversion-units-field.tsx
+++ b/app/configurator/components/chart-options-selector/conversion-units-field.tsx
@@ -1,6 +1,6 @@
 import { t, Trans } from "@lingui/macro";
 import { Box, Typography } from "@mui/material";
-import { ChangeEvent, ReactNode } from "react";
+import { ChangeEvent, ReactNode, useEffect, useState } from "react";
 
 import { EncodingFieldType } from "@/charts/chart-config-ui-options";
 import Flex from "@/components/flex";
@@ -448,9 +448,24 @@ const ConversionUnitContent = ({
   const [_, dispatch] = useConfiguratorState(isConfiguring);
   const definedConversionUnit =
     conversionUnit ?? getDefaultConversionUnit({ originalUnit });
+  const [inputValue, setInputValue] = useState(
+    `${definedConversionUnit.multiplier}`
+  );
+
+  useEffect(() => {
+    setInputValue(`${definedConversionUnit.multiplier}`);
+  }, [definedConversionUnit.multiplier]);
+
   const handleMultiplierChange = useEvent(
     (e: ChangeEvent<HTMLInputElement>) => {
-      const newMultiplier = +e.target.value;
+      const newInputValue = e.target.value;
+      setInputValue(newInputValue);
+
+      if (newInputValue === "") {
+        return;
+      }
+
+      const newMultiplier = +newInputValue;
 
       if (!isNaN(newMultiplier) && newMultiplier > 0) {
         dispatch({
@@ -468,6 +483,14 @@ const ConversionUnitContent = ({
       }
     }
   );
+
+  const handleMultiplierBlur = useEvent(() => {
+    const numericValue = +inputValue;
+
+    if (inputValue === "" || isNaN(numericValue) || numericValue <= 0) {
+      setInputValue(`${definedConversionUnit.multiplier}`);
+    }
+  });
 
   const handleLabelChange = useEvent((locale: Locale, value: string) => {
     dispatch({
@@ -503,8 +526,9 @@ const ConversionUnitContent = ({
             message: "Multiplier",
           })}
           name="multiplier"
-          value={definedConversionUnit.multiplier}
+          value={inputValue}
           onChange={handleMultiplierChange}
+          onBlur={handleMultiplierBlur}
         />
       </Flex>
       <Flex sx={{ flexDirection: "column", gap: 1 }}>


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2347

<!--- Describe the changes -->

This PR improves the conversion unit input element UX by allowing clearing the input value and only updating the application state when the multiplier value is valid. The input also resets back to a correct, previous value in case user enters a wrong value and the input loses focus.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-feat-conversion-units-ui-imp-cede5c-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10&dataSource=Prod&flag__convert-units=true).
2. Open Vertical Axis.
3. Enable conversion units.
4. ✅ See that the multiplier input is much more user friendly – e.g. it's possible to remove multiplier.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code