### PR TITLE
feat: Remove IXT from newsletter mail bcc

### DIFF
--- a/app/docs/homepage.docs.mdx
+++ b/app/docs/homepage.docs.mdx
@@ -65,7 +65,7 @@ import { Contribute, Examples, Intro, Tutorial, Newsletter, BugReport, FeatureRe
  buttonUrl={createMailtoLink("en", {
   recipients: {
     to: "visualize@bafu.admin.ch",
-    bcc: "supprt@interactivethings.com",
+    bcc: "support@interactivethings.com",
   },
   template: featureRequestTemplates,
   subject: "Visualize Feature Request",

--- a/app/docs/homepage.docs.mdx
+++ b/app/docs/homepage.docs.mdx
@@ -62,14 +62,14 @@ import { Contribute, Examples, Intro, Tutorial, Newsletter, BugReport, FeatureRe
   headline="New feature request"
   description="Submit your feature requests today and help shape the future of our platform!"
   buttonLabel="Submit"
- buttonUrl={createMailtoLink("en", {
-  recipients: {
-    to: "visualize@bafu.admin.ch",
-    bcc: "support@interactivethings.com",
-  },
-  template: featureRequestTemplates,
-  subject: "Visualize Feature Request",
-})}
+  buttonUrl={createMailtoLink("en", {
+    recipients: {
+      to: "visualize@bafu.admin.ch",
+      bcc: "support@interactivethings.com",
+    },
+    template: featureRequestTemplates,
+    subject: "Visualize Feature Request",
+  })}
 />
  <BugReport
   headline="Found a bug?"

--- a/app/docs/homepage.stories.tsx
+++ b/app/docs/homepage.stories.tsx
@@ -57,7 +57,6 @@ const HomepageStory = {
             buttonUrl: createMailtoLink("en", {
               recipients: {
                 to: OWNER_ORGANIZATION_EMAIL,
-                bcc: SUPPORT_EMAIL,
               },
               template: newsletterTemplates,
               subject: "Visualize Newsletter Subscribe",

--- a/app/static-pages/de/index.mdx
+++ b/app/static-pages/de/index.mdx
@@ -44,7 +44,6 @@ export const contentId = "home";
     buttonUrl: createMailtoLink("de", {
       recipients: {
         to: OWNER_ORGANIZATION_EMAIL,
-        bcc: SUPPORT_EMAIL,
       },
       template: newsletterTemplates,
       subject: "Visualize Newsletter Abonnieren",

--- a/app/static-pages/en/index.mdx
+++ b/app/static-pages/en/index.mdx
@@ -43,7 +43,6 @@ export const contentId = "home";
     buttonUrl: createMailtoLink("en", {
       recipients: {
         to: OWNER_ORGANIZATION_EMAIL,
-        bcc: SUPPORT_EMAIL,
       },
       template: newsletterTemplates,
       subject: "Visualize Newsletter Subscribe",

--- a/app/static-pages/fr/index.mdx
+++ b/app/static-pages/fr/index.mdx
@@ -43,7 +43,6 @@ export const contentId = "home";
     buttonUrl: createMailtoLink("fr", {
       recipients: {
         to: OWNER_ORGANIZATION_EMAIL,
-        bcc: SUPPORT_EMAIL,
       },
       template: newsletterTemplates,
       subject: "Visualize Newsletter Abonnement",

--- a/app/static-pages/it/index.mdx
+++ b/app/static-pages/it/index.mdx
@@ -44,7 +44,6 @@ export const contentId = "home";
     buttonUrl: createMailtoLink("it", {
       recipients: {
         to: OWNER_ORGANIZATION_EMAIL,
-        bcc: SUPPORT_EMAIL,
       },
       template: newsletterTemplates,
       subject: "Visualize Newsletter Iscrizione",

--- a/app/templates/email/index.ts
+++ b/app/templates/email/index.ts
@@ -2,21 +2,24 @@ import { bugReportTemplates } from "./bug-report";
 
 type EmailRecipients = {
   to: string;
-  bcc: string;
+  bcc?: string;
 };
 
 export const createMailtoLink = (
   lang: keyof typeof bugReportTemplates,
-  options: {
+  {
+    recipients,
+    template: _template,
+    subject,
+  }: {
     recipients: EmailRecipients;
     template: typeof bugReportTemplates;
     subject: string;
   }
 ) => {
-  const template = options.template[lang];
-  return `mailto:${options.recipients.to}?bcc=${
-    options.recipients.bcc
-  }&subject=${encodeURIComponent(options.subject)}&body=${encodeURIComponent(
+  const template = _template[lang];
+
+  return `mailto:${recipients.to}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(
     template
-  )}`;
+  )}${recipients.bcc ? `&bcc=${recipients.bcc}` : ""}`;
 };


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2369

<!--- Describe the changes -->

This PR removes IXT from newsletter subscriptions (bcc emails).

<!--- Test instructions -->

## How to test

1. Go to this link.
2. Click on `Subscribe` button at the bottom of the page (newsletter).
3. ✅ See that the mail would only be sent to visualize@bafu.admin.ch.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I made a self-review of my own code
