### PR TITLE
fix: Hide database-related actions in chart previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ You can also check the
   - Use most recent value toggle is now correctly displaying in the single
     filters section
   - Dataset browse view is now correctly displayed on mobile devices
+  - Database-related actions are now hidden in preview mode (copy URL, share)
 - Security
   - Added additional protection against data source URL injection
   - Removed feature flag for custom GraphQL endpoint

--- a/app/components/chart-published.tsx
+++ b/app/components/chart-published.tsx
@@ -124,10 +124,12 @@ export const ChartPublished = ({
   configKey,
   embedParams,
   shouldShrink,
+  isPreview,
 }: {
   configKey?: string;
   embedParams?: EmbedQueryParams;
   shouldShrink?: boolean;
+  isPreview?: boolean;
 }) => {
   const [state] = useConfiguratorState(isPublished);
   const { dataSource } = state;
@@ -234,6 +236,7 @@ export const ChartPublished = ({
                     metadataPanelStore={metadataPanelStore}
                     embedParams={embedParams}
                     shouldShrink={shouldShrink}
+                    isPreview={isPreview}
                   />
                 </ChartWrapper>
               </ChartTablePreviewProvider>
@@ -285,6 +288,7 @@ type ChartPublishInnerProps = {
   metadataPanelStore: ReturnType<typeof createMetadataPanelStore>;
   embedParams?: EmbedQueryParams;
   shouldShrink?: boolean;
+  isPreview?: boolean;
 };
 
 const ChartPublishedInnerImpl = ({
@@ -297,6 +301,7 @@ const ChartPublishedInnerImpl = ({
   metadataPanelStore,
   embedParams,
   shouldShrink: _shouldShrink,
+  isPreview,
 }: ChartPublishInnerProps) => {
   const { meta } = chartConfig;
   const rootRef = useRef<HTMLDivElement>(null);
@@ -448,6 +453,7 @@ const ChartPublishedInnerImpl = ({
                     chartKey={chartConfig.key}
                     chartWrapperNode={rootRef.current}
                     components={allComponents}
+                    disableDatabaseRelatedActions={isPreview}
                   />
                 </ActionElementsContainer>
               )}

--- a/app/components/chart-shared.tsx
+++ b/app/components/chart-shared.tsx
@@ -164,11 +164,13 @@ export const ChartMoreButton = ({
   chartKey,
   chartWrapperNode,
   components,
+  disableDatabaseRelatedActions,
 }: {
   configKey?: string;
   chartKey: string;
   chartWrapperNode?: HTMLElement | null;
   components: Component[];
+  disableDatabaseRelatedActions?: boolean;
 }) => {
   const locale = useLocale();
   const [state, dispatch] = useConfiguratorState(hasChartConfigs);
@@ -227,7 +229,9 @@ export const ChartMoreButton = ({
                 />
               </>
             ) : null}
-            {state.layout.type !== "dashboard" && configKey ? (
+            {state.layout.type !== "dashboard" &&
+            configKey &&
+            !disableDatabaseRelatedActions ? (
               <>
                 <CopyChartMenuActionItem configKey={configKey} />
                 <ShareChartMenuActionItem configKey={configKey} />

--- a/app/pages/preview.tsx
+++ b/app/pages/preview.tsx
@@ -8,10 +8,10 @@ import {
   ConfiguratorStatePublished,
   decodeConfiguratorState,
 } from "@/config-types";
+import { ConfiguratorStateProvider } from "@/configurator/configurator-state";
 import { GraphqlProvider } from "@/graphql/graphql-provider";
 import { i18n } from "@/locales/locales";
 import { LocaleProvider, useLocale } from "@/locales/use-locale";
-import { ConfiguratorStateProvider } from "@/src";
 import * as federalTheme from "@/themes/theme";
 import { migrateConfiguratorState } from "@/utils/chart-config/versioning";
 import { hashStringToObject } from "@/utils/hash-utils";
@@ -101,7 +101,7 @@ export default function Preview() {
                 chartId="published"
                 initialState={state}
               >
-                <ChartPublished configKey="preview" {...state} />
+                <ChartPublished configKey="preview" isPreview {...state} />
               </ConfiguratorStateProvider>
             ) : null}
           </ThemeProvider>

--- a/app/pages/preview_post.tsx
+++ b/app/pages/preview_post.tsx
@@ -82,7 +82,11 @@ export default function Preview({ configuratorState, locale }: PageProps) {
                 chartId="published"
                 initialState={parsedState}
               >
-                <ChartPublished configKey="preview" {...parsedState} />
+                <ChartPublished
+                  configKey="preview"
+                  isPreview
+                  {...parsedState}
+                />
               </ConfiguratorStateProvider>
             ) : null}
           </ThemeProvider>


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2397

<!--- Describe the changes -->

This PR makes sure we can't use database-related actions in preview charts (that do not exist in a database).

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-hide-database-related-ac-2daa83-ixt1.vercel.app/en/preview#version=4.6.0||state=CONFIGURING_CHART||dataSource__SEP__type=sparql||dataSource__SEP__url=https://lindas-cached.cluster.ldbar.ch/query||layout__SEP__type=tab||layout__SEP__meta__SEP__title__SEP__de=||layout__SEP__meta__SEP__title__SEP__en=||layout__SEP__meta__SEP__title__SEP__fr=||layout__SEP__meta__SEP__title__SEP__it=||layout__SEP__meta__SEP__description__SEP__de=||layout__SEP__meta__SEP__description__SEP__en=||layout__SEP__meta__SEP__description__SEP__fr=||layout__SEP__meta__SEP__description__SEP__it=||layout__SEP__meta__SEP__label__SEP__de=||layout__SEP__meta__SEP__label__SEP__en=||layout__SEP__meta__SEP__label__SEP__fr=||layout__SEP__meta__SEP__label__SEP__it=||layout__SEP__blocks__SEP__0__SEP__type=chart||layout__SEP__blocks__SEP__0__SEP__key=rw5fPCaeHCwz||layout__SEP__blocks__SEP__0__SEP__initialized=false||layout__SEP__activeField=undefined||chartConfigs__SEP__0__SEP__key=rw5fPCaeHCwz||chartConfigs__SEP__0__SEP__version=4.5.0||chartConfigs__SEP__0__SEP__meta__SEP__title__SEP__en=||chartConfigs__SEP__0__SEP__meta__SEP__title__SEP__de=||chartConfigs__SEP__0__SEP__meta__SEP__title__SEP__fr=||chartConfigs__SEP__0__SEP__meta__SEP__title__SEP__it=||chartConfigs__SEP__0__SEP__meta__SEP__description__SEP__en=||chartConfigs__SEP__0__SEP__meta__SEP__description__SEP__de=||chartConfigs__SEP__0__SEP__meta__SEP__description__SEP__fr=||chartConfigs__SEP__0__SEP__meta__SEP__description__SEP__it=||chartConfigs__SEP__0__SEP__meta__SEP__label__SEP__en=||chartConfigs__SEP__0__SEP__meta__SEP__label__SEP__de=||chartConfigs__SEP__0__SEP__meta__SEP__label__SEP__fr=||chartConfigs__SEP__0__SEP__meta__SEP__label__SEP__it=||chartConfigs__SEP__0__SEP__cubes__SEP__0__SEP__iri=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10||chartConfigs__SEP__0__SEP__cubes__SEP__0__SEP__filters__SEP__https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Kanton__SEP__type=single||chartConfigs__SEP__0__SEP__cubes__SEP__0__SEP__filters__SEP__https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Kanton__SEP__value=https://ld.admin.ch/canton/1||chartConfigs__SEP__0__SEP__limits={}||chartConfigs__SEP__0__SEP__conversionUnitsByComponentId={}||chartConfigs__SEP__0__SEP__chartType=column||chartConfigs__SEP__0__SEP__interactiveFiltersConfig__SEP__legend__SEP__active=false||chartConfigs__SEP__0__SEP__interactiveFiltersConfig__SEP__legend__SEP__componentId=||chartConfigs__SEP__0__SEP__interactiveFiltersConfig__SEP__timeRange__SEP__active=false||chartConfigs__SEP__0__SEP__interactiveFiltersConfig__SEP__timeRange__SEP__componentId=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr||chartConfigs__SEP__0__SEP__interactiveFiltersConfig__SEP__timeRange__SEP__presets__SEP__type=range||chartConfigs__SEP__0__SEP__interactiveFiltersConfig__SEP__timeRange__SEP__presets__SEP__from=||chartConfigs__SEP__0__SEP__interactiveFiltersConfig__SEP__timeRange__SEP__presets__SEP__to=||chartConfigs__SEP__0__SEP__interactiveFiltersConfig__SEP__dataFilters__SEP__active=false||chartConfigs__SEP__0__SEP__interactiveFiltersConfig__SEP__dataFilters__SEP__componentIds=[]||chartConfigs__SEP__0__SEP__interactiveFiltersConfig__SEP__dataFilters__SEP__defaultOpen=true||chartConfigs__SEP__0__SEP__interactiveFiltersConfig__SEP__calculation__SEP__active=false||chartConfigs__SEP__0__SEP__interactiveFiltersConfig__SEP__calculation__SEP__type=identity||chartConfigs__SEP__0__SEP__fields__SEP__x__SEP__componentId=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/Jahr||chartConfigs__SEP__0__SEP__fields__SEP__x__SEP__sorting__SEP__sortingType=byAuto||chartConfigs__SEP__0__SEP__fields__SEP__x__SEP__sorting__SEP__sortingOrder=asc||chartConfigs__SEP__0__SEP__fields__SEP__y__SEP__componentId=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen(VISUALIZE.ADMIN_COMPONENT_ID_SEPARATOR)https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/AnzahlAnlagen||chartConfigs__SEP__0__SEP__fields__SEP__color__SEP__type=single||chartConfigs__SEP__0__SEP__fields__SEP__color__SEP__paletteId=category10||chartConfigs__SEP__0__SEP__fields__SEP__color__SEP__color=#1D4ED8||chartConfigs__SEP__0__SEP__activeField=undefined||activeChartKey=rw5fPCaeHCwz||dashboardFilters__SEP__timeRange__SEP__active=false||dashboardFilters__SEP__timeRange__SEP__timeUnit=||dashboardFilters__SEP__timeRange__SEP__presets__SEP__from=||dashboardFilters__SEP__timeRange__SEP__presets__SEP__to=||dashboardFilters__SEP__dataFilters__SEP__componentIds=[]||dashboardFilters__SEP__dataFilters__SEP__filters={}).
2. Open more options menu.
3. ✅ See that `Copy and edit` and `Share` actions are not available.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
