### PR TITLE
doc: fix embed script filename in dev setup docs

### DIFF
--- a/readme/dev.md
+++ b/readme/dev.md
@@ -77,7 +77,7 @@ please add `E2E_ENV=true` to your environment.
 
 The embed script is not automatically built when the dev server starts.
 
-Run the following command after changes to the `embed/index.ts` file:
+Run the following command after changes to the `embed/index.tsx` file:
 
 ```sh
 yarn dev:rollup

--- a/readme/testing-general.md
+++ b/readme/testing-general.md
@@ -20,5 +20,5 @@ with example mocked event payloads defined in [the act/ directory](../act).
 After
 [installing the act library](https://nektosact.com/installation/index.html), you
 can run a given action like e.g.
-`act deployment_status -W ".github/workflows/performance-tests-pr.yml" -e act/deployment_status.json`,
+`act deployment_status -W ".github/workflows/performance-tests-pr.yaml" -e act/deployment_status.json`,
 modifying the event payload or adding a new one as needed.

--- a/readme/testing-performance.md
+++ b/readme/testing-performance.md
@@ -60,8 +60,7 @@ k6 run k6/script-name.js
 
 replacing the `script-name` with an actual name of the test you want to run.
 Optionally, you can tweak the configuration of each test by directly modifying
-the `options` object inside a given script and running `yarn k6:codegen` to make
-the JavaScript files up-to-date.
+the `options` object inside a given script.
 
 For the GraphQL tests, you'll also need to pass `--env ENV=(test|int|prod)` flag
 to point to the proper environment and


### PR DESCRIPTION
<!--- Link this pull request to an issue (fixes or closes #issue_number) -->

Closes # Not Applicable

<!--- Describe the changes -->

This PR fixes a wrong file path in the dev setup docs.

`readme/dev.md` told contributors to run `yarn dev:rollup` "after changes to
the `embed/index.ts` file". That file does not exist. The real embed entry
file is `embed/index.tsx` — confirmed by `rollup.config.js` (`input:
"embed/index.tsx"`) and by the file that is actually on disk at
`embed/index.tsx`. This corrects the extension so the docs match the code.

## How to test

1. Open `readme/dev.md` and check the "Build the embed script" section.
2. Confirm it now says `embed/index.tsx`.
3. Confirm `embed/index.tsx` exists in the repo and `rollup.config.js` uses
   that same path as its `input`.

---

- [ ] I added a CHANGELOG entry — skipped, this is a one-line docs typo fix
      with no user-facing or behavioural change
- [x] I made a self-review of my own code
- [ ] I wrote tests for the changes (if applicable) — N/A, docs-only change
- [ ] I wrote configurator and chart config migrations (if applicable) — N/A