### PR TITLE
fix: Segmented value label colors in PNG export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ You can also check the
 
 # Unreleased
 
-Nothing yet.
+- Fixes
+  - Segmented bar and column charts now correctly display value labels when
+    downloading an image
 
 # 5.8.2 - 2025-06-03
 

--- a/app/charts/shared/render-value-labels.ts
+++ b/app/charts/shared/render-value-labels.ts
@@ -123,7 +123,6 @@ export const setSegmentWrapperValueLabelProps = <
   g: Selection<BaseType, T, SVGGElement, null>
 ) => {
   return g
-    .attr(DISABLE_SCREENSHOT_COLOR_WIPE_KEY, true)
     .style("display", "flex")
     .style("justify-content", "center")
     .style("align-items", "center")
@@ -138,6 +137,7 @@ export const setSegmentValueLabelProps = <
   g: Selection<BaseType, T, SVGGElement, null>
 ) => {
   return g
+    .attr(DISABLE_SCREENSHOT_COLOR_WIPE_KEY, true)
     .style("overflow", "hidden")
     .style("font-size", "12px")
     .style("white-space", "nowrap")


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2361

<!--- Describe the changes -->

This PR makes sure the segmented value label colors persist when downloading PNG image of a chart.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-segment-value-labels-png-ixt1.vercel.app/en/v/UBM1nX43UAd-?dataSource=Prod).
2. Export PNG image.
3. ✅ See that the value label colors are correct.

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
