### PR TITLE
feat: Improve error handling in unit multiplier input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ You can also check the
 
 # Unreleased
 
+- Features
+  - Improved UX of interacting with conversion units multiplier input
 - Fixes
   - Interactive calculation is now correctly reset when removing segmentation
   - Tooltips are now correctly displayed in data preview table

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -636,12 +636,20 @@ msgid "controls.convert-unit.enable"
 msgstr "Einheitenumrechnung aktivieren"
 
 #: app/configurator/components/chart-options-selector/conversion-units-field.tsx
+msgid "controls.convert-unit.invalid-number-error"
+msgstr "Bitte geben Sie eine gültige Nummer ein"
+
+#: app/configurator/components/chart-options-selector/conversion-units-field.tsx
 msgid "controls.convert-unit.multiplier"
 msgstr "Multiplikator"
 
 #: app/configurator/components/chart-options-selector/conversion-units-field.tsx
 msgid "controls.convert-unit.original"
 msgstr "Ursprüngliche Einheit: {0}"
+
+#: app/configurator/components/chart-options-selector/conversion-units-field.tsx
+msgid "controls.convert-unit.positive-number-error"
+msgstr "Der Multiplikator muss grösser als 0 sein"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
@@ -745,7 +753,6 @@ msgstr "Beschreibung hinzufügen"
 
 #: app/charts/shared/chart-data-filters.tsx
 #: app/charts/shared/chart-data-filters.tsx
-#: app/configurator/components/field.tsx
 #: app/configurator/components/field.tsx
 msgid "controls.dimensionvalue.none"
 msgstr "Kein Filter"
@@ -1294,7 +1301,6 @@ msgstr "Dimension auswählen"
 msgid "controls.select.measure"
 msgstr "Messwert auswählen"
 
-#: app/configurator/components/field.tsx
 #: app/configurator/components/field.tsx
 msgid "controls.select.optional"
 msgstr "optional"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -636,12 +636,20 @@ msgid "controls.convert-unit.enable"
 msgstr "Enable unit conversion"
 
 #: app/configurator/components/chart-options-selector/conversion-units-field.tsx
+msgid "controls.convert-unit.invalid-number-error"
+msgstr "Please enter a valid number"
+
+#: app/configurator/components/chart-options-selector/conversion-units-field.tsx
 msgid "controls.convert-unit.multiplier"
 msgstr "Multiplier"
 
 #: app/configurator/components/chart-options-selector/conversion-units-field.tsx
 msgid "controls.convert-unit.original"
 msgstr "Original unit: {0}"
+
+#: app/configurator/components/chart-options-selector/conversion-units-field.tsx
+msgid "controls.convert-unit.positive-number-error"
+msgstr "Multiplier must be greater than 0"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
@@ -745,7 +753,6 @@ msgstr "Description"
 
 #: app/charts/shared/chart-data-filters.tsx
 #: app/charts/shared/chart-data-filters.tsx
-#: app/configurator/components/field.tsx
 #: app/configurator/components/field.tsx
 msgid "controls.dimensionvalue.none"
 msgstr "No Filter"
@@ -1294,7 +1301,6 @@ msgstr "Select a dimension"
 msgid "controls.select.measure"
 msgstr "Select a measure"
 
-#: app/configurator/components/field.tsx
 #: app/configurator/components/field.tsx
 msgid "controls.select.optional"
 msgstr "optional"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -636,12 +636,20 @@ msgid "controls.convert-unit.enable"
 msgstr "Activer la conversion d'unité"
 
 #: app/configurator/components/chart-options-selector/conversion-units-field.tsx
+msgid "controls.convert-unit.invalid-number-error"
+msgstr "Veuillez entrer un numéro valide"
+
+#: app/configurator/components/chart-options-selector/conversion-units-field.tsx
 msgid "controls.convert-unit.multiplier"
 msgstr "Multiplicateur"
 
 #: app/configurator/components/chart-options-selector/conversion-units-field.tsx
 msgid "controls.convert-unit.original"
 msgstr "Unité d'origine : {0}"
+
+#: app/configurator/components/chart-options-selector/conversion-units-field.tsx
+msgid "controls.convert-unit.positive-number-error"
+msgstr "Le multiplicateur doit être supérieur à 0"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
@@ -745,7 +753,6 @@ msgstr "Description"
 
 #: app/charts/shared/chart-data-filters.tsx
 #: app/charts/shared/chart-data-filters.tsx
-#: app/configurator/components/field.tsx
 #: app/configurator/components/field.tsx
 msgid "controls.dimensionvalue.none"
 msgstr "Aucune filtre"
@@ -1294,7 +1301,6 @@ msgstr "Sélectionner une dimension"
 msgid "controls.select.measure"
 msgstr "Sélectionner une variable"
 
-#: app/configurator/components/field.tsx
 #: app/configurator/components/field.tsx
 msgid "controls.select.optional"
 msgstr "optionnel"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -636,12 +636,20 @@ msgid "controls.convert-unit.enable"
 msgstr "Abilita conversione unità"
 
 #: app/configurator/components/chart-options-selector/conversion-units-field.tsx
+msgid "controls.convert-unit.invalid-number-error"
+msgstr "Inserisci un numero valido"
+
+#: app/configurator/components/chart-options-selector/conversion-units-field.tsx
 msgid "controls.convert-unit.multiplier"
 msgstr "Moltiplicatore"
 
 #: app/configurator/components/chart-options-selector/conversion-units-field.tsx
 msgid "controls.convert-unit.original"
 msgstr "Unità originale: {0}"
+
+#: app/configurator/components/chart-options-selector/conversion-units-field.tsx
+msgid "controls.convert-unit.positive-number-error"
+msgstr "Il moltiplicatore deve essere maggiore di 0"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx
@@ -745,7 +753,6 @@ msgstr "Descrizione"
 
 #: app/charts/shared/chart-data-filters.tsx
 #: app/charts/shared/chart-data-filters.tsx
-#: app/configurator/components/field.tsx
 #: app/configurator/components/field.tsx
 msgid "controls.dimensionvalue.none"
 msgstr "Nessun filtro"
@@ -1294,7 +1301,6 @@ msgstr "Seleziona una dimensione"
 msgid "controls.select.measure"
 msgstr "Seleziona una misura"
 
-#: app/configurator/components/field.tsx
 #: app/configurator/components/field.tsx
 msgid "controls.select.optional"
 msgstr "opzionale"


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2371

<!--- Describe the changes -->

This PR improves the UX of interacting with unit multiplier input by providing clear error messages when input is invalid.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-feat-errors-in-conversion-mu-2df098-ixt1.vercel.app/en/browse?previous=%7B%22order%22%3A%22SCORE%22%2C%22search%22%3A%22photo%22%7D&dataset=https%3A%2F%2Fenergy.ld.admin.ch%2Fsfoe%2Fbfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen%2F10&dataSource=Prod&flag__custom-scale-domain=true&flag__convert-units=true).
2. Start a visualization.
3. Open Vertical Axis panel.
4. Enable custom scale domain and unit conversion.
5. Try to enter an invalid value in custom scale domain input and see that an error appears.
6. ✅ Try to enter an invalid value in unit conversion multiplier input and see that it behaves in the same way as custom scale domain input.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
