### PR TITLE
fix: Markdown in user profile chart titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ You can also check the
     filters section
   - Dataset browse view is now correctly displayed on mobile devices
   - Database-related actions are now hidden in preview mode (copy URL, share)
+  - Chart titles in user profile are now correctly rendered
 - Security
   - Added additional protection against data source URL injection
   - Removed feature flag for custom GraphQL endpoint

--- a/app/components/markdown.tsx
+++ b/app/components/markdown.tsx
@@ -69,6 +69,39 @@ export const Markdown = (
   );
 };
 
+export const InlineMarkdown = ({
+  children,
+  ...rest
+}: Omit<ComponentProps<typeof ReactMarkdown>, "components">) => {
+  const inlineMarkdown = children?.replace(/\r?\n|\r/g, " ");
+
+  return (
+    <ReactMarkdown
+      components={{
+        p: ({ children }) => <>{children}</>,
+        strong: ({ children }) => <strong>{children}</strong>,
+        em: ({ children }) => <em>{children}</em>,
+        a: ({ children, href }) => <a href={href}>{children}</a>,
+        h1: () => null,
+        h2: () => null,
+        h3: () => null,
+        h4: () => null,
+        h5: () => null,
+        h6: () => null,
+        ul: () => null,
+        li: () => null,
+        blockquote: () => null,
+        code: ({ children }) => <code>{children}</code>,
+        br: () => <> </>,
+      }}
+      skipHtml
+      {...rest}
+    >
+      {inlineMarkdown}
+    </ReactMarkdown>
+  );
+};
+
 const componentsInheritFonts: ComponentProps<
   typeof ReactMarkdown
 >["components"] = {

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -362,7 +362,7 @@ const ProfileVisualizationsRow = (props: {
         >
           <Link>
             <OverflowTooltip arrow title={chartTitle} color="primary.main">
-              <Typography variant="body3" noWrap>
+              <Typography variant="body3" component="p" noWrap>
                 {chartTitle}
               </Typography>
             </OverflowTooltip>

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -21,6 +21,7 @@ import sortBy from "lodash/sortBy";
 import NextLink from "next/link";
 import { ReactNode, useMemo, useState } from "react";
 
+import { InlineMarkdown, Markdown } from "@/components/markdown";
 import { MenuActionProps } from "@/components/menu-action-item";
 import { OverflowTooltip } from "@/components/overflow-tooltip";
 import {
@@ -361,9 +362,13 @@ const ProfileVisualizationsRow = (props: {
           legacyBehavior
         >
           <Link>
-            <OverflowTooltip arrow title={chartTitle} color="primary.main">
+            <OverflowTooltip
+              arrow
+              title={<Markdown>{chartTitle}</Markdown>}
+              color="primary.main"
+            >
               <Typography variant="body3" component="p" noWrap>
-                {chartTitle}
+                <InlineMarkdown>{chartTitle}</InlineMarkdown>
               </Typography>
             </OverflowTooltip>
           </Link>


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2008

<!--- Describe the changes -->

This PR improves the user profile page by:
- fixing chart names that were overflowing,
- rendering inline Markdown for the first line preview, and full Markdown in the tooltip, in case of overflowing.

<!--- Test instructions -->

## How to test

1. Go to this link.
2. ...

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [ ] I added a CHANGELOG entry
- [ ] I made a self-review of my own code
- [ ] I wrote tests for the changes (if applicable)
- [ ] I wrote configurator and chart config migrations (if applicable)
