### PR TITLE
fix: Always show chart tab scroll buttons when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ You can also check the
     filters section
   - Dataset browse view is now correctly displayed on mobile devices
   - Database-related actions are now hidden in preview mode (copy URL, share)
+- Styles
+  - Scroll buttons in the chart selection tabs are now always shown when needed
 - Security
   - Added additional protection against data source URL injection
   - Removed feature flag for custom GraphQL endpoint

--- a/app/components/chart-selection-tabs.tsx
+++ b/app/components/chart-selection-tabs.tsx
@@ -456,13 +456,11 @@ const TabsInner = ({
                     style={{ cursor: disabled ? "auto" : "pointer" }}
                     variant="text"
                   >
-                    {disabled ? null : (
-                      <Icon
-                        name={
-                          direction === "left" ? "chevronLeft" : "chevronRight"
-                        }
-                      />
-                    )}
+                    <Icon
+                      name={
+                        direction === "left" ? "chevronLeft" : "chevronRight"
+                      }
+                    />
                   </Button>
                 )}
               >


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #1776

<!--- Describe the changes -->

This PR makes sure we always show scroll arrows when needed to avoid empty spaces.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-feat-always-show-scroll-butt-ad5f82-ixt1.vercel.app/en/v/WUo-ZwN8m6WW?dataSource=Prod).
2. ✅ See that the left arrow is visible without having to scroll.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
