### PR TITLE
fix: Drop global unique name constrain, scope to user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ You can also check the
   - Invalid URL error message is now translated
   - Improved UX of interacting with conversion units multiplier input
 - Fixes
+  - Custom color palette names are not required to be globally unique anymore,
+    but unique per user
   - Fixed an infinite render loop when adding a custom map layer
 - Styles
   - Fixed some smaller UI inconsistencies, mostly in table charts

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -69,7 +69,7 @@ enum PALETTE_TYPE {
 
 model Palette {
   paletteId  String       @id @default(uuid())
-  name       String       @unique @db.VarChar(100)
+  name       String       @db.VarChar(100)
   type       PALETTE_TYPE  
   colors     String[]
   created_at DateTime     @default(now()) @db.Timestamp(6)
@@ -79,4 +79,5 @@ model Palette {
   user_id    Int?
 
   @@map("palettes")
+  @@unique([name, user_id])
 }


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2358

<!--- Describe the changes -->

This PR makes sure we only enforce uniqueness of color palettes on a user level, not globally.

---

- [ ] I added a CHANGELOG entry
- [ ] I made a self-review of my own code
