### PR TITLE
feat: Add view stats to personal user profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ You can also check the
   - Updated WMS & WMTS providers list
   - Added missing OpenGraph tags to the application (description, image) and
     updated the title
+  - Added chart view count to user profile
 - Fixes
   - Interactive calculation is now correctly reset when removing segmentation
   - Tooltips are now correctly displayed in data preview table

--- a/app/components/row-actions.tsx
+++ b/app/components/row-actions.tsx
@@ -5,8 +5,7 @@ import { MenuActionItem, MenuActionProps } from "@/components/menu-action-item";
 import { useFlipMenu } from "@/components/use-flip-menu";
 import { Icon } from "@/icons";
 
-export const RowActions = (props: { actions: MenuActionProps[] }) => {
-  const { actions } = props;
+export const RowActions = ({ actions }: { actions: MenuActionProps[] }) => {
   const [primaryAction, ...otherActions] = actions;
   const {
     buttonRef,

--- a/app/components/row-actions.tsx
+++ b/app/components/row-actions.tsx
@@ -1,5 +1,6 @@
-import { Box, IconButton } from "@mui/material";
+import { IconButton } from "@mui/material";
 
+import { Flex } from "@/components/flex";
 import { MenuActionItem, MenuActionProps } from "@/components/menu-action-item";
 import { useFlipMenu } from "@/components/use-flip-menu";
 import { Icon } from "@/icons";
@@ -20,7 +21,7 @@ export const RowActions = (props: { actions: MenuActionProps[] }) => {
     primaryAction.type === "button" ? { onDialogClose: handleClose } : {};
 
   return (
-    <Box gap="0.5rem" display="flex" alignItems="center">
+    <Flex gap="0.5rem" justifyContent="flex-end" alignItems="center">
       <MenuActionItem as="button" {...primaryAction} {...additionalProps} />
       <IconButton ref={buttonRef} onClick={handleOpenElClick}>
         <Icon name="more" size={16} />
@@ -47,6 +48,6 @@ export const RowActions = (props: { actions: MenuActionProps[] }) => {
           />
         ))}
       </Wrapper>
-    </Box>
+    </Flex>
   );
 };

--- a/app/configurator/components/chart-controls/color-picker.tsx
+++ b/app/configurator/components/chart-controls/color-picker.tsx
@@ -1,5 +1,5 @@
 import { Trans } from "@lingui/macro";
-import { Box, Button, Popover, styled, Typography } from "@mui/material";
+import { Box, Button, Popover, styled } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import { hexToHsva, hsvaToHex } from "@uiw/react-color";
 import { color as d3Color } from "d3-color";
@@ -73,18 +73,21 @@ const ColorPickerButton = styled(Button)({
 
 const ColorPickerBox = styled(Box)(({ theme }) => ({
   lineHeight: "16px",
+
   "& > button": {
     backgroundColor: theme.palette.grey[100],
     borderRadius: 4,
     overflow: "hidden",
     borderWidth: 1,
-    p: 0,
+    padding: 0,
   },
+
   "& > button:hover": {
     backgroundColor: "transparent",
     cursor: "pointer",
     opacity: 0.8,
   },
+
   "& > button[disabled]": {
     backgroundColor: "transparent",
   },
@@ -124,8 +127,8 @@ export const ColorPickerMenu = ({
   );
 
   return (
-    <Box
-      sx={{
+    <div
+      style={{
         opacity: disabled ? 0.5 : 1,
         pointerEvents: disabled ? "none" : "auto",
       }}
@@ -143,17 +146,11 @@ export const ColorPickerMenu = ({
           <Icon name="swatch" size={16} />
         </ColorPickerButton>
         {colorId && onRemove && (
-          <ColorPickerButton onClick={() => onRemove(colorId)}>
+          <ColorPickerButton variant="text" onClick={() => onRemove(colorId)}>
             <VisuallyHidden>
               <Trans id="controls.colorpicker.remove">Remove Color</Trans>
             </VisuallyHidden>
-            <Typography
-              aria-hidden
-              color="secondary"
-              sx={{ backgroundColor: "transparent" }}
-            >
-              <Icon name="close" size={24} />
-            </Typography>
+            <Icon name="close" size={16} />
           </ColorPickerButton>
         )}
       </ColorPickerBox>
@@ -167,7 +164,7 @@ export const ColorPickerMenu = ({
         onClose={close}
         slotProps={{ paper: { sx: { boxShadow: 4 } } }}
       >
-        <Box ref={popoverRef}>
+        <div ref={popoverRef}>
           <CustomColorPicker
             defaultSelection={initialSelected}
             onChange={handleColorChange}
@@ -177,8 +174,8 @@ export const ColorPickerMenu = ({
                 : colors) as ColorItem[]
             }
           />
-        </Box>
+        </div>
       </Popover>
-    </Box>
+    </div>
   );
 };

--- a/app/db/config.ts
+++ b/app/db/config.ts
@@ -281,8 +281,20 @@ export const getUserConfigs = async (userId: number) => {
     },
   });
   const parsedConfigs = await Promise.all(configs.map(parseDbConfig));
+  const upgradedConfigs = await Promise.all(parsedConfigs.map(upgradeDbConfig));
 
-  return await Promise.all(parsedConfigs.map(upgradeDbConfig));
+  const configsWithViewCount = await Promise.all(
+    upgradedConfigs.map(async (config) => {
+      return {
+        ...config,
+        viewCount: await getConfigViewCount(config.key),
+      };
+    })
+  );
+  return configsWithViewCount;
 };
 
 export type ParsedConfig = Awaited<ReturnType<typeof parseDbConfig>>;
+export type ParsedConfigWithViewCount = Awaited<
+  ReturnType<typeof getUserConfigs>
+>[number];

--- a/app/domain/user-configs.ts
+++ b/app/domain/user-configs.ts
@@ -1,28 +1,64 @@
 import { useCallback } from "react";
 
-import { ParsedConfig } from "@/db/config";
-import { fetchChartConfig, fetchChartConfigs } from "@/utils/chart-config/api";
+import { ParsedConfigWithViewCount } from "@/db/config";
+import {
+  fetchChartConfig,
+  fetchChartConfigs,
+  fetchChartViewCount,
+} from "@/utils/chart-config/api";
 import { useFetchData, UseFetchDataOptions } from "@/utils/use-fetch-data";
 
 export const userConfigsKey = ["userConfigs"];
 const userConfigKey = (t: string) => ["userConfigs", t];
 
-export const useUserConfigs = (options?: UseFetchDataOptions<ParsedConfig[]>) =>
-  useFetchData({
+export const useUserConfigs = (
+  options?: UseFetchDataOptions<ParsedConfigWithViewCount[]>
+) => {
+  const queryFn = useCallback(async () => {
+    const configs = await fetchChartConfigs();
+
+    const configsWithViewCount = await Promise.all(
+      configs.map(async (config) => {
+        return {
+          ...config,
+          viewCount: await fetchChartViewCount(config.key),
+        };
+      })
+    );
+
+    return configsWithViewCount;
+  }, []);
+
+  const result = useFetchData({
     queryKey: userConfigsKey,
-    queryFn: fetchChartConfigs,
+    queryFn,
     options,
   });
+
+  return result;
+};
 
 export const useUserConfig = (
   chartId: string | undefined,
   options?: UseFetchDataOptions
 ) => {
-  const queryFn = useCallback(() => {
-    return fetchChartConfig(chartId ?? "");
+  const queryFn = useCallback(async () => {
+    const [config, viewCount] = await Promise.all([
+      fetchChartConfig(chartId!),
+      fetchChartViewCount(chartId!),
+    ]);
+
+    if (!config) {
+      throw new Error("Config not found");
+    }
+
+    return {
+      ...config,
+      viewCount,
+    };
   }, [chartId]);
 
-  return useFetchData({
+  const result = useFetchData({
     queryKey: userConfigKey(chartId!),
     queryFn,
     options: {
@@ -30,4 +66,6 @@ export const useUserConfig = (
       ...options,
     },
   });
+
+  return result;
 };

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -782,6 +782,7 @@ msgid "controls.filter.show-values.none"
 msgstr "Keine Werte anzeigen"
 
 #: app/configurator/components/field.tsx
+#: app/configurator/components/field.tsx
 #: app/configurator/components/filters.tsx
 msgid "controls.filter.use-most-recent"
 msgstr "Letztes Datum verwenden"
@@ -1862,10 +1863,6 @@ msgid "login.profile.my-visualizations"
 msgstr "Meine Visualisierungen"
 
 #: app/login/components/profile-tables.tsx
-msgid "login.profile.my-visualizations.chart-actions"
-msgstr "Aktionen"
-
-#: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.chart-name"
 msgstr "Name"
 
@@ -1876,6 +1873,10 @@ msgstr "Typ"
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.chart-updated-date"
 msgstr "Geändert"
+
+#: app/login/components/profile-tables.tsx
+msgid "login.profile.my-visualizations.chart-views"
+msgstr "Ansichten"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.dataset-name"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -782,6 +782,7 @@ msgid "controls.filter.show-values.none"
 msgstr "Show no values"
 
 #: app/configurator/components/field.tsx
+#: app/configurator/components/field.tsx
 #: app/configurator/components/filters.tsx
 msgid "controls.filter.use-most-recent"
 msgstr "Use most recent"
@@ -1862,10 +1863,6 @@ msgid "login.profile.my-visualizations"
 msgstr "My visualizations"
 
 #: app/login/components/profile-tables.tsx
-msgid "login.profile.my-visualizations.chart-actions"
-msgstr "Actions"
-
-#: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.chart-name"
 msgstr "Name"
 
@@ -1876,6 +1873,10 @@ msgstr "Type"
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.chart-updated-date"
 msgstr "Updated"
+
+#: app/login/components/profile-tables.tsx
+msgid "login.profile.my-visualizations.chart-views"
+msgstr "Views"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.dataset-name"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -1821,7 +1821,7 @@ msgstr "Home"
 #: app/login/components/profile-content-tabs.tsx
 #: app/login/components/profile-content-tabs.tsx
 msgid "login.profile.my-color-palettes"
-msgstr "My color palettes"
+msgstr "My Color Palettes"
 
 #: app/configurator/components/chart-controls/color-palette.tsx
 #: app/configurator/components/chart-controls/color-ramp.tsx

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -782,6 +782,7 @@ msgid "controls.filter.show-values.none"
 msgstr "N'afficher aucune valeur"
 
 #: app/configurator/components/field.tsx
+#: app/configurator/components/field.tsx
 #: app/configurator/components/filters.tsx
 msgid "controls.filter.use-most-recent"
 msgstr "Utiliser le plus récent"
@@ -1862,10 +1863,6 @@ msgid "login.profile.my-visualizations"
 msgstr "Mes visualisations"
 
 #: app/login/components/profile-tables.tsx
-msgid "login.profile.my-visualizations.chart-actions"
-msgstr "Actions"
-
-#: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.chart-name"
 msgstr "Nom"
 
@@ -1876,6 +1873,10 @@ msgstr "Type"
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.chart-updated-date"
 msgstr "Modifié"
+
+#: app/login/components/profile-tables.tsx
+msgid "login.profile.my-visualizations.chart-views"
+msgstr "Vues"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.dataset-name"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -782,6 +782,7 @@ msgid "controls.filter.show-values.none"
 msgstr "Non mostrare alcun valore"
 
 #: app/configurator/components/field.tsx
+#: app/configurator/components/field.tsx
 #: app/configurator/components/filters.tsx
 msgid "controls.filter.use-most-recent"
 msgstr "Usare il più recente"
@@ -1862,10 +1863,6 @@ msgid "login.profile.my-visualizations"
 msgstr "Le mie visualizzazioni"
 
 #: app/login/components/profile-tables.tsx
-msgid "login.profile.my-visualizations.chart-actions"
-msgstr "Azioni"
-
-#: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.chart-name"
 msgstr "Nome"
 
@@ -1876,6 +1873,10 @@ msgstr "Tipo"
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.chart-updated-date"
 msgstr "Aggiornato"
+
+#: app/login/components/profile-tables.tsx
+msgid "login.profile.my-visualizations.chart-views"
+msgstr "Visualizzazioni"
 
 #: app/login/components/profile-tables.tsx
 msgid "login.profile.my-visualizations.dataset-name"

--- a/app/login/components/color-palettes/color-palette-types.tsx
+++ b/app/login/components/color-palettes/color-palette-types.tsx
@@ -246,7 +246,6 @@ const CategoricalColorPaletteCreator = (props: ColorPaletteCreatorProps) => {
           ))}
         </Box>
       )}
-
       <Button
         variant="text"
         fullWidth

--- a/app/login/components/color-palettes/profile-color-palette-content.tsx
+++ b/app/login/components/color-palettes/profile-color-palette-content.tsx
@@ -1,6 +1,6 @@
 import { useEvent } from "@dnd-kit/utilities";
 import { Trans } from "@lingui/macro";
-import { Box, Button, Grid, styled, Typography } from "@mui/material";
+import { Button, Grid, IconButton, styled, Typography } from "@mui/material";
 import { useState } from "react";
 
 import { Flex } from "@/components/flex";
@@ -75,12 +75,14 @@ export const ProfileColorPaletteContent = ({ title }: ProfileContentProps) => {
             </Typography>
           )}
           <Button
-            variant="contained"
+            size="sm"
             startIcon={<Icon name="plus" />}
             sx={{ width: "fit-content" }}
             onClick={showAddForm}
           >
-            <Trans id="login.profile.my-color-palettes.add" />
+            <Trans id="login.profile.my-color-palettes.add">
+              Add color palette
+            </Trans>
           </Button>
         </Flex>
       ) : (
@@ -95,40 +97,19 @@ export const ProfileColorPaletteContent = ({ title }: ProfileContentProps) => {
   );
 };
 
-const EditButton = styled(Button)({
-  padding: 0,
+const EditButton = styled(IconButton)(({ theme }) => ({
+  padding: theme.spacing(1),
   minWidth: "auto",
-  minHeight: "auto",
-  lineHeight: "24px",
   backgroundColor: "transparent",
-});
+  lineHeight: 0,
+}));
 
-const DeleteButton = styled(Button)({
-  padding: 0,
+const DeleteButton = styled(IconButton)(({ theme }) => ({
+  padding: theme.spacing(1),
   minWidth: "auto",
-  minHeight: "auto",
-  lineHeight: "24px",
   backgroundColor: "transparent",
-});
-
-const ColorRowFlex = styled(Flex)({
-  lineHeight: "16px",
-  "& > button": {
-    backgroundColor: "grey.100",
-    borderRadius: 4,
-    overflow: "hidden",
-    borderWidth: 1,
-    p: 0,
-  },
-  "& > button:hover": {
-    backgroundColor: "transparent",
-    cursor: "pointer",
-    opacity: 0.8,
-  },
-  "& > button[aria-expanded]": {
-    borderColor: "primary.active",
-  },
-});
+  lineHeight: 0,
+}));
 
 const ColorPaletteRow = ({
   colors,
@@ -149,23 +130,24 @@ const ColorPaletteRow = ({
   });
 
   return (
-    <ColorRowFlex
+    <Flex
       sx={{
-        paddingY: 3,
-        paddingRight: 4,
         justifyContent: "space-between",
         alignItems: "center",
+        py: 3,
+        pr: 4,
       }}
     >
-      <Box>
+      <div>
         <Typography variant="caption">{name}</Typography>
         <Grid
           container
           spacing={0.5}
           sx={{
             display: "flex",
-            width: "240px",
             alignItems: "center",
+            width: "240px",
+
             "& .MuiGrid-item": {
               display: "flex",
               alignItems: "center",
@@ -178,13 +160,14 @@ const ColorPaletteRow = ({
             type={type}
           />
         </Grid>
-      </Box>
-      <ColorRowFlex gap={3}>
+      </div>
+      <Flex gap={2.5}>
         <EditButton onClick={() => onEdit(paletteId)}>
           <Typography
+            component="span"
+            color="text.primary"
             aria-hidden
-            color="primary.main"
-            sx={{ backgroundColor: "transparent" }}
+            style={{ lineHeight: 0 }}
           >
             <VisuallyHidden>
               <Trans id="login.profile.my-color-palettes.edit">
@@ -204,15 +187,16 @@ const ColorPaletteRow = ({
             </Trans>
           </VisuallyHidden>
           <Typography
+            component="span"
+            color="text.primary"
             aria-hidden
-            color="primary.main"
-            sx={{ backgroundColor: "transparent" }}
+            style={{ lineHeight: 0 }}
           >
             <Icon name="trash" size={24} />
           </Typography>
         </DeleteButton>
-      </ColorRowFlex>
-    </ColorRowFlex>
+      </Flex>
+    </Flex>
   );
 };
 
@@ -227,7 +211,7 @@ const ColorPaletteDisplay = ({
         <>
           {colors.map((color, i) => (
             <Grid item key={`${paletteId}-${color}-${i}`}>
-              <ColorSquare color={color as string} />
+              <ColorSquare color={color} />
             </Grid>
           ))}
         </>

--- a/app/login/components/profile-content-tabs.tsx
+++ b/app/login/components/profile-content-tabs.tsx
@@ -4,8 +4,9 @@ import { Box, Tab, Theme } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import clsx from "clsx";
 import groupBy from "lodash/groupBy";
-import { SyntheticEvent, useMemo, useState } from "react";
+import { type SyntheticEvent, useMemo, useState } from "react";
 
+import { ParsedConfigWithViewCount } from "@/db/config";
 import { useUserConfigs } from "@/domain/user-configs";
 import { ProfileColorPaletteContent } from "@/login/components/color-palettes/profile-color-palette-content";
 import { ProfileVisualizationsTable } from "@/login/components/profile-tables";
@@ -48,6 +49,7 @@ export const ProfileContentTabs = (props: ProfileContentTabsProps) => {
   const { userId } = props;
 
   const { data: userConfigs } = useUserConfigs();
+
   const [value, setValue] = useState("home");
   const handleChange = useEvent((_: SyntheticEvent, v: string) => {
     setValue(v);
@@ -59,7 +61,7 @@ export const ProfileContentTabs = (props: ProfileContentTabsProps) => {
     useMemo(() => {
       return groupBy(
         userConfigs,
-        (x: { published_state: any }) => x.published_state
+        (config: ParsedConfigWithViewCount) => config.published_state
       );
     }, [userConfigs]);
 

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -106,31 +106,27 @@ export const ProfileVisualizationsTable = (
           <StyledTable>
             <TableHead>
               <TableRow>
-                <TableCell component="th">
+                <TableCell component="th" width="10%">
                   <Trans id="login.profile.my-visualizations.chart-type">
                     Type
                   </Trans>
                 </TableCell>
-                <TableCell component="th">
+                <TableCell component="th" width="30%">
                   <Trans id="login.profile.my-visualizations.chart-name">
                     Name
                   </Trans>
                 </TableCell>
-                <TableCell component="th">
+                <TableCell component="th" width="30%">
                   <Trans id="login.profile.my-visualizations.dataset-name">
                     Dataset
                   </Trans>
                 </TableCell>
-                <TableCell component="th">
+                <TableCell component="th" width="15%">
                   <Trans id="login.profile.my-visualizations.chart-updated-date">
                     Last edit
                   </Trans>
                 </TableCell>
-                <TableCell component="th">
-                  <Trans id="login.profile.my-visualizations.chart-actions">
-                    Actions
-                  </Trans>
-                </TableCell>
+                <TableCell component="th" width="15%" />
               </TableRow>
             </TableHead>
             <TableBody>
@@ -350,12 +346,12 @@ const ProfileVisualizationsRow = (props: {
 
   return (
     <TableRow>
-      <TableCell width="10%">
+      <TableCell>
         {isSingleChart
           ? t({ id: "controls.layout.chart", message: "Chart" })
           : t({ id: "controls.layout.dashboard", message: "Dashboard" })}
       </TableCell>
-      <TableCell width="30%">
+      <TableCell>
         <NextLink
           href={isPublished ? publishLink : editLink}
           passHref
@@ -374,7 +370,7 @@ const ProfileVisualizationsRow = (props: {
           </Link>
         </NextLink>
       </TableCell>
-      <TableCell width="30%">
+      <TableCell>
         {fetching ? (
           <Skeleton width="50%" height={32} />
         ) : dataSet ? (
@@ -406,13 +402,13 @@ const ProfileVisualizationsRow = (props: {
           </Typography>
         )}
       </TableCell>
-      <TableCell width="10%">
+      <TableCell>
         {config.updated_at.toLocaleString("de", {
           dateStyle: "medium",
           timeStyle: "short",
         })}
       </TableCell>
-      <TableCell width="20%" align="right">
+      <TableCell align="right">
         <RowActions actions={actions} />
         <TriggeredPopover
           popoverProps={{

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -124,14 +124,14 @@ export const ProfileVisualizationsTable = ({
                     Dataset
                   </Trans>
                 </TableCell>
-                <TableCell component="th" width="12.5%">
-                  <Trans id="login.profile.my-visualizations.chart-updated-date">
-                    Last edit
-                  </Trans>
-                </TableCell>
                 <TableCell component="th" width="10%">
                   <Trans id="login.profile.my-visualizations.chart-views">
                     Views
+                  </Trans>
+                </TableCell>
+                <TableCell component="th" width="12.5%">
+                  <Trans id="login.profile.my-visualizations.chart-updated-date">
+                    Last edit
                   </Trans>
                 </TableCell>
                 <TableCell component="th" width="12.5%" />
@@ -413,15 +413,15 @@ const ProfileVisualizationsRow = ({
         )}
       </TableCell>
       <TableCell>
+        <Typography variant="body3" component="p" noWrap>
+          {formatInteger(config.viewCount)}
+        </Typography>
+      </TableCell>
+      <TableCell>
         {config.updated_at.toLocaleString("de", {
           dateStyle: "medium",
           timeStyle: "short",
         })}
-      </TableCell>
-      <TableCell>
-        <Typography variant="body3" component="p" noWrap>
-          {formatInteger(config.viewCount)}
-        </Typography>
       </TableCell>
       <TableCell align="right">
         <RowActions actions={actions} />

--- a/app/login/components/profile-tables.tsx
+++ b/app/login/components/profile-tables.tsx
@@ -33,7 +33,7 @@ import { RenameDialog } from "@/components/rename-dialog";
 import { RowActions } from "@/components/row-actions";
 import { useDisclosure } from "@/components/use-disclosure";
 import { CONFIGURATOR_STATE_LAYOUTING } from "@/config-types";
-import { ParsedConfig } from "@/db/config";
+import { ParsedConfigWithViewCount } from "@/db/config";
 import { sourceToLabel } from "@/domain/data-source";
 import { truthy } from "@/domain/types";
 import { useUserConfigs } from "@/domain/user-configs";
@@ -41,6 +41,7 @@ import { useDataCubesMetadataQuery } from "@/graphql/hooks";
 import { Icon } from "@/icons";
 import { useLocale } from "@/locales/use-locale";
 import { useRootStyles } from "@/login/utils";
+import { formatInteger } from "@/statistics/formatters";
 import { removeConfig, updateConfig } from "@/utils/chart-config/api";
 import { useMutate } from "@/utils/use-fetch-data";
 
@@ -71,7 +72,7 @@ export const SectionContent = ({
 type ProfileVisualizationsTableProps = {
   title: string;
   userId: number;
-  userConfigs: ParsedConfig[];
+  userConfigs: ParsedConfigWithViewCount[];
   preview?: boolean;
   onShowAll?: () => void;
 };
@@ -94,11 +95,13 @@ const StyledTable = styled(Table)(({ theme }) => ({
   },
 }));
 
-export const ProfileVisualizationsTable = (
-  props: ProfileVisualizationsTableProps
-) => {
-  const { title, userId, userConfigs, preview, onShowAll } = props;
-
+export const ProfileVisualizationsTable = ({
+  title,
+  userId,
+  userConfigs,
+  preview,
+  onShowAll,
+}: ProfileVisualizationsTableProps) => {
   return (
     <SectionContent title={title}>
       {userConfigs.length > 0 ? (
@@ -111,22 +114,27 @@ export const ProfileVisualizationsTable = (
                     Type
                   </Trans>
                 </TableCell>
-                <TableCell component="th" width="30%">
+                <TableCell component="th" width="27.5%">
                   <Trans id="login.profile.my-visualizations.chart-name">
                     Name
                   </Trans>
                 </TableCell>
-                <TableCell component="th" width="30%">
+                <TableCell component="th" width="27.5%">
                   <Trans id="login.profile.my-visualizations.dataset-name">
                     Dataset
                   </Trans>
                 </TableCell>
-                <TableCell component="th" width="15%">
+                <TableCell component="th" width="12.5%">
                   <Trans id="login.profile.my-visualizations.chart-updated-date">
                     Last edit
                   </Trans>
                 </TableCell>
-                <TableCell component="th" width="15%" />
+                <TableCell component="th" width="10%">
+                  <Trans id="login.profile.my-visualizations.chart-views">
+                    Views
+                  </Trans>
+                </TableCell>
+                <TableCell component="th" width="12.5%" />
               </TableRow>
             </TableHead>
             <TableBody>
@@ -169,11 +177,13 @@ export const ProfileVisualizationsTable = (
   );
 };
 
-const ProfileVisualizationsRow = (props: {
+const ProfileVisualizationsRow = ({
+  userId,
+  config,
+}: {
   userId: number;
-  config: ParsedConfig;
+  config: ParsedConfigWithViewCount;
 }) => {
-  const { userId, config } = props;
   const { dataSource } = config.data;
   const dataSets = Array.from(
     new Set(config.data.chartConfigs.flatMap((d) => d.cubes.map((d) => d.iri)))
@@ -407,6 +417,11 @@ const ProfileVisualizationsRow = (props: {
           dateStyle: "medium",
           timeStyle: "short",
         })}
+      </TableCell>
+      <TableCell>
+        <Typography variant="body3" component="p" noWrap>
+          {formatInteger(config.viewCount)}
+        </Typography>
       </TableCell>
       <TableCell align="right">
         <RowActions actions={actions} />

--- a/app/login/utils.ts
+++ b/app/login/utils.ts
@@ -23,7 +23,7 @@ export const useRootStyles = makeStyles<Theme>((theme) => ({
   },
   sectionContent: {
     width: "100%",
-    maxWidth: 1400,
+    maxWidth: 1548,
     margin: "0 auto",
   },
 }));

--- a/app/pages/api/config/view.ts
+++ b/app/pages/api/config/view.ts
@@ -1,7 +1,21 @@
-import { increaseConfigViewCount } from "../../../db/config";
+import {
+  getConfigViewCount,
+  increaseConfigViewCount,
+} from "../../../db/config";
 import { api } from "../../../server/nextkit";
 
 const route = api({
+  GET: async ({ req }) => {
+    const { id } = req.query;
+
+    if (typeof id !== "string") {
+      throw new Error("Invalid config id");
+    }
+
+    const viewCount = await getConfigViewCount(id);
+
+    return viewCount;
+  },
   POST: async ({ req }) => {
     const { type } = JSON.parse(req.body);
 

--- a/app/utils/chart-config/api.ts
+++ b/app/utils/chart-config/api.ts
@@ -109,6 +109,10 @@ export const fetchChartConfigs = async () => {
   return await apiFetch<ParsedConfig[]>(`/api/config/list`);
 };
 
+export const fetchChartViewCount = async (id: string) => {
+  return await apiFetch<number>(`/api/config/view?id=${id}`);
+};
+
 export const createCustomColorPalette = async (
   options: CreateCustomColorPalette
 ) => {


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #1796

<!--- Describe the changes -->

This PR:
- adds a new, `Views` column to user profile tables that displays the number of times a given chart was displayed,
- aligns some login styles with the design.

<img width="1920" height="971" alt="Screenshot 2025-07-23 at 15 02 15" src="https://github.com/user-attachments/assets/49762ab2-ec61-4102-a5a9-1eb1e6916b5f" />

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-feat-improve-profile-page-ixt1.vercel.app/en).
2. Log in as test user.
3. Open your profile.
4. ✅ See that there's a Views column in the tables.
5. Open the published chart and go back to the table.
6. ✅ See that the view count has increased.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
