### PR TITLE
chore: transfer package name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ You can also check the
   - Remove dependencies which used old versions of `node-fetch`
   - Upgrade dependencies which used old versions of `nth-check`
   - Updated `@deck.gl/*` packages and `fast-xml-parser`
+  - Rename package
 - Documentation
   - Add publiccode.yml for discoverability
   - Reorganize & improve README

--- a/app/package.json
+++ b/app/package.json
@@ -10,7 +10,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "yarn workspace @foen-admin-ch/visualize-app run build"
+    "build": "yarn workspace @foen-admin-ch/visualize run build"
   },
   "dependencies": {
     "@apollo/client": "^3.3.20",

--- a/app/package.json
+++ b/app/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "@interactivethings/visualize-app",
+  "name": "@foen-admin-ch/visualize-app",
   "version": "3.4.9",
   "publishConfig": {
     "access": "public"
   },
-  "main": "dist/interactivethings-visualize-app.cjs.js",
-  "module": "dist/interactivethings-visualize-app.esm.js",
+  "main": "dist/visualize-app.cjs.js",
+  "module": "dist/visualize-app.esm.js",
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "yarn workspace @visualize-admin/visualization-tool run build"
+    "build": "yarn workspace @foen-admin-ch/visualize-app run build"
   },
   "dependencies": {
     "@apollo/client": "^3.3.20",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@visualize-admin/visualization-tool",
+  "name": "@foen-admin-ch/visualize",
   "version": "6.4.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR changes the package name defined in package.json from interactivethings to a name that is connected to the client instead of the service provider itself.

The upcoming transfer from visualize-admin to foen-admin-ch is also reflected in this change.


- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
