### PR TITLE
fix: Sorting in the multi filter panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ You can also check the
   - It's now possible to share filters between tables in dashboards
   - Charts are not animating in and out anymore when interacting with UI in some
     rare cases
+  - Sorting of values in the multi filter panel is now consistent with the rest
+    of the application
 - Styles
   - Added missing paddings in details panel autocomplete component and in banner
     component for smaller breakpoints

--- a/app/configurator/components/filters.spec.ts
+++ b/app/configurator/components/filters.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { getHasColorMapping } from "@/configurator/components/filters";
-import { TemporalDimension } from "@/domain/data";
+import { getHasColorMapping, sortFilterValues } from "@/configurator/components/filters";
+import { HierarchyValue, TemporalDimension } from "@/domain/data";
 import { TimeUnit } from "@/graphql/resolver-types";
 import { getD3TimeFormatLocale } from "@/locales/locales";
 import { getTimeFilterOptions } from "@/utils/time-filter-options";
@@ -40,5 +40,40 @@ describe("colorMapping", () => {
         filterDimensionId: "123",
       })
     ).toBe(false);
+  });
+});
+
+describe("sortFilterValues", () => {
+  it("should sort values numerically by identifier when identifiers are numeric strings", () => {
+    const values: HierarchyValue[] = [
+      {
+        depth: 0,
+        dimensionId: "test",
+        value: "1",
+        hasValue: true,
+        label: "One",
+        identifier: "1",
+      },
+      {
+        depth: 0,
+        dimensionId: "test",
+        value: "10",
+        hasValue: true,
+        label: "Ten",
+        identifier: "10",
+      },
+      {
+        depth: 0,
+        dimensionId: "test",
+        value: "2",
+        hasValue: true,
+        label: "Two",
+        identifier: "2",
+      },
+    ];
+
+    const sortedValues = sortFilterValues(values);
+
+    expect(sortedValues.map(v => v.identifier)).toEqual(["1", "2", "10"]);
   });
 });

--- a/app/configurator/components/filters.tsx
+++ b/app/configurator/components/filters.tsx
@@ -21,7 +21,6 @@ import { ascending, groups, max, sum } from "d3-array";
 import get from "lodash/get";
 import groupBy from "lodash/groupBy";
 import keyBy from "lodash/keyBy";
-import orderBy from "lodash/orderBy";
 import uniqBy from "lodash/uniqBy";
 import {
   ChangeEvent,
@@ -183,6 +182,18 @@ const groupByParent = (node: { parents: HierarchyValue[] }) => {
   return joinParents(node?.parents);
 };
 
+export const sortFilterValues = (values: HierarchyValue[]) => {
+  return values.sort((a, b) => {
+    return (
+      ascending(a.position ?? 0, b.position ?? 0) ||
+      `${a.identifier}`.localeCompare(`${b.identifier}`, undefined, {
+        numeric: true,
+      }) ||
+      a.label.localeCompare(b.label)
+    );
+  });
+};
+
 const getColorConfig = (chartConfig: ChartConfig) => {
   if (isColorInConfig(chartConfig)) {
     return get(chartConfig.fields, ["color"]) as ColorField | undefined;
@@ -292,10 +303,7 @@ const MultiFilterContent = ({
             ) || ascending(a[0], b[0])
       )
       .map(([parent, group]) => {
-        return [
-          parent,
-          orderBy(group, ["position", "identifier", "label"]),
-        ] as const;
+        return [parent, sortFilterValues(group)] as const;
       });
 
     return {


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2468

<!--- Describe the changes -->

This PR makes sure the sorting of values in the multi filter panel is consistent with the rest of the application.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-sorting-multifilter-panel-ixt1.vercel.app/en/create/new?cube=https://energy.ld.admin.ch/sfoe/bfe_ogd84_einmalverguetung_fuer_photovoltaikanlagen/10&dataSource=Prod).
2. Add segmentation by `Kanton`.
3. ✅ See that the list of cantons in the left panel matches the order in other places (Zurich, Bern, ...).

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
- [x] I wrote tests for the changes (if applicable)
