### PR TITLE
fix: csp headers for index pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ You can also check the
 
 ## Unreleased
 
+- Fixes
+  - Correctly set CSP headers for index pages
+
 ## 6.5.0 – 2026-06-01
 
 - Features

--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -64,6 +64,12 @@ export function middleware(request: NextRequest) {
 
 export const config = {
   matcher: [
+    // The negative-lookahead pattern below gets compiled by Next.js (when i18n
+    // is configured) into a regex that requires two path segments (locale +
+    // rest), which silently excludes bare locale-root paths like "/", "/de",
+    // "/en". Add those explicitly so they still go through the middleware.
+    "/",
+    "/(de|fr|it|en)",
     {
       source: "/((?!_next/static|_next/image|favicon\\.ico).*)",
       missing: [

--- a/e2e/csp-headers.spec.ts
+++ b/e2e/csp-headers.spec.ts
@@ -1,0 +1,25 @@
+import { setup } from "./common";
+
+const { test, describe, expect } = setup();
+
+describe("CSP headers", () => {
+  test("should be set on the index page", async ({ page }) => {
+    const response = await page.goto("/en");
+    expect(response).not.toBeNull();
+    const csp =
+      response!.headers()["content-security-policy"] ??
+      response!.headers()["content-security-policy-report-only"];
+    expect(csp).toBeTruthy();
+    expect(csp).toContain("frame-ancestors");
+  });
+
+  test("should be set on the imprint page", async ({ page }) => {
+    const response = await page.goto("/en/imprint");
+    expect(response).not.toBeNull();
+    const csp =
+      response!.headers()["content-security-policy"] ??
+      response!.headers()["content-security-policy-report-only"];
+    expect(csp).toBeTruthy();
+    expect(csp).toContain("frame-ancestors");
+  });
+});


### PR DESCRIPTION
No CSP Header was set for index pages, e.g. https://visualize.admin.ch/en 

Pages with more than one path segment included the correct headers: https://visualize.admin.ch/en/imprint

The cause was that the matcher in middleware.ts was is recompiled for i18n routing during the build. The newly generated matcher did only match routes with at least two path segments, e.g. `/en/imprint`, but not `/en` itself.

It is not known to me whether upgrading next.js would fix this too.


---

- [ x ] I added a CHANGELOG entry
- [ x ] I made a self-review of my own code
