### PR TITLE
fix: Resetting of fields when removing segmentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ You can also check the
 
 # Unreleased
 
+- Fixes
+  - Interactive calculation is now correctly reset when removing segmentation
 - Security
   - Added additional protection against data source URL injection
 

--- a/app/configurator/configurator-state/reducer.spec.tsx
+++ b/app/configurator/configurator-state/reducer.spec.tsx
@@ -691,6 +691,74 @@ describe("CHART_FIELD_DELETED", () => {
       color: "#1D4ED8",
     });
   });
+
+  it("should correctly clear calculation config when segment field is deleted", () => {
+    const state = {
+      state: "CONFIGURING_CHART",
+      dataSource: { type: "sparql", url: "test-url" },
+      chartConfigs: [
+        {
+          key: "test-chart",
+          chartType: "column",
+          cubes: [{ iri: "test-cube", filters: {} }],
+          fields: {
+            y: { componentId: "yComponentId" },
+            segment: {
+              componentId: "segmentComponentId",
+              type: "stacked",
+            },
+            color: {
+              type: "segment",
+              paletteId: "category10",
+              colorMapping: {},
+            },
+          },
+          interactiveFiltersConfig: {
+            legend: { active: false, componentId: "" },
+            timeRange: {
+              active: false,
+              componentId: "",
+              presets: { type: "range", from: "", to: "" },
+            },
+            dataFilters: { active: false, componentIds: [] },
+            calculation: { active: true, type: "percent" },
+          },
+          limits: {},
+          conversionUnitsByComponentId: {},
+        },
+      ],
+    };
+
+    getCachedComponents.mockReturnValue({
+      dimensions: [],
+      measures: [],
+    });
+
+    const newState = produce(state, (state: ConfiguratorState) => {
+      return handleChartFieldDeleted(state, {
+        type: "CHART_FIELD_DELETED",
+        value: {
+          locale: "en",
+          field: "segment",
+        },
+      });
+    });
+
+    const chartConfig = newState.chartConfigs[0];
+
+    expect(chartConfig.interactiveFiltersConfig?.calculation).toEqual({
+      active: false,
+      type: "identity",
+    });
+
+    expect(chartConfig.fields.segment).toBeUndefined();
+
+    expect(chartConfig.fields.color).toEqual({
+      type: "single",
+      paletteId: "category10",
+      color: "#1D4ED8",
+    });
+  });
 });
 
 describe("colorMapping", () => {

--- a/app/configurator/configurator-state/reducer.tsx
+++ b/app/configurator/configurator-state/reducer.tsx
@@ -450,11 +450,6 @@ export const handleChartFieldDeleted = (
       joinBy: cube.joinBy,
     })),
   });
-  const dimensions = dataCubesComponents?.dimensions ?? [];
-  const newConfig = deriveFiltersFromFields(chartConfig, { dimensions });
-  const index = draft.chartConfigs.findIndex((d) => d.key === chartConfig.key);
-  draft.chartConfigs[index] = newConfig;
-
   if (action.value.field === "segment") {
     if (chartConfig.interactiveFiltersConfig) {
       chartConfig.interactiveFiltersConfig.calculation.active = false;
@@ -470,6 +465,11 @@ export const handleChartFieldDeleted = (
       chartConfig.fields.color = newColorField;
     }
   }
+
+  const dimensions = dataCubesComponents?.dimensions ?? [];
+  const newConfig = deriveFiltersFromFields(chartConfig, { dimensions });
+  const index = draft.chartConfigs.findIndex((d) => d.key === chartConfig.key);
+  draft.chartConfigs[index] = newConfig;
 
   const sideEffect = getChartFieldDeleteSideEffect(chartConfig, field);
   sideEffect?.({ chartConfig });


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2383

<!--- Describe the changes -->

This PR fixes running of the side effects when removing a segment.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-removing-segmentation-si-ad1f6e-ixt1.vercel.app/en/v/tmHLSGffxmWC?dataSource=Prod).
2. Copy and edit this visualization.
3. Remove segmentation.
4. ✅ See that the interactive 100% mode toggle was removed, and the chart is no longer in 100% mode.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
- [x] I wrote tests for the changes (if applicable)
