### PR TITLE
feat: Improve sorting by totalSize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ You can also check the
 - Features
   - Table sorting is not reset anymore on data / filter change
   - Visualize now supports multiple cube contact points
+  - Order of groups when sorting by total segment size is now more intuitive
 - Fixes
   - Hiding a temporal column and then enabling an interactive filter doesn't
     result in broken state anymore

--- a/app/utils/sorting-values.spec.ts
+++ b/app/utils/sorting-values.spec.ts
@@ -249,4 +249,32 @@ describe("makeDimensionValueSorters", () => {
       "2020-01-01",
     ]);
   });
+
+  it("should correctly sort byTotalSize (reversed order)", () => {
+    const totalSizeDimension = {
+      values: [
+        { value: "A", label: "A" },
+        { value: "B", label: "B" },
+        { value: "C", label: "C" },
+        { value: "D", label: "D" },
+      ],
+    } as unknown as Dimension;
+    const values = totalSizeDimension.values.map((d) => d.value);
+    const sorting: NonNullable<SortingField["sorting"]> = {
+      sortingType: "byTotalSize",
+      sortingOrder: "asc",
+    };
+    const sorters = makeDimensionValueSorters(totalSizeDimension, {
+      sorting,
+      sumsBySegment: { A: 1, B: 2, C: 3, D: 4 },
+    });
+    const sortingOrders = getSortingOrders(sorters, sorting);
+    // Should be reversed
+    expect(orderBy(values, sorters, sortingOrders)).toEqual([
+      "D",
+      "C",
+      "B",
+      "A",
+    ]);
+  });
 });

--- a/app/utils/sorting-values.ts
+++ b/app/utils/sorting-values.ts
@@ -175,7 +175,18 @@ export const getSortingOrders = (
   sorters: ((...args: any[]) => any)[],
   sorting: SortingField["sorting"]
 ) => {
-  return Array(sorters.length).fill(
-    sorting?.sortingOrder === "desc" ? "desc" : "asc"
-  );
+  const order = sorting?.sortingOrder;
+  const type = sorting?.sortingType;
+  const result = Array(sorters.length);
+
+  switch (order) {
+    case "desc":
+      return result.fill(type === "byTotalSize" ? "asc" : "desc");
+    case "asc":
+    case undefined:
+      return result.fill(type === "byTotalSize" ? "desc" : "asc");
+    default:
+      const _exhaustiveCheck: never = order;
+      return _exhaustiveCheck;
+  }
 };


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #1629
Closes #2469

<!--- Describe the changes -->

This PR reverses the sorting order when sorting by total size to make the legend and tooltip items match the order of segments in the chart.

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-reverse-total-size-sorti-61ff26-ixt1.vercel.app/en/v/0LxTUcFE39TS?dataSource=Prod).
2. ✅ See that the order of legend and tooltip items matches chart's order.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
- [x] I wrote tests for the changes (if applicable)
