### PR TITLE
chore: Remove GQL endpoint flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ You can also check the
   - Tooltips are now correctly displayed in data preview table
 - Security
   - Added additional protection against data source URL injection
+  - Removed feature flag for custom GraphQL endpoint
 
 # 5.8.3 - 2025-06-10
 

--- a/app/flags/types.ts
+++ b/app/flags/types.ts
@@ -20,11 +20,6 @@ export const FLAGS = [
     type: "boolean" as FlagType,
   },
   {
-    name: "graphql.endpoint" as const,
-    description: "Specifies custom GraphQL endpoint for testing purposes.",
-    type: "text" as FlagType,
-  },
-  {
     name: "easter-eggs" as const,
     description: "Enables hidden easter egg features.",
     type: "boolean" as FlagType,

--- a/app/graphql/client.tsx
+++ b/app/graphql/client.tsx
@@ -5,17 +5,8 @@ import { flag } from "@/flags/flag";
 // @ts-ignore - dynamic package import based on NODE_ENV
 import { devtoolsExchanges } from "@/graphql/devtools";
 
-const graphqlEndpointFlag = flag("graphql.endpoint");
-
-if (graphqlEndpointFlag) {
-  console.log("ℹ️ Using custom GraphQL endpoint:", graphqlEndpointFlag);
-}
-
 export const client = createClient({
-  url:
-    typeof graphqlEndpointFlag === "string"
-      ? graphqlEndpointFlag
-      : GRAPHQL_ENDPOINT,
+  url: GRAPHQL_ENDPOINT,
   exchanges: [...devtoolsExchanges, ...defaultExchanges],
   fetchOptions: {
     headers: getHeaders(),


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2376

<!--- Describe the changes -->

This PR removes a way to set custom GQL endpoint. I am not aware of any current use case that requires it, and keeping it is a real security issue.

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
