### PR TITLE
fix: Duplicated color squares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ You can also check the
   - Tooltips are now correctly displayed in data preview table
   - Grid lines do not overlap the chart elements anymore in case of negative
     values
+  - Color squares in color palette picker are now correctly reset when changing
+    the palette
 - Security
   - Added additional protection against data source URL injection
   - Removed feature flag for custom GraphQL endpoint

--- a/app/configurator/components/chart-controls/color-palette.tsx
+++ b/app/configurator/components/chart-controls/color-palette.tsx
@@ -240,7 +240,9 @@ export const ColorPalette = ({
             }
 
             return (
-              <Flex gap={0.5} flexWrap="wrap">
+              // Key to reset the color squares when the palette changes,
+              // otherwise the squares are duplicated
+              <Flex key={currentPalette?.value} gap={0.5} flexWrap="wrap">
                 {currentPalette
                   ? currentPalette.colors.map((color) => (
                       <ColorSquare


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2367

<!--- Describe the changes -->

This PR fixes duplicated color squares that were starting to appear when switching between custom and default color palettes.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-duplicated-color-squares-ixt1.vercel.app/en?dataSource=Prod).
2. Sign in.
3. Go to [this link](https://visualization-tool-git-fix-duplicated-color-squares-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10&dataSource=Prod).
4. Open `Vertical Axis`.
5. ✅ Switch between custom and default color palettes and see that the color squares are not being duplicated.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
