### PR TITLE
fix: Update runner selection tag for CI/CD

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ build:
   image: docker.io/docker:stable
   stage: build
   tags:
-    - medium
+    - k8s-privileged
   script:
     - DOCKER_IMAGE_TAGS="$MAIN_IMAGE_TAG" ./scripts/docker-build-push.sh
   only:
@@ -30,7 +30,7 @@ release:
   image: docker.io/docker:stable
   stage: release
   tags:
-    - medium
+    - k8s-privileged
   script:
     - pwd
     - env DOCKER_IMAGE_TAGS="$RELEASE_IMAGE_TAG


### PR DESCRIPTION
This PR fixes an issue with GitLab runners which was causing build failures in the CI/CD pipeline.

## How to test

N/A – it is not possible to easily test this change without deploying it.

---

- [ ] I added a CHANGELOG entry
- [x] I made a self-review of my own code
