### PR TITLE
fix: Grid lines overlapping with chart elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ You can also check the
 - Fixes
   - Interactive calculation is now correctly reset when removing segmentation
   - Tooltips are now correctly displayed in data preview table
+  - Grid lines do not overlap the chart elements anymore in case of negative
+    values
 - Security
   - Added additional protection against data source URL injection
   - Removed feature flag for custom GraphQL endpoint

--- a/app/charts/area/chart-area.tsx
+++ b/app/charts/area/chart-area.tsx
@@ -42,10 +42,10 @@ const ChartAreas = memo((props: ChartProps<AreaConfig>) => {
       <ChartContainer>
         <ChartSvg>
           <AxisHeightLinear />
-          <Areas />
           <AxisHideXOverflowRect />
           <AxisTime />
           <AxisTimeDomain />
+          <Areas />
           <VerticalLimits {...limits} />
           <InteractionHorizontal />
           {interactiveFiltersConfig?.timeRange.active === true && <BrushTime />}

--- a/app/charts/bar/chart-bar.tsx
+++ b/app/charts/bar/chart-bar.tsx
@@ -62,10 +62,10 @@ const ChartBars = memo((props: ChartProps<BarConfig>) => {
           <ChartContainer>
             <ChartSvg>
               <AxisWidthLinear />
-              <BarsStacked />
               <AxisHideYOverflowRect />
               <AxisHeightBand />
               <AxisHeightBandDomain />
+              <BarsStacked />
               <InteractionBars />
               {showTimeBrush && <BrushTime />}
             </ChartSvg>
@@ -93,10 +93,10 @@ const ChartBars = memo((props: ChartProps<BarConfig>) => {
           <ChartContainer>
             <ChartSvg>
               <AxisWidthLinear />
-              <BarsGrouped />
               <AxisHideYOverflowRect />
               <AxisHeightBand />
               <AxisHeightBandDomain />
+              <BarsGrouped />
               <ErrorWhiskersGrouped />
               <InteractionBars />
               {showTimeBrush && <BrushTime />}
@@ -125,10 +125,10 @@ const ChartBars = memo((props: ChartProps<BarConfig>) => {
           <ChartContainer>
             <ChartSvg>
               <AxisWidthLinear />
-              <Bars />
               <AxisHideYOverflowRect />
               <AxisHeightBand />
               <AxisHeightBandDomain />
+              <Bars />
               <ErrorWhiskers />
               <HorizontalLimits {...limits} />
               <InteractionBars />

--- a/app/charts/column/chart-column.tsx
+++ b/app/charts/column/chart-column.tsx
@@ -62,10 +62,10 @@ const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
           <ChartContainer>
             <ChartSvg>
               <AxisHeightLinear />
-              <ColumnsStacked />
               <AxisHideXOverflowRect />
               <AxisWidthBand />
               <AxisWidthBandDomain />
+              <ColumnsStacked />
               <InteractionColumns />
               {showTimeBrush && <BrushTime />}
             </ChartSvg>
@@ -93,10 +93,10 @@ const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
           <ChartContainer>
             <ChartSvg>
               <AxisHeightLinear />
-              <ColumnsGrouped />
               <AxisHideXOverflowRect />
               <AxisWidthBand />
               <AxisWidthBandDomain />
+              <ColumnsGrouped />
               <ErrorWhiskersGrouped />
               <InteractionColumns />
               {showTimeBrush && <BrushTime />}
@@ -125,10 +125,10 @@ const ChartColumns = memo((props: ChartProps<ColumnConfig>) => {
           <ChartContainer>
             <ChartSvg>
               <AxisHeightLinear />
-              <Columns />
               <AxisHideXOverflowRect />
               <AxisWidthBand />
               <AxisWidthBandDomain />
+              <Columns />
               <ErrorWhiskers />
               <VerticalLimits {...limits} />
               <InteractionColumns />

--- a/app/charts/line/chart-lines.tsx
+++ b/app/charts/line/chart-lines.tsx
@@ -45,6 +45,9 @@ const ChartLines = memo((props: ChartProps<LineConfig>) => {
       <ChartContainer>
         <ChartSvg>
           <AxisHeightLinear />
+          <AxisHideXOverflowRect />
+          <AxisTime />
+          <AxisTimeDomain />
           <Lines
             dotSize={
               "showDots" in chartConfig.fields.y &&
@@ -54,9 +57,6 @@ const ChartLines = memo((props: ChartProps<LineConfig>) => {
                 : undefined
             }
           />
-          <AxisHideXOverflowRect />
-          <AxisTime />
-          <AxisTimeDomain />
           <ErrorWhiskers />
           <VerticalLimits {...limits} />
           <InteractionHorizontal />


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2382

<!--- Describe the changes -->

This PR fixes grid lines overlapping chart elements in area, bar, column and line charts in case of the data having negative values.

<!--- Test instructions -->

## How to test

1. Go to this link.
2. ...

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [ ] I added a CHANGELOG entry
- [ ] I made a self-review of my own code
- [ ] I wrote tests for the changes (if applicable)
- [ ] I wrote configurator and chart config migrations (if applicable)
