### PR TITLE
fix: Missing dataset preview tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ You can also check the
 
 - Fixes
   - Interactive calculation is now correctly reset when removing segmentation
+  - Tooltips are now correctly displayed in data preview table
 - Security
   - Added additional protection against data source URL injection
 

--- a/app/browse/component-label.tsx
+++ b/app/browse/component-label.tsx
@@ -20,7 +20,9 @@ export const ComponentLabel = ({
     </OpenMetadataPanelWrapper>
   ) : component.description ? (
     <MaybeTooltip title={component.description} tooltipProps={tooltipProps}>
-      <ComponentLabelInner component={component} />
+      <div>
+        <ComponentLabelInner component={component} />
+      </div>
     </MaybeTooltip>
   ) : (
     <ComponentLabelInner component={component} />


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2381

<!--- Describe the changes -->

This PR makes sure we show dataset preview tooltips when needed.

<!--- Test instructions -->

## How to test

1. Go to this link.
2. Hover over column headers.
3. ✅ See that tooltip appears.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [ ] I added a CHANGELOG entry
- [ ] I made a self-review of my own code
- [ ] I wrote tests for the changes (if applicable)
- [ ] I wrote configurator and chart config migrations (if applicable)
