### PR TITLE
fix: Y axis band title click behavior for bar charts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ You can also check the
 
 ## Unreleased
 
-Nothing yet.
+- Fix
+  - Clicking on Y axis title in bar charts now open Data tab in the details
+    panels, as in other chart types
 
 ### 6.1.2 - 2025-10-22
 

--- a/app/charts/shared/axis-height-band.tsx
+++ b/app/charts/shared/axis-height-band.tsx
@@ -102,7 +102,7 @@ export const AxisHeightBand = () => {
         height={leftAxisLabelSize.height}
         style={{ display: "flex" }}
       >
-        <OpenMetadataPanelWrapper>
+        <OpenMetadataPanelWrapper component={yDimension}>
           <span style={{ fontSize: axisLabelFontSize, lineHeight: 1.5 }}>
             {yDimension.label}
           </span>


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #2481

<!--- Describe the changes -->

This PR...

<!--- Test instructions -->

## How to test

1. Go to [this link](https://visualization-tool-git-fix-bar-chart-details-panel-link-ixt1.vercel.app/en/v/m-QU8hNfQvDB?dataSource=Prod).
2. Click the Y axis title.
3. ✅ See that the Details panel opened with a Data tab pre-selected.

<!-- ## Steps to reproduce

1. Go to this link.
2. ... -->

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
