### PR TITLE
Add i18n table links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ You can also check the
   - Add SPARQL endpoints in the OpenTelemetry traces
   - Add Sentry integration back
   - Action tiles replaced with a link to the service desk
+  - Allow the definition of language-specific links in table diagrams
 - Refactoring
   - Incorporate the Swiss-Federal-CI library into this repository.
 - Fixes

--- a/app/charts/index.ts
+++ b/app/charts/index.ts
@@ -620,7 +620,12 @@ export const getInitialConfig = (
         },
         links: {
           enabled: false,
-          baseUrl: "",
+          baseUrl: {
+            de: "",
+            fr: "",
+            it: "",
+            en: "",
+          },
           componentId: "",
           targetComponentId: "",
         },

--- a/app/charts/table/linked-cell-wrapper.tsx
+++ b/app/charts/table/linked-cell-wrapper.tsx
@@ -9,6 +9,7 @@ import { ColumnMeta } from "@/charts/table/table-state";
 import { TableLinks } from "@/config-types";
 import { Observation } from "@/domain/data";
 import { Icon } from "@/icons";
+import { useLocale } from "@/locales/use-locale";
 
 const useStyles = makeStyles((theme: Theme) => ({
   link: {
@@ -55,13 +56,14 @@ export const LinkedCellWrapper = ({
   links: TableLinks;
 }) => {
   const classes = useStyles();
+  const locale = useLocale();
   const isLinkedColumn =
     links.enabled &&
-    links.baseUrl.trim() !== "" &&
+    links.baseUrl[locale].trim() !== "" &&
     links.componentId.trim() !== "" &&
     links.targetComponentId.trim() !== "" &&
     getSlugifiedId(links.targetComponentId) === columnMeta.slugifiedId;
-  const href = getLinkHref(cell, links.baseUrl, links.componentId);
+  const href = getLinkHref(cell, links.baseUrl[locale], links.componentId);
 
   if (!isLinkedColumn || !href) {
     return <>{children}</>;

--- a/app/config-types.ts
+++ b/app/config-types.ts
@@ -825,9 +825,17 @@ const TableSettings = t.type({
 });
 export type TableSettings = t.TypeOf<typeof TableSettings>;
 
+const TableLinksBaseUrl = t.type({
+  de: t.string,
+  fr: t.string,
+  it: t.string,
+  en: t.string,
+});
+export type TableLinksBaseUrl = t.TypeOf<typeof TableLinksBaseUrl>;
+
 const TableLinks = t.type({
   enabled: t.boolean,
-  baseUrl: t.string,
+  baseUrl: TableLinksBaseUrl,
   componentId: t.string,
   targetComponentId: t.string,
 });

--- a/app/configurator/configurator-state/mocks.ts
+++ b/app/configurator/configurator-state/mocks.ts
@@ -1305,7 +1305,12 @@ export const configJoinedCubes: Partial<
     },
     links: {
       enabled: false,
-      baseUrl: "",
+      baseUrl: {
+        de: "",
+        fr: "",
+        it: "",
+        en: "",
+      },
       componentId: "",
       targetComponentId: "",
     },

--- a/app/configurator/configurator-state/reducer.spec.tsx
+++ b/app/configurator/configurator-state/reducer.spec.tsx
@@ -606,7 +606,7 @@ describe("deriveFiltersFromFields", () => {
             "it": "",
           },
         },
-        "version": "5.2.0",
+        "version": "5.3.0",
       }
     `);
   });

--- a/app/configurator/table/configurator/link-base-url-input.tsx
+++ b/app/configurator/table/configurator/link-base-url-input.tsx
@@ -1,0 +1,109 @@
+import { sanitizeUrl } from "@braintree/sanitize-url";
+import { t } from "@lingui/macro";
+import { KeyboardEvent, useEffect, useState } from "react";
+
+import { Input } from "@/components/form";
+import { getFieldLabel } from "@/configurator/components/field-i18n";
+import {
+  isConfiguring,
+  useConfiguratorState,
+} from "@/configurator/configurator-state";
+import { useLocale } from "@/locales/use-locale";
+import { useEvent } from "@/utils/use-event";
+
+export const LinkBaseUrlInput = ({
+  value,
+  disabled,
+  locale,
+}: {
+  value: string;
+  disabled: boolean;
+  locale: string;
+}) => {
+  const currentLocale = useLocale();
+  const [_, dispatch] = useConfiguratorState(isConfiguring);
+
+  const [inputValue, setInputValue] = useState(value);
+  const [isValid, setIsValid] = useState(true);
+
+  useEffect(() => {
+    setInputValue(value);
+  }, [value]);
+
+  const updateBaseUrl = useEvent((newValue: string) => {
+    dispatch({
+      type: "CHART_FIELD_UPDATED",
+      value: {
+        locale: currentLocale,
+        field: null,
+        path: `links.baseUrl.${locale}`,
+        value: newValue,
+      },
+    });
+  });
+
+  const handleCommit = useEvent(() => {
+    if (inputValue === "") {
+      setIsValid(true);
+      updateBaseUrl("");
+
+      return;
+    }
+
+    const sanitizedUrl = sanitizeUrl(inputValue);
+
+    if (sanitizedUrl === "about:blank") {
+      setIsValid(false);
+      updateBaseUrl("");
+
+      return;
+    }
+
+    try {
+      const url = new URL(sanitizedUrl);
+      const normalizedUrl = normalizeUrl(url);
+
+      updateBaseUrl(normalizedUrl);
+      setIsValid(true);
+      setInputValue(normalizedUrl);
+    } catch {
+      setIsValid(false);
+    }
+  });
+
+  const handleKeyDown = useEvent((e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      handleCommit();
+    }
+  });
+
+  return (
+    <Input
+      type="url"
+      label={`${t({
+        id: "controls.tableSettings.baseUrl",
+        message: "Base URL",
+      })} (${getFieldLabel(locale)})`}
+      name={`links.baseUrl.${locale}`}
+      placeholder="https://example.com/"
+      value={inputValue}
+      disabled={disabled}
+      error={!isValid}
+      errorMessage={t({
+        id: "controls.tableSettings.baseUrlInvalid",
+        message: "Please enter a valid URL",
+      })}
+      onChange={(e) => setInputValue(e.target.value)}
+      onBlur={handleCommit}
+      onKeyDown={handleKeyDown}
+    />
+  );
+};
+
+const normalizeUrl = (url: URL) => {
+  if (!url.pathname.endsWith("/")) {
+    url.pathname = url.pathname + "/";
+  }
+
+  return url.toString();
+};

--- a/app/configurator/table/configurator/links-section.tsx
+++ b/app/configurator/table/configurator/links-section.tsx
@@ -1,9 +1,8 @@
-import { sanitizeUrl } from "@braintree/sanitize-url";
 import { t, Trans } from "@lingui/macro";
 import { SelectChangeEvent } from "@mui/material";
-import { KeyboardEvent, useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 
-import { Input, Select } from "@/components/form";
+import { Select } from "@/components/form";
 import { TableConfig } from "@/config-types";
 import {
   ControlSection,
@@ -16,8 +15,10 @@ import {
   useConfiguratorState,
 } from "@/configurator/configurator-state";
 import { Dimension } from "@/domain/data";
-import { useLocale } from "@/locales/use-locale";
+import { useLocale, useOrderedLocales } from "@/locales/use-locale";
 import { useEvent } from "@/utils/use-event";
+
+import { LinkBaseUrlInput } from "./link-base-url-input";
 
 export const TableLinksSection = ({
   chartConfig,
@@ -27,6 +28,7 @@ export const TableLinksSection = ({
   dimensions: Dimension[];
 }) => {
   const locale = useLocale();
+  const orderedLocales = useOrderedLocales();
   const [_, dispatch] = useConfiguratorState(isConfiguring);
 
   const dimensionOptions = useMemo(() => {
@@ -92,10 +94,15 @@ export const TableLinksSection = ({
           field={null}
           path="links.enabled"
         />
-        <BaseUrlInput
-          value={chartConfig.links.baseUrl}
-          disabled={!chartConfig.links.enabled}
-        />
+        {orderedLocales.map((locale) => (
+          <div key={`${locale}-table-link`}>
+            <LinkBaseUrlInput
+              value={chartConfig.links.baseUrl[locale]}
+              disabled={!chartConfig.links.enabled}
+              locale={locale}
+            />
+          </div>
+        ))}
         <Select
           id="links.componentId"
           size="sm"
@@ -125,99 +132,4 @@ export const TableLinksSection = ({
       </ControlSectionContent>
     </ControlSection>
   );
-};
-
-const BaseUrlInput = ({
-  value,
-  disabled,
-}: {
-  value: string;
-  disabled: boolean;
-}) => {
-  const locale = useLocale();
-  const [_, dispatch] = useConfiguratorState(isConfiguring);
-
-  const [inputValue, setInputValue] = useState(value);
-  const [isValid, setIsValid] = useState(true);
-
-  useEffect(() => {
-    setInputValue(value);
-  }, [value]);
-
-  const updateBaseUrl = useEvent((newValue: string) => {
-    dispatch({
-      type: "CHART_FIELD_UPDATED",
-      value: {
-        locale,
-        field: null,
-        path: "links.baseUrl",
-        value: newValue,
-      },
-    });
-  });
-
-  const handleCommit = useEvent(() => {
-    if (inputValue === "") {
-      setIsValid(true);
-      updateBaseUrl("");
-
-      return;
-    }
-
-    const sanitizedUrl = sanitizeUrl(inputValue);
-
-    if (sanitizedUrl === "about:blank") {
-      setIsValid(false);
-      updateBaseUrl("");
-
-      return;
-    }
-
-    try {
-      const url = new URL(sanitizedUrl);
-      const normalizedUrl = normalizeUrl(url);
-
-      updateBaseUrl(normalizedUrl);
-      setIsValid(true);
-      setInputValue(normalizedUrl);
-    } catch {
-      setIsValid(false);
-    }
-  });
-
-  const handleKeyDown = useEvent((e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") {
-      handleCommit();
-    }
-  });
-
-  return (
-    <Input
-      type="url"
-      label={t({
-        id: "controls.tableSettings.baseUrl",
-        message: "Base URL",
-      })}
-      name="links.baseUrl"
-      placeholder="https://example.com/"
-      value={inputValue}
-      disabled={disabled}
-      error={!isValid}
-      errorMessage={t({
-        id: "controls.tableSettings.baseUrlInvalid",
-        message: "Please enter a valid URL",
-      })}
-      onChange={(e) => setInputValue(e.target.value)}
-      onBlur={handleCommit}
-      onKeyDown={handleKeyDown}
-    />
-  );
-};
-
-const normalizeUrl = (url: URL) => {
-  if (!url.pathname.endsWith("/")) {
-    url.pathname = url.pathname + "/";
-  }
-
-  return url.toString();
 };

--- a/app/docs/fixtures.ts
+++ b/app/docs/fixtures.ts
@@ -1145,7 +1145,7 @@ export const tableConfig: TableConfig = {
   settings: { showSearch: true, showAllRows: true, limitColumnWidths: false },
   links: {
     enabled: false,
-    baseUrl: "",
+    baseUrl: { de: "", fr: "", it: "", en: "" },
     componentId: "",
     targetComponentId: "",
   },

--- a/app/utils/chart-config/constants.ts
+++ b/app/utils/chart-config/constants.ts
@@ -1,3 +1,3 @@
-export const CONFIGURATOR_STATE_VERSION = "5.2.0";
+export const CONFIGURATOR_STATE_VERSION = "5.3.0";
 
-export const CHART_CONFIG_VERSION = "5.2.0";
+export const CHART_CONFIG_VERSION = "5.3.0";

--- a/app/utils/chart-config/versioning.spec.ts
+++ b/app/utils/chart-config/versioning.spec.ts
@@ -368,6 +368,37 @@ describe("config migrations", () => {
     expect(decodedMapConfig).toBeDefined();
   });
 
+  it("should migrate table links.baseUrl from string to per-locale object", async () => {
+    const tableConfigV5_2_0 = {
+      version: "5.2.0",
+      chartType: "table",
+      links: {
+        enabled: true,
+        baseUrl: "https://example.com/",
+        componentId: "",
+        targetComponentId: "",
+      },
+    };
+
+    const migrated = (await migrateChartConfig(tableConfigV5_2_0, {
+      toVersion: "5.3.0",
+      migrationProps: CONFIGURATOR_STATE,
+    })) as any;
+
+    expect(migrated.links.baseUrl).toEqual({
+      de: "https://example.com/",
+      fr: "https://example.com/",
+      it: "https://example.com/",
+      en: "https://example.com/",
+    });
+
+    const downgraded = (await migrateChartConfig(migrated, {
+      toVersion: "5.2.0",
+      migrationProps: CONFIGURATOR_STATE,
+    })) as any;
+    expect(downgraded.links.baseUrl).toBe("https://example.com/");
+  });
+
   it("should not migrate joinBy iris", async () => {
     const migratedConfig = await migrateChartConfig(configJoinedCubes.table, {
       toVersion: CHART_CONFIG_VERSION,

--- a/app/utils/chart-config/versioning.ts
+++ b/app/utils/chart-config/versioning.ts
@@ -1702,6 +1702,53 @@ export const chartConfigMigrations: Migration[] = [
       return newConfig;
     },
   },
+  {
+    from: "5.2.0",
+    to: "5.3.0",
+    description: `table chart {
+      links {
+        baseUrl: string -> { de, fr, it, en }
+      }
+    }`,
+    up: (config) => {
+      const newConfig = { ...config, version: "5.3.0" };
+
+      if (newConfig.chartType === "table") {
+        const previous: string =
+          typeof newConfig.links?.baseUrl === "string"
+            ? newConfig.links.baseUrl
+            : "";
+        newConfig.links = {
+          ...newConfig.links,
+          baseUrl: {
+            de: previous,
+            fr: previous,
+            it: previous,
+            en: previous,
+          },
+        };
+      }
+
+      return newConfig;
+    },
+    down: (config) => {
+      const newConfig = { ...config, version: "5.2.0" };
+
+      if (newConfig.chartType === "table") {
+        const baseUrl = newConfig.links?.baseUrl;
+        const collapsed =
+          baseUrl && typeof baseUrl === "object"
+            ? (baseUrl.de ?? baseUrl.en ?? baseUrl.fr ?? baseUrl.it ?? "")
+            : (baseUrl ?? "");
+        newConfig.links = {
+          ...newConfig.links,
+          baseUrl: collapsed,
+        };
+      }
+
+      return newConfig;
+    },
+  },
 ];
 
 export const migrateChartConfig = makeMigrate<ChartConfig>(
@@ -2344,6 +2391,12 @@ export const configuratorStateMigrations: Migration[] = [
     toVersion: "5.2.0",
     fromChartConfigVersion: "5.1.0",
     toChartConfigVersion: "5.2.0",
+  }),
+  makeBumpChartConfigVersionMigration({
+    fromVersion: "5.2.0",
+    toVersion: "5.3.0",
+    fromChartConfigVersion: "5.2.0",
+    toChartConfigVersion: "5.3.0",
   }),
 ];
 

--- a/e2e/table-links.spec.ts
+++ b/e2e/table-links.spec.ts
@@ -1,0 +1,93 @@
+import { setup } from "./common";
+import { harReplayGraphqlEndpointQueryParam } from "./har-utils";
+
+const { test, expect } = setup();
+
+test("it updates per-locale table link base URLs and renders the correct href per locale", async ({
+  actions,
+  selectors,
+  page,
+  within,
+  replayFromHAR,
+}) => {
+  await replayFromHAR();
+
+  // Use "Red List" of species with "Species group" dimension, whose IRIs are
+  // locale-invariant
+  await actions.chart.createFrom({
+    iri: "https://environment.ld.admin.ch/foen/ubd003001/10",
+    dataSource: "Prod",
+    createURLParams: harReplayGraphqlEndpointQueryParam,
+  });
+
+  await selectors.edition.drawerLoaded();
+  await actions.editor.changeRegularChartType("Table");
+  await selectors.chart.loaded();
+
+  // Expand "Links" section
+  const linksSection = selectors.edition.controlSectionByTitle("Links");
+  await linksSection.scrollIntoViewIfNeeded();
+  await linksSection.locator("h6:text-is('Links')").click();
+
+  // Enable links
+  await (
+    await within(linksSection).findByText("Enable links", undefined, {
+      timeout: 5_000,
+    })
+  ).click();
+
+  // Fill the per-locale base URL inputs
+  for (const loc of ["de", "fr", "it", "en"] as const) {
+    const input = page.locator(`input[name="links.baseUrl.${loc}"]`);
+    await input.fill(`https://example.com/${loc}`);
+    await input.blur();
+  }
+
+  // Set source column + target column to "Species group"
+  await linksSection.locator('[id="links.componentId"]').click();
+  await actions.mui.selectOption("Species group");
+
+  await linksSection.locator('[id="links.targetComponentId"]').click();
+  await actions.mui.selectOption("Species group");
+
+  await selectors.chart.loaded();
+
+  async function collectTableLinks() {
+    const anchors = page.locator(
+      'a[target="_parent"][href^="https://example.com/"]'
+    );
+    await anchors.first().waitFor({ timeout: 10_000 });
+    return anchors.evaluateAll((els) =>
+      (els as HTMLAnchorElement[]).map((a) => a.getAttribute("href") ?? "")
+    );
+  }
+
+  // German links should use the german base URL
+  await actions.common.switchLang("de");
+  await selectors.chart.loaded();
+
+  const germanLinks = await collectTableLinks();
+  expect(germanLinks.length).toBeGreaterThan(0);
+  for (const href of germanLinks) {
+    // e.g. https://example.com/de/<species-group-iri-tail>
+    expect(href).toMatch(/^https:\/\/example\.com\/de\/[^/]+$/);
+  }
+
+  // French links should use the french base URL
+  await actions.common.switchLang("fr");
+  await selectors.chart.loaded();
+
+  const frenchLinks = await collectTableLinks();
+  expect(frenchLinks.length).toBe(germanLinks.length);
+  for (const href of frenchLinks) {
+    expect(href).toMatch(/^https:\/\/example\.com\/fr\/[^/]+$/);
+  }
+
+  // The IRI tails (entity identifier) used in the URLs should stay the same
+  // independent of the selected language
+  expect(getIriTails(frenchLinks)).toEqual(getIriTails(germanLinks));
+});
+
+function getIriTails(urls: string[]) {
+  return urls.map((h) => h.split("/").pop() ?? "").sort();
+}


### PR DESCRIPTION
Closes these issues:
https://gitlab.lindas.admin.ch/bafu/bafu-visualize/visualization-tool/-/issues/106
https://gitlab.lindas.admin.ch/bafu/bafu-visualize/visualize/-/issues/765

This PR extends the links attributes of table diagrams such that a language-specific base URL can be defined (currently it is only possible to define a single base URL across all languages). As implemented, there is no fallback mechanism between languages; if a language has no base URL defined, the column won't be linked. Previous chart configs with a base URL defined, will be migrated, such that this URL will be used for each language.

## How to test

- Prior to this change, create a chart diagram for the "Federal Councillors, Party, Canton, Terms" cube, enable the "Enable links" option and define a "Base URL" then choose the "Name" column as source and target column. The name column in the table should now have a link.
- Then with this change, open the previously created chart. The name column should still have the link (also if you switch the language).
- Additionally, with the change, create a new chart and define per language base URLs. The name column should have the language-specific link, depending on the currently active language.

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
- [x] I wrote tests for the changes (if applicable)
- [x] I wrote configurator and chart config migrations (if applicable)
