### PR TITLE
feat: add support suffix to service desk link

### DIFF
--- a/app/locales/de/messages.po
+++ b/app/locales/de/messages.po
@@ -1134,7 +1134,7 @@ msgstr "LINDAS Linked Data Dienste"
 
 #: app/components/footer.tsx
 msgid "footer.button.service-desk"
-msgstr "Service-Desk"
+msgstr "Service-Desk (Support)"
 
 #: app/configurator/components/chart-options-selector/imputation-field.tsx
 #: app/configurator/components/field-i18n.ts

--- a/app/locales/en/messages.po
+++ b/app/locales/en/messages.po
@@ -1134,7 +1134,7 @@ msgstr "LINDAS Linked Data Services"
 
 #: app/components/footer.tsx
 msgid "footer.button.service-desk"
-msgstr "Service-Desk"
+msgstr "Service Desk (Support)"
 
 #: app/configurator/components/chart-options-selector/imputation-field.tsx
 #: app/configurator/components/field-i18n.ts

--- a/app/locales/fr/messages.po
+++ b/app/locales/fr/messages.po
@@ -1134,7 +1134,7 @@ msgstr "Services de données liées LINDAS"
 
 #: app/components/footer.tsx
 msgid "footer.button.service-desk"
-msgstr "Service d'assistance"
+msgstr "Service d'assistance (support)"
 
 #: app/configurator/components/chart-options-selector/imputation-field.tsx
 #: app/configurator/components/field-i18n.ts

--- a/app/locales/it/messages.po
+++ b/app/locales/it/messages.po
@@ -1134,7 +1134,7 @@ msgstr "Servizi di dati collegati LINDAS"
 
 #: app/components/footer.tsx
 msgid "footer.button.service-desk"
-msgstr "Sportello di assistenza"
+msgstr "Sportello di assistenza (supporto)"
 
 #: app/configurator/components/chart-options-selector/imputation-field.tsx
 #: app/configurator/components/field-i18n.ts


### PR DESCRIPTION
As requested - add "support" to the service desk link

---

- [ ] I added a CHANGELOG entry
- [x] I made a self-review of my own code
- [ ] I wrote tests for the changes (if applicable)
- [ ] I wrote configurator and chart config migrations (if applicable)
