### PR TITLE
sh:or for sh:datatype was not checked in preview query

### DIFF
--- a/app/rdf/query-cube-preview.ts
+++ b/app/rdf/query-cube-preview.ts
@@ -113,20 +113,32 @@ CONSTRUCT {
     ?cube cube:observationConstraint/sh:property/sh:path ?observationPredicate .
     { SELECT ?observation ?observationPredicate ?observationValue ?observationLabel ?observationPosition WHERE {
     { 
-#pragma evaluate on  ## improve preview speed (wrt Stardog issue 2094 on Stardog >= 10 // see also SBAR-1122)
+      #pragma evaluate on  ## improve preview speed (wrt Stardog issue 2094 on Stardog >= 10 // see also SBAR-1122)
       SELECT ?observation WHERE {
       VALUES ?cube { <${iri}> }
       ?cube cube:observationSet ?observationSet .
       ?observationSet cube:observation ?observation .
-      FILTER(EXISTS { ?cube cube:observationConstraint/sh:property/sh:datatype cube:Undefined . } || NOT EXISTS { ?observation ?p ""^^cube:Undefined . })
+      FILTER(
+        EXISTS { 
+          ?cube cube:observationConstraint/sh:property/sh:datatype cube:Undefined . 
+        }
+        || 
+        EXISTS { 
+          ?cube cube:observationConstraint/sh:property/sh:or/rdf:rest*/rdf:first/sh:datatype cube:Undefined . 
+        }
+        || 
+        NOT EXISTS {
+          ?observation ?p ""^^cube:Undefined .
+        }
+      )
     } LIMIT 10 }
       ?observation ?observationPredicate ?observationValue .
       ${buildLocalizedSubQuery(
-        "observationValue",
-        "schema:name",
-        "observationLabel",
-        { locale }
-      )}
+      "observationValue",
+      "schema:name",
+      "observationLabel",
+      { locale }
+    )}
       OPTIONAL { ?observationValue schema:position ?observationPosition . }
       FILTER(?observationPredicate != cube:observedBy && ?observationPredicate != rdf:type)
     }}


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes #

<!--- Describe the changes -->
The preview query did not check if there is a datatype with OR.
In the case of the ELCOM cube it was `xsd:decimal` or `cube:Undefined`. 
Added the OR condition to the FILTER expression. 


```sparql
FILTER(
        EXISTS { 
          ?cube cube:observationConstraint/sh:property/sh:datatype cube:Undefined . 
        }
        || 
        EXISTS { 
          ?cube cube:observationConstraint/sh:property/sh:or/rdf:rest*/rdf:first/sh:datatype cube:Undefined . 
        }
        || 
        NOT EXISTS {
          ?observation ?p ""^^cube:Undefined .
        }
      )
```

<!--- Test instructions -->

## How to test

1. "Strompreis per Stromnetzbetreiber" cube shows a preview now. 

- [ ] I added a CHANGELOG entry
- [ ] I made a self-review of my own code
- [ ] I wrote tests for the changes (if applicable)
- [ ] I wrote configurator and chart config migrations (if applicable)
