### PR TITLE
feat: Open table links in the same tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ You can also check the
 
 ## Unreleased
 
-Nothing yet.
+- Features
+  - Links in table charts now open in the same tab
 
 ### 6.2.1 - 2025-11-24
 

--- a/app/charts/table/linked-cell-wrapper.tsx
+++ b/app/charts/table/linked-cell-wrapper.tsx
@@ -68,7 +68,7 @@ export const LinkedCellWrapper = ({
     <Link
       className={classes.link}
       href={href}
-      target="_blank"
+      target="_parent"
       title={href}
       style={{ flex: 1, justifyContent: "space-between" }}
     >


### PR DESCRIPTION
This PR makes sure the table links open in the same, not new tab.

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
