### PR TITLE
refactor: satisfies

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*    @bprusinowski @noahonyejese
+*    @bprusinowski

--- a/app/browser/dataset-browse.spec.tsx
+++ b/app/browser/dataset-browse.spec.tsx
@@ -8,7 +8,7 @@ describe("getFiltersFromParams", () => {
     const params = {
       type: "organization",
       iri: "https://fake-iri-organization",
-    } as BrowseParams;
+    } satisfies BrowseParams;
     const filters = getFiltersFromParams(params);
     expect(filters).toEqual([
       {
@@ -24,7 +24,7 @@ describe("getFiltersFromParams", () => {
       iri: "https://fake-iri-theme",
       subtype: "organization",
       subiri: "https://fake-iri-organization",
-    } as BrowseParams;
+    } satisfies BrowseParams;
     const filters = getFiltersFromParams(params);
     expect(filters).toEqual([
       { iri: "https://fake-iri-theme", __typename: "DataCubeTheme" },
@@ -41,7 +41,7 @@ describe("getFiltersFromParams", () => {
       iri: "https://fake-iri-organization",
       subtype: "theme",
       subiri: "https://fake-iri-theme",
-    } as BrowseParams;
+    } satisfies BrowseParams;
     const filters = getFiltersFromParams(params);
     expect(filters).toEqual([
       {
@@ -59,7 +59,7 @@ describe("getFiltersFromParams", () => {
     const params = {
       type: "dataset",
       iri: "https://fake-iri-dataset",
-    } as BrowseParams;
+    } satisfies BrowseParams;
     const filters = getFiltersFromParams(params);
     expect(filters).toEqual([]);
   });

--- a/app/browser/dataset-browse.tsx
+++ b/app/browser/dataset-browse.tsx
@@ -688,9 +688,8 @@ export const SearchFilters = ({
     DataCubeOrganization: orgFilter,
     DataCubeTermset: termsetFilter,
   } = useMemo(() => {
-    const result = keyBy(filters, (f) => f.__typename) as {
-      [K in BrowseFilter["__typename"]]?: BrowseFilter;
-    };
+    const result = keyBy(filters, (f) => f.__typename);
+
     return {
       DataCubeTheme: result.DataCubeTheme as DataCubeTheme | undefined,
       DataCubeOrganization: result.DataCubeOrganization as
@@ -841,10 +840,10 @@ export const SearchFilters = ({
   ];
   const navs = sortBy(baseNavs, (x) => {
     const i = filters.findIndex((f) => f.__typename === x.__typename);
+
     return i === -1
       ? // If the filter is not in the list, we want to put it at the end
-        navOrder[x.__typename as BrowseFilter["__typename"]] +
-          Object.keys(navOrder).length
+        navOrder[x.__typename] + Object.keys(navOrder).length
       : i;
   });
 

--- a/app/browser/select-dataset-step.tsx
+++ b/app/browser/select-dataset-step.tsx
@@ -126,9 +126,11 @@ const formatBackLink = (
   query: Router["query"]
 ): ComponentProps<typeof NextLink>["href"] => {
   const backParameters = softJSONParse(query.previous as string);
+
   if (!backParameters) {
     return "/browse";
   }
+
   return buildURLFromBrowseState(backParameters);
 };
 
@@ -294,10 +296,9 @@ const SelectDatasetStepContent = ({
 
   const pageTitle = useMemo(() => {
     return queryFilters
-      .map((d) => {
+      .map((queryFilter) => {
         const searchList = (() => {
-          const type = d.type;
-          switch (type) {
+          switch (queryFilter.type) {
             case SearchCubeFilterType.DataCubeTheme:
               return themes;
             case SearchCubeFilterType.DataCubeOrganization:
@@ -305,18 +306,18 @@ const SelectDatasetStepContent = ({
             case SearchCubeFilterType.DataCubeTermset:
               return termsets;
             case SearchCubeFilterType.DataCubeAbout:
-              return [];
             case SearchCubeFilterType.TemporalDimension:
               return [];
             default:
-              const check: never = type;
-              throw Error(`Invalid search cube filter type ${check}`);
+              const _exhaustiveCheck: never = queryFilter.type;
+              return _exhaustiveCheck;
           }
         })();
-        const item = (searchList as { iri: string; label?: string }[]).find(
-          ({ iri }) => iri === d.value
-        );
-        return (item ?? d).label;
+        const foundQueryFilter = (
+          searchList as { iri: string; label?: string }[]
+        ).find(({ iri }) => iri === queryFilter.value);
+
+        return (foundQueryFilter ?? queryFilter).label;
       })
       .join(", ");
   }, [orgs, queryFilters, termsets, themes]);
@@ -336,7 +337,7 @@ const SelectDatasetStepContent = ({
       sourceUrl: configState.dataSource.url,
       locale,
       cubeFilter: {
-        iri: dataset!,
+        iri: dataset ?? "",
       },
     },
     pause: !dataset,

--- a/app/charts/area/areas-state.tsx
+++ b/app/charts/area/areas-state.tsx
@@ -417,7 +417,7 @@ const useAreasState = (
   const getAnnotationInfo = useCallback(
     (datum: Observation): TooltipInfo => {
       const x = getXAsString(datum);
-      const tooltipValues = chartDataGroupedByX.get(x) as Observation[];
+      const tooltipValues = chartDataGroupedByX.get(x) ?? [];
       const yValues = tooltipValues.map(getY);
       const sortedTooltipValues = sortByIndex({
         data: tooltipValues,
@@ -456,13 +456,13 @@ const useAreasState = (
         datum: {
           label: fields.segment && getSegmentAbbreviationOrLabel(datum),
           value: yValueFormatter(getY(datum), getIdentityY(datum)),
-          color: colors(getSegment(datum)) as string,
+          color: colors(getSegment(datum)),
         },
         values: fields.segment
-          ? sortedTooltipValues.map((td) => ({
-              label: getSegmentAbbreviationOrLabel(td),
-              value: yValueFormatter(getY(td), getIdentityY(td)),
-              color: colors(getSegment(td)) as string,
+          ? sortedTooltipValues.map((d) => ({
+              label: getSegmentAbbreviationOrLabel(d),
+              value: yValueFormatter(getY(d), getIdentityY(d)),
+              color: colors(getSegment(d)),
             }))
           : undefined,
       };

--- a/app/charts/area/areas.tsx
+++ b/app/charts/area/areas.tsx
@@ -32,7 +32,7 @@ export const Areas = () => {
     .x((d) => xScale(getX(d.data)))
     .y0((d) => yScale(d[0]))
     .y1((d) => yScale(d[1]));
-  const renderData: RenderAreaDatum[] = useMemo(() => {
+  const renderData = useMemo(() => {
     return series.map((d) => {
       return {
         key: d.key,
@@ -46,7 +46,7 @@ export const Areas = () => {
           })
         ) as string,
         color: colors(d.key),
-      };
+      } satisfies RenderAreaDatum;
     });
   }, [series, areaGenerator, colors]);
 

--- a/app/charts/bar/bars-grouped-state.tsx
+++ b/app/charts/bar/bars-grouped-state.tsx
@@ -446,15 +446,15 @@ const useBarsGroupedState = (
         label: fields.segment && getSegmentAbbreviationOrLabel(datum),
         value: xValueFormatter(getX(datum)),
         error: getFormattedXUncertainty(datum),
-        color: colors(getSegment(datum)) as string,
+        color: colors(getSegment(datum)),
       },
-      values: sortedTooltipValues.map((td) => ({
-        label: getSegmentAbbreviationOrLabel(td),
+      values: sortedTooltipValues.map((d) => ({
+        label: getSegmentAbbreviationOrLabel(d),
         value: xMeasure.unit
-          ? `${formatNumber(getX(td))} ${xMeasure.unit}`
-          : formatNumber(getX(td)),
-        error: getFormattedXUncertainty(td),
-        color: colors(getSegment(td)) as string,
+          ? `${formatNumber(getX(d))} ${xMeasure.unit}`
+          : formatNumber(getX(d)),
+        error: getFormattedXUncertainty(d),
+        color: colors(getSegment(d)),
       })),
     };
   };

--- a/app/charts/bar/bars-grouped.tsx
+++ b/app/charts/bar/bars-grouped.tsx
@@ -26,12 +26,13 @@ export const ErrorWhiskers = () => {
   const ref = useRef<SVGGElement>(null);
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
-  const renderData: RenderHorizontalWhiskerDatum[] = useMemo(() => {
+  const renderData = useMemo(() => {
     if (!getXErrorRange || !showXUncertainty) {
       return [];
     }
 
     const bandwidth = yScaleIn.bandwidth();
+
     return grouped
       .filter((d) => d[1].some(getXErrorPresent))
       .flatMap(([segment, observations]) =>
@@ -39,13 +40,14 @@ export const ErrorWhiskers = () => {
           const y0 = yScaleIn(getSegment(d)) as number;
           const barHeight = Math.min(bandwidth, 15);
           const [x1, x2] = getXErrorRange(d);
+
           return {
             key: `${segment}-${getSegment(d)}`,
             y: (yScale(segment) as number) + y0 + bandwidth / 2 - barHeight / 2,
             x1: xScale(x1),
             x2: xScale(x2),
             height: barHeight,
-          } as RenderHorizontalWhiskerDatum;
+          } satisfies RenderHorizontalWhiskerDatum;
         })
       );
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/charts/bar/bars-stacked-state.tsx
+++ b/app/charts/bar/bars-stacked-state.tsx
@@ -403,17 +403,12 @@ const useBarsStackedState = (
           : stackOrderDescending
         : // Reverse segments here, so they're sorted from top to bottom
           stackOrderReverse;
-
     const stacked = stack()
       .order(stackOrder)
       .offset(stackOffsetDiverging)
       .keys(segments);
 
-    return stacked(
-      chartWideData as {
-        [key: string]: number;
-      }[]
-    );
+    return stacked(chartWideData as { [key: string]: number }[]);
   }, [chartWideData, fields.segment?.sorting, segments]);
 
   /** Chart dimensions */
@@ -480,7 +475,7 @@ const useBarsStackedState = (
       const bw = yScale.bandwidth();
       const y = getY(datum);
 
-      const tooltipValues = chartDataGroupedByY.get(y) as Observation[];
+      const tooltipValues = chartDataGroupedByY.get(y) ?? [];
       const xValues = tooltipValues.map(getX);
       const sortedTooltipValues = sortByIndex({
         data: tooltipValues,
@@ -504,7 +499,6 @@ const useBarsStackedState = (
         ? MOBILE_TOOLTIP_PLACEMENT
         : getCenteredTooltipPlacement({
             chartWidth,
-            //NOTE: this might be wrong
             xAnchor,
             topAnchor: !fields.segment,
           });
@@ -518,12 +512,12 @@ const useBarsStackedState = (
         datum: {
           label: fields.segment && getSegmentAbbreviationOrLabel(datum),
           value: xValueFormatter(getX(datum), getIdentityX(datum)),
-          color: colors(getSegment(datum)) as string,
+          color: colors(getSegment(datum)),
         },
-        values: sortedTooltipValues.map((td) => ({
-          label: getSegmentAbbreviationOrLabel(td),
-          value: xValueFormatter(getX(td), getIdentityX(td)),
-          color: colors(getSegment(td)) as string,
+        values: sortedTooltipValues.map((d) => ({
+          label: getSegmentAbbreviationOrLabel(d),
+          value: xValueFormatter(getX(d), getIdentityX(d)),
+          color: colors(getSegment(d)),
         })),
       };
     },

--- a/app/charts/bar/bars-stacked.tsx
+++ b/app/charts/bar/bars-stacked.tsx
@@ -26,7 +26,7 @@ export const BarsStacked = () => {
   const { margins, height } = bounds;
   const bandwidth = yScale.bandwidth();
   const x0 = xScale(0);
-  const renderData: RenderBarDatum[] = useMemo(() => {
+  const renderData = useMemo(() => {
     return series.flatMap((s) => {
       const segmentLabel = s.key;
       const segment =
@@ -35,6 +35,7 @@ export const BarsStacked = () => {
 
       return s.map((d) => {
         const observation = d.data;
+        const x = xScale(d[0]);
         const value = observation[segmentLabel];
         const valueLabel =
           segment && showValuesBySegmentMapping[segment]
@@ -47,13 +48,13 @@ export const BarsStacked = () => {
         return {
           key: getRenderingKey(observation, segmentLabel),
           y: yScale(getY(observation)) as number,
-          x: xScale(d[0]),
+          x,
           height: bandwidth,
-          width: Math.min(0, xScale(d[0]) - xScale(d[1])) * -1,
+          width: Math.min(0, x - xScale(d[1])) * -1,
           color,
           valueLabel,
           valueLabelColor,
-        };
+        } satisfies RenderBarDatum;
       });
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/charts/bar/bars.tsx
+++ b/app/charts/bar/bars.tsx
@@ -31,7 +31,7 @@ export const ErrorWhiskers = () => {
   const ref = useRef<SVGGElement>(null);
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
-  const renderData: RenderHorizontalWhiskerDatum[] = useMemo(() => {
+  const renderData = useMemo(() => {
     if (!getXErrorRange || !showXUncertainty) {
       return [];
     }
@@ -49,7 +49,7 @@ export const ErrorWhiskers = () => {
         x1: xScale(x1),
         x2: xScale(x2),
         height: barHeight,
-      } as RenderHorizontalWhiskerDatum;
+      } satisfies RenderHorizontalWhiskerDatum;
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
@@ -104,7 +104,7 @@ export const Bars = () => {
   const transitionDuration = useTransitionStore((state) => state.duration);
   const bandwidth = yScale.bandwidth();
   const x0 = xScale(0);
-  const renderData: RenderBarDatum[] = useMemo(() => {
+  const renderData = useMemo(() => {
     return chartData.map((d) => {
       const key = getRenderingKey(d);
       const yScaled = yScale(getY(d)) as number;
@@ -121,7 +121,7 @@ export const Bars = () => {
         width,
         height: bandwidth,
         color: colors(d.key as string) ?? schemeCategory10[0],
-      };
+      } satisfies RenderBarDatum;
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [

--- a/app/charts/bar/show-values-utils.ts
+++ b/app/charts/bar/show-values-utils.ts
@@ -20,7 +20,7 @@ export const useBarValueLabelsData = () => {
     getValueOffset,
   } = useChartState() as BarsState;
   const bandwidth = yScale.bandwidth();
-  const valueLabelsData: RenderTotalValueLabelDatum[] = useMemo(() => {
+  const valueLabelsData = useMemo(() => {
     if (!showValues || !width || !height) {
       return [];
     }
@@ -43,7 +43,7 @@ export const useBarValueLabelsData = () => {
           x: xScaled + valueOffset,
           y: yRender + bandwidth / 2,
           valueLabel: valueLabelFormatter(value),
-        };
+        } satisfies RenderTotalValueLabelDatum;
       })
       .filter(truthy);
   }, [

--- a/app/charts/column/columns-grouped-state.tsx
+++ b/app/charts/column/columns-grouped-state.tsx
@@ -447,15 +447,15 @@ const useColumnsGroupedState = (
         label: fields.segment && getSegmentAbbreviationOrLabel(datum),
         value: yValueFormatter(getY(datum)),
         error: getFormattedYUncertainty(datum),
-        color: colors(getSegment(datum)) as string,
+        color: colors(getSegment(datum)),
       },
-      values: sortedTooltipValues.map((td) => ({
-        label: getSegmentAbbreviationOrLabel(td),
+      values: sortedTooltipValues.map((d) => ({
+        label: getSegmentAbbreviationOrLabel(d),
         value: yMeasure.unit
-          ? `${formatNumber(getY(td))} ${yMeasure.unit}`
-          : formatNumber(getY(td)),
-        error: getFormattedYUncertainty(td),
-        color: colors(getSegment(td)) as string,
+          ? `${formatNumber(getY(d))} ${yMeasure.unit}`
+          : formatNumber(getY(d)),
+        error: getFormattedYUncertainty(d),
+        color: colors(getSegment(d)),
       })),
     };
   };

--- a/app/charts/column/columns-stacked-state.tsx
+++ b/app/charts/column/columns-stacked-state.tsx
@@ -407,11 +407,7 @@ const useColumnsStackedState = (
       .offset(stackOffsetDiverging)
       .keys(segments);
 
-    return stacked(
-      chartWideData as {
-        [key: string]: number;
-      }[]
-    );
+    return stacked(chartWideData as { [key: string]: number }[]);
   }, [chartWideData, fields.segment?.sorting, segments]);
 
   /** Chart dimensions */
@@ -468,7 +464,7 @@ const useColumnsStackedState = (
       const bw = xScale.bandwidth();
       const x = getX(datum);
 
-      const tooltipValues = chartDataGroupedByX.get(x) as Observation[];
+      const tooltipValues = chartDataGroupedByX.get(x) ?? [];
       const yValues = tooltipValues.map(getY);
       const sortedTooltipValues = sortByIndex({
         data: tooltipValues,
@@ -505,12 +501,12 @@ const useColumnsStackedState = (
         datum: {
           label: fields.segment && getSegmentAbbreviationOrLabel(datum),
           value: yValueFormatter(getY(datum), getIdentityY(datum)),
-          color: colors(getSegment(datum)) as string,
+          color: colors(getSegment(datum)),
         },
-        values: sortedTooltipValues.map((td) => ({
-          label: getSegmentAbbreviationOrLabel(td),
-          value: yValueFormatter(getY(td), getIdentityY(td)),
-          color: colors(getSegment(td)) as string,
+        values: sortedTooltipValues.map((d) => ({
+          label: getSegmentAbbreviationOrLabel(d),
+          value: yValueFormatter(getY(d), getIdentityY(d)),
+          color: colors(getSegment(d)),
         })),
       };
     },

--- a/app/charts/column/columns-stacked.tsx
+++ b/app/charts/column/columns-stacked.tsx
@@ -29,7 +29,7 @@ export const ColumnsStacked = () => {
   const { margins, height } = bounds;
   const bandwidth = xScale.bandwidth();
   const y0 = yScale(0);
-  const renderData: RenderColumnDatum[] = useMemo(() => {
+  const renderData = useMemo(() => {
     return series.flatMap((s) => {
       const segmentLabel = s.key;
       const segment =
@@ -46,17 +46,18 @@ export const ColumnsStacked = () => {
         const valueLabelColor = valueLabel
           ? getContrastingColor(color)
           : undefined;
+        const y = yScale(d[1]) as number;
 
         return {
           key: getRenderingKey(observation, segmentLabel),
           x: xScale(getX(observation)) as number,
-          y: yScale(d[1]),
+          y,
           width: bandwidth,
-          height: Math.max(0, yScale(d[0]) - yScale(d[1])),
+          height: Math.max(0, yScale(d[0]) - y),
           color,
           valueLabel,
           valueLabelColor,
-        };
+        } satisfies RenderColumnDatum;
       });
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/charts/column/columns.tsx
+++ b/app/charts/column/columns.tsx
@@ -20,6 +20,7 @@ import { useTransitionStore } from "@/stores/transition";
 export const ErrorWhiskers = () => {
   const {
     getX,
+    getY,
     getYErrorPresent,
     getYErrorRange,
     chartData,
@@ -33,7 +34,7 @@ export const ErrorWhiskers = () => {
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
   const bandwidth = xScale.bandwidth();
-  const renderData: RenderVerticalWhiskerDatum[] = useMemo(() => {
+  const renderData = useMemo(() => {
     if (!getYErrorRange || !showYUncertainty) {
       return [];
     }
@@ -41,15 +42,17 @@ export const ErrorWhiskers = () => {
     return chartData.filter(getYErrorPresent).map((d, i) => {
       const x0 = xScale(getX(d)) as number;
       const barWidth = Math.min(bandwidth, 15);
+      const y = getY(d) as number;
       const [y1, y2] = getYErrorRange(d);
 
       return {
         key: `${i}`,
         x: x0 + bandwidth / 2 - barWidth / 2,
+        y: yScale(y),
         y1: yScale(y1),
         y2: yScale(y2),
         width: barWidth,
-      } as RenderVerticalWhiskerDatum;
+      } satisfies RenderVerticalWhiskerDatum;
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
@@ -104,7 +107,7 @@ export const Columns = () => {
   const transitionDuration = useTransitionStore((state) => state.duration);
   const bandwidth = xScale.bandwidth();
   const y0 = yScale(0);
-  const columnsData: RenderColumnDatum[] = useMemo(() => {
+  const columnsData = useMemo(() => {
     return chartData.map((d) => {
       const key = getRenderingKey(d);
       const valueRaw = getY(d);
@@ -119,13 +122,12 @@ export const Columns = () => {
 
       return {
         key,
-        value,
         x: xScaled,
         y: yRender,
         width: bandwidth,
         height,
         color,
-      };
+      } satisfies RenderColumnDatum;
     });
   }, [
     chartData,

--- a/app/charts/column/overlay-columns.tsx
+++ b/app/charts/column/overlay-columns.tsx
@@ -34,6 +34,7 @@ export const InteractionColumns = ({ temporal }: { temporal?: boolean }) => {
     },
     [formatXDate, getX, getXAsDate, temporal]
   );
+  const bandwidth = xScaleInteraction.bandwidth();
 
   return (
     <g transform={`translate(${margins.left} ${margins.top})`}>
@@ -46,7 +47,7 @@ export const InteractionColumns = ({ temporal }: { temporal?: boolean }) => {
             key={i}
             x={xScaled}
             y={0}
-            width={xScaleInteraction.bandwidth()}
+            width={bandwidth}
             height={Math.max(0, chartHeight)}
             fill="hotpink"
             fillOpacity={0}

--- a/app/charts/column/show-values-utils.ts
+++ b/app/charts/column/show-values-utils.ts
@@ -20,7 +20,7 @@ export const useColumnValueLabelsData = () => {
     valueLabelFormatter,
   } = useChartState() as ColumnsState;
   const bandwidth = xScale.bandwidth();
-  const valueLabelsData: RenderTotalValueLabelDatum[] = useMemo(() => {
+  const valueLabelsData = useMemo(() => {
     if (!showValues || !width || !height) {
       return [];
     }
@@ -43,7 +43,7 @@ export const useColumnValueLabelsData = () => {
           x: xScaled + bandwidth / 2,
           y: yRender + valueOffset,
           valueLabel: valueLabelFormatter(value),
-        };
+        } satisfies RenderTotalValueLabelDatum;
       })
       .filter(truthy);
   }, [

--- a/app/charts/combo/combo-line-column-state.tsx
+++ b/app/charts/combo/combo-line-column-state.tsx
@@ -36,7 +36,7 @@ import {
   CommonChartState,
   InteractiveXTimeRangeState,
 } from "@/charts/shared/chart-state";
-import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
+import { TooltipInfo, TooltipValue } from "@/charts/shared/interaction/tooltip";
 import {
   getCenteredTooltipPlacement,
   MOBILE_TOOLTIP_PLACEMENT,
@@ -193,7 +193,7 @@ const useComboLineColumnState = (
   const isMobile = useIsMobile();
 
   // Tooltip
-  const getAnnotationInfo = (d: Observation): TooltipInfo => {
+  const getAnnotationInfo = (d: Observation) => {
     const x = getXAsDate(d);
     const xScaled =
       (xScale(formatXDate(x)) as number) + xScale.bandwidth() * 0.5;
@@ -213,7 +213,7 @@ const useComboLineColumnState = (
           hide: y === null,
           yPos,
           symbol: chartType === "line" ? "line" : "square",
-        };
+        } satisfies TooltipValue;
       })
       .filter(truthy);
     const yAnchor = isMobile ? chartHeight : mean(values.map((d) => d.yPos));
@@ -229,10 +229,10 @@ const useComboLineColumnState = (
       datum: { label: "", value: "0", color: schemeCategory10[0] },
       xAnchor: xScaled,
       yAnchor,
-      value: timeFormatUnit(x, variables.xTimeUnit as TimeUnit),
+      value: timeFormatUnit(x, xTimeUnit),
       placement,
       values,
-    } as TooltipInfo;
+    } satisfies TooltipInfo;
   };
 
   return {

--- a/app/charts/combo/combo-line-column.tsx
+++ b/app/charts/combo/combo-line-column.tsx
@@ -34,7 +34,7 @@ const Columns = () => {
       ? yOrientationScales.left
       : yOrientationScales.right;
   const y0 = yScale(0);
-  const renderData: RenderColumnDatum[] = useMemo(() => {
+  const renderData = useMemo(() => {
     return chartData.map((d) => {
       const key = getRenderingKey(d);
       const xDate = getXAsDate(d);
@@ -47,13 +47,12 @@ const Columns = () => {
 
       return {
         key,
-        value: y,
         x: xScaled,
         y: yRender,
         width: bandwidth,
         height,
         color,
-      };
+      } satisfies RenderColumnDatum;
     });
   }, [
     chartData,

--- a/app/charts/combo/combo-line-dual-state.tsx
+++ b/app/charts/combo/combo-line-dual-state.tsx
@@ -28,7 +28,7 @@ import {
   CommonChartState,
   InteractiveXTimeRangeState,
 } from "@/charts/shared/chart-state";
-import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
+import { TooltipInfo, TooltipValue } from "@/charts/shared/interaction/tooltip";
 import {
   getCenteredTooltipPlacement,
   MOBILE_TOOLTIP_PLACEMENT,
@@ -179,7 +179,7 @@ const useComboLineDualState = (
   const isMobile = useIsMobile();
 
   // Tooltip
-  const getAnnotationInfo = (d: Observation): TooltipInfo => {
+  const getAnnotationInfo = (d: Observation) => {
     const x = getX(d);
     const xScaled = xScale(x);
 
@@ -198,7 +198,7 @@ const useComboLineDualState = (
           hide: y === null,
           yPos: yPos,
           symbol: "line",
-        };
+        } satisfies TooltipValue;
       })
       .filter(truthy);
     const yAnchor = isMobile
@@ -219,7 +219,7 @@ const useComboLineDualState = (
       value: timeFormatUnit(x, xDimension.timeUnit),
       placement,
       values,
-    } as TooltipInfo;
+    } satisfies TooltipInfo;
   };
 
   return {

--- a/app/charts/combo/combo-line-single-state.tsx
+++ b/app/charts/combo/combo-line-single-state.tsx
@@ -27,7 +27,7 @@ import {
   CommonChartState,
   InteractiveXTimeRangeState,
 } from "@/charts/shared/chart-state";
-import { TooltipInfo } from "@/charts/shared/interaction/tooltip";
+import { TooltipInfo, TooltipValue } from "@/charts/shared/interaction/tooltip";
 import {
   getCenteredTooltipPlacement,
   MOBILE_TOOLTIP_PLACEMENT,
@@ -141,7 +141,7 @@ const useComboLineSingleState = (
   const isMobile = useIsMobile();
 
   // Tooltip
-  const getAnnotationInfo = (d: Observation): TooltipInfo => {
+  const getAnnotationInfo = (d: Observation) => {
     const x = getX(d);
     const xScaled = xScale(x);
     const values = variables.y.lines
@@ -158,7 +158,7 @@ const useComboLineSingleState = (
           hide: y === null,
           yPos: yScale(y ?? 0),
           symbol: "line",
-        };
+        } satisfies TooltipValue;
       })
       .filter(truthy);
     const yAnchor = isMobile
@@ -179,7 +179,7 @@ const useComboLineSingleState = (
       value: timeFormatUnit(x, xDimension.timeUnit),
       placement,
       values,
-    } as TooltipInfo;
+    } satisfies TooltipInfo;
   };
 
   return {

--- a/app/charts/line/lines-state.tsx
+++ b/app/charts/line/lines-state.tsx
@@ -308,7 +308,7 @@ const useLinesState = (
   const isMobile = useIsMobile();
 
   // Tooltip
-  const getAnnotationInfo = (datum: Observation): TooltipInfo => {
+  const getAnnotationInfo = (datum: Observation) => {
     const x = getX(datum);
     const tooltipValues = chartData.filter(
       (d) => getX(d).getTime() === x.getTime()
@@ -348,17 +348,17 @@ const useLinesState = (
         label: fields.segment && getSegmentAbbreviationOrLabel(datum),
         value: yValueFormatter(getY(datum)),
         error: getFormattedYUncertainty(datum),
-        color: colors(getSegment(datum)) as string,
+        color: colors(getSegment(datum)),
       },
-      values: sortedTooltipValues.map((td) => ({
-        hide: getY(td) === null,
-        label: getSegmentAbbreviationOrLabel(td),
-        value: yValueFormatter(getY(td)),
-        color: colors(getSegment(td)) as string,
-        yPos: yScale(getY(td) ?? 0),
+      values: sortedTooltipValues.map((d) => ({
+        hide: getY(d) === null,
+        label: getSegmentAbbreviationOrLabel(d),
+        value: yValueFormatter(getY(d)),
+        color: colors(getSegment(d)),
+        yPos: yScale(getY(d) ?? 0),
         symbol: "line",
       })),
-    };
+    } satisfies TooltipInfo;
   };
 
   return {

--- a/app/charts/line/lines.tsx
+++ b/app/charts/line/lines.tsx
@@ -34,7 +34,7 @@ export const ErrorWhiskers = () => {
   const ref = useRef<SVGGElement>(null);
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
-  const renderData: RenderVerticalWhiskerDatum[] = useMemo(() => {
+  const renderData = useMemo(() => {
     if (!getYErrorRange || !showYUncertainty) {
       return [];
     }
@@ -45,6 +45,7 @@ export const ErrorWhiskers = () => {
       const barWidth = 15;
       const y = getY(d) as number;
       const [y1, y2] = getYErrorRange(d);
+
       return {
         key: `${i}`,
         x: x0 - barWidth / 2,
@@ -54,7 +55,7 @@ export const ErrorWhiskers = () => {
         width: barWidth,
         fill: colors(segment),
         renderMiddleCircle: true,
-      } as RenderVerticalWhiskerDatum;
+      } satisfies RenderVerticalWhiskerDatum;
     });
   }, [
     chartData,

--- a/app/charts/map/get-base-layer-style.ts
+++ b/app/charts/map/get-base-layer-style.ts
@@ -33,7 +33,7 @@ const emptyStyle = {
       },
     },
   ],
-} as MapboxStyle;
+} satisfies MapboxStyle;
 
 type AnyLayer = MapboxStyle["layers"][number];
 
@@ -63,9 +63,9 @@ const getBaseLayerStyle = ({
           "text-field": `{${languageTag}}`,
           visibility: textLayersVisibility,
         },
-      }) as AnyLayer;
+      }) satisfies AnyLayer;
     } else {
-      return layer as AnyLayer;
+      return layer satisfies AnyLayer;
     }
   });
 

--- a/app/charts/map/map.tsx
+++ b/app/charts/map/map.tsx
@@ -301,7 +301,7 @@ export const MapComponent = ({
       features.areaLayer?.shapes?.features,
       geoArea,
       "desc"
-    ) as GeoFeature[];
+    ) satisfies GeoFeature[];
 
     return {
       ...features.areaLayer?.shapes,

--- a/app/charts/pie/pie-state.tsx
+++ b/app/charts/pie/pie-state.tsx
@@ -30,7 +30,7 @@ import { useChartFormatters } from "@/charts/shared/use-chart-formatters";
 import { InteractionProvider } from "@/charts/shared/use-interaction";
 import { useSize } from "@/charts/shared/use-size";
 import { PieConfig } from "@/configurator";
-import { Dimension, Observation } from "@/domain/data";
+import { Observation } from "@/domain/data";
 import { formatNumberWithUnit, useFormatNumber } from "@/formatters";
 import { getPalette } from "@/palettes";
 import {
@@ -69,7 +69,7 @@ const usePieState = (
     yAxisLabel,
   } = variables;
   // Segment dimension is guaranteed to be present, because it is required.
-  const segmentDimension = _segmentDimension as Dimension;
+  const segmentDimension = _segmentDimension!;
   const { chartData, segmentData, allData } = data;
   const { fields } = chartConfig;
   const { y } = fields;

--- a/app/charts/pie/pie.tsx
+++ b/app/charts/pie/pie.tsx
@@ -45,7 +45,7 @@ export const Pie = () => {
   const xTranslate = width / 2;
   const yTranslate = height / 2;
 
-  const renderData: RenderDatum[] = useMemo(() => {
+  const renderData = useMemo(() => {
     const arcs = getPieData(chartData);
 
     return arcs.map((arcDatum) => {
@@ -55,9 +55,8 @@ export const Pie = () => {
         key: getRenderingKey(arcDatum.data),
         value: y === null || isNaN(y) ? 0 : y,
         arcDatum,
-        innerRadius,
         color: colors(getSegment(arcDatum.data)),
-      };
+      } satisfies RenderDatum;
     });
   }, [getPieData, chartData, getY, getRenderingKey, colors, getSegment]);
 

--- a/app/charts/scatterplot/scatterplot.tsx
+++ b/app/charts/scatterplot/scatterplot.tsx
@@ -27,14 +27,14 @@ export const Scatterplot = () => {
   const ref = useRef<SVGGElement>(null);
   const enableTransition = useTransitionStore((state) => state.enable);
   const transitionDuration = useTransitionStore((state) => state.duration);
-  const renderData: RenderDatum[] = useMemo(() => {
+  const renderData = useMemo(() => {
     return chartData.map((d) => {
       return {
         key: getRenderingKey(d),
         cx: xScale(getX(d) ?? NaN),
         cy: yScale(getY(d) ?? NaN),
         color: hasSegment ? colors(getSegment(d)) : schemeCategory10[0],
-      };
+      } satisfies RenderDatum;
     });
   }, [
     chartData,

--- a/app/charts/shared/limits/create-component.tsx
+++ b/app/charts/shared/limits/create-component.tsx
@@ -40,7 +40,7 @@ export const createLimitsComponent = <
     const measureScale = isHorizontal ? xScale : yScale;
     const chartSize = isHorizontal ? chartHeight : chartWidth;
 
-    const renderData: RenderLimitDatum[] = useMemo(() => {
+    const renderData = useMemo(() => {
       if (!limits.length) {
         return [];
       }
@@ -76,18 +76,21 @@ export const createLimitsComponent = <
           const axisOffset = isBandScale ? size / 2 : 0;
           const hasValidAxis = axis1 !== undefined && axis2 !== undefined;
           const hasNoAxis = relatedAxisDimensionValueLabel === undefined;
-          let x1, x2, y1, y2;
+          let x1: number;
+          let x2: number;
+          let y1: number;
+          let y2: number;
 
           if (isHorizontal) {
             y1 = axis1 ? axis1 + axisOffset : 0;
             y2 = axis2 ? axis2 + axisOffset : chartSize;
-            x1 = measure1;
-            x2 = measure2;
+            x1 = measure1 ?? 0;
+            x2 = measure2 ?? 0;
           } else {
             x1 = axis1 ? axis1 + axisOffset : 0;
             x2 = axis2 ? axis2 + axisOffset : chartSize;
-            y1 = measure1;
-            y2 = measure2;
+            y1 = measure1 ?? 0;
+            y2 = measure2 ?? 0;
           }
 
           const datum = {
@@ -100,7 +103,7 @@ export const createLimitsComponent = <
             fill: configLimit.color,
             lineType: configLimit.lineType,
             symbolType: configLimit.symbolType,
-          } as RenderLimitDatum;
+          } satisfies RenderLimitDatum;
 
           return hasValidAxis || hasNoAxis ? [datum] : [];
         }


### PR DESCRIPTION
This PR:
- improves application's type safety by using `satisfies` instead of `as` in some places, which already revealed some mistakes we had (also see https://frontendmasters.com/blog/satisfies-in-typescript),
- cleans up some code,
- removes @noahonyejese from CODEOWNERS for now – I hope it makes sense to remove some of the spam Noah 😅 