### PR TITLE
fix: sanitize urls from external sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ You can also check the
 - Refactoring
   - Incorporate the Swiss-Federal-CI library into this repository.
 - Fixes
-  - Sanitize urls for links in tables
+  - Sanitize URLs from external sources
   - Improve CSP header configuration
 - Maintenance
   - Remove Google Analytics integration (it is no longer in use)

--- a/app/components/dataset-metadata.tsx
+++ b/app/components/dataset-metadata.tsx
@@ -1,3 +1,4 @@
+import { sanitizeUrl } from "@braintree/sanitize-url";
 import { Trans } from "@lingui/macro";
 import {
   Box,
@@ -104,7 +105,7 @@ export const DatasetMetadata = ({
           <DatasetMetadataBody sx={{ mt: "1px" }}>
             {cube.landingPage ? (
               <DatasetMetadataLink
-                href={cube.landingPage}
+                href={sanitizeUrl(cube.landingPage)}
                 external
                 label={
                   <Trans id="dataset.metadata.learnmore">

--- a/app/package.json
+++ b/app/package.json
@@ -16,7 +16,7 @@
     "@apollo/client": "^3.3.20",
     "@apollo/server-plugin-landing-page-graphql-playground": "^4.0.1",
     "@babel/standalone": "^7.11.6",
-    "@braintree/sanitize-url": "^7.1.1",
+    "@braintree/sanitize-url": "7.1.2",
     "@deck.gl/core": "^9.1.2",
     "@deck.gl/extensions": "^9.1.2",
     "@deck.gl/geo-layers": "^9.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2506,10 +2506,10 @@
   dependencies:
     buffer "^6.0.3"
 
-"@braintree/sanitize-url@^7.1.1":
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-7.1.1.tgz#15e19737d946559289b915e5dad3b4c28407735e"
-  integrity sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw==
+"@braintree/sanitize-url@7.1.2":
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz#ca2035b0fefe956a8676ff0c69af73e605fcd81f"
+  integrity sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==
 
 "@catalog/core@^4.0.1-canary.2":
   version "4.0.1-canary.2"


### PR DESCRIPTION
* Sanitize additional urls that come from external sources.
* pin sanitize-url dependency
* configure lates node version in .nvmrc (this aligns local development with github workflows)

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
