### PR TITLE
feat: read org metadata from multiple graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ You can also check the
   - Add Sentry integration back
   - Action tiles replaced with a link to the service desk
   - Allow the definition of language-specific links in table diagrams
+  - Get Cube Creators from https://lindas.admin.ch/fch/rvov too
 - Refactoring
   - Incorporate the Swiss-Federal-CI library into this repository.
 - Fixes

--- a/app/rdf/query-search.ts
+++ b/app/rdf/query-search.ts
@@ -330,8 +330,8 @@ const mkScoresQuery = (
           <https://lindas.admin.ch/sfa/opendataswiss>
         }
         GRAPH ?creatorGraph {
+          VALUES ?creatorType { schema:Organization schema:GovernmentOrganization }
           ?creatorIri a ?creatorType .
-          FILTER (?creatorType IN (schema:Organization, schema:GovernmentOrganization))
             ${buildLocalizedSubQuery(
               "creatorIri",
               "schema:name",

--- a/app/rdf/query-search.ts
+++ b/app/rdf/query-search.ts
@@ -320,13 +320,18 @@ const mkScoresQuery = (
 
       ${creatorValues.length ? makeInFilter("creatorIri", creatorValues) : ""}
       OPTIONAL {
-        ?iri dcterms:creator ?creatorIri .
+        {
+          ?iri dcterms:creator ?creatorIri .
+        } UNION {
+          ?iri schema:creator ?creatorIri .
+        }
         VALUES ?creatorGraph {
           <https://lindas.admin.ch/fch/rvov>
           <https://lindas.admin.ch/sfa/opendataswiss>
         }
         GRAPH ?creatorGraph {
-          ?creatorIri a schema:Organization ;
+          ?creatorIri a ?creatorType .
+          FILTER (?creatorType IN (schema:Organization, schema:GovernmentOrganization))
             ${buildLocalizedSubQuery(
               "creatorIri",
               "schema:name",

--- a/app/rdf/query-search.ts
+++ b/app/rdf/query-search.ts
@@ -321,9 +321,12 @@ const mkScoresQuery = (
       ${creatorValues.length ? makeInFilter("creatorIri", creatorValues) : ""}
       OPTIONAL {
         ?iri dcterms:creator ?creatorIri .
-        GRAPH <https://lindas.admin.ch/sfa/opendataswiss> {
+        VALUES ?creatorGraph {
+          <https://lindas.admin.ch/fch/rvov>
+          <https://lindas.admin.ch/sfa/opendataswiss>
+        }
+        GRAPH ?creatorGraph {
           ?creatorIri a schema:Organization ;
-            schema:inDefinedTermSet <https://register.ld.admin.ch/opendataswiss/org> .
             ${buildLocalizedSubQuery(
               "creatorIri",
               "schema:name",
@@ -372,7 +375,7 @@ const mkScoresQuery = (
           "subthemeLabel",
           { locale }
         )}
-      } 
+      }
       `
           : ""
       }
@@ -396,31 +399,31 @@ const mkScoresQuery = (
         CONTAINS(LCASE(?title_it), LCASE(?keyword)) ||
         CONTAINS(LCASE(?title_en), LCASE(?keyword)) ||
         CONTAINS(LCASE(?title_),   LCASE(?keyword)) ||
-      
+
         CONTAINS(LCASE(?description_de), LCASE(?keyword)) ||
         CONTAINS(LCASE(?description_fr), LCASE(?keyword)) ||
         CONTAINS(LCASE(?description_it), LCASE(?keyword)) ||
         CONTAINS(LCASE(?description_en), LCASE(?keyword)) ||
         CONTAINS(LCASE(?description_),   LCASE(?keyword)) ||
-          
-        CONTAINS(LCASE(?creatorLabel_de), LCASE(?keyword)) || 
-        CONTAINS(LCASE(?creatorLabel_fr), LCASE(?keyword)) || 
-        CONTAINS(LCASE(?creatorLabel_it), LCASE(?keyword)) || 
-        CONTAINS(LCASE(?creatorLabel_en), LCASE(?keyword)) || 
-        CONTAINS(LCASE(?creatorLabel_),   LCASE(?keyword)) || 
-          
-        CONTAINS(LCASE(?themeLabel_de), LCASE(?keyword)) || 
-        CONTAINS(LCASE(?themeLabel_fr), LCASE(?keyword)) || 
-        CONTAINS(LCASE(?themeLabel_it), LCASE(?keyword)) || 
-        CONTAINS(LCASE(?themeLabel_en), LCASE(?keyword)) || 
-        CONTAINS(LCASE(?themeLabel_),   LCASE(?keyword)) || 
-          
-        CONTAINS(LCASE(?subthemeLabel_de), LCASE(?keyword)) || 
-        CONTAINS(LCASE(?subthemeLabel_fr), LCASE(?keyword)) || 
-        CONTAINS(LCASE(?subthemeLabel_it), LCASE(?keyword)) || 
-        CONTAINS(LCASE(?subthemeLabel_en), LCASE(?keyword)) || 
-        CONTAINS(LCASE(?subthemeLabel_),   LCASE(?keyword)) || 
-          
+
+        CONTAINS(LCASE(?creatorLabel_de), LCASE(?keyword)) ||
+        CONTAINS(LCASE(?creatorLabel_fr), LCASE(?keyword)) ||
+        CONTAINS(LCASE(?creatorLabel_it), LCASE(?keyword)) ||
+        CONTAINS(LCASE(?creatorLabel_en), LCASE(?keyword)) ||
+        CONTAINS(LCASE(?creatorLabel_),   LCASE(?keyword)) ||
+
+        CONTAINS(LCASE(?themeLabel_de), LCASE(?keyword)) ||
+        CONTAINS(LCASE(?themeLabel_fr), LCASE(?keyword)) ||
+        CONTAINS(LCASE(?themeLabel_it), LCASE(?keyword)) ||
+        CONTAINS(LCASE(?themeLabel_en), LCASE(?keyword)) ||
+        CONTAINS(LCASE(?themeLabel_),   LCASE(?keyword)) ||
+
+        CONTAINS(LCASE(?subthemeLabel_de), LCASE(?keyword)) ||
+        CONTAINS(LCASE(?subthemeLabel_fr), LCASE(?keyword)) ||
+        CONTAINS(LCASE(?subthemeLabel_it), LCASE(?keyword)) ||
+        CONTAINS(LCASE(?subthemeLabel_en), LCASE(?keyword)) ||
+        CONTAINS(LCASE(?subthemeLabel_),   LCASE(?keyword)) ||
+
         CONTAINS(LCASE(?publisher), LCASE(?keyword))
       )`
           : ""

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -48,6 +48,7 @@ test("search results count coherence", async ({
   ];
 
   const themes = [
+    "Federal Chancellery",
     "Federal Office for the Environment FOEN",
     "Swiss Federal Archives SFA",
     "Swiss Federal Office of Energy SFOE",


### PR DESCRIPTION
cube creators can also be defined in https://lindas.admin.ch/fch/rvov 

This PR adjusts the search cubes query to get creators from both graphs. 
Unfortunatly, one uses `dcterms:creator` and the other `schema:creator` thats why an additional union was necessary:

```
{
    ?iri dcterms:creator ?creatorIri .
} UNION {
    ?iri schema:creator ?creatorIri .
}
```

This took me quite some time to figure it out.

Currently, there are only cubes from the Federal Chancellery that use this graph for creators. I added the Federal Chancellery to the search spec (e2e) to verify that is shows up and the count is correct.

Without this change, e.g. currently on int or prod, there is no filter for the Federal Chancellery available.


---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
- [x] I wrote tests for the changes (if applicable)
- [ ] I wrote configurator and chart config migrations (if applicable)
