### PR TITLE
fix: Most recent date toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ You can also check the
     values
   - Color squares in color palette picker are now correctly reset when changing
     the palette
+  - Use most recent value toggle is now correctly displaying in the single
+    filters section
 - Security
   - Added additional protection against data source URL injection
   - Removed feature flag for custom GraphQL endpoint

--- a/app/configurator/components/field.tsx
+++ b/app/configurator/components/field.tsx
@@ -275,19 +275,35 @@ export const DataFilterSelect = ({
       size="sm"
       label={
         canUseMostRecentValue ? (
-          <Switch
-            label={label}
-            checked={usesMostRecentValue}
-            onChange={() =>
-              fieldProps.onChange({
-                target: {
-                  value: usesMostRecentValue
-                    ? `${maxValue}`
-                    : VISUALIZE_MOST_RECENT_VALUE,
-                },
-              })
-            }
-          />
+          <div style={{ width: "100%" }}>
+            <Flex justifyContent="flex-end" sx={{ mb: 0.5, mr: 7 }}>
+              <Switch
+                label={t({
+                  id: "controls.filter.use-most-recent",
+                  message: "Use most recent",
+                })}
+                size="sm"
+                checked={usesMostRecentValue}
+                onChange={() =>
+                  fieldProps.onChange({
+                    target: {
+                      value: usesMostRecentValue
+                        ? `${maxValue}`
+                        : VISUALIZE_MOST_RECENT_VALUE,
+                    },
+                  })
+                }
+              />
+            </Flex>
+            <Flex
+              justifyContent="space-between"
+              alignItems="center"
+              gap={1}
+              width="100%"
+            >
+              {label}
+            </Flex>
+          </div>
         ) : (
           <FieldLabel label={label} />
         )


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2390

<!--- Describe the changes -->

This PR fixes the display of most recent date toggle in the single filters panel.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-use-most-recent-toggle-ixt1.vercel.app/en/create/new?cube=https://environment.ld.admin.ch/foen/nfi/nfi_T-changes/cube/2024-1&dataSource=Prod).
2. Switch to a map chart.
3. ✅ Scroll down the left panel to the filters section and see that "Use most recent" toggle is correctly rendered.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
