### PR TITLE
release: prepare v6.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ You can also check the
 
 ## Unreleased
 
+## 6.5.1 – 2026-07-10
+
 - Fixes
 
   - Correctly set CSP headers for index pages

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foen-admin-ch/visualize",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/visualize-admin/visualization-tool.git"


### PR DESCRIPTION
Release v6.5.1

Includes: 

- Fixes

  - Correctly set CSP headers for index pages
  - Harden markdown renderer sanitization
  - Make measure id optional for symbol layers in map charts. Fixes issues with
    invalid view configuration that prevents that users could copy and edit an
    existing visualization

- Maintenance
  - Add dev-container support

---

- [x] I added a CHANGELOG entry
- [x] I made a self-review of my own code
- [ ] I wrote tests for the changes (if applicable)
- [ ] I wrote configurator and chart config migrations (if applicable)
