### PR TITLE
feat: add link to service desk link in footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ You can also check the
 - Features
   - Add SPARQL endpoints in the OpenTelemetry traces
   - Add Sentry integration back
+  - Action tiles replaced with a link to the service desk
 - Refactoring
   - Incorporate the Swiss-Federal-CI library into this repository.
 - Fixes

--- a/app/components/footer.tsx
+++ b/app/components/footer.tsx
@@ -105,6 +105,19 @@ export const Footer = ({ sx }: { sx?: SxProps }) => {
           />
         </Link>
         <Link
+          href={`https://cognizone.atlassian.net/servicedesk/customer/portal/1`}
+          target="_blank"
+          underline="none"
+        >
+          <FooterSectionButton
+            iconName="external"
+            label={t({
+              id: "footer.button.service-desk",
+              message: "Service Desk",
+            })}
+          />
+        </Link>
+        <Link
           href={`https://www.youtube.com/@visualizetutorials`}
           target="_blank"
           underline="none"

--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -1132,6 +1132,10 @@ msgstr "Responsive Spaltenbreiten"
 msgid "footer.button.lindas"
 msgstr "LINDAS Linked Data Dienste"
 
+#: app/components/footer.tsx
+msgid "footer.button.service-desk"
+msgstr "Service-Desk"
+
 #: app/configurator/components/chart-options-selector/imputation-field.tsx
 #: app/configurator/components/field-i18n.ts
 msgid "controls.imputation.type.linear"

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -1132,6 +1132,10 @@ msgstr "Responsive column widths"
 msgid "footer.button.lindas"
 msgstr "LINDAS Linked Data Services"
 
+#: app/components/footer.tsx
+msgid "footer.button.service-desk"
+msgstr "Service-Desk"
+
 #: app/configurator/components/chart-options-selector/imputation-field.tsx
 #: app/configurator/components/field-i18n.ts
 msgid "controls.imputation.type.linear"

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -1132,6 +1132,10 @@ msgstr "Largeurs de colonnes adaptatives"
 msgid "footer.button.lindas"
 msgstr "Services de données liées LINDAS"
 
+#: app/components/footer.tsx
+msgid "footer.button.service-desk"
+msgstr "Service d'assistance"
+
 #: app/configurator/components/chart-options-selector/imputation-field.tsx
 #: app/configurator/components/field-i18n.ts
 msgid "controls.imputation.type.linear"

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -1132,6 +1132,10 @@ msgstr "Larghezze delle colonne reattive"
 msgid "footer.button.lindas"
 msgstr "Servizi di dati collegati LINDAS"
 
+#: app/components/footer.tsx
+msgid "footer.button.service-desk"
+msgstr "Sportello di assistenza"
+
 #: app/configurator/components/chart-options-selector/imputation-field.tsx
 #: app/configurator/components/field-i18n.ts
 msgid "controls.imputation.type.linear"

--- a/app/static-pages/de/index.mdx
+++ b/app/static-pages/de/index.mdx
@@ -1,6 +1,5 @@
 import { bugReportTemplates } from "@/templates/email/bug-report";
 import { featureRequestTemplates } from "@/templates/email/feature-request";
-import { newsletterTemplates } from "@/templates/email/newsletter";
 import { Divider } from "@mui/material";
 import { createMailtoLink } from "../../../app/templates/email";
 import { OWNER_ORGANIZATION_EMAIL } from "../../../app/templates/email/config";
@@ -24,52 +23,4 @@ export const contentId = "home";
   example1Description="Wählen Sie aus einer Vielzahl von Diagrammtypen und konfigurieren Sie diese entsprechend Ihren Anforderungen."
   example2Headline="Entdecken Sie die umfangreichen Möglichkeiten"
   example2Description="Mit Hilfe von benutzerdefinierten Filtern und Darstellungsoptionen, können selbst komplexe Sachverhalte visualisiert werden."
-/>
-<Actions
-  contribute={{
-    headline: "Möchten Sie Ihre eigenen Daten visualisieren?",
-    description:
-      "Erfahren Sie, wie Ihre Daten in den Linked-Data Dienst (LINDAS) des Bundesarchivs integriert werden können.",
-    buttonLabel: "Mehr erfahren",
-    buttonUrl: "https://lindas.admin.ch/?lang=de",
-  }}
-  newsletter={{
-    headline: "Newsletter abonnieren",
-    description:
-      "Bleiben Sie auf dem Laufenden und abonnieren Sie unseren Newsletter",
-    buttonLabel: "Abonnieren",
-    buttonUrl: createMailtoLink("de", {
-      recipients: {
-        to: OWNER_ORGANIZATION_EMAIL,
-      },
-      template: newsletterTemplates,
-      subject: "Visualize Newsletter Abonnieren",
-    }),
-  }}
-  bugReport={{
-    headline: "Fehler melden",
-    description:
-      "Bitte melden Sie uns den Fehler, damit wir ihn so schnell wie möglich beheben können.",
-    buttonLabel: "Fehler melden",
-    buttonUrl: createMailtoLink("de", {
-      recipients: {
-        to: OWNER_ORGANIZATION_EMAIL,
-      },
-      template: bugReportTemplates,
-      subject: "Visualize Bug Report",
-    }),
-  }}
-  featureRequest={{
-    headline: "Neue Funktion wünschen",
-    description:
-      "Senden Sie uns Ihre Funktionsanfragen und helfen Sie, die Zukunft unserer Plattform zu gestalten!",
-    buttonLabel: "Einreichen",
-    buttonUrl: createMailtoLink("de", {
-      recipients: {
-        to: OWNER_ORGANIZATION_EMAIL,
-      },
-      template: featureRequestTemplates,
-      subject: "Visualize Feature Request",
-    }),
-  }}
 />

--- a/app/static-pages/en/index.mdx
+++ b/app/static-pages/en/index.mdx
@@ -1,6 +1,5 @@
 import { bugReportTemplates } from "@/templates/email/bug-report";
 import { featureRequestTemplates } from "@/templates/email/feature-request";
-import { newsletterTemplates } from "@/templates/email/newsletter";
 import { Divider } from "@mui/material";
 import { createMailtoLink } from "../../../app/templates/email";
 import { OWNER_ORGANIZATION_EMAIL } from "../../../app/templates/email/config";
@@ -24,50 +23,4 @@ export const contentId = "home";
   example1Description="Choose from a wide range of chart types and configure them according to your needs."
   example2Headline="Use powerful customizations"
   example2Description="With the help of custom filters and data segmentation, even complex issues can be visualized."
-/>
-<Actions
-  contribute={{
-    headline: "Would you like to visualize your own data?",
-    description:
-      "Find out how you can integrate your data into the LINDAS Linked Data Service.",
-    buttonLabel: "Learn how",
-    buttonUrl: "https://lindas.admin.ch/?lang=en",
-  }}
-  newsletter={{
-    headline: "Subscribe to our Newsletter",
-    description: "Stay up to date and subscribe to our newsletter.",
-    buttonLabel: "Subscribe",
-    buttonUrl: createMailtoLink("en", {
-      recipients: {
-        to: OWNER_ORGANIZATION_EMAIL,
-      },
-      template: newsletterTemplates,
-      subject: "Visualize Newsletter Subscribe",
-    }),
-  }}
-  bugReport={{
-    headline: "Found a bug?",
-    description: "Please report the bug, so can fix it as soon as possible",
-    buttonLabel: "Report a bug",
-    buttonUrl: createMailtoLink("en", {
-      recipients: {
-        to: OWNER_ORGANIZATION_EMAIL,
-      },
-      template: bugReportTemplates,
-      subject: "Visualize Bug Report",
-    }),
-  }}
-  featureRequest={{
-    headline: "New feature request",
-    description:
-      "Submit your feature requests today and help shape the future of our platform!",
-    buttonLabel: "Submit",
-    buttonUrl: createMailtoLink("en", {
-      recipients: {
-        to: OWNER_ORGANIZATION_EMAIL,
-      },
-      template: featureRequestTemplates,
-      subject: "Visualize Feature Request",
-    }),
-  }}
 />

--- a/app/static-pages/fr/index.mdx
+++ b/app/static-pages/fr/index.mdx
@@ -1,6 +1,5 @@
 import { bugReportTemplates } from "@/templates/email/bug-report";
 import { featureRequestTemplates } from "@/templates/email/feature-request";
-import { newsletterTemplates } from "@/templates/email/newsletter";
 import { Divider } from "@mui/material";
 import { createMailtoLink } from "../../../app/templates/email";
 import { OWNER_ORGANIZATION_EMAIL } from "../../../app/templates/email/config";
@@ -24,51 +23,4 @@ export const contentId = "home";
   example1Description="Choisissez un type de graphique et configurez-le selon vos besoins."
   example2Headline="Exploitez les nombreuses options disponibles"
   example2Description="Grâce aux filtres et aux options d'affichage, même des problèmes complexes peuvent être visualisés."
-/>
-<Actions
-  contribute={{
-    headline: "Voulez-vous visualiser vos propres données?",
-    description:
-      "Apprenez comment intégrer vos données au service LINDAS (Linked Data).",
-    buttonLabel: "En savoir plus",
-    buttonUrl: "https://lindas.admin.ch/?lang=fr",
-  }}
-  newsletter={{
-    headline: "S'abonner à notre newsletter",
-    description: "Restez informé et abonnez-vous à notre newsletter.",
-    buttonLabel: "S'abonner",
-    buttonUrl: createMailtoLink("fr", {
-      recipients: {
-        to: OWNER_ORGANIZATION_EMAIL,
-      },
-      template: newsletterTemplates,
-      subject: "Visualize Newsletter Abonnement",
-    }),
-  }}
-  bugReport={{
-    headline: "Un bug a été trouvé?",
-    description:
-      "Veuillez nous signaler le bug afin que nous puissions le corriger le plus rapidement possible.",
-    buttonLabel: "Signaler un bug",
-    buttonUrl: createMailtoLink("fr", {
-      recipients: {
-        to: OWNER_ORGANIZATION_EMAIL,
-      },
-      template: bugReportTemplates,
-      subject: "Visualize Bug Report",
-    }),
-  }}
-  featureRequest={{
-    headline: "Nouvelle demande de fonctionnalité",
-    description:
-      "Envoyez-nous vos demandes de fonctionnalités dès aujourd'hui et aidez à façonner l'avenir de notre plateforme!",
-    buttonLabel: "Soumettre",
-    buttonUrl: createMailtoLink("fr", {
-      recipients: {
-        to: OWNER_ORGANIZATION_EMAIL,
-      },
-      template: featureRequestTemplates,
-      subject: "Visualize Feature Request",
-    }),
-  }}
 />

--- a/app/static-pages/it/index.mdx
+++ b/app/static-pages/it/index.mdx
@@ -1,6 +1,5 @@
 import { bugReportTemplates } from "@/templates/email/bug-report";
 import { featureRequestTemplates } from "@/templates/email/feature-request";
-import { newsletterTemplates } from "@/templates/email/newsletter";
 import { Divider } from "@mui/material";
 
 import { createMailtoLink } from "../../../app/templates/email";
@@ -25,51 +24,4 @@ export const contentId = "home";
   example1Description="Scegli tra i numerosi tipi di grafici e configurali in base alle tue esigenze."
   example2Headline="Personalizzale come desideri"
   example2Description="Grazie ai filtri personalizzati e alle opzioni di selezione dei dati, è possibile visualizzare anche problemi complessi."
-/>
-<Actions
-  contribute={{
-    headline: "Vuoi visualizzare i tuoi dati?",
-    description:
-      "Scopri come integrare i tuoi dati nel servizio LINDAS (Linked Data).",
-    buttonLabel: "Scopri come farlo",
-    buttonUrl: "https://lindas.admin.ch/?lang=it",
-  }}
-  newsletter={{
-    headline: "Si iscriva alla nostra newsletter",
-    description: "Rimani aggiornato e si iscriva alla nostra newsletter.",
-    buttonLabel: "Iscriviti",
-    buttonUrl: createMailtoLink("it", {
-      recipients: {
-        to: OWNER_ORGANIZATION_EMAIL,
-      },
-      template: newsletterTemplates,
-      subject: "Visualize Newsletter Iscrizione",
-    }),
-  }}
-  bugReport={{
-    headline: "Ha trovato un errore?",
-    description:
-      "Ce lo faccia sapere così possiamo correggerlo il prima possibile.",
-    buttonLabel: "Segnala un bug",
-    buttonUrl: createMailtoLink("it", {
-      recipients: {
-        to: OWNER_ORGANIZATION_EMAIL,
-      },
-      template: bugReportTemplates,
-      subject: "Visualize Bug Report",
-    }),
-  }}
-  featureRequest={{
-    headline: "Richiesta di nuove funzionalità",
-    description:
-      "Invia le tue richieste di funzionalità oggi stesso e aiutaci a plasmare il futuro della nostra piattaforma!",
-    buttonLabel: "Invia",
-    buttonUrl: createMailtoLink("it", {
-      recipients: {
-        to: OWNER_ORGANIZATION_EMAIL,
-      },
-      template: featureRequestTemplates,
-      subject: "Visualize Feature Request",
-    }),
-  }}
 />


### PR DESCRIPTION
* adds the linke to the service desk in the footer
* removes "action" tiles - and unused email templates.
    * templates for bug reports and feature requests seem to be still used in the login-menu
---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
- [ ] I wrote tests for the changes (if applicable)
- [ ] I wrote configurator and chart config migrations (if applicable)
