### PR TITLE
fix: Preload Varnish Cache

### DIFF
--- a/.github/workflows/preload-varnish-cache.yml
+++ b/.github/workflows/preload-varnish-cache.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
       - name: Run Playwright test to preload Varnish cache
-        run: ./node_modules/.bin/ts-node --esm ./e2e/varnish-cache-preload.ts
+        run: ./node_modules/.bin/ts-node ./e2e/varnish-cache-preload.ts

--- a/.github/workflows/preload-varnish-cache.yml
+++ b/.github/workflows/preload-varnish-cache.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
       - name: Run Playwright test to preload Varnish cache
-        run: ./node_modules/.bin/ts-node ./e2e/varnish-cache-preload.ts
+        run: ./node_modules/.bin/ts-node --esm ./e2e/varnish-cache-preload.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ You can also check the
 
 ## Unreleased
 
-Nothing yet.
+- Fixes
+  - Fixed workflow for populating Varnish cache
 
 ### 6.0.0 - 2025-09-05
 

--- a/e2e/varnish-cache-preload.ts
+++ b/e2e/varnish-cache-preload.ts
@@ -1,5 +1,5 @@
 import fetch from "node-fetch";
-import pLimit from "p-limit";
+import * as pLimit from "p-limit";
 import { chromium, Page } from "playwright";
 
 import { locales } from "../app/locales/constants";


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2449

<!--- Describe the changes -->

This PR addresses the failing workflow for preloading the Varnish cache.

<!--- Test instructions -->

## How to test

Potentially, this workflow could be tested locally, see [here](https://github.com/visualize-admin/visualization-tool?tab=readme-ov-file#4-developing-github-actions). However, it can also be directly tested through the Actions menu in this repo by triggering it manually.

<!-- ## Steps to reproduce

N/A

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
- [ ] I wrote tests for the changes (if applicable)
- [ ] I wrote configurator and chart config migrations (if applicable)
